### PR TITLE
feat: harden PR4 lifecycle resume/status/tail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "bookforge-core",
  "rusqlite",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror",
 ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ MVP functionality is implemented:
 - Bounded parallel segment translation with `--concurrency`
 - SQLite checkpoint store
 - Resume and retry commands
+- Status and tail commands for persisted jobs
 - Segment-level cache reuse for compatible prior translations
 - QA reports in JSON and Markdown
 - Optional LLM QA review pass
@@ -73,6 +74,26 @@ cargo run -p bookforge-cli -- translate book.epub \
   --out book.it.epub
 ```
 
+Translate with the v1 fast preset:
+
+```bash
+cargo run -p bookforge-cli -- translate book.epub \
+  --target Italian \
+  --provider-preset openrouter-paid-fast \
+  --profile v1-fast \
+  --ui progress \
+  --out book.it.epub
+```
+
+Check provider and storage health:
+
+```bash
+cargo run -p bookforge-cli -- doctor --storage
+cargo run -p bookforge-cli -- doctor \
+  --provider openrouter \
+  --model google/gemini-2.5-flash-lite
+```
+
 Translate with DeepSeek:
 
 ```bash
@@ -107,6 +128,13 @@ Resume a job:
 
 ```bash
 cargo run -p bookforge-cli -- resume <job-id> --timeout-seconds 120
+```
+
+Inspect persisted job state and recent events:
+
+```bash
+cargo run -p bookforge-cli -- status <job-id>
+cargo run -p bookforge-cli -- tail <job-id> --lines 40
 ```
 
 Retry failed or review-needed segments:
@@ -144,6 +172,29 @@ Runtime state is stored in:
 ```
 
 That path is ignored by git. Segment translations are persisted as each segment completes. New jobs reuse compatible cached translations when the source hash, prompt version, provider, model, source language, and target language match.
+
+Progress events can be written in every UI mode:
+
+```bash
+cargo run -p bookforge-cli -- translate book.epub \
+  --target Italian \
+  --provider mock \
+  --model mock-prefix-target \
+  --ui json \
+  --progress-jsonl .bookforge/runs/example/events.jsonl
+```
+
+Known limitations: resume depends on the original input path remaining available, provider API keys are read from environment variables, and validation is intentionally pragmatic rather than a full EPUBCheck replacement.
+
+## Benchmarks
+
+Run the mock release smoke benchmark with:
+
+```bash
+scripts/bench-mock.sh
+```
+
+See `docs/benchmarks.md` for metrics to capture in real-provider runs.
 
 ## Secrets And Local Tests
 

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -6,7 +6,8 @@ use std::{
 
 use anyhow::Result;
 use bookforge_core::{
-    NullProgressSink,
+    ProgressEvent, ProgressSink, ResolvedRunSettings, RunConfigSnapshot,
+    progress::now_ms,
     segment::{BlockTranslation, Segment, SegmentStatus, build_segments, compute_cache_namespace},
 };
 use bookforge_epub::{read_epub, rebuild_epub};
@@ -27,7 +28,7 @@ use crate::{
 
 use super::translate::{
     CacheContext, CheckpointContext, apply_cached_translations, mock_mode, qa_reviews_for_mode,
-    translate_and_checkpoint,
+    translate_and_checkpoint, translate_and_checkpoint_batch,
 };
 
 #[derive(Debug, Args)]
@@ -77,6 +78,48 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         );
     };
 
+    let progress_jsonl = args
+        .progress_jsonl
+        .clone()
+        .or_else(|| snapshot.events_path.clone());
+    let reporter = crate::progress::ProgressReporter::spawn_with_append(
+        args.ui.unwrap_or(crate::progress::UiMode::Auto),
+        progress_jsonl,
+        true,
+    );
+    let progress = reporter.sink();
+
+    let run_result = run_inner(args, store, job, &mut snapshot, progress).await;
+    finalize_reporter(run_result, reporter).await
+}
+
+async fn finalize_reporter<T>(
+    result: Result<T, anyhow::Error>,
+    reporter: crate::progress::ProgressReporter,
+) -> Result<T> {
+    let reporter_result = reporter.shutdown().await;
+    match (result, reporter_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(e)) => Err(e),
+        (Err(e), Ok(())) => Err(e),
+        (Err(main_err), Err(progress_err)) => Err(anyhow::anyhow!(
+            "{main_err}; additionally progress reporter failed: {progress_err}"
+        )),
+    }
+}
+
+async fn run_inner(
+    args: ResumeArgs,
+    store: JobStore,
+    job: JobRecord,
+    snapshot: &mut RunConfigSnapshot,
+    progress: Arc<dyn ProgressSink>,
+) -> Result<()> {
+    let started = std::time::Instant::now();
+    progress.emit(ProgressEvent::StageStarted {
+        stage: "resume".to_string(),
+        timestamp_ms: now_ms(),
+    });
     let input = snapshot.input_path.clone();
     let output = args
         .output
@@ -90,6 +133,12 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         store.update_job_event_path(&job.id, &path)?;
         snapshot.events_path = Some(path);
     }
+    progress.emit(ProgressEvent::JobCreated {
+        job_id: job.id.clone(),
+        input_path: input.display().to_string(),
+        output_path: output.display().to_string(),
+        timestamp_ms: now_ms(),
+    });
     let book = read_epub(&input)?;
     let mut settings = snapshot.settings.to_settings();
     if let Some(value) = args.concurrency {
@@ -110,6 +159,34 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     if args.no_thinking {
         settings.provider.thinking_disabled = true;
     }
+    progress.emit(ProgressEvent::RuntimeConfigResolved {
+        profile: format!("{:?}", settings.profile),
+        provider_preset: snapshot
+            .provider_preset
+            .as_ref()
+            .map(|preset| format!("{preset:?}")),
+        provider: snapshot.provider.clone(),
+        model: snapshot.model.clone(),
+        concurrency: settings.scheduler.concurrency,
+        max_attempts: settings.scheduler.max_attempts,
+        provider_max_attempts: settings.provider.provider_max_attempts,
+        validation_max_attempts: settings.provider.validation_max_attempts,
+        retry_after_policy: format!("{:?}", settings.provider.retry_after_policy),
+        max_backoff_seconds: settings.provider.max_backoff_seconds,
+        timeout_seconds: settings.provider.timeout_seconds,
+        batch_enabled: settings.batch.enabled,
+        batch_target_tokens: settings.batch.target_tokens,
+        batch_max_items: settings.batch.max_items,
+        adaptive_batch_sizing: settings.batch.adaptive_sizing,
+        adaptive_concurrency: settings.adaptive_concurrency,
+        compact_prompts: settings.compact_prompts,
+        thinking_disabled: settings.provider.thinking_disabled,
+        json_mode: format!("{:?}", settings.provider.json_mode),
+        model_context_tokens: settings.provider.model_context_tokens,
+        max_output_tokens: settings.provider.max_output_tokens,
+        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+        timestamp_ms: now_ms(),
+    });
     let segments = build_segments(&book, &settings.segmentation)?;
     let pending_ids = store.resumable_segment_ids(&job.id)?;
 
@@ -166,50 +243,94 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     )?;
     let pending_segments =
         select_pending_segments(&segments, &store.resumable_segment_ids(&job.id)?)?;
+    progress.emit(ProgressEvent::CacheScanFinished {
+        hits: cached_translations.len(),
+        misses: pending_segments.len(),
+        timestamp_ms: now_ms(),
+    });
     store.mark_job_running(&job.id)?;
 
     let fresh_translations = if pending_segments.is_empty() {
         Vec::new()
     } else {
-        let writer =
-            CheckpointWriter::spawn(store.path().to_path_buf(), Arc::new(NullProgressSink));
+        let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
         let sender = writer.sender();
         let result = match job.provider.as_str() {
             "mock" => {
                 let provider =
                     MockProvider::new(mock_mode(&snapshot.model), &snapshot.target_language);
-                translate_and_checkpoint(
-                    provider.clone(),
-                    &pending_segments,
-                    &run_config,
-                    CheckpointContext {
-                        store: &store,
-                        job_id: &job.id,
-                        provider: &snapshot.provider,
-                        model: &snapshot.model,
-                        prompt_version,
-                        sender: &sender,
-                    },
-                )
-                .await
+                if settings.batch.enabled {
+                    let batch_run_config = batch_run_config(&run_config, &settings);
+                    translate_and_checkpoint_batch(
+                        provider.clone(),
+                        &pending_segments,
+                        &batch_run_config,
+                        &settings,
+                        CheckpointContext {
+                            store: &store,
+                            job_id: &job.id,
+                            provider: &snapshot.provider,
+                            model: &snapshot.model,
+                            prompt_version,
+                            sender: &sender,
+                        },
+                        progress.clone(),
+                    )
+                    .await
+                } else {
+                    translate_and_checkpoint(
+                        provider.clone(),
+                        &pending_segments,
+                        &run_config,
+                        CheckpointContext {
+                            store: &store,
+                            job_id: &job.id,
+                            provider: &snapshot.provider,
+                            model: &snapshot.model,
+                            prompt_version,
+                            sender: &sender,
+                        },
+                    )
+                    .await
+                }
             }
             "deepseek" | "openrouter" | "openai-compatible" => {
-                let provider_config = openai_compatible_config(&job, &snapshot, &settings)?;
+                let provider_config = openai_compatible_config(&job, snapshot, &settings)?;
                 let provider = OpenAiCompatibleProvider::new(provider_config)?;
-                translate_and_checkpoint(
-                    provider.clone(),
-                    &pending_segments,
-                    &run_config,
-                    CheckpointContext {
-                        store: &store,
-                        job_id: &job.id,
-                        provider: &snapshot.provider,
-                        model: &snapshot.model,
-                        prompt_version,
-                        sender: &sender,
-                    },
-                )
-                .await
+                if settings.batch.enabled {
+                    let batch_run_config = batch_run_config(&run_config, &settings);
+                    translate_and_checkpoint_batch(
+                        provider.clone(),
+                        &pending_segments,
+                        &batch_run_config,
+                        &settings,
+                        CheckpointContext {
+                            store: &store,
+                            job_id: &job.id,
+                            provider: &snapshot.provider,
+                            model: &snapshot.model,
+                            prompt_version,
+                            sender: &sender,
+                        },
+                        progress.clone(),
+                    )
+                    .await
+                } else {
+                    translate_and_checkpoint(
+                        provider.clone(),
+                        &pending_segments,
+                        &run_config,
+                        CheckpointContext {
+                            store: &store,
+                            job_id: &job.id,
+                            provider: &snapshot.provider,
+                            model: &snapshot.model,
+                            prompt_version,
+                            sender: &sender,
+                        },
+                    )
+                    .await
+                }
             }
             provider => anyhow::bail!("cannot resume unsupported provider '{provider}'"),
         };
@@ -230,8 +351,9 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         &segments,
         &translations,
         &run_config,
+        snapshot,
+        &settings,
         args.qa,
-        settings.provider.timeout_seconds,
     )
     .await?;
     let block_translations =
@@ -260,7 +382,21 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     store.update_job_report_paths(&job.id, &report.json, &report.markdown)?;
     snapshot.report_json_path = Some(report.json.clone());
     snapshot.report_markdown_path = Some(report.markdown.clone());
-    store.update_job_config_snapshot(&job.id, &snapshot)?;
+    store.update_job_config_snapshot(&job.id, snapshot)?;
+    progress.emit(ProgressEvent::ArtifactWritten {
+        path: output.display().to_string(),
+        timestamp_ms: now_ms(),
+    });
+    progress.emit(ProgressEvent::TranslationFinished {
+        succeeded: summary.succeeded,
+        cached: summary.cached,
+        needs_review: summary.needs_review,
+        failed: summary.failed,
+        input_tokens: summary.input_tokens,
+        output_tokens: summary.output_tokens,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        timestamp_ms: now_ms(),
+    });
 
     println!(
         "Translated: {}/{} segments",
@@ -315,17 +451,35 @@ fn select_pending_segments(segments: &[Segment], pending_ids: &[String]) -> Resu
 
 fn openai_compatible_config(
     job: &JobRecord,
-    snapshot: &bookforge_core::RunConfigSnapshot,
-    settings: &bookforge_core::ResolvedRunSettings,
+    snapshot: &RunConfigSnapshot,
+    settings: &ResolvedRunSettings,
+) -> Result<OpenAiCompatibleConfig> {
+    openai_compatible_config_from_parts(
+        job.provider.as_str(),
+        &snapshot.model,
+        snapshot.base_url.as_deref(),
+        snapshot.api_key_env.as_deref(),
+        &job.id,
+        settings,
+    )
+}
+
+fn openai_compatible_config_from_parts(
+    provider: &str,
+    model: &str,
+    base_url: Option<&str>,
+    api_key_env: Option<&str>,
+    job_id: &str,
+    settings: &ResolvedRunSettings,
 ) -> Result<OpenAiCompatibleConfig> {
     let provider_max_attempts = settings.provider.provider_max_attempts.max(1);
-    if job.provider == "deepseek" {
-        let mut config = OpenAiCompatibleConfig::deepseek(Some(snapshot.model.clone()));
-        if let Some(base_url) = &snapshot.base_url {
-            config.base_url = base_url.clone();
+    if provider == "deepseek" {
+        let mut config = OpenAiCompatibleConfig::deepseek(Some(model.to_string()));
+        if let Some(base_url) = base_url {
+            config.base_url = base_url.to_string();
         }
-        if let Some(api_key_env) = &snapshot.api_key_env {
-            config.api_key_env = api_key_env.clone();
+        if let Some(api_key_env) = api_key_env {
+            config.api_key_env = api_key_env.to_string();
         }
         config.timeout_seconds = settings.provider.timeout_seconds;
         config.provider_max_attempts = provider_max_attempts;
@@ -337,17 +491,15 @@ fn openai_compatible_config(
         return Ok(config);
     }
 
-    if job.provider == "openrouter" {
+    if provider == "openrouter" {
         return Ok(OpenAiCompatibleConfig {
-            base_url: snapshot
-                .base_url
-                .clone()
+            base_url: base_url
+                .map(String::from)
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
-            api_key_env: snapshot
-                .api_key_env
-                .clone()
+            api_key_env: api_key_env
+                .map(String::from)
                 .unwrap_or_else(|| "OPENROUTER_API_KEY".to_string()),
-            model: snapshot.model.clone(),
+            model: model.to_string(),
             timeout_seconds: settings.provider.timeout_seconds,
             provider_max_attempts,
             thinking_disabled: settings.provider.thinking_disabled,
@@ -359,17 +511,16 @@ fn openai_compatible_config(
     }
 
     Ok(OpenAiCompatibleConfig {
-        base_url: snapshot.base_url.clone().ok_or_else(|| {
+        base_url: base_url.map(String::from).ok_or_else(|| {
             anyhow::anyhow!(
                 "job '{}' does not have a stored base URL for openai-compatible resume",
-                job.id
+                job_id
             )
         })?,
-        api_key_env: snapshot
-            .api_key_env
-            .clone()
+        api_key_env: api_key_env
+            .map(String::from)
             .unwrap_or_else(|| "OPENAI_API_KEY".to_string()),
-        model: snapshot.model.clone(),
+        model: model.to_string(),
         timeout_seconds: settings.provider.timeout_seconds,
         provider_max_attempts,
         thinking_disabled: settings.provider.thinking_disabled,
@@ -378,6 +529,29 @@ fn openai_compatible_config(
         max_idle_per_host: settings.provider.max_idle_per_host,
         json_mode: settings.provider.json_mode,
     })
+}
+
+fn batch_run_config(
+    run_config: &TranslationRunConfig,
+    settings: &ResolvedRunSettings,
+) -> TranslationRunConfig {
+    TranslationRunConfig {
+        source_language: run_config.source_language.clone(),
+        target_language: run_config.target_language.clone(),
+        provider: run_config.provider.clone(),
+        model: run_config.model.clone(),
+        prompt_version: run_config.prompt_version.clone(),
+        temperature: run_config.temperature,
+        scheduler: bookforge_core::SchedulerConfig {
+            concurrency: run_config.scheduler.concurrency,
+            max_attempts: settings.provider.provider_max_attempts,
+        },
+        profile: settings.profile,
+        model_context_tokens: settings.provider.model_context_tokens,
+        max_output_tokens: settings.provider.max_output_tokens,
+        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+        compact_prompts: settings.compact_prompts,
+    }
 }
 
 fn mark_job_from_summary(store: &JobStore, job_id: &str) -> Result<()> {
@@ -398,64 +572,44 @@ async fn qa_after_resume(
     segments: &[Segment],
     translations: &[SegmentTranslation],
     config: &TranslationRunConfig,
+    snapshot: &RunConfigSnapshot,
+    settings: &ResolvedRunSettings,
     qa_mode: QaMode,
-    timeout_seconds: u64,
 ) -> Result<Vec<QaSegmentReview>> {
-    let qa_config = bookforge_core::QaRunConfig {
-        concurrency: 4,
-        batch_target_tokens: 4_000,
-        model: None,
-        provider: None,
-        base_url: None,
-        api_key_env: None,
-    };
-    match job.provider.as_str() {
+    let qa_config = &settings.qa;
+    let provider_name = qa_config.provider.as_deref().unwrap_or(&snapshot.provider);
+    let model = qa_config.model.as_deref().unwrap_or(&snapshot.model);
+    let base_url = qa_config
+        .base_url
+        .as_deref()
+        .or(snapshot.base_url.as_deref());
+    let api_key_env = qa_config
+        .api_key_env
+        .as_deref()
+        .or(snapshot.api_key_env.as_deref());
+
+    match provider_name {
         "mock" => {
-            let provider = MockProvider::new(mock_mode(&job.model), &job.target_lang);
-            Ok(qa_reviews_for_mode(
-                provider,
-                segments,
-                translations,
-                config,
-                &qa_config,
-                qa_mode,
+            let provider = MockProvider::new(mock_mode(model), &job.target_lang);
+            Ok(
+                qa_reviews_for_mode(provider, segments, translations, config, qa_config, qa_mode)
+                    .await,
             )
-            .await)
         }
         "deepseek" | "openrouter" | "openai-compatible" => {
-            let snapshot = bookforge_core::RunConfigSnapshot {
-                input_path: job.input_path.clone(),
-                output_path: job.output_path.clone(),
-                events_path: job.events_path.clone(),
-                report_json_path: job.report_json_path.clone(),
-                report_markdown_path: job.report_markdown_path.clone(),
-                source_language: job.source_lang.clone(),
-                target_language: job.target_lang.clone(),
-                provider: job.provider.clone(),
-                model: job.model.clone(),
-                base_url: job.base_url.clone(),
-                api_key_env: job.api_key_env.clone(),
-                profile: config.profile,
-                provider_preset: None,
-                prompt_version: config.prompt_version.clone(),
-                cache_namespace: String::new(),
-                settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(
-                    &config.profile.resolve(),
-                ),
-            };
-            let mut settings = config.profile.resolve();
-            settings.provider.timeout_seconds = timeout_seconds;
-            let provider_config = openai_compatible_config(job, &snapshot, &settings)?;
+            let provider_config = openai_compatible_config_from_parts(
+                provider_name,
+                model,
+                base_url,
+                api_key_env,
+                &job.id,
+                settings,
+            )?;
             let provider = OpenAiCompatibleProvider::new(provider_config)?;
-            Ok(qa_reviews_for_mode(
-                provider,
-                segments,
-                translations,
-                config,
-                &qa_config,
-                qa_mode,
+            Ok(
+                qa_reviews_for_mode(provider, segments, translations, config, qa_config, qa_mode)
+                    .await,
             )
-            .await)
         }
         _ => Ok(Vec::new()),
     }

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -7,9 +7,6 @@ use std::{
 use anyhow::Result;
 use bookforge_core::{
     NullProgressSink,
-    config::SegmentationConfig,
-    config::TranslationProfile,
-    scheduler::SchedulerConfig,
     segment::{BlockTranslation, Segment, SegmentStatus, build_segments, compute_cache_namespace},
 };
 use bookforge_epub::{read_epub, rebuild_epub};
@@ -24,30 +21,45 @@ use crate::{
     QaMode,
     checkpoint::CheckpointWriter,
     cost::estimate_cost_usd,
-    default_output_path,
+    performance::performance_summary_from_events,
     report::{ReportInput, write_report},
 };
 
 use super::translate::{
-    CacheContext, CheckpointContext, apply_cached_translations, mock_mode,
-    pending_segments_for_job, qa_reviews_for_mode, translate_and_checkpoint,
+    CacheContext, CheckpointContext, apply_cached_translations, mock_mode, qa_reviews_for_mode,
+    translate_and_checkpoint,
 };
 
 #[derive(Debug, Args)]
 pub struct ResumeArgs {
     pub job_id: String,
 
-    #[arg(long, default_value_t = 4)]
-    pub concurrency: usize,
+    #[arg(long)]
+    pub concurrency: Option<usize>,
 
-    #[arg(long, default_value_t = 3)]
-    pub max_attempts: usize,
+    #[arg(long)]
+    pub max_attempts: Option<usize>,
+
+    #[arg(long)]
+    pub provider_max_attempts: Option<usize>,
+
+    #[arg(long)]
+    pub validation_max_attempts: Option<usize>,
 
     #[arg(long, value_enum, default_value_t = QaMode::Off)]
     pub qa: QaMode,
 
-    #[arg(long, default_value_t = 120)]
-    pub timeout_seconds: u64,
+    #[arg(long)]
+    pub timeout_seconds: Option<u64>,
+
+    #[arg(long)]
+    pub ui: Option<crate::progress::UiMode>,
+
+    #[arg(long)]
+    pub progress_jsonl: Option<PathBuf>,
+
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     pub no_thinking: bool,
@@ -58,12 +70,48 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     let Some(job) = store.get_job(&args.job_id)? else {
         anyhow::bail!("job '{}' was not found", args.job_id);
     };
+    let Some(mut snapshot) = store.load_job_config_snapshot(&args.job_id)? else {
+        anyhow::bail!(
+            "job '{}' does not have a run configuration snapshot; it cannot be resumed deterministically",
+            args.job_id
+        );
+    };
 
-    let input = job_input_path(&job)?;
-    let output = job_output_path(&job);
+    let input = snapshot.input_path.clone();
+    let output = args
+        .output
+        .clone()
+        .unwrap_or_else(|| snapshot.output_path.clone());
+    if args.output.is_some() {
+        store.update_job_output_path(&job.id, &output)?;
+        snapshot.output_path = output.clone();
+    }
+    if let Some(path) = args.progress_jsonl.clone() {
+        store.update_job_event_path(&job.id, &path)?;
+        snapshot.events_path = Some(path);
+    }
     let book = read_epub(&input)?;
-    let segments = build_segments(&book, &SegmentationConfig::default())?;
-    let pending_ids = store.pending_segment_ids(&job.id)?;
+    let mut settings = snapshot.settings.to_settings();
+    if let Some(value) = args.concurrency {
+        settings.scheduler.concurrency = value.max(1);
+    }
+    if let Some(value) = args.max_attempts {
+        settings.scheduler.max_attempts = value.max(1);
+    }
+    if let Some(value) = args.provider_max_attempts {
+        settings.provider.provider_max_attempts = value.max(1);
+    }
+    if let Some(value) = args.validation_max_attempts {
+        settings.provider.validation_max_attempts = value.max(1);
+    }
+    if let Some(value) = args.timeout_seconds {
+        settings.provider.timeout_seconds = value;
+    }
+    if args.no_thinking {
+        settings.provider.thinking_disabled = true;
+    }
+    let segments = build_segments(&book, &settings.segmentation)?;
+    let pending_ids = store.resumable_segment_ids(&job.id)?;
 
     println!("Job: {}", job.id);
     println!("Input: {}", input.display());
@@ -71,50 +119,54 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     println!("Provider: {}", job.provider);
     println!("Pending: {}", pending_ids.len());
 
-    let pending_segments = pending_segments(&segments, &pending_ids)?;
-    let prompt_version = "v1";
+    let pending_segments = select_pending_segments(&segments, &pending_ids)?;
+    let prompt_version = snapshot.prompt_version.as_str();
     let run_config = TranslationRunConfig {
-        source_language: job.source_lang.clone(),
-        target_language: job.target_lang.clone(),
-        provider: job.provider.clone(),
-        model: job.model.clone(),
-        prompt_version: prompt_version.to_string(),
+        source_language: snapshot.source_language.clone(),
+        target_language: snapshot.target_language.clone(),
+        provider: snapshot.provider.clone(),
+        model: snapshot.model.clone(),
+        prompt_version: snapshot.prompt_version.clone(),
         temperature: 0.2,
-        scheduler: SchedulerConfig {
-            concurrency: args.concurrency,
-            max_attempts: args.max_attempts,
-        },
-        profile: TranslationProfile::Balanced,
-        model_context_tokens: None,
-        max_output_tokens: None,
-        batch_max_output_tokens: None,
-        compact_prompts: false,
+        scheduler: settings.scheduler.clone(),
+        profile: settings.profile,
+        model_context_tokens: settings.provider.model_context_tokens,
+        max_output_tokens: settings.provider.max_output_tokens,
+        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+        compact_prompts: settings.compact_prompts,
     };
 
-    // Resume currently rebuilds segments from defaults; namespace must
-    // match what insert_segments stored on the original run.
-    let segmentation = SegmentationConfig::default();
     let cache_namespace = compute_cache_namespace(
-        segmentation.max_segment_tokens,
-        segmentation.context_tokens,
+        settings.segmentation.max_segment_tokens,
+        settings.segmentation.context_tokens,
         run_config.profile.namespace_str(),
-        false,
+        settings.batch.enabled,
         prompt_version,
     );
+    if cache_namespace != snapshot.cache_namespace {
+        anyhow::bail!(
+            "resume cache namespace mismatch for job '{}': snapshot={}, recomputed={}",
+            job.id,
+            snapshot.cache_namespace,
+            cache_namespace
+        );
+    }
     let mut cached_translations = apply_cached_translations(
         &pending_segments,
         CacheContext {
             store: &store,
             job_id: &job.id,
             prompt_version,
-            provider: &job.provider,
-            model: &job.model,
-            source_lang: job.source_lang.as_deref(),
-            target_lang: &job.target_lang,
+            provider: &snapshot.provider,
+            model: &snapshot.model,
+            source_lang: snapshot.source_language.as_deref(),
+            target_lang: &snapshot.target_language,
             cache_namespace: &cache_namespace,
         },
     )?;
-    let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
+    let pending_segments =
+        select_pending_segments(&segments, &store.resumable_segment_ids(&job.id)?)?;
+    store.mark_job_running(&job.id)?;
 
     let fresh_translations = if pending_segments.is_empty() {
         Vec::new()
@@ -124,7 +176,8 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         let sender = writer.sender();
         let result = match job.provider.as_str() {
             "mock" => {
-                let provider = MockProvider::new(mock_mode(&job.model), &job.target_lang);
+                let provider =
+                    MockProvider::new(mock_mode(&snapshot.model), &snapshot.target_language);
                 translate_and_checkpoint(
                     provider.clone(),
                     &pending_segments,
@@ -132,8 +185,8 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
                     CheckpointContext {
                         store: &store,
                         job_id: &job.id,
-                        provider: &job.provider,
-                        model: &job.model,
+                        provider: &snapshot.provider,
+                        model: &snapshot.model,
                         prompt_version,
                         sender: &sender,
                     },
@@ -141,8 +194,7 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
                 .await
             }
             "deepseek" | "openrouter" | "openai-compatible" => {
-                let provider_config =
-                    openai_compatible_config(&job, args.timeout_seconds, 6, args.no_thinking)?;
+                let provider_config = openai_compatible_config(&job, &snapshot, &settings)?;
                 let provider = OpenAiCompatibleProvider::new(provider_config)?;
                 translate_and_checkpoint(
                     provider.clone(),
@@ -151,8 +203,8 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
                     CheckpointContext {
                         store: &store,
                         job_id: &job.id,
-                        provider: &job.provider,
-                        model: &job.model,
+                        provider: &snapshot.provider,
+                        model: &snapshot.model,
                         prompt_version,
                         sender: &sender,
                     },
@@ -171,14 +223,15 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     mark_job_from_summary(&store, &job.id)?;
 
     let stored_blocks = store.load_block_translations(&job.id)?;
-    let translations = rebuild_segment_translations(&segments, &stored_blocks);
+    let segment_records = store.segment_records(&job.id)?;
+    let translations = rebuild_segment_translations(&segments, &stored_blocks, &segment_records);
     let qa_reviews = qa_after_resume(
         &job,
         &segments,
         &translations,
         &run_config,
         args.qa,
-        args.timeout_seconds,
+        settings.provider.timeout_seconds,
     )
     .await?;
     let block_translations =
@@ -191,7 +244,6 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     let summary = store
         .summary(&job.id)?
         .ok_or_else(|| anyhow::anyhow!("job '{}' was not found after resume", job.id))?;
-    let segment_records = store.segment_records(&job.id)?;
     let report = write_report(ReportInput {
         job: &job,
         summary: &summary,
@@ -199,8 +251,16 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         segment_records: &segment_records,
         translations: &translations,
         qa_reviews: &qa_reviews,
+        performance: snapshot
+            .events_path
+            .as_ref()
+            .and_then(|path| performance_summary_from_events(path).ok().flatten()),
         output: &output,
     })?;
+    store.update_job_report_paths(&job.id, &report.json, &report.markdown)?;
+    snapshot.report_json_path = Some(report.json.clone());
+    snapshot.report_markdown_path = Some(report.markdown.clone());
+    store.update_job_config_snapshot(&job.id, &snapshot)?;
 
     println!(
         "Translated: {}/{} segments",
@@ -226,25 +286,7 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     Ok(())
 }
 
-fn job_input_path(job: &JobRecord) -> Result<PathBuf> {
-    if job.input_path.as_os_str().is_empty() {
-        anyhow::bail!(
-            "job '{}' does not have an input path; it was created before resume metadata was persisted",
-            job.id
-        );
-    }
-    Ok(job.input_path.clone())
-}
-
-fn job_output_path(job: &JobRecord) -> PathBuf {
-    if job.output_path.as_os_str().is_empty() {
-        default_output_path(&job.input_path, &job.target_lang)
-    } else {
-        job.output_path.clone()
-    }
-}
-
-fn pending_segments(segments: &[Segment], pending_ids: &[String]) -> Result<Vec<Segment>> {
+fn select_pending_segments(segments: &[Segment], pending_ids: &[String]) -> Result<Vec<Segment>> {
     let pending = pending_ids.iter().cloned().collect::<HashSet<_>>();
     let found = segments
         .iter()
@@ -273,65 +315,68 @@ fn pending_segments(segments: &[Segment], pending_ids: &[String]) -> Result<Vec<
 
 fn openai_compatible_config(
     job: &JobRecord,
-    timeout_seconds: u64,
-    provider_max_attempts: usize,
-    thinking_disabled: bool,
+    snapshot: &bookforge_core::RunConfigSnapshot,
+    settings: &bookforge_core::ResolvedRunSettings,
 ) -> Result<OpenAiCompatibleConfig> {
-    let provider_max_attempts = provider_max_attempts.max(1);
+    let provider_max_attempts = settings.provider.provider_max_attempts.max(1);
     if job.provider == "deepseek" {
-        let mut config = OpenAiCompatibleConfig::deepseek(Some(job.model.clone()));
-        if let Some(base_url) = &job.base_url {
+        let mut config = OpenAiCompatibleConfig::deepseek(Some(snapshot.model.clone()));
+        if let Some(base_url) = &snapshot.base_url {
             config.base_url = base_url.clone();
         }
-        if let Some(api_key_env) = &job.api_key_env {
+        if let Some(api_key_env) = &snapshot.api_key_env {
             config.api_key_env = api_key_env.clone();
         }
-        config.timeout_seconds = timeout_seconds;
+        config.timeout_seconds = settings.provider.timeout_seconds;
         config.provider_max_attempts = provider_max_attempts;
-        config.thinking_disabled = thinking_disabled;
+        config.thinking_disabled = settings.provider.thinking_disabled;
+        config.retry_after_policy = settings.provider.retry_after_policy;
+        config.max_backoff_seconds = settings.provider.max_backoff_seconds;
+        config.max_idle_per_host = settings.provider.max_idle_per_host;
+        config.json_mode = settings.provider.json_mode;
         return Ok(config);
     }
 
     if job.provider == "openrouter" {
         return Ok(OpenAiCompatibleConfig {
-            base_url: job
+            base_url: snapshot
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
-            api_key_env: job
+            api_key_env: snapshot
                 .api_key_env
                 .clone()
                 .unwrap_or_else(|| "OPENROUTER_API_KEY".to_string()),
-            model: job.model.clone(),
-            timeout_seconds,
+            model: snapshot.model.clone(),
+            timeout_seconds: settings.provider.timeout_seconds,
             provider_max_attempts,
-            thinking_disabled,
-            retry_after_policy: bookforge_core::RetryAfterPolicy::JitteredExponential,
-            max_backoff_seconds: 30,
-            max_idle_per_host: 32,
-            json_mode: bookforge_core::JsonMode::Auto,
+            thinking_disabled: settings.provider.thinking_disabled,
+            retry_after_policy: settings.provider.retry_after_policy,
+            max_backoff_seconds: settings.provider.max_backoff_seconds,
+            max_idle_per_host: settings.provider.max_idle_per_host,
+            json_mode: settings.provider.json_mode,
         });
     }
 
     Ok(OpenAiCompatibleConfig {
-        base_url: job.base_url.clone().ok_or_else(|| {
+        base_url: snapshot.base_url.clone().ok_or_else(|| {
             anyhow::anyhow!(
                 "job '{}' does not have a stored base URL for openai-compatible resume",
                 job.id
             )
         })?,
-        api_key_env: job
+        api_key_env: snapshot
             .api_key_env
             .clone()
             .unwrap_or_else(|| "OPENAI_API_KEY".to_string()),
-        model: job.model.clone(),
-        timeout_seconds,
+        model: snapshot.model.clone(),
+        timeout_seconds: settings.provider.timeout_seconds,
         provider_max_attempts,
-        thinking_disabled,
-        retry_after_policy: bookforge_core::RetryAfterPolicy::JitteredExponential,
-        max_backoff_seconds: 30,
-        max_idle_per_host: 32,
-        json_mode: bookforge_core::JsonMode::Auto,
+        thinking_disabled: settings.provider.thinking_disabled,
+        retry_after_policy: settings.provider.retry_after_policy,
+        max_backoff_seconds: settings.provider.max_backoff_seconds,
+        max_idle_per_host: settings.provider.max_idle_per_host,
+        json_mode: settings.provider.json_mode,
     })
 }
 
@@ -378,7 +423,29 @@ async fn qa_after_resume(
             .await)
         }
         "deepseek" | "openrouter" | "openai-compatible" => {
-            let provider_config = openai_compatible_config(job, timeout_seconds, 6, false)?;
+            let snapshot = bookforge_core::RunConfigSnapshot {
+                input_path: job.input_path.clone(),
+                output_path: job.output_path.clone(),
+                events_path: job.events_path.clone(),
+                report_json_path: job.report_json_path.clone(),
+                report_markdown_path: job.report_markdown_path.clone(),
+                source_language: job.source_lang.clone(),
+                target_language: job.target_lang.clone(),
+                provider: job.provider.clone(),
+                model: job.model.clone(),
+                base_url: job.base_url.clone(),
+                api_key_env: job.api_key_env.clone(),
+                profile: config.profile,
+                provider_preset: None,
+                prompt_version: config.prompt_version.clone(),
+                cache_namespace: String::new(),
+                settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(
+                    &config.profile.resolve(),
+                ),
+            };
+            let mut settings = config.profile.resolve();
+            settings.provider.timeout_seconds = timeout_seconds;
+            let provider_config = openai_compatible_config(job, &snapshot, &settings)?;
             let provider = OpenAiCompatibleProvider::new(provider_config)?;
             Ok(qa_reviews_for_mode(
                 provider,
@@ -427,6 +494,7 @@ fn rebuild_block_translations(
 fn rebuild_segment_translations(
     segments: &[Segment],
     stored: &[StoredBlockTranslation],
+    records: &[bookforge_store::SegmentRecord],
 ) -> Vec<SegmentTranslation> {
     let mut by_segment_block = HashMap::<(String, String), String>::new();
     for translation in stored {
@@ -435,6 +503,15 @@ fn rebuild_segment_translations(
             translation.text.clone(),
         );
     }
+    let status_by_segment = records
+        .iter()
+        .map(|record| {
+            (
+                record.id.as_str(),
+                (record.status.as_str(), record.error.clone()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     let mut translations = Vec::new();
     for segment in segments {
@@ -450,15 +527,19 @@ fn rebuild_segment_translations(
             }
         }
         if !blocks.is_empty() {
+            let (status, error) = status_by_segment
+                .get(segment.id.0.as_str())
+                .cloned()
+                .unwrap_or(("succeeded", None));
             translations.push(SegmentTranslation {
                 segment_id: segment.id.clone(),
                 ordinal: segment.ordinal,
                 block_ids: segment.block_ids.clone(),
                 blocks,
                 checksum: segment.checksum.clone(),
-                status: SegmentStatus::Succeeded,
+                status: segment_status(status),
                 template: "stored".to_string(),
-                error: None,
+                error,
                 input_tokens: None,
                 output_tokens: None,
             });
@@ -466,4 +547,13 @@ fn rebuild_segment_translations(
     }
 
     translations
+}
+
+fn segment_status(status: &str) -> SegmentStatus {
+    match status {
+        "skipped_cached" => SegmentStatus::SkippedCached,
+        "needs_review" => SegmentStatus::NeedsReview,
+        "failed" => SegmentStatus::Failed,
+        _ => SegmentStatus::Succeeded,
+    }
 }

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -30,6 +30,9 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     if let Some(ref base_url) = job.base_url {
         println!("Base URL: {base_url}");
     }
+    if let Some(ref api_key_env) = job.api_key_env {
+        println!("API key env: {api_key_env}");
+    }
     println!();
     println!("Segments:");
     println!("  total:       {}", summary.total_segments);
@@ -49,6 +52,18 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
         std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id));
     if event_log_path.exists() {
         println!("Event log: {}", event_log_path.display());
+    }
+    let report_path =
+        std::path::PathBuf::from(format!(".bookforge/runs/{}/report.md", args.job_id));
+    if report_path.exists() {
+        println!("Report: {}", report_path.display());
+    }
+
+    if matches!(
+        summary.status.as_str(),
+        "failed" | "interrupted" | "retry_pending"
+    ) {
+        println!("Resume: bookforge resume {}", args.job_id);
     }
 
     Ok(())

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -2,6 +2,11 @@ use clap::Args;
 
 use bookforge_store::JobStore;
 
+use crate::{
+    performance::{RunPerformanceSummary, performance_summary_from_events},
+    report::report_paths,
+};
+
 #[derive(Debug, Args)]
 pub struct StatusArgs {
     pub job_id: String,
@@ -16,6 +21,7 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     let Some(summary) = store.summary(&args.job_id)? else {
         anyhow::bail!("job '{}' summary unavailable", args.job_id);
     };
+    let snapshot = store.load_job_config_snapshot(&args.job_id)?;
 
     println!("Job: {}", summary.id);
     println!("Status: {}", summary.status);
@@ -48,23 +54,78 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     println!();
     println!("Retried segments: {}", summary.retried);
 
-    let event_log_path =
-        std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id));
+    let event_log_path = job
+        .events_path
+        .clone()
+        .or_else(|| {
+            snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.events_path.clone())
+        })
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id))
+        });
     if event_log_path.exists() {
         println!("Event log: {}", event_log_path.display());
     }
-    let report_path =
-        std::path::PathBuf::from(format!(".bookforge/runs/{}/report.md", args.job_id));
+    let fallback_reports = report_paths(&job.output_path);
+    let report_path = job
+        .report_markdown_path
+        .clone()
+        .or_else(|| {
+            snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.report_markdown_path.clone())
+        })
+        .unwrap_or(fallback_reports.markdown);
     if report_path.exists() {
         println!("Report: {}", report_path.display());
     }
 
-    if matches!(
-        summary.status.as_str(),
-        "failed" | "interrupted" | "retry_pending"
-    ) {
+    println!();
+    println!("Performance:");
+    match performance_summary_from_events(&event_log_path)? {
+        Some(perf) => print_performance(&perf),
+        None => println!("  unavailable: no event log found"),
+    }
+
+    if summary.failed > 0 || summary.retry_pending > 0 || summary.status == "interrupted" {
         println!("Resume: bookforge resume {}", args.job_id);
+    } else if summary.needs_review > 0 {
+        println!(
+            "Review: segments need manual review; default resume skips needs-review segments."
+        );
     }
 
     Ok(())
+}
+
+fn print_performance(perf: &RunPerformanceSummary) {
+    println!("  requests: {}", perf.request_count);
+    println!(
+        "  latency p50/p95: {}/{} ms",
+        fmt_opt(perf.p50_latency_ms),
+        fmt_opt(perf.p95_latency_ms)
+    );
+    println!("  retries: {}", perf.retries);
+    println!(
+        "  429/timeouts/server errors: {}/{}/{}",
+        perf.rate_limited, perf.timeouts, perf.server_errors
+    );
+    println!(
+        "  invalid/truncated: {}/{}",
+        perf.invalid_responses, perf.truncations
+    );
+    println!("  checkpoint flushes: {}", perf.checkpoint_flushes);
+    if let Some(rate) = perf.blocks_per_minute {
+        println!("  blocks/min: {rate:.2}");
+    } else {
+        println!("  blocks/min: n/a");
+    }
+}
+
+fn fmt_opt(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
 }

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -4,17 +4,29 @@ use std::io::BufRead;
 
 use serde_json::Value;
 
+use bookforge_store::JobStore;
+
 #[derive(Debug, Args)]
 pub struct TailArgs {
     pub job_id: String,
 
-    #[arg(long, default_value_t = 20)]
-    pub lines: usize,
+    #[arg(long, alias = "lines", default_value_t = 20)]
+    pub last: usize,
+
+    #[arg(long)]
+    pub json: bool,
 }
 
 pub async fn run(args: TailArgs) -> anyhow::Result<()> {
-    let event_log_path =
-        std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id));
+    let store = JobStore::open_default()?;
+    let job = store.get_job(&args.job_id)?;
+    let snapshot = store.load_job_config_snapshot(&args.job_id)?;
+    let event_log_path = job
+        .and_then(|job| job.events_path)
+        .or_else(|| snapshot.and_then(|snapshot| snapshot.events_path))
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id))
+        });
 
     if !event_log_path.exists() {
         anyhow::bail!(
@@ -35,11 +47,20 @@ pub async fn run(args: TailArgs) -> anyhow::Result<()> {
         }
     }
 
-    let start = events.len().saturating_sub(args.lines);
+    let start = events.len().saturating_sub(args.last);
     let recent: Vec<&String> = events.iter().skip(start).collect();
 
     if recent.is_empty() {
-        println!("(no events)");
+        if !args.json {
+            println!("(no events)");
+        }
+        return Ok(());
+    }
+
+    if args.json {
+        for line in recent {
+            println!("{line}");
+        }
         return Ok(());
     }
 

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -1,0 +1,149 @@
+use std::path::PathBuf;
+
+use bookforge_core::{
+    JsonMode, ProviderPreset,
+    config::{DoubleCheckMode, FallbackScope, TranslationProfile},
+};
+use clap::Args;
+
+use crate::{LanguageArgs, ProviderArgs as CliProviderArgs, QaMode, progress::UiMode};
+
+#[derive(Debug, Args)]
+pub struct TranslateArgs {
+    pub input: PathBuf,
+
+    #[command(flatten)]
+    pub language: LanguageArgs,
+
+    #[command(flatten)]
+    pub provider: CliProviderArgs,
+
+    #[arg(long, value_enum, default_value_t = TranslationProfile::Balanced)]
+    pub profile: TranslationProfile,
+
+    #[arg(long)]
+    pub max_segment_tokens: Option<usize>,
+
+    #[arg(long)]
+    pub context_tokens: Option<usize>,
+
+    #[arg(long)]
+    pub batch_target_tokens: Option<usize>,
+
+    #[arg(long)]
+    pub batch_max_items: Option<usize>,
+
+    #[arg(long)]
+    pub compact_prompts: Option<bool>,
+
+    #[arg(long)]
+    pub retry_failed_only: Option<bool>,
+
+    #[arg(long)]
+    pub adaptive_concurrency: Option<bool>,
+
+    #[arg(long)]
+    pub turbo_text_only: bool,
+
+    #[arg(long)]
+    pub concurrency: Option<usize>,
+
+    #[arg(long)]
+    pub max_attempts: Option<usize>,
+
+    #[arg(long)]
+    pub provider_max_attempts: Option<usize>,
+
+    #[arg(long)]
+    pub validation_max_attempts: Option<usize>,
+
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = QaMode::Off)]
+    pub qa: QaMode,
+
+    #[arg(long, default_value_t = 8)]
+    pub qa_concurrency: usize,
+
+    #[arg(long)]
+    pub qa_batch_target_tokens: Option<usize>,
+
+    #[arg(long)]
+    pub qa_model: Option<String>,
+
+    #[arg(long)]
+    pub qa_provider: Option<String>,
+
+    #[arg(long)]
+    pub qa_base_url: Option<String>,
+
+    #[arg(long)]
+    pub qa_api_key_env: Option<String>,
+
+    #[arg(long, value_enum, default_value_t = DoubleCheckMode::Off)]
+    pub double_check: DoubleCheckMode,
+
+    #[arg(long)]
+    pub double_check_model: Option<String>,
+
+    #[arg(long)]
+    pub double_check_provider: Option<String>,
+
+    #[arg(long)]
+    pub double_check_base_url: Option<String>,
+
+    #[arg(long)]
+    pub double_check_api_key_env: Option<String>,
+
+    #[arg(long, default_value_t = 4)]
+    pub double_check_concurrency: usize,
+
+    #[arg(long)]
+    pub double_check_batch_target_tokens: Option<usize>,
+
+    #[arg(long, default_value_t = false)]
+    pub auto_correct: bool,
+
+    #[arg(long, default_value_t = 1)]
+    pub correction_rounds: usize,
+
+    #[arg(long)]
+    pub fallback_provider: Option<String>,
+
+    #[arg(long)]
+    pub fallback_model: Option<String>,
+
+    #[arg(long)]
+    pub fallback_base_url: Option<String>,
+
+    #[arg(long)]
+    pub fallback_api_key_env: Option<String>,
+
+    #[arg(long, value_enum, default_value_t = FallbackScope::Failed)]
+    pub fallback_only: FallbackScope,
+
+    #[arg(long, default_value_t = false)]
+    pub no_thinking: bool,
+
+    #[arg(long)]
+    pub model_context_tokens: Option<u32>,
+
+    #[arg(long)]
+    pub max_output_tokens: Option<u32>,
+
+    #[arg(long)]
+    pub batch_max_output_tokens: Option<u32>,
+
+    #[arg(long, value_enum, default_value_t = JsonMode::Auto)]
+    pub json_mode: JsonMode,
+
+    #[arg(long, value_enum, default_value_t = UiMode::Auto)]
+    pub ui: UiMode,
+
+    #[arg(long)]
+    pub progress_jsonl: Option<PathBuf>,
+
+    #[arg(long, value_enum)]
+    pub provider_preset: Option<ProviderPreset>,
+}

--- a/crates/bookforge-cli/src/commands/translate/cache.rs
+++ b/crates/bookforge-cli/src/commands/translate/cache.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use bookforge_core::segment::{Segment, SegmentStatus};
+use bookforge_llm::SegmentTranslation;
+use bookforge_store::{JobStore, SaveCachedTranslation};
+
+#[derive(Clone, Copy)]
+pub struct CacheContext<'a> {
+    pub store: &'a JobStore,
+    pub job_id: &'a str,
+    pub prompt_version: &'a str,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub source_lang: Option<&'a str>,
+    pub target_lang: &'a str,
+    pub cache_namespace: &'a str,
+}
+
+pub fn apply_cached_translations(
+    segments: &[Segment],
+    cache: CacheContext<'_>,
+) -> Result<Vec<SegmentTranslation>> {
+    let mut cached = Vec::new();
+
+    let request = bookforge_store::CacheLookupRequest {
+        prompt_version: cache.prompt_version,
+        provider: cache.provider,
+        model: cache.model,
+        source_lang: cache.source_lang,
+        target_lang: cache.target_lang,
+        cache_namespace: cache.cache_namespace,
+    };
+
+    let hits = cache
+        .store
+        .find_cached_translations_batch(segments, request)?;
+
+    for segment in segments {
+        let Some(hit) = hits.get(&segment.id.0) else {
+            continue;
+        };
+        cache.store.save_cached_translation(SaveCachedTranslation {
+            job_id: cache.job_id,
+            segment_id: &segment.id.0,
+            translated_text: &hit.translated_text,
+            blocks: &hit.blocks,
+            provider: cache.provider,
+            model: cache.model,
+            prompt_version: cache.prompt_version,
+        })?;
+        cached.push(SegmentTranslation {
+            segment_id: segment.id.clone(),
+            ordinal: segment.ordinal,
+            block_ids: segment.block_ids.clone(),
+            blocks: hit.blocks.clone(),
+            checksum: segment.checksum.clone(),
+            status: SegmentStatus::SkippedCached,
+            template: "cached".to_string(),
+            error: None,
+            input_tokens: None,
+            output_tokens: None,
+        });
+    }
+    Ok(cached)
+}
+
+pub fn pending_segments_for_job(
+    store: &JobStore,
+    job_id: &str,
+    segments: &[Segment],
+) -> Result<Vec<Segment>> {
+    let pending_ids = store.pending_segment_ids(job_id)?;
+    let pending = pending_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::HashSet<_>>();
+    Ok(segments
+        .iter()
+        .filter(|segment| pending.contains(segment.id.0.as_str()))
+        .cloned()
+        .collect())
+}

--- a/crates/bookforge-cli/src/commands/translate/checkpointing.rs
+++ b/crates/bookforge-cli/src/commands/translate/checkpointing.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+use crate::checkpoint::{CheckpointSender, CheckpointWriter};
+
+pub async fn finalize_writer<T>(
+    translation_result: Result<T, anyhow::Error>,
+    sender: CheckpointSender,
+    writer: CheckpointWriter,
+) -> Result<T> {
+    drop(sender);
+    let writer_result = writer.shutdown().await;
+    match (translation_result, writer_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(writer_err)) => Err(writer_err),
+        (Err(translation_err), Ok(())) => Err(translation_err),
+        (Err(translation_err), Err(writer_err)) => Err(anyhow::anyhow!(
+            "{translation_err}; additionally checkpoint writer failed: {writer_err}"
+        )),
+    }
+}

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -767,7 +767,7 @@ fn provider_config(
     })
 }
 
-async fn translate_and_checkpoint_batch<P>(
+pub(crate) async fn translate_and_checkpoint_batch<P>(
     provider: P,
     segments: &[Segment],
     config: &TranslationRunConfig,

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -34,12 +34,14 @@ mod cache;
 mod checkpointing;
 mod reporting;
 mod settings;
+mod snapshot;
 
 pub use args::TranslateArgs;
 pub(crate) use cache::{CacheContext, apply_cached_translations, pending_segments_for_job};
 use checkpointing::finalize_writer;
 use reporting::print_summary_rebuild_and_report;
 use settings::{apply_provider_preset, resolve_settings, retry_amplification_warning};
+use snapshot::persist_snapshot;
 
 pub async fn run(
     args: TranslateArgs,
@@ -92,8 +94,15 @@ pub async fn run(
     let run_result = async {
         match config.provider.as_str() {
             "mock" => {
-                run_mock_translation(&args.input, &config, &effective_provider, &args, &settings)
-                    .await
+                run_mock_translation(
+                    &args.input,
+                    &config,
+                    &effective_provider,
+                    &args,
+                    &settings,
+                    progress_sink,
+                )
+                .await
             }
             "deepseek" | "openrouter" | "openai-compatible" => {
                 run_openai_compatible_translation(
@@ -139,12 +148,30 @@ async fn finalize_reporter<T>(
 async fn run_mock_translation(
     input: &PathBuf,
     config: &TranslationConfig,
-    _provider_args: &CliProviderArgs,
-    _cli_args: &TranslateArgs,
+    provider_args: &CliProviderArgs,
+    cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
+    let started = std::time::Instant::now();
+    progress.emit(bookforge_core::ProgressEvent::StageStarted {
+        stage: "read_epub".to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
     let book = read_epub(input)?;
+    progress.emit(bookforge_core::ProgressEvent::StageFinished {
+        stage: "read_epub".to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
+    progress.emit(bookforge_core::ProgressEvent::StageStarted {
+        stage: "segmentation".to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
     let segments = build_segments(&book, &settings.segmentation)?;
+    progress.emit(bookforge_core::ProgressEvent::SegmentationFinished {
+        segment_count: segments.len(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
     let model = config
         .model
         .clone()
@@ -162,6 +189,12 @@ async fn run_mock_translation(
         api_key_env: None,
     })?;
     println!("Job: {}", job.id);
+    progress.emit(bookforge_core::ProgressEvent::JobCreated {
+        job_id: job.id.clone(),
+        input_path: input.display().to_string(),
+        output_path: config.output.display().to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
     let cache_namespace = compute_cache_namespace(
         settings.segmentation.max_segment_tokens,
         settings.segmentation.context_tokens,
@@ -169,6 +202,20 @@ async fn run_mock_translation(
         settings.batch.enabled,
         prompt_version,
     );
+    persist_snapshot(
+        &store,
+        &job,
+        input,
+        &config.output,
+        provider_args,
+        cli_args,
+        settings,
+        prompt_version,
+        &cache_namespace,
+        &model,
+        None,
+        None,
+    )?;
     store.insert_segments(
         &job.id,
         &segments,
@@ -206,7 +253,12 @@ async fn run_mock_translation(
         },
     )?;
     let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
-    let writer = CheckpointWriter::spawn(store.path().to_path_buf(), Arc::new(NullProgressSink));
+    progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
+        hits: translations.len(),
+        misses: pending_segments.len(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
+    let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
     let sender = writer.sender();
     let translation_result = translate_and_checkpoint(
         provider.clone(),
@@ -231,7 +283,7 @@ async fn run_mock_translation(
         &translations,
         &run_config,
         &settings.qa,
-        _cli_args.qa,
+        cli_args.qa,
     )
     .await;
     mark_job_finished(&store, &job.id, &translations)?;
@@ -244,6 +296,23 @@ async fn run_mock_translation(
         &qa_reviews,
         config,
     )?;
+    let summary = store
+        .summary(&job.id)?
+        .ok_or_else(|| anyhow::anyhow!("job '{}' summary unavailable", job.id))?;
+    progress.emit(bookforge_core::ProgressEvent::ArtifactWritten {
+        path: config.output.display().to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
+    progress.emit(bookforge_core::ProgressEvent::TranslationFinished {
+        succeeded: summary.succeeded,
+        cached: summary.cached,
+        needs_review: summary.needs_review,
+        failed: summary.failed,
+        input_tokens: summary.input_tokens,
+        output_tokens: summary.output_tokens,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
 
     Ok(())
 }
@@ -267,6 +336,7 @@ async fn run_openai_compatible_translation(
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
+    let started = std::time::Instant::now();
     let mut provider_config = match provider_config(
         &config.provider,
         config.model.as_deref(),
@@ -369,6 +439,20 @@ async fn run_openai_compatible_translation(
         settings.batch.enabled,
         run_prompt_version,
     );
+    persist_snapshot(
+        &store,
+        &job,
+        input,
+        &config.output,
+        provider_args,
+        cli_args,
+        settings,
+        run_prompt_version,
+        &cache_namespace,
+        &model,
+        Some(provider_config.base_url.clone()),
+        Some(provider_config.api_key_env.clone()),
+    )?;
     store.insert_segments(
         &job.id,
         &segments,
@@ -466,6 +550,8 @@ async fn run_openai_compatible_translation(
             &run_config,
             config,
             &book,
+            progress.clone(),
+            started,
         )
         .await?;
     } else {
@@ -522,6 +608,8 @@ async fn run_openai_compatible_translation(
             &run_config,
             config,
             &book,
+            progress.clone(),
+            started,
         )
         .await?;
     }
@@ -556,6 +644,8 @@ async fn finish_translation_pipeline(
     run_config: &TranslationRunConfig,
     config: &TranslationConfig,
     book: &bookforge_core::ir::Book,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    started: std::time::Instant,
 ) -> Result<()> {
     translations.sort_by_key(|t| t.ordinal);
 
@@ -603,6 +693,23 @@ async fn finish_translation_pipeline(
         &qa_reviews,
         config,
     )?;
+    let summary = store
+        .summary(&job.id)?
+        .ok_or_else(|| anyhow::anyhow!("job '{}' summary unavailable", job.id))?;
+    progress.emit(bookforge_core::ProgressEvent::ArtifactWritten {
+        path: config.output.display().to_string(),
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
+    progress.emit(bookforge_core::ProgressEvent::TranslationFinished {
+        succeeded: summary.succeeded,
+        cached: summary.cached,
+        needs_review: summary.needs_review,
+        failed: summary.failed,
+        input_tokens: summary.input_tokens,
+        output_tokens: summary.output_tokens,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
 
     Ok(())
 }

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
+#[cfg(test)]
+use bookforge_core::config::TranslationProfile;
 use bookforge_core::{
     NullProgressSink,
-    config::{
-        DoubleCheckMode, FallbackScope, ResolvedRunSettings, TranslationConfig, TranslationProfile,
-    },
+    config::{DoubleCheckMode, FallbackScope, ResolvedRunSettings, TranslationConfig},
     scheduler::SchedulerConfig,
-    segment::{BlockTranslation, Segment, SegmentStatus, build_segments, compute_cache_namespace},
+    segment::{Segment, SegmentStatus, build_segments, compute_cache_namespace},
 };
-use bookforge_epub::{read_epub, rebuild_epub};
+use bookforge_epub::read_epub;
 #[cfg(test)]
 use bookforge_llm::translate_segments;
 use bookforge_llm::{
@@ -17,287 +17,29 @@ use bookforge_llm::{
     qa_segments_parallel, run_double_check, telemetry_summary, translate_batches_with_callback,
     translate_segments_with_callback,
 };
-use bookforge_store::{CreateJob, JobRecord, JobStore, SaveCachedTranslation};
+use bookforge_store::{CreateJob, JobRecord, JobStore};
 use clap::Args;
 use std::{path::PathBuf, sync::Arc};
 
+#[cfg(test)]
+use crate::LanguageArgs;
 use crate::{
-    LanguageArgs, ProviderArgs as CliProviderArgs, QaMode,
+    ProviderArgs as CliProviderArgs, QaMode,
     checkpoint::{CheckpointCommand, CheckpointSender, CheckpointWriter},
-    cost::estimate_cost_usd,
     default_output_path,
-    report::{ReportInput, write_report},
 };
 
-async fn finalize_writer<T>(
-    translation_result: Result<T, anyhow::Error>,
-    sender: CheckpointSender,
-    writer: CheckpointWriter,
-) -> Result<T> {
-    drop(sender);
-    let writer_result = writer.shutdown().await;
-    match (translation_result, writer_result) {
-        (Ok(value), Ok(())) => Ok(value),
-        (Ok(_), Err(writer_err)) => Err(writer_err),
-        (Err(translation_err), Ok(())) => Err(translation_err),
-        (Err(translation_err), Err(writer_err)) => Err(anyhow::anyhow!(
-            "{translation_err}; additionally checkpoint writer failed: {writer_err}"
-        )),
-    }
-}
+pub mod args;
+mod cache;
+mod checkpointing;
+mod reporting;
+mod settings;
 
-#[derive(Debug, Args)]
-pub struct TranslateArgs {
-    pub input: PathBuf,
-
-    #[command(flatten)]
-    pub language: LanguageArgs,
-
-    #[command(flatten)]
-    pub provider: CliProviderArgs,
-
-    #[arg(long, value_enum, default_value_t = TranslationProfile::Balanced)]
-    pub profile: TranslationProfile,
-
-    #[arg(long)]
-    pub max_segment_tokens: Option<usize>,
-
-    #[arg(long)]
-    pub context_tokens: Option<usize>,
-
-    #[arg(long)]
-    pub batch_target_tokens: Option<usize>,
-
-    #[arg(long)]
-    pub batch_max_items: Option<usize>,
-
-    #[arg(long)]
-    pub compact_prompts: Option<bool>,
-
-    #[arg(long)]
-    pub retry_failed_only: Option<bool>,
-
-    #[arg(long)]
-    pub adaptive_concurrency: Option<bool>,
-
-    #[arg(long)]
-    pub turbo_text_only: bool,
-
-    #[arg(long)]
-    pub concurrency: Option<usize>,
-
-    #[arg(long)]
-    pub max_attempts: Option<usize>,
-
-    #[arg(long)]
-    pub provider_max_attempts: Option<usize>,
-
-    #[arg(long)]
-    pub validation_max_attempts: Option<usize>,
-
-    #[arg(long)]
-    pub out: Option<PathBuf>,
-
-    #[arg(long, value_enum, default_value_t = QaMode::Off)]
-    pub qa: QaMode,
-
-    #[arg(long, default_value_t = 8)]
-    pub qa_concurrency: usize,
-
-    #[arg(long)]
-    pub qa_batch_target_tokens: Option<usize>,
-
-    #[arg(long)]
-    pub qa_model: Option<String>,
-
-    #[arg(long)]
-    pub qa_provider: Option<String>,
-
-    #[arg(long)]
-    pub qa_base_url: Option<String>,
-
-    #[arg(long)]
-    pub qa_api_key_env: Option<String>,
-
-    #[arg(long, value_enum, default_value_t = DoubleCheckMode::Off)]
-    pub double_check: DoubleCheckMode,
-
-    #[arg(long)]
-    pub double_check_model: Option<String>,
-
-    #[arg(long)]
-    pub double_check_provider: Option<String>,
-
-    #[arg(long)]
-    pub double_check_base_url: Option<String>,
-
-    #[arg(long)]
-    pub double_check_api_key_env: Option<String>,
-
-    #[arg(long, default_value_t = 4)]
-    pub double_check_concurrency: usize,
-
-    #[arg(long)]
-    pub double_check_batch_target_tokens: Option<usize>,
-
-    #[arg(long, default_value_t = false)]
-    pub auto_correct: bool,
-
-    #[arg(long, default_value_t = 1)]
-    pub correction_rounds: usize,
-
-    #[arg(long)]
-    pub fallback_provider: Option<String>,
-
-    #[arg(long)]
-    pub fallback_model: Option<String>,
-
-    #[arg(long)]
-    pub fallback_base_url: Option<String>,
-
-    #[arg(long)]
-    pub fallback_api_key_env: Option<String>,
-
-    #[arg(long, value_enum, default_value_t = FallbackScope::Failed)]
-    pub fallback_only: FallbackScope,
-
-    #[arg(long, default_value_t = false)]
-    pub no_thinking: bool,
-
-    #[arg(long)]
-    pub model_context_tokens: Option<u32>,
-
-    #[arg(long)]
-    pub max_output_tokens: Option<u32>,
-
-    #[arg(long)]
-    pub batch_max_output_tokens: Option<u32>,
-
-    #[arg(long, value_enum, default_value_t = bookforge_core::JsonMode::Auto)]
-    pub json_mode: bookforge_core::JsonMode,
-
-    #[arg(long, value_enum, default_value_t = crate::progress::UiMode::Auto)]
-    pub ui: crate::progress::UiMode,
-
-    #[arg(long)]
-    pub progress_jsonl: Option<PathBuf>,
-
-    #[arg(long, value_enum)]
-    pub provider_preset: Option<bookforge_core::ProviderPreset>,
-}
-
-fn apply_provider_preset(
-    explicit: &CliProviderArgs,
-    preset: Option<bookforge_core::ProviderPreset>,
-) -> CliProviderArgs {
-    let Some(p) = preset else {
-        return explicit.clone();
-    };
-    let endpoint = p.endpoint_or_default(None);
-    CliProviderArgs {
-        provider: endpoint.provider,
-        model: explicit.model.clone().or(Some(endpoint.model)),
-        base_url: explicit.base_url.clone().or(endpoint.base_url),
-        api_key_env: explicit.api_key_env.clone().or(endpoint.api_key_env),
-        timeout_seconds: explicit.timeout_seconds,
-    }
-}
-
-fn resolve_settings(args: &TranslateArgs) -> ResolvedRunSettings {
-    let effective_profile =
-        if args.turbo_text_only && !matches!(args.profile, TranslationProfile::TurboTextOnly) {
-            TranslationProfile::TurboTextOnly
-        } else {
-            args.profile
-        };
-
-    let mut settings = effective_profile.resolve();
-
-    if let Some(preset) = args.provider_preset.and_then(|preset| preset.resolve()) {
-        settings.apply_provider_preset_runtime(preset.runtime);
-    }
-
-    if let Some(v) = args.max_segment_tokens {
-        settings.segmentation.max_segment_tokens = v;
-    }
-    if let Some(v) = args.context_tokens {
-        settings.segmentation.context_tokens = v;
-    }
-    if let Some(v) = args.batch_target_tokens {
-        settings.batch.target_tokens = v;
-    }
-    if let Some(v) = args.batch_max_items {
-        settings.batch.max_items = v;
-    }
-    if let Some(v) = args.compact_prompts {
-        settings.compact_prompts = v;
-    }
-    if let Some(v) = args.retry_failed_only {
-        settings.retry_failed_only = v;
-    }
-    if let Some(v) = args.adaptive_concurrency {
-        settings.adaptive_concurrency = v;
-    }
-
-    if let Some(v) = args.concurrency {
-        settings.scheduler.concurrency = v;
-    }
-    if let Some(v) = args.max_attempts {
-        settings.scheduler.max_attempts = v;
-    }
-
-    if let Some(v) = args.provider_max_attempts {
-        settings.provider.provider_max_attempts = v;
-    }
-    if let Some(v) = args.validation_max_attempts {
-        settings.provider.validation_max_attempts = v;
-    }
-    if let Some(v) = args.provider.timeout_seconds {
-        settings.provider.timeout_seconds = v;
-    }
-    if args.no_thinking {
-        settings.provider.thinking_disabled = true;
-    }
-    if let Some(v) = args.model_context_tokens {
-        settings.provider.model_context_tokens = Some(v);
-    }
-    if let Some(v) = args.max_output_tokens {
-        settings.provider.max_output_tokens = Some(v);
-    }
-    if let Some(v) = args.batch_max_output_tokens {
-        settings.provider.batch_max_output_tokens = Some(v);
-    }
-    settings.provider.json_mode = args.json_mode;
-
-    settings.qa.concurrency = args.qa_concurrency;
-    if let Some(v) = args.qa_batch_target_tokens {
-        settings.qa.batch_target_tokens = v;
-    }
-    settings.qa.model = args.qa_model.clone();
-    settings.qa.provider = args.qa_provider.clone();
-    settings.qa.base_url = args.qa_base_url.clone();
-    settings.qa.api_key_env = args.qa_api_key_env.clone();
-
-    settings.double_check.mode = args.double_check;
-    settings.double_check.model = args.double_check_model.clone();
-    settings.double_check.provider = args.double_check_provider.clone();
-    settings.double_check.base_url = args.double_check_base_url.clone();
-    settings.double_check.api_key_env = args.double_check_api_key_env.clone();
-    settings.double_check.concurrency = args.double_check_concurrency;
-    if let Some(v) = args.double_check_batch_target_tokens {
-        settings.double_check.batch_target_tokens = v;
-    }
-    settings.double_check.auto_correct = args.auto_correct;
-    settings.double_check.correction_rounds = args.correction_rounds;
-
-    if settings.double_check.mode != DoubleCheckMode::Off && settings.double_check.model.is_none() {
-        eprintln!(
-            "--double-check requires --double-check-model unless a default double-check model is configured"
-        );
-    }
-
-    settings
-}
+pub use args::TranslateArgs;
+pub(crate) use cache::{CacheContext, apply_cached_translations, pending_segments_for_job};
+use checkpointing::finalize_writer;
+use reporting::print_summary_rebuild_and_report;
+use settings::{apply_provider_preset, resolve_settings, retry_amplification_warning};
 
 pub async fn run(
     args: TranslateArgs,
@@ -377,23 +119,6 @@ pub async fn run(
     .await;
 
     finalize_reporter(run_result, reporter).await
-}
-
-fn retry_amplification_warning(settings: &ResolvedRunSettings) -> Option<String> {
-    let scheduler_provider_product =
-        settings.scheduler.max_attempts * settings.provider.provider_max_attempts;
-    if scheduler_provider_product < 6 {
-        return None;
-    }
-    let total = scheduler_provider_product * settings.provider.validation_max_attempts;
-    Some(format!(
-        "scheduler attempts {} x provider attempts {} can produce up to {} calls per failed unit before validation retries ({} total with validation attempts {})",
-        settings.scheduler.max_attempts,
-        settings.provider.provider_max_attempts,
-        scheduler_provider_product,
-        total,
-        settings.provider.validation_max_attempts
-    ))
 }
 
 async fn finalize_reporter<T>(
@@ -1292,18 +1017,6 @@ pub(crate) struct CheckpointContext<'a> {
     pub sender: &'a CheckpointSender,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct CacheContext<'a> {
-    pub store: &'a JobStore,
-    pub job_id: &'a str,
-    pub prompt_version: &'a str,
-    pub provider: &'a str,
-    pub model: &'a str,
-    pub source_lang: Option<&'a str>,
-    pub target_lang: &'a str,
-    pub cache_namespace: &'a str,
-}
-
 pub(crate) async fn translate_and_checkpoint<P>(
     provider: P,
     segments: &[Segment],
@@ -1392,71 +1105,6 @@ where
     }
 }
 
-pub(crate) fn apply_cached_translations(
-    segments: &[Segment],
-    cache: CacheContext<'_>,
-) -> Result<Vec<SegmentTranslation>> {
-    let mut cached = Vec::new();
-
-    let request = bookforge_store::CacheLookupRequest {
-        prompt_version: cache.prompt_version,
-        provider: cache.provider,
-        model: cache.model,
-        source_lang: cache.source_lang,
-        target_lang: cache.target_lang,
-        cache_namespace: cache.cache_namespace,
-    };
-
-    let hits = cache
-        .store
-        .find_cached_translations_batch(segments, request)?;
-
-    for segment in segments {
-        let Some(hit) = hits.get(&segment.id.0) else {
-            continue;
-        };
-        cache.store.save_cached_translation(SaveCachedTranslation {
-            job_id: cache.job_id,
-            segment_id: &segment.id.0,
-            translated_text: &hit.translated_text,
-            blocks: &hit.blocks,
-            provider: cache.provider,
-            model: cache.model,
-            prompt_version: cache.prompt_version,
-        })?;
-        cached.push(SegmentTranslation {
-            segment_id: segment.id.clone(),
-            ordinal: segment.ordinal,
-            block_ids: segment.block_ids.clone(),
-            blocks: hit.blocks.clone(),
-            checksum: segment.checksum.clone(),
-            status: SegmentStatus::SkippedCached,
-            template: "cached".to_string(),
-            error: None,
-            input_tokens: None,
-            output_tokens: None,
-        });
-    }
-    Ok(cached)
-}
-
-pub(crate) fn pending_segments_for_job(
-    store: &JobStore,
-    job_id: &str,
-    segments: &[Segment],
-) -> Result<Vec<Segment>> {
-    let pending_ids = store.pending_segment_ids(job_id)?;
-    let pending = pending_ids
-        .iter()
-        .map(String::as_str)
-        .collect::<std::collections::HashSet<_>>();
-    Ok(segments
-        .iter()
-        .filter(|segment| pending.contains(segment.id.0.as_str()))
-        .cloned()
-        .collect())
-}
-
 pub(crate) async fn qa_reviews_for_mode<P>(
     provider: P,
     segments: &[Segment],
@@ -1513,9 +1161,11 @@ fn mark_unfinished_segments_failed(
     segments: &[Segment],
     error: &str,
 ) -> Result<()> {
-    for segment in segments {
-        store.mark_segment_failed_if_unfinished(job_id, &segment.id.0, error)?;
-    }
+    let segment_ids = segments
+        .iter()
+        .map(|segment| segment.id.0.clone())
+        .collect::<Vec<_>>();
+    store.mark_unfinished_segments_failed(job_id, &segment_ids, error)?;
     Ok(())
 }
 
@@ -1539,62 +1189,6 @@ pub(crate) fn mark_job_finished(
         return Ok(());
     }
     store.mark_job_complete(job_id)?;
-    Ok(())
-}
-
-pub(crate) fn block_translations(translations: &[SegmentTranslation]) -> Vec<BlockTranslation> {
-    translations
-        .iter()
-        .flat_map(|translation| translation.blocks.iter().cloned())
-        .collect()
-}
-
-pub(crate) fn print_summary_rebuild_and_report(
-    store: &JobStore,
-    job: &JobRecord,
-    book: &bookforge_core::ir::Book,
-    segments: &[Segment],
-    translations: &[SegmentTranslation],
-    qa_reviews: &[QaSegmentReview],
-    config: &TranslationConfig,
-) -> Result<()> {
-    let block_translations = block_translations(translations);
-    rebuild_epub(book, &block_translations, &config.output)?;
-    let summary = store
-        .summary(&job.id)?
-        .ok_or_else(|| anyhow::anyhow!("job '{}' was not found after translation", job.id))?;
-    let segment_records = store.segment_records(&job.id)?;
-    let report = write_report(ReportInput {
-        job,
-        summary: &summary,
-        segments,
-        segment_records: &segment_records,
-        translations,
-        qa_reviews,
-        output: &config.output,
-    })?;
-
-    println!(
-        "Translated: {}/{} segments",
-        summary.succeeded, summary.total_segments
-    );
-    println!("Cached: {}", summary.cached);
-    println!("Retried: {}", summary.retried);
-    println!("Needs review: {}", summary.needs_review);
-    println!("Failed: {}", summary.failed);
-    println!("Input tokens: {}", summary.input_tokens);
-    println!("Output tokens: {}", summary.output_tokens);
-    if let Some(cost) = estimate_cost_usd(
-        &job.provider,
-        &job.model,
-        summary.input_tokens,
-        summary.output_tokens,
-    ) {
-        println!("Estimated cost: ${cost:.6}");
-    }
-    println!("Output: {}", config.output.display());
-    println!("Report: {}", report.markdown.display());
-
     Ok(())
 }
 

--- a/crates/bookforge-cli/src/commands/translate/reporting.rs
+++ b/crates/bookforge-cli/src/commands/translate/reporting.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use bookforge_core::{
+    config::TranslationConfig,
+    segment::{BlockTranslation, Segment},
+};
+use bookforge_epub::rebuild_epub;
+use bookforge_llm::{QaSegmentReview, SegmentTranslation};
+use bookforge_store::{JobRecord, JobStore};
+
+use crate::{
+    cost::estimate_cost_usd,
+    report::{ReportInput, write_report},
+};
+
+pub fn block_translations(translations: &[SegmentTranslation]) -> Vec<BlockTranslation> {
+    translations
+        .iter()
+        .flat_map(|translation| translation.blocks.iter().cloned())
+        .collect()
+}
+
+pub fn print_summary_rebuild_and_report(
+    store: &JobStore,
+    job: &JobRecord,
+    book: &bookforge_core::ir::Book,
+    segments: &[Segment],
+    translations: &[SegmentTranslation],
+    qa_reviews: &[QaSegmentReview],
+    config: &TranslationConfig,
+) -> Result<()> {
+    let block_translations = block_translations(translations);
+    rebuild_epub(book, &block_translations, &config.output)?;
+    let summary = store
+        .summary(&job.id)?
+        .ok_or_else(|| anyhow::anyhow!("job '{}' was not found after translation", job.id))?;
+    let segment_records = store.segment_records(&job.id)?;
+    let report = write_report(ReportInput {
+        job,
+        summary: &summary,
+        segments,
+        segment_records: &segment_records,
+        translations,
+        qa_reviews,
+        output: &config.output,
+    })?;
+
+    println!(
+        "Translated: {}/{} segments",
+        summary.succeeded, summary.total_segments
+    );
+    println!("Cached: {}", summary.cached);
+    println!("Retried: {}", summary.retried);
+    println!("Needs review: {}", summary.needs_review);
+    println!("Failed: {}", summary.failed);
+    println!("Input tokens: {}", summary.input_tokens);
+    println!("Output tokens: {}", summary.output_tokens);
+    if let Some(cost) = estimate_cost_usd(
+        &job.provider,
+        &job.model,
+        summary.input_tokens,
+        summary.output_tokens,
+    ) {
+        println!("Estimated cost: ${cost:.6}");
+    }
+    println!("Output: {}", config.output.display());
+    println!("Report: {}", report.markdown.display());
+
+    Ok(())
+}

--- a/crates/bookforge-cli/src/commands/translate/reporting.rs
+++ b/crates/bookforge-cli/src/commands/translate/reporting.rs
@@ -9,6 +9,7 @@ use bookforge_store::{JobRecord, JobStore};
 
 use crate::{
     cost::estimate_cost_usd,
+    performance::performance_summary_from_events,
     report::{ReportInput, write_report},
 };
 
@@ -33,16 +34,25 @@ pub fn print_summary_rebuild_and_report(
     let summary = store
         .summary(&job.id)?
         .ok_or_else(|| anyhow::anyhow!("job '{}' was not found after translation", job.id))?;
+    let report_job = store
+        .get_job(&job.id)?
+        .ok_or_else(|| anyhow::anyhow!("job '{}' was not found after translation", job.id))?;
     let segment_records = store.segment_records(&job.id)?;
+    let performance = report_job
+        .events_path
+        .as_ref()
+        .and_then(|path| performance_summary_from_events(path).ok().flatten());
     let report = write_report(ReportInput {
-        job,
+        job: &report_job,
         summary: &summary,
         segments,
         segment_records: &segment_records,
         translations,
         qa_reviews,
+        performance,
         output: &config.output,
     })?;
+    store.update_job_report_paths(&job.id, &report.json, &report.markdown)?;
 
     println!(
         "Translated: {}/{} segments",

--- a/crates/bookforge-cli/src/commands/translate/settings.rs
+++ b/crates/bookforge-cli/src/commands/translate/settings.rs
@@ -1,0 +1,135 @@
+use bookforge_core::config::{DoubleCheckMode, ResolvedRunSettings, TranslationProfile};
+
+use crate::ProviderArgs as CliProviderArgs;
+
+use super::TranslateArgs;
+
+pub fn apply_provider_preset(
+    explicit: &CliProviderArgs,
+    preset: Option<bookforge_core::ProviderPreset>,
+) -> CliProviderArgs {
+    let Some(p) = preset else {
+        return explicit.clone();
+    };
+    let endpoint = p.endpoint_or_default(None);
+    CliProviderArgs {
+        provider: endpoint.provider,
+        model: explicit.model.clone().or(Some(endpoint.model)),
+        base_url: explicit.base_url.clone().or(endpoint.base_url),
+        api_key_env: explicit.api_key_env.clone().or(endpoint.api_key_env),
+        timeout_seconds: explicit.timeout_seconds,
+    }
+}
+
+pub fn resolve_settings(args: &TranslateArgs) -> ResolvedRunSettings {
+    let effective_profile =
+        if args.turbo_text_only && !matches!(args.profile, TranslationProfile::TurboTextOnly) {
+            TranslationProfile::TurboTextOnly
+        } else {
+            args.profile
+        };
+
+    let mut settings = effective_profile.resolve();
+
+    if let Some(preset) = args.provider_preset.and_then(|preset| preset.resolve()) {
+        settings.apply_provider_preset_runtime(preset.runtime);
+    }
+
+    if let Some(v) = args.max_segment_tokens {
+        settings.segmentation.max_segment_tokens = v;
+    }
+    if let Some(v) = args.context_tokens {
+        settings.segmentation.context_tokens = v;
+    }
+    if let Some(v) = args.batch_target_tokens {
+        settings.batch.target_tokens = v;
+    }
+    if let Some(v) = args.batch_max_items {
+        settings.batch.max_items = v;
+    }
+    if let Some(v) = args.compact_prompts {
+        settings.compact_prompts = v;
+    }
+    if let Some(v) = args.retry_failed_only {
+        settings.retry_failed_only = v;
+    }
+    if let Some(v) = args.adaptive_concurrency {
+        settings.adaptive_concurrency = v;
+    }
+
+    if let Some(v) = args.concurrency {
+        settings.scheduler.concurrency = v;
+    }
+    if let Some(v) = args.max_attempts {
+        settings.scheduler.max_attempts = v;
+    }
+
+    if let Some(v) = args.provider_max_attempts {
+        settings.provider.provider_max_attempts = v;
+    }
+    if let Some(v) = args.validation_max_attempts {
+        settings.provider.validation_max_attempts = v;
+    }
+    if let Some(v) = args.provider.timeout_seconds {
+        settings.provider.timeout_seconds = v;
+    }
+    if args.no_thinking {
+        settings.provider.thinking_disabled = true;
+    }
+    if let Some(v) = args.model_context_tokens {
+        settings.provider.model_context_tokens = Some(v);
+    }
+    if let Some(v) = args.max_output_tokens {
+        settings.provider.max_output_tokens = Some(v);
+    }
+    if let Some(v) = args.batch_max_output_tokens {
+        settings.provider.batch_max_output_tokens = Some(v);
+    }
+    settings.provider.json_mode = args.json_mode;
+
+    settings.qa.concurrency = args.qa_concurrency;
+    if let Some(v) = args.qa_batch_target_tokens {
+        settings.qa.batch_target_tokens = v;
+    }
+    settings.qa.model = args.qa_model.clone();
+    settings.qa.provider = args.qa_provider.clone();
+    settings.qa.base_url = args.qa_base_url.clone();
+    settings.qa.api_key_env = args.qa_api_key_env.clone();
+
+    settings.double_check.mode = args.double_check;
+    settings.double_check.model = args.double_check_model.clone();
+    settings.double_check.provider = args.double_check_provider.clone();
+    settings.double_check.base_url = args.double_check_base_url.clone();
+    settings.double_check.api_key_env = args.double_check_api_key_env.clone();
+    settings.double_check.concurrency = args.double_check_concurrency;
+    if let Some(v) = args.double_check_batch_target_tokens {
+        settings.double_check.batch_target_tokens = v;
+    }
+    settings.double_check.auto_correct = args.auto_correct;
+    settings.double_check.correction_rounds = args.correction_rounds;
+
+    if settings.double_check.mode != DoubleCheckMode::Off && settings.double_check.model.is_none() {
+        eprintln!(
+            "--double-check requires --double-check-model unless a default double-check model is configured"
+        );
+    }
+
+    settings
+}
+
+pub fn retry_amplification_warning(settings: &ResolvedRunSettings) -> Option<String> {
+    let scheduler_provider_product =
+        settings.scheduler.max_attempts * settings.provider.provider_max_attempts;
+    if scheduler_provider_product < 6 {
+        return None;
+    }
+    let total = scheduler_provider_product * settings.provider.validation_max_attempts;
+    Some(format!(
+        "scheduler attempts {} x provider attempts {} can produce up to {} calls per failed unit before validation retries ({} total with validation attempts {})",
+        settings.scheduler.max_attempts,
+        settings.provider.provider_max_attempts,
+        scheduler_provider_product,
+        total,
+        settings.provider.validation_max_attempts
+    ))
+}

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -1,0 +1,57 @@
+use std::path::{Path, PathBuf};
+
+use bookforge_core::{ResolvedRunSettings, ResolvedRunSettingsSnapshot, RunConfigSnapshot};
+use bookforge_store::{JobRecord, JobStore};
+
+use crate::{ProviderArgs as CliProviderArgs, report::report_paths};
+
+use super::args::TranslateArgs;
+
+pub(crate) fn default_event_path(job_id: &str) -> PathBuf {
+    PathBuf::from(".bookforge/runs")
+        .join(job_id)
+        .join("events.jsonl")
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn persist_snapshot(
+    store: &JobStore,
+    job: &JobRecord,
+    input: &Path,
+    output: &Path,
+    provider_args: &CliProviderArgs,
+    cli_args: &TranslateArgs,
+    settings: &ResolvedRunSettings,
+    prompt_version: &str,
+    cache_namespace: &str,
+    model: &str,
+    base_url: Option<String>,
+    api_key_env: Option<String>,
+) -> anyhow::Result<RunConfigSnapshot> {
+    let reports = report_paths(output);
+    let events_path = cli_args
+        .progress_jsonl
+        .clone()
+        .unwrap_or_else(|| default_event_path(&job.id));
+    let snapshot = RunConfigSnapshot {
+        input_path: input.to_path_buf(),
+        output_path: output.to_path_buf(),
+        events_path: Some(events_path.clone()),
+        report_json_path: Some(reports.json),
+        report_markdown_path: Some(reports.markdown),
+        source_language: cli_args.language.source.clone(),
+        target_language: cli_args.language.target.clone(),
+        provider: provider_args.provider.clone(),
+        model: model.to_string(),
+        base_url,
+        api_key_env,
+        profile: settings.profile,
+        provider_preset: cli_args.provider_preset,
+        prompt_version: prompt_version.to_string(),
+        cache_namespace: cache_namespace.to_string(),
+        settings: ResolvedRunSettingsSnapshot::from_settings(settings),
+    };
+    store.update_job_config_snapshot(&job.id, &snapshot)?;
+    store.update_job_event_path(&job.id, &events_path)?;
+    Ok(snapshot)
+}

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod checkpoint;
 mod commands;
 mod cost;
+mod performance;
 mod progress;
 mod report;
 

--- a/crates/bookforge-cli/src/performance.rs
+++ b/crates/bookforge-cli/src/performance.rs
@@ -1,0 +1,158 @@
+use std::{fs::File, io::BufRead, path::Path};
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct RunPerformanceSummary {
+    pub request_count: usize,
+    pub p50_latency_ms: Option<u64>,
+    pub p95_latency_ms: Option<u64>,
+    pub rate_limited: usize,
+    pub timeouts: usize,
+    pub server_errors: usize,
+    pub invalid_responses: usize,
+    pub truncations: usize,
+    pub retries: usize,
+    pub batch_splits: usize,
+    pub repair_batches: usize,
+    pub repair_failures: usize,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub blocks_per_minute: Option<f64>,
+    pub checkpoint_flushes: usize,
+    pub elapsed_ms: Option<u64>,
+}
+
+pub(crate) fn performance_summary_from_events(
+    path: &Path,
+) -> Result<Option<RunPerformanceSummary>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let file = File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let mut summary = RunPerformanceSummary::default();
+    let mut latencies = Vec::<u64>::new();
+    let mut first_ts = None::<u64>;
+    let mut last_ts = None::<u64>;
+    let mut finished_segments = 0usize;
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some((kind, payload)) = value.as_object().and_then(|object| object.iter().next())
+        else {
+            continue;
+        };
+        if let Some(ts) = payload.get("timestamp_ms").and_then(Value::as_u64) {
+            first_ts = Some(first_ts.map_or(ts, |current| current.min(ts)));
+            last_ts = Some(last_ts.map_or(ts, |current| current.max(ts)));
+        }
+        match kind.as_str() {
+            "RequestFinished" => {
+                summary.request_count += 1;
+                if let Some(latency) = payload.get("latency_ms").and_then(Value::as_u64) {
+                    latencies.push(latency);
+                }
+                let status = payload.get("status").and_then(Value::as_str).unwrap_or("");
+                let code = payload.get("status_code").and_then(Value::as_u64);
+                let error_kind = payload
+                    .get("error_kind")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if code == Some(429) || status.contains("rate") {
+                    summary.rate_limited += 1;
+                }
+                if status.contains("timeout") || error_kind.contains("timeout") {
+                    summary.timeouts += 1;
+                }
+                if code.is_some_and(|code| (500..600).contains(&code)) {
+                    summary.server_errors += 1;
+                }
+                if error_kind.contains("json")
+                    || error_kind.contains("invalid")
+                    || status.contains("invalid")
+                {
+                    summary.invalid_responses += 1;
+                }
+                if payload
+                    .get("finish_reason")
+                    .and_then(Value::as_str)
+                    .is_some_and(|reason| reason.eq_ignore_ascii_case("length"))
+                {
+                    summary.truncations += 1;
+                }
+                summary.retries += payload
+                    .get("retry_count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                summary.input_tokens += payload
+                    .get("input_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                summary.output_tokens += payload
+                    .get("output_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+            }
+            "SegmentFinished" => {
+                finished_segments += 1;
+                summary.input_tokens += payload
+                    .get("input_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                summary.output_tokens += payload
+                    .get("output_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+            }
+            "BatchSplit" => summary.batch_splits += 1,
+            "BatchRepairStarted" => summary.repair_batches += 1,
+            "BatchRepairFinished"
+                if payload
+                    .get("still_failed_items")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+                    > 0 =>
+            {
+                summary.repair_failures += 1;
+            }
+            "BatchRepairFinished" => {}
+            "CheckpointFlushed" => summary.checkpoint_flushes += 1,
+            "TranslationFinished" => {
+                summary.elapsed_ms = payload.get("elapsed_ms").and_then(Value::as_u64);
+            }
+            _ => {}
+        }
+    }
+
+    latencies.sort_unstable();
+    summary.p50_latency_ms = percentile(&latencies, 0.50);
+    summary.p95_latency_ms = percentile(&latencies, 0.95);
+    let elapsed_ms = summary.elapsed_ms.or_else(|| {
+        first_ts
+            .zip(last_ts)
+            .map(|(first, last)| last.saturating_sub(first))
+    });
+    summary.elapsed_ms = elapsed_ms;
+    if let Some(elapsed_ms) = elapsed_ms.filter(|elapsed| *elapsed > 0) {
+        summary.blocks_per_minute = Some(finished_segments as f64 / (elapsed_ms as f64 / 60_000.0));
+    }
+
+    Ok(Some(summary))
+}
+
+fn percentile(values: &[u64], percentile: f64) -> Option<u64> {
+    if values.is_empty() {
+        return None;
+    }
+    let index = ((values.len() - 1) as f64 * percentile).round() as usize;
+    values.get(index).copied()
+}

--- a/crates/bookforge-cli/src/performance.rs
+++ b/crates/bookforge-cli/src/performance.rs
@@ -38,6 +38,11 @@ pub(crate) fn performance_summary_from_events(
     let mut first_ts = None::<u64>;
     let mut last_ts = None::<u64>;
     let mut finished_segments = 0usize;
+    let mut request_input_tokens = 0u64;
+    let mut request_output_tokens = 0u64;
+    let mut request_events_with_tokens = 0usize;
+    let mut segment_input_tokens = 0u64;
+    let mut segment_output_tokens = 0u64;
 
     for line in reader.lines() {
         let line = line?;
@@ -93,22 +98,21 @@ pub(crate) fn performance_summary_from_events(
                     .get("retry_count")
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as usize;
-                summary.input_tokens += payload
-                    .get("input_tokens")
-                    .and_then(Value::as_u64)
-                    .unwrap_or(0);
-                summary.output_tokens += payload
-                    .get("output_tokens")
-                    .and_then(Value::as_u64)
-                    .unwrap_or(0);
+                let input_tokens = payload.get("input_tokens").and_then(Value::as_u64);
+                let output_tokens = payload.get("output_tokens").and_then(Value::as_u64);
+                if input_tokens.is_some() || output_tokens.is_some() {
+                    request_events_with_tokens += 1;
+                }
+                request_input_tokens += input_tokens.unwrap_or(0);
+                request_output_tokens += output_tokens.unwrap_or(0);
             }
             "SegmentFinished" => {
                 finished_segments += 1;
-                summary.input_tokens += payload
+                segment_input_tokens += payload
                     .get("input_tokens")
                     .and_then(Value::as_u64)
                     .unwrap_or(0);
-                summary.output_tokens += payload
+                segment_output_tokens += payload
                     .get("output_tokens")
                     .and_then(Value::as_u64)
                     .unwrap_or(0);
@@ -136,6 +140,13 @@ pub(crate) fn performance_summary_from_events(
     latencies.sort_unstable();
     summary.p50_latency_ms = percentile(&latencies, 0.50);
     summary.p95_latency_ms = percentile(&latencies, 0.95);
+    if request_events_with_tokens > 0 {
+        summary.input_tokens = request_input_tokens;
+        summary.output_tokens = request_output_tokens;
+    } else {
+        summary.input_tokens = segment_input_tokens;
+        summary.output_tokens = segment_output_tokens;
+    }
     let elapsed_ms = summary.elapsed_ms.or_else(|| {
         first_ts
             .zip(last_ts)
@@ -155,4 +166,68 @@ fn percentile(values: &[u64], percentile: f64) -> Option<u64> {
     }
     let index = ((values.len() - 1) as f64 * percentile).round() as usize;
     values.get(index).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn request_and_segment_tokens_are_not_double_counted() {
+        let path = temp_path("request-segment-tokens.jsonl");
+        fs::write(
+            &path,
+            [
+                r#"{"RequestFinished":{"request_id":"r1","batch_id":null,"segment_id":"s1","status":"ok","latency_ms":10,"status_code":null,"finish_reason":null,"retry_count":0,"input_tokens":11,"output_tokens":7,"error_kind":null,"timestamp_ms":1}}"#,
+                r#"{"SegmentFinished":{"segment_id":"s1","status":"succeeded","input_tokens":11,"output_tokens":7,"timestamp_ms":2}}"#,
+            ]
+            .join("\n"),
+        )
+        .expect("fixture should be written");
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.input_tokens, 11);
+        assert_eq!(summary.output_tokens, 7);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn segment_tokens_are_used_when_request_tokens_are_absent() {
+        let path = temp_path("segment-only-tokens.jsonl");
+        fs::write(
+            &path,
+            [
+                r#"{"RequestFinished":{"request_id":"r1","batch_id":null,"segment_id":"s1","status":"ok","latency_ms":10,"status_code":null,"finish_reason":null,"retry_count":0,"input_tokens":null,"output_tokens":null,"error_kind":null,"timestamp_ms":1}}"#,
+                r#"{"SegmentFinished":{"segment_id":"s1","status":"succeeded","input_tokens":13,"output_tokens":5,"timestamp_ms":2}}"#,
+            ]
+            .join("\n"),
+        )
+        .expect("fixture should be written");
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.input_tokens, 13);
+        assert_eq!(summary.output_tokens, 5);
+        let _ = fs::remove_file(path);
+    }
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bookforge-performance-test-{}-{nanos}-{name}",
+            std::process::id()
+        ))
+    }
 }

--- a/crates/bookforge-cli/src/progress.rs
+++ b/crates/bookforge-cli/src/progress.rs
@@ -61,11 +61,15 @@ pub struct ProgressReporter {
 
 impl ProgressReporter {
     pub fn spawn(ui_mode: UiMode, jsonl_path: Option<PathBuf>) -> Self {
+        Self::spawn_with_append(ui_mode, jsonl_path, false)
+    }
+
+    pub fn spawn_with_append(ui_mode: UiMode, jsonl_path: Option<PathBuf>, append: bool) -> Self {
         let (tx, rx) = mpsc::channel::<ProgressEvent>(PROGRESS_EVENT_QUEUE_CAPACITY);
         let dropped = Arc::new(AtomicUsize::new(0));
         let dropped_clone = dropped.clone();
 
-        let join = tokio::spawn(render_loop(rx, ui_mode, jsonl_path, dropped_clone));
+        let join = tokio::spawn(render_loop(rx, ui_mode, jsonl_path, append, dropped_clone));
 
         Self { tx, join, dropped }
     }
@@ -90,10 +94,11 @@ async fn render_loop(
     mut rx: mpsc::Receiver<ProgressEvent>,
     ui_mode: UiMode,
     jsonl_path: Option<PathBuf>,
+    append: bool,
     dropped: Arc<AtomicUsize>,
 ) -> Result<()> {
     let render_mode = resolve_render_mode(ui_mode, std::io::stderr().is_terminal());
-    let mut file_writer = JsonlFileWriter::new(jsonl_path);
+    let mut file_writer = JsonlFileWriter::new(jsonl_path, append);
     let mut renderer = Renderer::new(render_mode)?;
 
     while let Some(event) = rx.recv().await {
@@ -134,15 +139,17 @@ struct JsonlFileWriter {
     writer: Option<BufWriter<std::fs::File>>,
     failed: bool,
     last_flush: Instant,
+    append: bool,
 }
 
 impl JsonlFileWriter {
-    fn new(path: Option<PathBuf>) -> Self {
+    fn new(path: Option<PathBuf>, append: bool) -> Self {
         Self {
             path,
             writer: None,
             failed: false,
             last_flush: Instant::now(),
+            append,
         }
     }
 
@@ -156,7 +163,13 @@ impl JsonlFileWriter {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        match std::fs::File::create(path) {
+        let file_result = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .append(self.append)
+            .truncate(!self.append)
+            .open(path);
+        match file_result {
             Ok(file) => {
                 self.writer = Some(BufWriter::new(file));
                 self.last_flush = Instant::now();
@@ -495,6 +508,7 @@ mod tests {
             rx,
             UiMode::Quiet,
             Some(path.clone()),
+            false,
             Arc::new(AtomicUsize::new(0)),
         );
         let handle = tokio::spawn(reporter_task);
@@ -532,6 +546,7 @@ mod tests {
             rx,
             UiMode::Json,
             Some(path.clone()),
+            false,
             Arc::new(AtomicUsize::new(0)),
         );
         let handle = tokio::spawn(reporter_task);
@@ -564,6 +579,7 @@ mod tests {
             rx,
             UiMode::Progress,
             Some(path.clone()),
+            false,
             Arc::new(AtomicUsize::new(0)),
         );
         let handle = tokio::spawn(reporter_task);

--- a/crates/bookforge-cli/src/report.rs
+++ b/crates/bookforge-cli/src/report.rs
@@ -11,6 +11,7 @@ use bookforge_store::{JobRecord, JobSummary, SegmentRecord};
 use serde::Serialize;
 
 use crate::cost::estimate_cost_usd;
+use crate::performance::RunPerformanceSummary;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReportFiles {
@@ -26,6 +27,7 @@ pub(crate) struct ReportInput<'a> {
     pub segment_records: &'a [SegmentRecord],
     pub translations: &'a [SegmentTranslation],
     pub qa_reviews: &'a [QaSegmentReview],
+    pub performance: Option<RunPerformanceSummary>,
     pub output: &'a Path,
 }
 
@@ -50,6 +52,7 @@ struct QaReport {
     estimated_cost: Option<f64>,
     qa_reviewed_segments: usize,
     qa_warnings: Vec<QaWarning>,
+    performance: Option<RunPerformanceSummary>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -87,6 +90,7 @@ pub(crate) fn write_report(input: ReportInput<'_>) -> Result<ReportFiles> {
         ),
         qa_reviewed_segments: input.qa_reviews.len(),
         qa_warnings: qa_warnings(&input),
+        performance: input.performance.clone(),
     };
 
     if let Some(parent) = files.json.parent() {
@@ -97,7 +101,7 @@ pub(crate) fn write_report(input: ReportInput<'_>) -> Result<ReportFiles> {
     Ok(files)
 }
 
-fn report_paths(output: &Path) -> ReportFiles {
+pub(crate) fn report_paths(output: &Path) -> ReportFiles {
     let parent = output.parent().unwrap_or_else(|| Path::new(""));
     let stem = output
         .file_stem()
@@ -402,5 +406,46 @@ fn render_markdown(report: &QaReport) -> String {
         }
     }
 
+    output.push_str("\n## Performance\n\n");
+    if let Some(perf) = &report.performance {
+        output.push_str(&format!("- Requests: {}\n", perf.request_count));
+        output.push_str(&format!(
+            "- Latency p50/p95: {}/{} ms\n",
+            optional_u64(perf.p50_latency_ms),
+            optional_u64(perf.p95_latency_ms)
+        ));
+        output.push_str(&format!("- Retries: {}\n", perf.retries));
+        output.push_str(&format!(
+            "- 429/timeouts/server errors: {}/{}/{}\n",
+            perf.rate_limited, perf.timeouts, perf.server_errors
+        ));
+        output.push_str(&format!(
+            "- Invalid responses/truncations: {}/{}\n",
+            perf.invalid_responses, perf.truncations
+        ));
+        output.push_str(&format!(
+            "- Batch splits/repair batches/repair failures: {}/{}/{}\n",
+            perf.batch_splits, perf.repair_batches, perf.repair_failures
+        ));
+        output.push_str(&format!(
+            "- Checkpoint flushes: {}\n",
+            perf.checkpoint_flushes
+        ));
+        output.push_str(&format!(
+            "- Blocks/min: {}\n",
+            perf.blocks_per_minute
+                .map(|value| format!("{value:.2}"))
+                .unwrap_or_else(|| "n/a".to_string())
+        ));
+    } else {
+        output.push_str("Performance data unavailable: no event log was available.\n");
+    }
+
     output
+}
+
+fn optional_u64(value: Option<u64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
 }

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -4,6 +4,8 @@ use std::{
     process::Command,
 };
 
+use bookforge_store::JobStore;
+
 fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_bookforge"))
 }
@@ -115,6 +117,224 @@ fn resume_missing_job_fails_clearly() {
         .expect("resume command should run");
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("job 'job_missing' was not found"));
+}
+
+#[test]
+fn cli_resume_writes_progress_events_and_uses_batch_snapshot_mode() {
+    let cwd = temp_dir("resume-batch");
+    let input = workspace_root().join("test/test.epub");
+    let output = cwd.join("translated.epub");
+    let translate_events = cwd.join("translate-events.jsonl");
+    let resume_events = cwd.join("resume-events.jsonl");
+
+    let translate = Command::new(bin())
+        .current_dir(&cwd)
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            translate_events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("translate command should run");
+    assert!(
+        translate.status.success(),
+        "translate failed: {}",
+        String::from_utf8_lossy(&translate.stderr)
+    );
+    let job_id = job_id_from_stdout(&translate.stdout);
+
+    let store = JobStore::open(cwd.join(".bookforge/jobs.sqlite")).expect("store should open");
+    let segment_ids = store
+        .segment_records(&job_id)
+        .expect("segments should load")
+        .into_iter()
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    assert!(!segment_ids.is_empty(), "fixture should have segments");
+    for segment_id in segment_ids {
+        store
+            .mark_segment_failed(&job_id, &segment_id, "force resume")
+            .expect("segment should be marked failed");
+    }
+
+    let resume = Command::new(bin())
+        .current_dir(&cwd)
+        .args([
+            "resume",
+            &job_id,
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            resume_events.to_str().unwrap(),
+        ])
+        .output()
+        .expect("resume command should run");
+    assert!(
+        resume.status.success(),
+        "resume failed: {}\nstdout: {}",
+        String::from_utf8_lossy(&resume.stderr),
+        String::from_utf8_lossy(&resume.stdout)
+    );
+
+    let events = read_jsonl(&resume_events);
+    assert!(events.iter().any(|event| {
+        event
+            .get("StageStarted")
+            .and_then(|payload| payload.get("stage"))
+            .and_then(|stage| stage.as_str())
+            == Some("resume")
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| event.get("CacheScanFinished").is_some())
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.get("BatchQueued").is_some())
+            || events.iter().any(|event| event
+                .get("RequestStarted")
+                .and_then(|payload| payload.get("batch_id"))
+                .is_some_and(|batch_id| !batch_id.is_null())),
+        "resume should use batch progress events when the snapshot has batch enabled"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.get("ArtifactWritten").is_some())
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.get("TranslationFinished").is_some())
+    );
+
+    let summary = store
+        .summary(&job_id)
+        .expect("summary should load")
+        .expect("job should exist");
+    assert_eq!(summary.failed, 0);
+    assert_eq!(
+        summary.succeeded + summary.cached + summary.needs_review,
+        summary.total_segments
+    );
+
+    let tail = Command::new(bin())
+        .current_dir(&cwd)
+        .args(["tail", &job_id, "--last", "200", "--json"])
+        .output()
+        .expect("tail command should run");
+    assert!(tail.status.success());
+    let resume_lines = fs::read_to_string(&resume_events).expect("resume events should exist");
+    let resume_lines = resume_lines.lines().collect::<Vec<_>>();
+    let tail_stdout = String::from_utf8_lossy(&tail.stdout);
+    let tail_lines = tail_stdout.lines().collect::<Vec<_>>();
+    assert!(!tail_lines.is_empty(), "tail should emit JSONL events");
+    let expected_start = resume_lines.len().saturating_sub(tail_lines.len());
+    assert_eq!(
+        tail_lines[0], resume_lines[expected_start],
+        "tail should read the resume event path stored by --progress-jsonl"
+    );
+}
+
+#[test]
+fn resume_preserves_needs_review_segments_by_default() {
+    let cwd = temp_dir("resume-needs-review");
+    let input = workspace_root().join("test/test.epub");
+    let output = cwd.join("translated.epub");
+    let resume_events = cwd.join("resume-events.jsonl");
+
+    let translate = Command::new(bin())
+        .current_dir(&cwd)
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-malformed-json",
+            "--profile",
+            "v1-fast",
+            "--ui",
+            "quiet",
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("translate command should run");
+    assert!(
+        translate.status.success(),
+        "translate failed: {}",
+        String::from_utf8_lossy(&translate.stderr)
+    );
+    let job_id = job_id_from_stdout(&translate.stdout);
+
+    let resume = Command::new(bin())
+        .current_dir(&cwd)
+        .args([
+            "resume",
+            &job_id,
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            resume_events.to_str().unwrap(),
+        ])
+        .output()
+        .expect("resume command should run");
+    assert!(
+        resume.status.success(),
+        "resume failed: {}",
+        String::from_utf8_lossy(&resume.stderr)
+    );
+
+    let store = JobStore::open(cwd.join(".bookforge/jobs.sqlite")).expect("store should open");
+    let summary = store
+        .summary(&job_id)
+        .expect("summary should load")
+        .expect("job should exist");
+    assert_eq!(summary.needs_review, summary.total_segments);
+    assert_eq!(summary.failed, 0);
+
+    let events = read_jsonl(&resume_events);
+    assert!(
+        events
+            .iter()
+            .all(|event| event.get("SegmentFinished").is_none()),
+        "resume should not reprocess needs_review segments by default"
+    );
+}
+
+fn job_id_from_stdout(stdout: &[u8]) -> String {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("Job: "))
+        .expect("command should print job id")
+        .to_string()
+}
+
+fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
+    fs::read_to_string(path)
+        .expect("JSONL file should exist")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("line should be valid JSON"))
+        .collect()
 }
 
 fn now_nanos() -> u128 {

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -1,0 +1,125 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_bookforge"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("cli crate should be under crates/bookforge-cli")
+        .to_path_buf()
+}
+
+fn temp_dir(name: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "bookforge-cli-{name}-{}-{}",
+        std::process::id(),
+        now_nanos()
+    ));
+    fs::create_dir_all(&path).expect("temp dir should be created");
+    path
+}
+
+#[test]
+fn mock_translate_status_and_tail_lifecycle() {
+    let cwd = temp_dir("lifecycle");
+    let input = workspace_root().join("test/test.epub");
+    let output = cwd.join("translated.epub");
+    let events = cwd.join("events.jsonl");
+
+    let translate = Command::new(bin())
+        .current_dir(&cwd)
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("translate command should run");
+    assert!(
+        translate.status.success(),
+        "translate failed: {}",
+        String::from_utf8_lossy(&translate.stderr)
+    );
+    assert!(output.exists(), "translated EPUB should exist");
+    assert!(events.exists(), "event log should exist");
+    assert!(
+        cwd.join("translated.report.md").exists(),
+        "report should exist"
+    );
+
+    let stdout = String::from_utf8_lossy(&translate.stdout);
+    let job_id = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Job: "))
+        .expect("translate should print job id")
+        .to_string();
+
+    let status = Command::new(bin())
+        .current_dir(&cwd)
+        .args(["status", &job_id])
+        .output()
+        .expect("status command should run");
+    assert!(status.status.success());
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status_stdout.contains("Status: succeeded"));
+    assert!(status_stdout.contains("Event log:"));
+    assert!(status_stdout.contains("Report:"));
+    assert!(status_stdout.contains("Performance:"));
+
+    let tail = Command::new(bin())
+        .current_dir(&cwd)
+        .args(["tail", &job_id, "--last", "3"])
+        .output()
+        .expect("tail command should run");
+    assert!(tail.status.success());
+    assert!(String::from_utf8_lossy(&tail.stdout).contains("Last "));
+
+    let tail_json = Command::new(bin())
+        .current_dir(&cwd)
+        .args(["tail", &job_id, "--last", "3", "--json"])
+        .output()
+        .expect("tail json command should run");
+    assert!(tail_json.status.success());
+    for line in String::from_utf8_lossy(&tail_json.stdout).lines() {
+        serde_json::from_str::<serde_json::Value>(line).expect("tail --json should emit JSONL");
+    }
+}
+
+#[test]
+fn resume_missing_job_fails_clearly() {
+    let cwd = temp_dir("resume-missing");
+    let output = Command::new(bin())
+        .current_dir(&cwd)
+        .args(["resume", "job_missing"])
+        .output()
+        .expect("resume command should run");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("job 'job_missing' was not found"));
+}
+
+fn now_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod ir;
 pub mod marker;
 pub mod progress;
+pub mod run_snapshot;
 pub mod scheduler;
 pub mod segment;
 
@@ -15,4 +16,5 @@ pub use config::{
 };
 pub use error::{BookforgeError, Result};
 pub use progress::{NullProgressSink, ProgressEvent, ProgressSink, now_ms};
+pub use run_snapshot::{ResolvedRunSettingsSnapshot, RunConfigSnapshot};
 pub use scheduler::SchedulerConfig;

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -1,0 +1,216 @@
+use std::path::PathBuf;
+
+use crate::{
+    BatchConfig, DoubleCheckConfig, JsonMode, ProviderPreset, ProviderRuntimeConfig, QaRunConfig,
+    ResolvedRunSettings, RetryAfterPolicy, SchedulerConfig, SegmentationConfig, TranslationProfile,
+};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RunConfigSnapshot {
+    pub input_path: PathBuf,
+    pub output_path: PathBuf,
+    pub events_path: Option<PathBuf>,
+    pub report_json_path: Option<PathBuf>,
+    pub report_markdown_path: Option<PathBuf>,
+    pub source_language: Option<String>,
+    pub target_language: String,
+    pub provider: String,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub api_key_env: Option<String>,
+    pub profile: TranslationProfile,
+    pub provider_preset: Option<ProviderPreset>,
+    pub prompt_version: String,
+    pub cache_namespace: String,
+    pub settings: ResolvedRunSettingsSnapshot,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ResolvedRunSettingsSnapshot {
+    pub profile: TranslationProfile,
+    pub segmentation: SegmentationConfigSnapshot,
+    pub batch: BatchConfigSnapshot,
+    pub scheduler: SchedulerConfigSnapshot,
+    pub provider: ProviderRuntimeConfigSnapshot,
+    pub compact_prompts: bool,
+    pub retry_failed_only: bool,
+    pub adaptive_concurrency: bool,
+    pub qa: QaRunConfigSnapshot,
+    pub double_check: DoubleCheckConfigSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SegmentationConfigSnapshot {
+    pub max_segment_tokens: usize,
+    pub context_tokens: usize,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct BatchConfigSnapshot {
+    pub enabled: bool,
+    pub target_tokens: usize,
+    pub max_items: usize,
+    pub adaptive_sizing: bool,
+    pub split_on_json_failure: bool,
+    pub repair_invalid_items: bool,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SchedulerConfigSnapshot {
+    pub concurrency: usize,
+    pub max_attempts: usize,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProviderRuntimeConfigSnapshot {
+    pub timeout_seconds: u64,
+    pub provider_max_attempts: usize,
+    pub validation_max_attempts: usize,
+    pub retry_after_policy: RetryAfterPolicy,
+    pub max_backoff_seconds: u64,
+    pub thinking_disabled: bool,
+    pub model_context_tokens: Option<u32>,
+    pub max_output_tokens: Option<u32>,
+    pub batch_max_output_tokens: Option<u32>,
+    pub json_mode: JsonMode,
+    pub max_idle_per_host: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct QaRunConfigSnapshot {
+    pub concurrency: usize,
+    pub batch_target_tokens: usize,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub base_url: Option<String>,
+    pub api_key_env: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct DoubleCheckConfigSnapshot {
+    pub mode: crate::DoubleCheckMode,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub base_url: Option<String>,
+    pub api_key_env: Option<String>,
+    pub concurrency: usize,
+    pub batch_target_tokens: usize,
+    pub auto_correct: bool,
+    pub correction_rounds: usize,
+}
+
+impl ResolvedRunSettingsSnapshot {
+    pub fn from_settings(settings: &ResolvedRunSettings) -> Self {
+        Self {
+            profile: settings.profile,
+            segmentation: SegmentationConfigSnapshot {
+                max_segment_tokens: settings.segmentation.max_segment_tokens,
+                context_tokens: settings.segmentation.context_tokens,
+            },
+            batch: BatchConfigSnapshot {
+                enabled: settings.batch.enabled,
+                target_tokens: settings.batch.target_tokens,
+                max_items: settings.batch.max_items,
+                adaptive_sizing: settings.batch.adaptive_sizing,
+                split_on_json_failure: settings.batch.split_on_json_failure,
+                repair_invalid_items: settings.batch.repair_invalid_items,
+            },
+            scheduler: SchedulerConfigSnapshot {
+                concurrency: settings.scheduler.concurrency,
+                max_attempts: settings.scheduler.max_attempts,
+            },
+            provider: ProviderRuntimeConfigSnapshot {
+                timeout_seconds: settings.provider.timeout_seconds,
+                provider_max_attempts: settings.provider.provider_max_attempts,
+                validation_max_attempts: settings.provider.validation_max_attempts,
+                retry_after_policy: settings.provider.retry_after_policy,
+                max_backoff_seconds: settings.provider.max_backoff_seconds,
+                thinking_disabled: settings.provider.thinking_disabled,
+                model_context_tokens: settings.provider.model_context_tokens,
+                max_output_tokens: settings.provider.max_output_tokens,
+                batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+                json_mode: settings.provider.json_mode,
+                max_idle_per_host: settings.provider.max_idle_per_host,
+            },
+            compact_prompts: settings.compact_prompts,
+            retry_failed_only: settings.retry_failed_only,
+            adaptive_concurrency: settings.adaptive_concurrency,
+            qa: QaRunConfigSnapshot {
+                concurrency: settings.qa.concurrency,
+                batch_target_tokens: settings.qa.batch_target_tokens,
+                model: settings.qa.model.clone(),
+                provider: settings.qa.provider.clone(),
+                base_url: settings.qa.base_url.clone(),
+                api_key_env: settings.qa.api_key_env.clone(),
+            },
+            double_check: DoubleCheckConfigSnapshot {
+                mode: settings.double_check.mode,
+                model: settings.double_check.model.clone(),
+                provider: settings.double_check.provider.clone(),
+                base_url: settings.double_check.base_url.clone(),
+                api_key_env: settings.double_check.api_key_env.clone(),
+                concurrency: settings.double_check.concurrency,
+                batch_target_tokens: settings.double_check.batch_target_tokens,
+                auto_correct: settings.double_check.auto_correct,
+                correction_rounds: settings.double_check.correction_rounds,
+            },
+        }
+    }
+
+    pub fn to_settings(&self) -> ResolvedRunSettings {
+        ResolvedRunSettings {
+            profile: self.profile,
+            segmentation: SegmentationConfig {
+                max_segment_tokens: self.segmentation.max_segment_tokens,
+                context_tokens: self.segmentation.context_tokens,
+            },
+            batch: BatchConfig {
+                enabled: self.batch.enabled,
+                target_tokens: self.batch.target_tokens,
+                max_items: self.batch.max_items,
+                adaptive_sizing: self.batch.adaptive_sizing,
+                split_on_json_failure: self.batch.split_on_json_failure,
+                repair_invalid_items: self.batch.repair_invalid_items,
+            },
+            scheduler: SchedulerConfig {
+                concurrency: self.scheduler.concurrency,
+                max_attempts: self.scheduler.max_attempts,
+            },
+            provider: ProviderRuntimeConfig {
+                timeout_seconds: self.provider.timeout_seconds,
+                provider_max_attempts: self.provider.provider_max_attempts,
+                validation_max_attempts: self.provider.validation_max_attempts,
+                retry_after_policy: self.provider.retry_after_policy,
+                max_backoff_seconds: self.provider.max_backoff_seconds,
+                thinking_disabled: self.provider.thinking_disabled,
+                model_context_tokens: self.provider.model_context_tokens,
+                max_output_tokens: self.provider.max_output_tokens,
+                batch_max_output_tokens: self.provider.batch_max_output_tokens,
+                json_mode: self.provider.json_mode,
+                max_idle_per_host: self.provider.max_idle_per_host,
+            },
+            compact_prompts: self.compact_prompts,
+            retry_failed_only: self.retry_failed_only,
+            adaptive_concurrency: self.adaptive_concurrency,
+            qa: QaRunConfig {
+                concurrency: self.qa.concurrency,
+                batch_target_tokens: self.qa.batch_target_tokens,
+                model: self.qa.model.clone(),
+                provider: self.qa.provider.clone(),
+                base_url: self.qa.base_url.clone(),
+                api_key_env: self.qa.api_key_env.clone(),
+            },
+            double_check: DoubleCheckConfig {
+                mode: self.double_check.mode,
+                model: self.double_check.model.clone(),
+                provider: self.double_check.provider.clone(),
+                base_url: self.double_check.base_url.clone(),
+                api_key_env: self.double_check.api_key_env.clone(),
+                concurrency: self.double_check.concurrency,
+                batch_target_tokens: self.double_check.batch_target_tokens,
+                auto_correct: self.double_check.auto_correct,
+                correction_rounds: self.double_check.correction_rounds,
+            },
+        }
+    }
+}

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1013,7 +1013,7 @@ where
     P: LlmProvider,
     F: FnMut(&SegmentTranslation) -> Result<(), LlmError>,
 {
-    let library = Arc::new(PromptLibrary::embedded());
+    let library = Arc::new(PromptLibrary::global().clone());
     let provider = Arc::new(provider);
     let config = Arc::new(config.clone());
     let concurrency = config.scheduler.concurrency.max(1);
@@ -2444,7 +2444,7 @@ mod tests {
     async fn batch_length_finish_reason_returns_invalid_response() {
         let batch = make_two_item_batch();
         let provider = Arc::new(StubProvider::new(StubBehavior::FinishLength));
-        let library = Arc::new(PromptLibrary::embedded());
+        let library = Arc::new(PromptLibrary::global().clone());
         let config = test_run_config();
 
         let result = translate_one_batch(provider, library, batch, &config).await;
@@ -2462,7 +2462,7 @@ mod tests {
         let provider = Arc::new(StubProvider::new(StubBehavior::ErrInvalid(
             "output was truncated".to_string(),
         )));
-        let library = Arc::new(PromptLibrary::embedded());
+        let library = Arc::new(PromptLibrary::global().clone());
         let config = test_run_config();
 
         let result = translate_one_batch(provider, library, batch, &config).await;

--- a/crates/bookforge-llm/src/double_check.rs
+++ b/crates/bookforge-llm/src/double_check.rs
@@ -102,7 +102,7 @@ where
         return Ok(Vec::new());
     }
 
-    let library = PromptLibrary::embedded();
+    let library = PromptLibrary::global();
     let by_segment = segments
         .iter()
         .map(|s| (s.id.0.as_str(), s))
@@ -143,7 +143,7 @@ where
     let mut all_issues = Vec::new();
     for chunk in &chunks {
         let audit_result =
-            run_audit_chunk(&provider, &library, chunk, config, double_check_config).await?;
+            run_audit_chunk(&provider, library, chunk, config, double_check_config).await?;
         all_issues.extend(audit_result);
     }
 
@@ -168,7 +168,7 @@ where
 
     let mut records = Vec::new();
     for corr_chunk in correction_items.chunks(chunk_size.max(1)) {
-        let corr_results = run_correction_chunk(&provider, &library, corr_chunk, config).await?;
+        let corr_results = run_correction_chunk(&provider, library, corr_chunk, config).await?;
 
         for result in corr_results {
             let valid = validate_correction(&result);

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -425,6 +425,23 @@ mod tests {
     }
 
     #[test]
+    fn prompt_library_global_returns_same_instance() {
+        let first = PromptLibrary::global() as *const PromptLibrary;
+        let second = PromptLibrary::global() as *const PromptLibrary;
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn prompt_library_global_contains_required_templates() {
+        let library = PromptLibrary::global();
+        assert_eq!(library.plain.name, "translate_segment");
+        assert_eq!(library.batch_plain.name, "translate_batch_plain");
+        assert_eq!(library.qa.name, "qa_segment");
+        assert_eq!(library.double_check_batch.name, "double_check_batch");
+        assert_eq!(library.correct_batch.name, "correct_batch");
+    }
+
+    #[test]
     fn compact_batch_prompt_is_shorter_than_standard_prompt() {
         let library = PromptLibrary::embedded();
         let standard = library.batch_plain.system.len() + library.batch_plain.user.len();

--- a/crates/bookforge-llm/src/qa_batch.rs
+++ b/crates/bookforge-llm/src/qa_batch.rs
@@ -28,7 +28,7 @@ pub async fn qa_segments_parallel<P>(
 where
     P: LlmProvider,
 {
-    let library = Arc::new(PromptLibrary::embedded());
+    let library = Arc::new(PromptLibrary::global().clone());
     let provider = Arc::new(provider);
     let semaphore = Arc::new(Semaphore::new(qa_config.concurrency.max(1)));
     let mut tasks = JoinSet::new();

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -169,7 +169,7 @@ where
         ));
     }
 
-    let library = Arc::new(PromptLibrary::embedded());
+    let library = Arc::new(PromptLibrary::global().clone());
     let provider = Arc::new(provider);
     let config = Arc::new(config.clone());
     let semaphore = Arc::new(Semaphore::new(config.scheduler.concurrency));
@@ -221,7 +221,7 @@ pub async fn qa_segments<P>(
 where
     P: LlmProvider,
 {
-    let library = PromptLibrary::embedded();
+    let library = PromptLibrary::global();
     let by_segment = segments
         .iter()
         .map(|segment| (segment.id.0.as_str(), segment))
@@ -235,7 +235,7 @@ where
         let Some(segment) = by_segment.get(translation.segment_id.0.as_str()) else {
             continue;
         };
-        match request_qa(&provider, &library, segment, translation, config).await {
+        match request_qa(&provider, library, segment, translation, config).await {
             Ok(review) => reviews.push(review),
             Err(error) => reviews.push(QaSegmentReview {
                 segment_id: translation.segment_id.clone(),

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -10,5 +10,6 @@ rust-version.workspace = true
 bookforge-core = { path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -418,12 +418,20 @@ impl JobStore {
         self.touch_job(job_id, "succeeded")
     }
 
+    pub fn mark_job_succeeded(&self, job_id: &str) -> Result<()> {
+        self.mark_job_complete(job_id)
+    }
+
     pub fn mark_job_needs_review(&self, job_id: &str) -> Result<()> {
         self.touch_job(job_id, "needs_review")
     }
 
     pub fn mark_job_interrupted(&self, job_id: &str) -> Result<()> {
         self.touch_job(job_id, "interrupted")
+    }
+
+    pub fn mark_job_failed(&self, job_id: &str) -> Result<()> {
+        self.touch_job(job_id, "failed")
     }
 
     pub fn mark_segment_failed(&self, job_id: &str, segment_id: &str, error: &str) -> Result<()> {
@@ -457,6 +465,47 @@ impl JobStore {
         }
         self.touch_job(job_id, "failed")?;
         Ok(())
+    }
+
+    pub fn mark_unfinished_segments_failed(
+        &self,
+        job_id: &str,
+        candidate_segment_ids: &[String],
+        error: &str,
+    ) -> Result<usize> {
+        const SQLITE_IN_CHUNK_SIZE: usize = 900;
+        let mut updated = 0;
+
+        for chunk in candidate_segment_ids.chunks(SQLITE_IN_CHUNK_SIZE) {
+            if chunk.is_empty() {
+                continue;
+            }
+
+            let placeholders = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "UPDATE segments
+                 SET status = 'failed', attempts = attempts + 1, error = ?
+                 WHERE job_id = ?
+                   AND id IN ({placeholders})
+                   AND status NOT IN ('succeeded', 'skipped_cached', 'needs_review')"
+            );
+
+            let conn = self.conn.borrow();
+            let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(chunk.len() + 2);
+            params.push(&error);
+            params.push(&job_id);
+            for id in chunk {
+                params.push(id);
+            }
+            updated += conn.execute(&sql, params.as_slice())?;
+        }
+
+        if updated > 0 {
+            self.touch_job(job_id, "failed")?;
+        }
+        Ok(updated)
     }
 
     pub fn get_job(&self, job_id: &str) -> Result<Option<JobRecord>> {
@@ -1200,6 +1249,117 @@ mod tests {
 
         let _ = fs::remove_file(input_path);
         (store, job, seg)
+    }
+
+    #[test]
+    fn mark_unfinished_segments_failed_preserves_terminal_segments() {
+        let db_path = temp_path("unfinished_preserve.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let segments = vec![
+            segment("seg_succeeded", 0),
+            segment("seg_cached", 1),
+            segment("seg_review", 2),
+            segment("seg_queued", 3),
+            segment("seg_retry", 4),
+        ];
+        store
+            .insert_segments(&job.id, &segments, "v1", "mock", "mock-prefix", "test_ns")
+            .expect("segments should insert");
+        store
+            .save_translation(SaveTranslation {
+                job_id: &job.id,
+                segment_id: "seg_succeeded",
+                translated_text: "Done",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000000".to_string()),
+                    text: "Done".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+                input_tokens: None,
+                output_tokens: None,
+            })
+            .expect("succeeded segment should save");
+        store
+            .save_cached_translation(SaveCachedTranslation {
+                job_id: &job.id,
+                segment_id: "seg_cached",
+                translated_text: "Cached",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000001".to_string()),
+                    text: "Cached".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+            })
+            .expect("cached segment should save");
+        store
+            .save_needs_review(SaveNeedsReview {
+                job_id: &job.id,
+                segment_id: "seg_review",
+                preserved_text: "Needs review",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000002".to_string()),
+                    text: "Needs review".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+                error: "qa issue",
+                input_tokens: None,
+                output_tokens: None,
+            })
+            .expect("needs-review segment should save");
+        store
+            .retry_segments(&job.id, RetryScope::Failed)
+            .expect("retry with no failed segments should be harmless");
+        {
+            let conn = store.conn.borrow();
+            conn.execute(
+                "UPDATE segments SET status = 'retry_pending' WHERE job_id = ?1 AND id = 'seg_retry'",
+                params![job.id],
+            )
+            .expect("test status update should work");
+        }
+
+        let candidate_ids = segments
+            .iter()
+            .map(|segment| segment.id.0.clone())
+            .collect::<Vec<_>>();
+        let changed = store
+            .mark_unfinished_segments_failed(&job.id, &candidate_ids, "run failed")
+            .expect("unfinished segments should be marked failed");
+        assert_eq!(changed, 2);
+
+        let records = store.segment_records(&job.id).expect("records should load");
+        let statuses = records
+            .into_iter()
+            .map(|record| (record.id, record.status))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(statuses["seg_succeeded"], "succeeded");
+        assert_eq!(statuses["seg_cached"], "skipped_cached");
+        assert_eq!(statuses["seg_review"], "needs_review");
+        assert_eq!(statuses["seg_queued"], "failed");
+        assert_eq!(statuses["seg_retry"], "failed");
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
     }
 
     #[test]

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -9,6 +9,7 @@ use std::{
 use bookforge_core::{
     Result as CoreResult,
     ir::BlockId,
+    run_snapshot::RunConfigSnapshot,
     segment::{BlockTranslation, Segment},
 };
 use rusqlite::{Connection, OptionalExtension, params};
@@ -26,6 +27,9 @@ pub enum StoreError {
 
     #[error("core error: {0}")]
     Core(#[from] bookforge_core::BookforgeError),
+
+    #[error("serialization error: {0}")]
+    Serialization(String),
 }
 
 pub struct JobStore {
@@ -46,6 +50,9 @@ pub struct JobRecord {
     pub base_url: Option<String>,
     pub api_key_env: Option<String>,
     pub status: String,
+    pub events_path: Option<PathBuf>,
+    pub report_json_path: Option<PathBuf>,
+    pub report_markdown_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -88,6 +95,16 @@ pub struct StoredBlockTranslation {
     pub segment_id: String,
     pub block_id: String,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredSegmentTranslation {
+    pub segment_id: String,
+    pub ordinal: usize,
+    pub status: String,
+    pub error: Option<String>,
+    pub translated_text: String,
+    pub blocks: Vec<BlockTranslation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -272,7 +289,105 @@ impl JobStore {
             base_url: request.base_url.map(ToOwned::to_owned),
             api_key_env: request.api_key_env.map(ToOwned::to_owned),
             status: "running".to_string(),
+            events_path: None,
+            report_json_path: None,
+            report_markdown_path: None,
         })
+    }
+
+    pub fn update_job_config_snapshot(
+        &self,
+        job_id: &str,
+        snapshot: &RunConfigSnapshot,
+    ) -> Result<()> {
+        let json = serde_json::to_string(snapshot)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let conn = self.conn.borrow();
+        conn.execute(
+            "UPDATE jobs
+             SET config_json = ?1,
+                 events_path = ?2,
+                 report_json_path = ?3,
+                 report_markdown_path = ?4,
+                 updated_at = ?5
+             WHERE id = ?6",
+            params![
+                json,
+                snapshot
+                    .events_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                snapshot
+                    .report_json_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                snapshot
+                    .report_markdown_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                timestamp_string(),
+                job_id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn load_job_config_snapshot(&self, job_id: &str) -> Result<Option<RunConfigSnapshot>> {
+        let conn = self.conn.borrow();
+        let Some(json) = conn
+            .query_row(
+                "SELECT config_json FROM jobs WHERE id = ?1",
+                params![job_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten()
+        else {
+            return Ok(None);
+        };
+
+        serde_json::from_str(&json)
+            .map(Some)
+            .map_err(|e| StoreError::Serialization(e.to_string()))
+    }
+
+    pub fn update_job_event_path(&self, job_id: &str, path: &Path) -> Result<()> {
+        let conn = self.conn.borrow();
+        conn.execute(
+            "UPDATE jobs SET events_path = ?1, updated_at = ?2 WHERE id = ?3",
+            params![path.to_string_lossy(), timestamp_string(), job_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_job_report_paths(
+        &self,
+        job_id: &str,
+        json_path: &Path,
+        markdown_path: &Path,
+    ) -> Result<()> {
+        let conn = self.conn.borrow();
+        conn.execute(
+            "UPDATE jobs
+             SET report_json_path = ?1, report_markdown_path = ?2, updated_at = ?3
+             WHERE id = ?4",
+            params![
+                json_path.to_string_lossy(),
+                markdown_path.to_string_lossy(),
+                timestamp_string(),
+                job_id
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_job_output_path(&self, job_id: &str, path: &Path) -> Result<()> {
+        let conn = self.conn.borrow();
+        conn.execute(
+            "UPDATE jobs SET output_path = ?1, updated_at = ?2 WHERE id = ?3",
+            params![path.to_string_lossy(), timestamp_string(), job_id],
+        )?;
+        Ok(())
     }
 
     pub fn insert_segments(
@@ -418,6 +533,10 @@ impl JobStore {
         self.touch_job(job_id, "succeeded")
     }
 
+    pub fn mark_job_running(&self, job_id: &str) -> Result<()> {
+        self.touch_job(job_id, "running")
+    }
+
     pub fn mark_job_succeeded(&self, job_id: &str) -> Result<()> {
         self.mark_job_complete(job_id)
     }
@@ -511,7 +630,8 @@ impl JobStore {
     pub fn get_job(&self, job_id: &str) -> Result<Option<JobRecord>> {
         let conn = self.conn.borrow();
         conn.query_row(
-            "SELECT id, input_path, output_path, input_hash, source_lang, target_lang, provider, model, base_url, api_key_env, status
+            "SELECT id, input_path, output_path, input_hash, source_lang, target_lang, provider, model, base_url, api_key_env, status,
+                    events_path, report_json_path, report_markdown_path
              FROM jobs WHERE id = ?1",
             params![job_id],
             |row| {
@@ -527,6 +647,9 @@ impl JobStore {
                     base_url: row.get(8)?,
                     api_key_env: row.get(9)?,
                     status: row.get(10)?,
+                    events_path: row.get::<_, Option<String>>(11)?.map(PathBuf::from),
+                    report_json_path: row.get::<_, Option<String>>(12)?.map(PathBuf::from),
+                    report_markdown_path: row.get::<_, Option<String>>(13)?.map(PathBuf::from),
                 })
             },
         )
@@ -642,6 +765,70 @@ impl JobStore {
                 text: row.get(2)?,
             })
         })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn load_terminal_segment_translations(
+        &self,
+        job_id: &str,
+    ) -> Result<Vec<StoredSegmentTranslation>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.ordinal, s.status, s.error, t.translated_text
+             FROM segments s
+             JOIN translations t ON t.job_id = s.job_id AND t.segment_id = s.id
+             WHERE s.job_id = ?1 AND s.status IN ('succeeded', 'skipped_cached', 'needs_review')
+             ORDER BY s.ordinal",
+        )?;
+        let rows = stmt.query_map(params![job_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })?;
+
+        let mut records = Vec::new();
+        for row in rows {
+            let (segment_id, ordinal, status, error, translated_text) = row?;
+            let mut block_stmt = conn.prepare(
+                "SELECT block_id, translated_text
+                 FROM translation_blocks
+                 WHERE job_id = ?1 AND segment_id = ?2
+                 ORDER BY block_id",
+            )?;
+            let blocks = block_stmt
+                .query_map(params![job_id, segment_id.as_str()], |row| {
+                    Ok(BlockTranslation {
+                        block_id: BlockId(row.get::<_, String>(0)?),
+                        text: row.get(1)?,
+                    })
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            records.push(StoredSegmentTranslation {
+                segment_id,
+                ordinal: ordinal as usize,
+                status,
+                error,
+                translated_text,
+                blocks,
+            });
+        }
+
+        Ok(records)
+    }
+
+    pub fn resumable_segment_ids(&self, job_id: &str) -> Result<Vec<String>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id FROM segments
+             WHERE job_id = ?1 AND status IN ('queued', 'retry_pending', 'failed')
+             ORDER BY ordinal",
+        )?;
+        let rows = stmt.query_map(params![job_id], |row| row.get::<_, String>(0))?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(StoreError::from)
     }
@@ -885,6 +1072,10 @@ impl JobStore {
               base_url TEXT,
               api_key_env TEXT,
               status TEXT NOT NULL,
+              config_json TEXT,
+              events_path TEXT,
+              report_json_path TEXT,
+              report_markdown_path TEXT,
               created_at TEXT NOT NULL,
               updated_at TEXT NOT NULL
             );
@@ -945,6 +1136,10 @@ impl JobStore {
         ensure_column(&conn, "jobs", "output_path", "TEXT NOT NULL DEFAULT ''")?;
         ensure_column(&conn, "jobs", "base_url", "TEXT")?;
         ensure_column(&conn, "jobs", "api_key_env", "TEXT")?;
+        ensure_column(&conn, "jobs", "config_json", "TEXT")?;
+        ensure_column(&conn, "jobs", "events_path", "TEXT")?;
+        ensure_column(&conn, "jobs", "report_json_path", "TEXT")?;
+        ensure_column(&conn, "jobs", "report_markdown_path", "TEXT")?;
         ensure_column(
             &conn,
             "segments",
@@ -1249,6 +1444,170 @@ mod tests {
 
         let _ = fs::remove_file(input_path);
         (store, job, seg)
+    }
+
+    #[test]
+    fn snapshot_round_trips_and_excludes_api_key_values() {
+        let db_path = temp_path("snapshot.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "openrouter",
+                model: "model",
+                base_url: Some("https://example.test/v1"),
+                api_key_env: Some("OPENROUTER_API_KEY"),
+            })
+            .expect("job should be created");
+        let settings = bookforge_core::TranslationProfile::Balanced.resolve();
+        let snapshot = RunConfigSnapshot {
+            input_path: input_path.clone(),
+            output_path: temp_path("translated.epub"),
+            events_path: Some(temp_path("events.jsonl")),
+            report_json_path: Some(temp_path("report.json")),
+            report_markdown_path: Some(temp_path("report.md")),
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "openrouter".to_string(),
+            model: "model".to_string(),
+            base_url: Some("https://example.test/v1".to_string()),
+            api_key_env: Some("OPENROUTER_API_KEY".to_string()),
+            profile: settings.profile,
+            provider_preset: None,
+            prompt_version: "batch_v1".to_string(),
+            cache_namespace: "cache_ns".to_string(),
+            settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+        };
+
+        store
+            .update_job_config_snapshot(&job.id, &snapshot)
+            .expect("snapshot should persist");
+        let loaded = store
+            .load_job_config_snapshot(&job.id)
+            .expect("snapshot should load")
+            .expect("snapshot should exist");
+        assert_eq!(loaded, snapshot);
+        let json = serde_json::to_string(&loaded).expect("snapshot should serialize");
+        assert!(json.contains("OPENROUTER_API_KEY"));
+        assert!(!json.contains("sk-live-secret"));
+
+        let reloaded_job = store
+            .get_job(&job.id)
+            .expect("job should load")
+            .expect("job should exist");
+        assert_eq!(reloaded_job.events_path, snapshot.events_path);
+        assert_eq!(reloaded_job.report_json_path, snapshot.report_json_path);
+        assert_eq!(
+            reloaded_job.report_markdown_path,
+            snapshot.report_markdown_path
+        );
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn terminal_loading_and_resumable_ids_preserve_lifecycle_boundaries() {
+        let db_path = temp_path("terminal_resume.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let segments = vec![
+            segment("seg_done", 0),
+            segment("seg_cached", 1),
+            segment("seg_review", 2),
+            segment("seg_failed", 3),
+            segment("seg_queued", 4),
+        ];
+        store
+            .insert_segments(&job.id, &segments, "v1", "mock", "mock-prefix", "ns")
+            .expect("segments should insert");
+        store
+            .save_translation(SaveTranslation {
+                job_id: &job.id,
+                segment_id: "seg_done",
+                translated_text: "Done",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000000".to_string()),
+                    text: "Done".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+                input_tokens: None,
+                output_tokens: None,
+            })
+            .expect("done should save");
+        store
+            .save_cached_translation(SaveCachedTranslation {
+                job_id: &job.id,
+                segment_id: "seg_cached",
+                translated_text: "Cached",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000001".to_string()),
+                    text: "Cached".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+            })
+            .expect("cached should save");
+        store
+            .save_needs_review(SaveNeedsReview {
+                job_id: &job.id,
+                segment_id: "seg_review",
+                preserved_text: "Review",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000002".to_string()),
+                    text: "Review".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+                error: "needs eyes",
+                input_tokens: None,
+                output_tokens: None,
+            })
+            .expect("review should save");
+        store
+            .mark_segment_failed(&job.id, "seg_failed", "failed")
+            .expect("failed should mark");
+
+        let terminal = store
+            .load_terminal_segment_translations(&job.id)
+            .expect("terminal records should load");
+        let ids = terminal
+            .iter()
+            .map(|record| record.segment_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["seg_done", "seg_cached", "seg_review"]);
+        assert_eq!(terminal[0].blocks[0].block_id.0, "b_000000");
+        assert_eq!(terminal[2].status, "needs_review");
+
+        let resumable = store
+            .resumable_segment_ids(&job.id)
+            .expect("resumable ids should load");
+        assert_eq!(resumable, vec!["seg_failed", "seg_queued"]);
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
     }
 
     #[test]

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,39 @@
+# Benchmarks
+
+BookForge benchmarks should record both wall-clock time and the event-log counters that explain the run.
+
+## Mock Smoke Benchmark
+
+Use the deterministic mock provider to verify the release path without network access:
+
+```bash
+scripts/bench-mock.sh
+```
+
+The script writes:
+
+```txt
+/tmp/bookforge-bench-events.jsonl
+/tmp/bookforge-bench.epub
+```
+
+By default the script uses `tests/fixtures/tiny.epub`, or `test/test.epub` when present in a local ignored workspace. Set `BOOKFORGE_BENCH_INPUT` to point at any tiny local EPUB fixture. Optional overrides:
+
+```bash
+BOOKFORGE_BENCH_EVENTS=/tmp/events.jsonl
+BOOKFORGE_BENCH_OUTPUT=/tmp/output.epub
+```
+
+## Metrics To Capture
+
+For provider benchmarks, capture:
+
+- elapsed time
+- request count
+- p50 and p95 latency
+- 429s, timeouts, invalid JSON, and truncations
+- input/output tokens
+- tokens per minute and blocks per minute
+- batch split count and repair count
+
+Real-provider scripts must require API keys through environment variables and must not print key values.

--- a/scripts/bench-mock.sh
+++ b/scripts/bench-mock.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EVENTS_PATH="${BOOKFORGE_BENCH_EVENTS:-/tmp/bookforge-bench-events.jsonl}"
+OUTPUT_PATH="${BOOKFORGE_BENCH_OUTPUT:-/tmp/bookforge-bench.epub}"
+DEFAULT_INPUT="${ROOT_DIR}/tests/fixtures/tiny.epub"
+if [[ ! -f "${DEFAULT_INPUT}" && -f "${ROOT_DIR}/test/test.epub" ]]; then
+  DEFAULT_INPUT="${ROOT_DIR}/test/test.epub"
+fi
+INPUT_PATH="${BOOKFORGE_BENCH_INPUT:-${DEFAULT_INPUT}}"
+
+if [[ ! -f "${INPUT_PATH}" ]]; then
+  echo "Missing benchmark input: ${INPUT_PATH}" >&2
+  echo "Set BOOKFORGE_BENCH_INPUT to a tiny EPUB fixture." >&2
+  exit 1
+fi
+
+rm -f "${EVENTS_PATH}" "${OUTPUT_PATH}"
+
+start_ms="$(date +%s%3N)"
+cargo run --release -p bookforge-cli -- translate "${INPUT_PATH}" \
+  --target Italian \
+  --provider mock \
+  --model mock-prefix-target \
+  --profile v1-fast \
+  --ui quiet \
+  --progress-jsonl "${EVENTS_PATH}" \
+  --out "${OUTPUT_PATH}"
+end_ms="$(date +%s%3N)"
+
+elapsed_ms="$((end_ms - start_ms))"
+if [[ -f "${EVENTS_PATH}" ]]; then
+  requests="$(grep -c 'RequestFinished' "${EVENTS_PATH}" || true)"
+  segments="$(grep -c 'SegmentFinished' "${EVENTS_PATH}" || true)"
+  events_note="${EVENTS_PATH}"
+else
+  requests="0"
+  segments="0"
+  events_note="${EVENTS_PATH} (not created)"
+fi
+
+echo "Elapsed ms: ${elapsed_ms}"
+echo "Requests: ${requests}"
+echo "Segments: ${segments}"
+echo "Events: ${events_note}"
+echo "Output: ${OUTPUT_PATH}"


### PR DESCRIPTION
## Summary

PR4 lifecycle hardening with limited supporting cleanup. This PR now focuses on durable run lifecycle behavior rather than claiming full PR5/PR6 completion.

- persist run configuration snapshots for translate jobs, including resolved segmentation, scheduler, provider/runtime, QA, double-check, prompt version, cache namespace, and artifact paths
- store event/output/report artifact metadata directly on jobs for reliable status/tail lookup
- make resume snapshot-driven, with optional runtime overrides, cache namespace validation, and default skipping of needs-review segments
- improve status artifact resolution, resume/review guidance, and event-derived performance output
- improve tail with `--last`, `--lines` alias, `--json`, and snapshot/stored event path resolution
- add report performance sections and focused store lifecycle tests
- keep the existing translate module cleanup and benchmark support without expanding deeper PR5/PR6 refactors

## Verification

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `scripts/bench-mock.sh`

Note: the full test suite needs localhost binding permission for `provider::tests::json_mode_auto_fallback_works_with_one_provider_attempt`; it passes when rerun with that permission.