### PR TITLE
test: lock v1 lifecycle resume/status/tail behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +167,7 @@ name = "bookforge-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "bookforge-core",
  "bookforge-epub",
  "bookforge-llm",
@@ -161,6 +177,7 @@ dependencies = [
  "indicatif",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -234,6 +251,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -443,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +531,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -958,6 +998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1156,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1317,6 +1390,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1543,6 +1629,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1855,6 +1960,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -25,3 +25,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+assert_cmd = "2"
+tempfile = "3"

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -71,12 +71,7 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     let Some(job) = store.get_job(&args.job_id)? else {
         anyhow::bail!("job '{}' was not found", args.job_id);
     };
-    let Some(mut snapshot) = store.load_job_config_snapshot(&args.job_id)? else {
-        anyhow::bail!(
-            "job '{}' does not have a run configuration snapshot; it cannot be resumed deterministically",
-            args.job_id
-        );
-    };
+    let mut snapshot = load_resume_snapshot(&store, &args.job_id)?;
 
     let progress_jsonl = args
         .progress_jsonl
@@ -91,6 +86,16 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
 
     let run_result = run_inner(args, store, job, &mut snapshot, progress).await;
     finalize_reporter(run_result, reporter).await
+}
+
+fn load_resume_snapshot(store: &JobStore, job_id: &str) -> Result<RunConfigSnapshot> {
+    let Some(snapshot) = store.load_job_config_snapshot(job_id)? else {
+        anyhow::bail!(
+            "job '{}' does not have a run configuration snapshot; it cannot be resumed deterministically",
+            job_id
+        );
+    };
+    Ok(snapshot)
 }
 
 async fn finalize_reporter<T>(
@@ -190,11 +195,14 @@ async fn run_inner(
     let segments = build_segments(&book, &settings.segmentation)?;
     let pending_ids = store.resumable_segment_ids(&job.id)?;
 
-    println!("Job: {}", job.id);
-    println!("Input: {}", input.display());
-    println!("Output: {}", output.display());
-    println!("Provider: {}", job.provider);
-    println!("Pending: {}", pending_ids.len());
+    let print_stdout = human_stdout_enabled(args.ui);
+    if print_stdout {
+        println!("Job: {}", job.id);
+        println!("Input: {}", input.display());
+        println!("Output: {}", output.display());
+        println!("Provider: {}", job.provider);
+        println!("Pending: {}", pending_ids.len());
+    }
 
     let pending_segments = select_pending_segments(&segments, &pending_ids)?;
     let prompt_version = snapshot.prompt_version.as_str();
@@ -398,28 +406,37 @@ async fn run_inner(
         timestamp_ms: now_ms(),
     });
 
-    println!(
-        "Translated: {}/{} segments",
-        summary.succeeded, summary.total_segments
-    );
-    println!("Cached: {}", summary.cached);
-    println!("Retried: {}", summary.retried);
-    println!("Needs review: {}", summary.needs_review);
-    println!("Failed: {}", summary.failed);
-    println!("Input tokens: {}", summary.input_tokens);
-    println!("Output tokens: {}", summary.output_tokens);
-    if let Some(cost) = estimate_cost_usd(
-        &job.provider,
-        &job.model,
-        summary.input_tokens,
-        summary.output_tokens,
-    ) {
-        println!("Estimated cost: ${cost:.6}");
+    if print_stdout {
+        println!(
+            "Translated: {}/{} segments",
+            summary.succeeded, summary.total_segments
+        );
+        println!("Cached: {}", summary.cached);
+        println!("Retried: {}", summary.retried);
+        println!("Needs review: {}", summary.needs_review);
+        println!("Failed: {}", summary.failed);
+        println!("Input tokens: {}", summary.input_tokens);
+        println!("Output tokens: {}", summary.output_tokens);
+        if let Some(cost) = estimate_cost_usd(
+            &job.provider,
+            &job.model,
+            summary.input_tokens,
+            summary.output_tokens,
+        ) {
+            println!("Estimated cost: ${cost:.6}");
+        }
+        println!("Output: {}", output.display());
+        println!("Report: {}", report.markdown.display());
     }
-    println!("Output: {}", output.display());
-    println!("Report: {}", report.markdown.display());
 
     Ok(())
+}
+
+fn human_stdout_enabled(ui: Option<crate::progress::UiMode>) -> bool {
+    !matches!(
+        ui,
+        Some(crate::progress::UiMode::Json | crate::progress::UiMode::Quiet)
+    )
 }
 
 fn select_pending_segments(segments: &[Segment], pending_ids: &[String]) -> Result<Vec<Segment>> {
@@ -709,5 +726,513 @@ fn segment_status(status: &str) -> SegmentStatus {
         "needs_review" => SegmentStatus::NeedsReview,
         "failed" => SegmentStatus::Failed,
         _ => SegmentStatus::Succeeded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bookforge_core::{
+        JsonMode, TranslationProfile,
+        ir::{BlockId, SectionId},
+        segment::{
+            SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
+            SegmentSource, SegmentTextRun,
+        },
+    };
+    use bookforge_store::{CreateJob, SaveNeedsReview, SaveTranslation};
+    use std::sync::Mutex;
+
+    struct RecordingSink {
+        events: Arc<Mutex<Vec<ProgressEvent>>>,
+    }
+
+    impl ProgressSink for RecordingSink {
+        fn emit(&self, event: ProgressEvent) {
+            self.events.lock().expect("events lock").push(event);
+        }
+    }
+
+    struct ResumeFixture {
+        _tempdir: tempfile::TempDir,
+        store: JobStore,
+        job: JobRecord,
+        snapshot: RunConfigSnapshot,
+        segments: Vec<Segment>,
+    }
+
+    #[tokio::test]
+    async fn resume_uses_snapshot_segmentation_settings() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        settings.segmentation.max_segment_tokens = 1377;
+        settings.segmentation.context_tokens = 77;
+        let mut fixture = resume_fixture(settings, 1);
+
+        run_fixture(&mut fixture)
+            .await
+            .expect("resume should use snapshot segmentation settings");
+
+        let summary = fixture
+            .store
+            .summary(&fixture.job.id)
+            .expect("summary should load")
+            .expect("job should exist");
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.succeeded, 1);
+    }
+
+    #[tokio::test]
+    async fn resume_uses_snapshot_profile_and_compact_prompt_settings() {
+        let mut settings = TranslationProfile::Safe.resolve();
+        settings.batch.enabled = false;
+        settings.compact_prompts = true;
+        let mut fixture = resume_fixture(settings, 1);
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("resume should succeed");
+        let runtime = runtime_config_event(&events);
+
+        assert_eq!(runtime.profile, "Safe");
+        assert!(runtime.compact_prompts);
+    }
+
+    #[tokio::test]
+    async fn resume_uses_snapshot_provider_json_mode_and_attempts() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        settings.provider.json_mode = JsonMode::PromptOnly;
+        settings.provider.provider_max_attempts = 4;
+        let mut fixture = resume_fixture(settings.clone(), 1);
+
+        let config = openai_compatible_config_from_parts(
+            "openrouter",
+            "snapshot-model",
+            Some("https://snapshot.example/v1"),
+            Some("SNAPSHOT_API_KEY"),
+            &fixture.job.id,
+            &settings,
+        )
+        .expect("provider config should build from snapshot settings");
+        assert_eq!(config.json_mode, JsonMode::PromptOnly);
+        assert_eq!(config.provider_max_attempts, 4);
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("resume should succeed");
+        let runtime = runtime_config_event(&events);
+        assert_eq!(runtime.json_mode, "PromptOnly");
+        assert_eq!(runtime.provider_max_attempts, 4);
+    }
+
+    #[tokio::test]
+    async fn resume_missing_config_snapshot_fails_clearly() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let input = fixture_input();
+        let output = tempdir.path().join("out.epub");
+        let store = JobStore::open(tempdir.path().join("jobs.sqlite")).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input,
+                output: &output,
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix-target",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+
+        let error = load_resume_snapshot(&store, &job.id)
+            .expect_err("missing snapshot should fail clearly");
+
+        assert!(error.to_string().contains("run configuration snapshot"));
+        assert!(
+            error
+                .to_string()
+                .contains("cannot be resumed deterministically")
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_reuses_checkpointed_segments_and_translates_only_resumable_segments() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        let mut fixture = resume_fixture(settings, 2);
+        save_succeeded(
+            &fixture.store,
+            &fixture.job.id,
+            &fixture.segments[0],
+            "stored",
+        );
+        fixture
+            .store
+            .mark_segment_failed(&fixture.job.id, &fixture.segments[1].id.0, "retry")
+            .expect("segment should be failed");
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("resume should succeed");
+        let finished = segment_finished_ids(&events);
+
+        assert_eq!(finished, vec![fixture.segments[1].id.0.clone()]);
+        let summary = fixture
+            .store
+            .summary(&fixture.job.id)
+            .expect("summary should load")
+            .expect("job should exist");
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn resume_skips_needs_review_by_default() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        let mut fixture = resume_fixture(settings, 2);
+        for segment in &fixture.segments {
+            save_needs_review(&fixture.store, &fixture.job.id, segment);
+        }
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("resume should succeed without retrying needs-review segments");
+
+        assert!(segment_finished_ids(&events).is_empty());
+        let summary = fixture
+            .store
+            .summary(&fixture.job.id)
+            .expect("summary should load")
+            .expect("job should exist");
+        assert_eq!(summary.needs_review, 2);
+        assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn resume_rebuilds_output_from_stored_and_fresh_translations_in_original_order() {
+        let segments = vec![
+            test_segment("seg_a", 0),
+            test_segment("seg_b", 1),
+            test_segment("seg_c", 2),
+        ];
+        let stored = vec![
+            StoredBlockTranslation {
+                segment_id: "seg_c".to_string(),
+                block_id: "b_000002".to_string(),
+                text: "stored c".to_string(),
+            },
+            StoredBlockTranslation {
+                segment_id: "seg_a".to_string(),
+                block_id: "b_000000".to_string(),
+                text: "stored a".to_string(),
+            },
+        ];
+        let fresh = vec![bookforge_llm::SegmentTranslation {
+            segment_id: SegmentId("seg_b".to_string()),
+            ordinal: 1,
+            block_ids: vec![BlockId("b_000001".to_string())],
+            blocks: vec![BlockTranslation {
+                block_id: BlockId("b_000001".to_string()),
+                text: "fresh b".to_string(),
+            }],
+            checksum: "checksum_1".to_string(),
+            status: SegmentStatus::Succeeded,
+            template: "mock".to_string(),
+            error: None,
+            input_tokens: None,
+            output_tokens: None,
+        }];
+
+        let rebuilt = rebuild_block_translations(&segments, &stored, &fresh);
+        let texts = rebuilt
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(texts, vec!["stored a", "fresh b", "stored c"]);
+    }
+
+    #[tokio::test]
+    async fn resume_errors_on_cache_namespace_mismatch() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        let mut fixture = resume_fixture(settings, 1);
+        fixture.snapshot.cache_namespace = "wrong-cache-namespace".to_string();
+
+        let error = run_fixture(&mut fixture)
+            .await
+            .expect_err("cache namespace mismatch should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("resume cache namespace mismatch")
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_errors_when_rebuilt_segments_do_not_match_stored_pending_ids() {
+        let segments = vec![test_segment("seg_a", 0)];
+        let pending_ids = vec!["seg_missing".to_string()];
+
+        let error = select_pending_segments(&segments, &pending_ids)
+            .expect_err("missing pending IDs should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("segment IDs that no longer exist")
+        );
+        assert!(error.to_string().contains("seg_missing"));
+    }
+
+    fn resume_fixture(settings: ResolvedRunSettings, segment_count: usize) -> ResumeFixture {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let input = fixture_input();
+        let output = tempdir.path().join("translated.epub");
+        let events = tempdir.path().join("events.jsonl");
+        let store = JobStore::open(tempdir.path().join("jobs.sqlite")).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input,
+                output: &output,
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix-target",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let book = read_epub(&input).expect("fixture EPUB should read");
+        let all_segments =
+            build_segments(&book, &settings.segmentation).expect("segments should build");
+        assert!(
+            all_segments.len() >= segment_count,
+            "fixture should have enough segments"
+        );
+        let segments = all_segments
+            .into_iter()
+            .take(segment_count)
+            .collect::<Vec<_>>();
+        let prompt_version = "v1";
+        let cache_namespace = compute_cache_namespace(
+            settings.segmentation.max_segment_tokens,
+            settings.segmentation.context_tokens,
+            settings.profile.namespace_str(),
+            settings.batch.enabled,
+            prompt_version,
+        );
+        store
+            .insert_segments(
+                &job.id,
+                &segments,
+                prompt_version,
+                "mock",
+                "mock-prefix-target",
+                &cache_namespace,
+            )
+            .expect("segments should insert");
+        let snapshot = RunConfigSnapshot {
+            input_path: input,
+            output_path: output,
+            events_path: Some(events),
+            report_json_path: None,
+            report_markdown_path: None,
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock-prefix-target".to_string(),
+            base_url: None,
+            api_key_env: None,
+            profile: settings.profile,
+            provider_preset: None,
+            prompt_version: prompt_version.to_string(),
+            cache_namespace,
+            settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+        };
+        store
+            .update_job_config_snapshot(&job.id, &snapshot)
+            .expect("snapshot should persist");
+
+        ResumeFixture {
+            _tempdir: tempdir,
+            store,
+            job,
+            snapshot,
+            segments,
+        }
+    }
+
+    async fn run_fixture(fixture: &mut ResumeFixture) -> Result<Vec<ProgressEvent>> {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::new(RecordingSink {
+            events: events.clone(),
+        });
+        let run_store = JobStore::open(fixture.store.path()).expect("store should reopen");
+        let args = ResumeArgs {
+            job_id: fixture.job.id.clone(),
+            concurrency: None,
+            max_attempts: None,
+            provider_max_attempts: None,
+            validation_max_attempts: None,
+            qa: QaMode::Off,
+            timeout_seconds: None,
+            ui: None,
+            progress_jsonl: None,
+            output: None,
+            no_thinking: false,
+        };
+
+        run_inner(
+            args,
+            run_store,
+            fixture.job.clone(),
+            &mut fixture.snapshot,
+            sink,
+        )
+        .await?;
+
+        Ok(events.lock().expect("events lock").clone())
+    }
+
+    fn runtime_config_event(events: &[ProgressEvent]) -> RuntimeConfigEvent<'_> {
+        events
+            .iter()
+            .find_map(|event| {
+                if let ProgressEvent::RuntimeConfigResolved {
+                    profile,
+                    provider_max_attempts,
+                    compact_prompts,
+                    json_mode,
+                    ..
+                } = event
+                {
+                    Some(RuntimeConfigEvent {
+                        profile,
+                        provider_max_attempts: *provider_max_attempts,
+                        compact_prompts: *compact_prompts,
+                        json_mode,
+                    })
+                } else {
+                    None
+                }
+            })
+            .expect("runtime config event should be emitted")
+    }
+
+    struct RuntimeConfigEvent<'a> {
+        profile: &'a str,
+        provider_max_attempts: usize,
+        compact_prompts: bool,
+        json_mode: &'a str,
+    }
+
+    fn segment_finished_ids(events: &[ProgressEvent]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|event| {
+                if let ProgressEvent::SegmentFinished { segment_id, .. } = event {
+                    Some(segment_id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn save_succeeded(store: &JobStore, job_id: &str, segment: &Segment, prefix: &str) {
+        let blocks = translated_blocks(segment, prefix);
+        let translated_text = blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        store
+            .save_translation(SaveTranslation {
+                job_id,
+                segment_id: &segment.id.0,
+                translated_text: &translated_text,
+                blocks: &blocks,
+                provider: "mock",
+                model: "mock-prefix-target",
+                prompt_version: "v1",
+                input_tokens: Some(1),
+                output_tokens: Some(1),
+            })
+            .expect("translation should save");
+    }
+
+    fn save_needs_review(store: &JobStore, job_id: &str, segment: &Segment) {
+        let blocks = translated_blocks(segment, "review");
+        let preserved_text = blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        store
+            .save_needs_review(SaveNeedsReview {
+                job_id,
+                segment_id: &segment.id.0,
+                preserved_text: &preserved_text,
+                blocks: &blocks,
+                provider: "mock",
+                model: "mock-prefix-target",
+                prompt_version: "v1",
+                error: "manual review",
+                input_tokens: Some(1),
+                output_tokens: Some(1),
+            })
+            .expect("needs-review translation should save");
+    }
+
+    fn translated_blocks(segment: &Segment, prefix: &str) -> Vec<BlockTranslation> {
+        segment
+            .source
+            .blocks
+            .iter()
+            .map(|block| BlockTranslation {
+                block_id: block.block_id.clone(),
+                text: format!("{prefix} {}", block.block_id.0),
+            })
+            .collect()
+    }
+
+    fn fixture_input() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("cli crate should be under crates/bookforge-cli")
+            .join("test/test.epub")
+    }
+
+    fn test_segment(id: &str, ordinal: usize) -> Segment {
+        let block_id = BlockId(format!("b_{ordinal:06}"));
+        Segment {
+            id: SegmentId(id.to_string()),
+            section_id: SectionId("sec_000000".to_string()),
+            ordinal,
+            block_ids: vec![block_id.clone()],
+            source: SegmentSource {
+                text: format!("Source {ordinal}"),
+                blocks: vec![SegmentBlock {
+                    block_id,
+                    kind: "paragraph".to_string(),
+                    text: format!("Source {ordinal}"),
+                    text_runs: vec![SegmentTextRun {
+                        id: format!("r{ordinal}"),
+                        text: format!("Source {ordinal}"),
+                    }],
+                    protected_spans: Vec::new(),
+                }],
+                token_estimate: 2,
+            },
+            context: SegmentContext::default(),
+            metadata: SegmentMetadata::default(),
+            constraints: SegmentConstraints::default(),
+            checksum: format!("checksum_{ordinal}"),
+        }
     }
 }

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -1,6 +1,9 @@
 use clap::Args;
 
-use bookforge_store::JobStore;
+use std::path::PathBuf;
+
+use bookforge_core::RunConfigSnapshot;
+use bookforge_store::{JobRecord, JobStore, JobSummary};
 
 use crate::{
     performance::{RunPerformanceSummary, performance_summary_from_events},
@@ -54,30 +57,11 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     println!();
     println!("Retried segments: {}", summary.retried);
 
-    let event_log_path = job
-        .events_path
-        .clone()
-        .or_else(|| {
-            snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.events_path.clone())
-        })
-        .unwrap_or_else(|| {
-            std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id))
-        });
+    let event_log_path = event_log_path_for_status(&job, snapshot.as_ref(), &args.job_id);
     if event_log_path.exists() {
         println!("Event log: {}", event_log_path.display());
     }
-    let fallback_reports = report_paths(&job.output_path);
-    let report_path = job
-        .report_markdown_path
-        .clone()
-        .or_else(|| {
-            snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.report_markdown_path.clone())
-        })
-        .unwrap_or(fallback_reports.markdown);
+    let report_path = report_path_for_status(&job, snapshot.as_ref());
     if report_path.exists() {
         println!("Report: {}", report_path.display());
     }
@@ -89,15 +73,52 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
         None => println!("  unavailable: no event log found"),
     }
 
-    if summary.failed > 0 || summary.retry_pending > 0 || summary.status == "interrupted" {
-        println!("Resume: bookforge resume {}", args.job_id);
-    } else if summary.needs_review > 0 {
-        println!(
-            "Review: segments need manual review; default resume skips needs-review segments."
-        );
+    match guidance_for_summary(&summary) {
+        Some(StatusGuidance::Resume) => println!("Resume: bookforge resume {}", args.job_id),
+        Some(StatusGuidance::Review) => {
+            println!(
+                "Review: segments need manual review; default resume skips needs-review segments."
+            );
+        }
+        None => {}
     }
 
     Ok(())
+}
+
+fn event_log_path_for_status(
+    job: &JobRecord,
+    snapshot: Option<&RunConfigSnapshot>,
+    job_id: &str,
+) -> PathBuf {
+    job.events_path
+        .clone()
+        .or_else(|| snapshot.and_then(|snapshot| snapshot.events_path.clone()))
+        .unwrap_or_else(|| PathBuf::from(format!(".bookforge/runs/{job_id}/events.jsonl")))
+}
+
+fn report_path_for_status(job: &JobRecord, snapshot: Option<&RunConfigSnapshot>) -> PathBuf {
+    let fallback_reports = report_paths(&job.output_path);
+    job.report_markdown_path
+        .clone()
+        .or_else(|| snapshot.and_then(|snapshot| snapshot.report_markdown_path.clone()))
+        .unwrap_or(fallback_reports.markdown)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatusGuidance {
+    Resume,
+    Review,
+}
+
+fn guidance_for_summary(summary: &JobSummary) -> Option<StatusGuidance> {
+    if summary.failed > 0 || summary.retry_pending > 0 || summary.status == "interrupted" {
+        Some(StatusGuidance::Resume)
+    } else if summary.needs_review > 0 {
+        Some(StatusGuidance::Review)
+    } else {
+        None
+    }
 }
 
 fn print_performance(perf: &RunPerformanceSummary) {
@@ -128,4 +149,122 @@ fn fmt_opt(value: Option<u64>) -> String {
     value
         .map(|value| value.to_string())
         .unwrap_or_else(|| "n/a".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job() -> JobRecord {
+        JobRecord {
+            id: "job_test".to_string(),
+            input_path: PathBuf::from("input.epub"),
+            output_path: PathBuf::from("/tmp/bookforge-status/out.epub"),
+            input_hash: "hash".to_string(),
+            source_lang: Some("English".to_string()),
+            target_lang: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock-prefix-target".to_string(),
+            base_url: None,
+            api_key_env: None,
+            status: "succeeded".to_string(),
+            events_path: None,
+            report_json_path: None,
+            report_markdown_path: None,
+        }
+    }
+
+    fn snapshot_with_paths(
+        events_path: Option<PathBuf>,
+        report_markdown_path: Option<PathBuf>,
+    ) -> RunConfigSnapshot {
+        let settings = bookforge_core::TranslationProfile::V1Fast.resolve();
+        RunConfigSnapshot {
+            input_path: PathBuf::from("input.epub"),
+            output_path: PathBuf::from("/tmp/bookforge-status/out.epub"),
+            events_path,
+            report_json_path: None,
+            report_markdown_path,
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock-prefix-target".to_string(),
+            base_url: None,
+            api_key_env: None,
+            profile: settings.profile,
+            provider_preset: None,
+            prompt_version: "v1".to_string(),
+            cache_namespace: "cache".to_string(),
+            settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+        }
+    }
+
+    #[test]
+    fn status_reports_actual_output_adjacent_report_path() {
+        let job = job();
+
+        assert_eq!(
+            report_path_for_status(&job, None),
+            PathBuf::from("/tmp/bookforge-status/out.report.md")
+        );
+    }
+
+    #[test]
+    fn status_uses_stored_event_path_when_present() {
+        let mut job = job();
+        job.events_path = Some(PathBuf::from("/tmp/stored-events.jsonl"));
+        let snapshot = snapshot_with_paths(Some(PathBuf::from("/tmp/snapshot-events.jsonl")), None);
+
+        assert_eq!(
+            event_log_path_for_status(&job, Some(&snapshot), &job.id),
+            PathBuf::from("/tmp/stored-events.jsonl")
+        );
+    }
+
+    #[test]
+    fn status_uses_snapshot_event_path_when_job_event_path_missing() {
+        let job = job();
+        let snapshot = snapshot_with_paths(Some(PathBuf::from("/tmp/snapshot-events.jsonl")), None);
+
+        assert_eq!(
+            event_log_path_for_status(&job, Some(&snapshot), &job.id),
+            PathBuf::from("/tmp/snapshot-events.jsonl")
+        );
+    }
+
+    #[test]
+    fn status_prints_resume_when_failed_segments_exist_even_if_job_status_needs_review() {
+        let summary = JobSummary {
+            id: "job_test".to_string(),
+            status: "needs_review".to_string(),
+            failed: 1,
+            ..JobSummary::default()
+        };
+
+        assert_eq!(guidance_for_summary(&summary), Some(StatusGuidance::Resume));
+    }
+
+    #[test]
+    fn status_prints_resume_when_retry_pending_segments_exist() {
+        let summary = JobSummary {
+            id: "job_test".to_string(),
+            status: "needs_review".to_string(),
+            retry_pending: 1,
+            ..JobSummary::default()
+        };
+
+        assert_eq!(guidance_for_summary(&summary), Some(StatusGuidance::Resume));
+    }
+
+    #[test]
+    fn status_does_not_print_resume_for_only_needs_review_by_default() {
+        let summary = JobSummary {
+            id: "job_test".to_string(),
+            status: "needs_review".to_string(),
+            needs_review: 1,
+            ..JobSummary::default()
+        };
+
+        assert_eq!(guidance_for_summary(&summary), Some(StatusGuidance::Review));
+    }
 }

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -1,10 +1,11 @@
 use clap::Args;
 
-use std::io::BufRead;
+use std::{io::BufRead, path::PathBuf};
 
+use bookforge_core::RunConfigSnapshot;
 use serde_json::Value;
 
-use bookforge_store::JobStore;
+use bookforge_store::{JobRecord, JobStore};
 
 #[derive(Debug, Args)]
 pub struct TailArgs {
@@ -21,20 +22,9 @@ pub async fn run(args: TailArgs) -> anyhow::Result<()> {
     let store = JobStore::open_default()?;
     let job = store.get_job(&args.job_id)?;
     let snapshot = store.load_job_config_snapshot(&args.job_id)?;
-    let event_log_path = job
-        .and_then(|job| job.events_path)
-        .or_else(|| snapshot.and_then(|snapshot| snapshot.events_path))
-        .unwrap_or_else(|| {
-            std::path::PathBuf::from(format!(".bookforge/runs/{}/events.jsonl", args.job_id))
-        });
+    let event_log_path = event_log_path_for_tail(job.as_ref(), snapshot.as_ref(), &args.job_id);
 
-    if !event_log_path.exists() {
-        anyhow::bail!(
-            "event log not found for job '{}' at {}",
-            args.job_id,
-            event_log_path.display()
-        );
-    }
+    ensure_event_log_exists(&args.job_id, &event_log_path)?;
 
     let file = std::fs::File::open(&event_log_path)?;
     let reader = std::io::BufReader::new(file);
@@ -47,28 +37,65 @@ pub async fn run(args: TailArgs) -> anyhow::Result<()> {
         }
     }
 
-    let start = events.len().saturating_sub(args.last);
+    print!(
+        "{}",
+        render_tail(&args.job_id, &events, args.last, args.json)
+    );
+
+    Ok(())
+}
+
+fn event_log_path_for_tail(
+    job: Option<&JobRecord>,
+    snapshot: Option<&RunConfigSnapshot>,
+    job_id: &str,
+) -> PathBuf {
+    job.and_then(|job| job.events_path.clone())
+        .or_else(|| snapshot.and_then(|snapshot| snapshot.events_path.clone()))
+        .unwrap_or_else(|| PathBuf::from(format!(".bookforge/runs/{job_id}/events.jsonl")))
+}
+
+fn ensure_event_log_exists(job_id: &str, event_log_path: &std::path::Path) -> anyhow::Result<()> {
+    if event_log_path.exists() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "event log not found for job '{}' at {}",
+        job_id,
+        event_log_path.display()
+    );
+}
+
+fn render_tail(job_id: &str, events: &[String], last: usize, json: bool) -> String {
+    let start = events.len().saturating_sub(last);
     let recent: Vec<&String> = events.iter().skip(start).collect();
 
     if recent.is_empty() {
-        if !args.json {
-            println!("(no events)");
-        }
-        return Ok(());
+        return if json {
+            String::new()
+        } else {
+            "(no events)\n".to_string()
+        };
     }
 
-    if args.json {
+    if json {
+        let mut output = String::new();
         for line in recent {
-            println!("{line}");
+            output.push_str(line);
+            output.push('\n');
         }
-        return Ok(());
+        return output;
     }
 
-    println!("Last {} events for job {}:", recent.len(), args.job_id);
-    println!();
+    let mut output = String::new();
+    output.push_str(&format!(
+        "Last {} events for job {}:\n\n",
+        recent.len(),
+        job_id
+    ));
 
     for line in &recent {
-        // Pretty-print each JSON event with a type header
         if let Ok(parsed) = serde_json::from_str::<Value>(line) {
             let event_type = parsed
                 .as_object()
@@ -76,13 +103,14 @@ pub async fn run(args: TailArgs) -> anyhow::Result<()> {
                 .map(|k| k.as_str())
                 .unwrap_or("?");
             let compact = serde_json::to_string(&parsed).unwrap_or_else(|_| line.to_string());
-            println!("[{event_type}] {compact}");
+            output.push_str(&format!("[{event_type}] {compact}\n"));
         } else {
-            println!("{line}");
+            output.push_str(line);
+            output.push('\n');
         }
     }
 
-    println!();
+    output.push('\n');
 
     // Reconstruct a simple dashboard from recent events
     let mut stage = String::new();
@@ -121,16 +149,122 @@ pub async fn run(args: TailArgs) -> anyhow::Result<()> {
         }
     }
 
-    println!("Reconstructed state:");
-    println!("  stage:        {stage}");
-    println!("  segments:     {segments_done}/{segments_total}");
-    println!(
+    output.push_str("Reconstructed state:\n");
+    output.push_str(&format!("  stage:        {stage}\n"));
+    output.push_str(&format!(
+        "  segments:     {segments_done}/{segments_total}\n"
+    ));
+    output.push_str(&format!(
         "  cache:        {} hits, {} misses",
         cache_hits, cache_misses
-    );
-    println!("  input tokens:  {input_tokens}");
-    println!("  output tokens: {output_tokens}");
-    println!("  checkpoints:   {checkpoint_flushed}");
+    ));
+    output.push('\n');
+    output.push_str(&format!("  input tokens:  {input_tokens}\n"));
+    output.push_str(&format!("  output tokens: {output_tokens}\n"));
+    output.push_str(&format!("  checkpoints:   {checkpoint_flushed}\n"));
 
-    Ok(())
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TailTestCli {
+        #[command(flatten)]
+        args: TailArgs,
+    }
+
+    fn job(events_path: Option<PathBuf>) -> JobRecord {
+        JobRecord {
+            id: "job_test".to_string(),
+            input_path: PathBuf::from("input.epub"),
+            output_path: PathBuf::from("out.epub"),
+            input_hash: "hash".to_string(),
+            source_lang: Some("English".to_string()),
+            target_lang: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock-prefix-target".to_string(),
+            base_url: None,
+            api_key_env: None,
+            status: "succeeded".to_string(),
+            events_path,
+            report_json_path: None,
+            report_markdown_path: None,
+        }
+    }
+
+    fn snapshot(events_path: Option<PathBuf>) -> RunConfigSnapshot {
+        let settings = bookforge_core::TranslationProfile::V1Fast.resolve();
+        RunConfigSnapshot {
+            input_path: PathBuf::from("input.epub"),
+            output_path: PathBuf::from("out.epub"),
+            events_path,
+            report_json_path: None,
+            report_markdown_path: None,
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock-prefix-target".to_string(),
+            base_url: None,
+            api_key_env: None,
+            profile: settings.profile,
+            provider_preset: None,
+            prompt_version: "v1".to_string(),
+            cache_namespace: "cache".to_string(),
+            settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+        }
+    }
+
+    #[test]
+    fn tail_accepts_last_argument() {
+        let parsed = TailTestCli::parse_from(["tail-test", "job_1", "--last", "7"]);
+
+        assert_eq!(parsed.args.last, 7);
+    }
+
+    #[test]
+    fn tail_lines_alias_still_works() {
+        let parsed = TailTestCli::parse_from(["tail-test", "job_1", "--lines", "9"]);
+
+        assert_eq!(parsed.args.last, 9);
+    }
+
+    #[test]
+    fn tail_json_outputs_raw_valid_json_lines() {
+        let events = vec![
+            r#"{"StageStarted":{"stage":"resume","timestamp_ms":1}}"#.to_string(),
+            r#"{"TranslationFinished":{"succeeded":1,"cached":0,"needs_review":0,"failed":0,"input_tokens":1,"output_tokens":1,"elapsed_ms":2,"timestamp_ms":3}}"#.to_string(),
+        ];
+
+        let output = render_tail("job_1", &events, 2, true);
+
+        assert!(!output.contains("Last "));
+        for line in output.lines() {
+            serde_json::from_str::<serde_json::Value>(line).expect("line should be raw JSON");
+        }
+    }
+
+    #[test]
+    fn tail_uses_snapshot_event_path_when_available() {
+        let job = job(None);
+        let snapshot = snapshot(Some(PathBuf::from("/tmp/snapshot-events.jsonl")));
+
+        assert_eq!(
+            event_log_path_for_tail(Some(&job), Some(&snapshot), &job.id),
+            PathBuf::from("/tmp/snapshot-events.jsonl")
+        );
+    }
+
+    #[test]
+    fn tail_missing_event_log_prints_clear_error() {
+        let path = PathBuf::from("/tmp/bookforge-tail-missing-events.jsonl");
+        let error =
+            ensure_event_log_exists("job_missing_log", &path).expect_err("missing log should fail");
+
+        assert!(error.to_string().contains("event log not found"));
+        assert!(error.to_string().contains("job_missing_log"));
+    }
 }

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -66,17 +66,19 @@ pub async fn run(
         output,
     };
 
-    println!("Input: {}", args.input.display());
-    println!("Output: {}", config.output.display());
-    println!("Target: {}", config.target_language);
-    println!("Provider: {}", config.provider);
-    println!("Profile: {:?}", args.profile);
-    println!("Concurrency: {}", config.concurrency);
-    println!("Batch enabled: {}", settings.batch.enabled);
+    if human_stdout_enabled(args.ui) {
+        println!("Input: {}", args.input.display());
+        println!("Output: {}", config.output.display());
+        println!("Target: {}", config.target_language);
+        println!("Provider: {}", config.provider);
+        println!("Profile: {:?}", args.profile);
+        println!("Concurrency: {}", config.concurrency);
+        println!("Batch enabled: {}", settings.batch.enabled);
 
-    if settings.batch.enabled {
-        println!("Batch target tokens: {}", settings.batch.target_tokens);
-        println!("Batch max items: {}", settings.batch.max_items);
+        if settings.batch.enabled {
+            println!("Batch target tokens: {}", settings.batch.target_tokens);
+            println!("Batch max items: {}", settings.batch.max_items);
+        }
     }
 
     let reporter = crate::progress::ProgressReporter::spawn(args.ui, args.progress_jsonl.clone());
@@ -117,10 +119,12 @@ pub async fn run(
                 .await
             }
             _ => {
-                println!(
-                    "Translation provider '{}' is not implemented yet.",
-                    config.provider
-                );
+                if human_stdout_enabled(args.ui) {
+                    println!(
+                        "Translation provider '{}' is not implemented yet.",
+                        config.provider
+                    );
+                }
                 Ok(())
             }
         }
@@ -128,6 +132,13 @@ pub async fn run(
     .await;
 
     finalize_reporter(run_result, reporter).await
+}
+
+fn human_stdout_enabled(ui: crate::progress::UiMode) -> bool {
+    !matches!(
+        ui,
+        crate::progress::UiMode::Json | crate::progress::UiMode::Quiet
+    )
 }
 
 async fn finalize_reporter<T>(
@@ -188,7 +199,9 @@ async fn run_mock_translation(
         base_url: None,
         api_key_env: None,
     })?;
-    println!("Job: {}", job.id);
+    if human_stdout_enabled(cli_args.ui) {
+        println!("Job: {}", job.id);
+    }
     progress.emit(bookforge_core::ProgressEvent::JobCreated {
         job_id: job.id.clone(),
         input_path: input.display().to_string(),
@@ -295,6 +308,7 @@ async fn run_mock_translation(
         &translations,
         &qa_reviews,
         config,
+        human_stdout_enabled(cli_args.ui),
     )?;
     let summary = store
         .summary(&job.id)?
@@ -425,7 +439,9 @@ async fn run_openai_compatible_translation(
         base_url: Some(&provider_config.base_url),
         api_key_env: Some(&provider_config.api_key_env),
     })?;
-    println!("Job: {}", job.id);
+    if human_stdout_enabled(cli_args.ui) {
+        println!("Job: {}", job.id);
+    }
     progress.emit(bookforge_core::ProgressEvent::JobCreated {
         job_id: job.id.clone(),
         input_path: input.display().to_string(),
@@ -692,6 +708,7 @@ async fn finish_translation_pipeline(
         translations,
         &qa_reviews,
         config,
+        human_stdout_enabled(cli_args.ui),
     )?;
     let summary = store
         .summary(&job.id)?
@@ -784,7 +801,7 @@ where
         return translate_and_checkpoint(provider, segments, config, checkpoint).await;
     }
 
-    println!("Batches: {}", batches.len());
+    eprintln!("Batches: {}", batches.len());
 
     use std::sync::Arc;
     let telemetry = Arc::new(TelemetryLog::new());
@@ -861,7 +878,7 @@ where
         (Ok(translations), Ok(Ok(()))) => {
             let snapshot = telemetry.snapshot();
             if !snapshot.is_empty() {
-                println!("\n{}", telemetry_summary(&snapshot));
+                eprintln!("\n{}", telemetry_summary(&snapshot));
             }
             Ok(translations)
         }

--- a/crates/bookforge-cli/src/commands/translate/reporting.rs
+++ b/crates/bookforge-cli/src/commands/translate/reporting.rs
@@ -20,6 +20,7 @@ pub fn block_translations(translations: &[SegmentTranslation]) -> Vec<BlockTrans
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn print_summary_rebuild_and_report(
     store: &JobStore,
     job: &JobRecord,
@@ -28,6 +29,7 @@ pub fn print_summary_rebuild_and_report(
     translations: &[SegmentTranslation],
     qa_reviews: &[QaSegmentReview],
     config: &TranslationConfig,
+    print_stdout: bool,
 ) -> Result<()> {
     let block_translations = block_translations(translations);
     rebuild_epub(book, &block_translations, &config.output)?;
@@ -54,26 +56,28 @@ pub fn print_summary_rebuild_and_report(
     })?;
     store.update_job_report_paths(&job.id, &report.json, &report.markdown)?;
 
-    println!(
-        "Translated: {}/{} segments",
-        summary.succeeded, summary.total_segments
-    );
-    println!("Cached: {}", summary.cached);
-    println!("Retried: {}", summary.retried);
-    println!("Needs review: {}", summary.needs_review);
-    println!("Failed: {}", summary.failed);
-    println!("Input tokens: {}", summary.input_tokens);
-    println!("Output tokens: {}", summary.output_tokens);
-    if let Some(cost) = estimate_cost_usd(
-        &job.provider,
-        &job.model,
-        summary.input_tokens,
-        summary.output_tokens,
-    ) {
-        println!("Estimated cost: ${cost:.6}");
+    if print_stdout {
+        println!(
+            "Translated: {}/{} segments",
+            summary.succeeded, summary.total_segments
+        );
+        println!("Cached: {}", summary.cached);
+        println!("Retried: {}", summary.retried);
+        println!("Needs review: {}", summary.needs_review);
+        println!("Failed: {}", summary.failed);
+        println!("Input tokens: {}", summary.input_tokens);
+        println!("Output tokens: {}", summary.output_tokens);
+        if let Some(cost) = estimate_cost_usd(
+            &job.provider,
+            &job.model,
+            summary.input_tokens,
+            summary.output_tokens,
+        ) {
+            println!("Estimated cost: ${cost:.6}");
+        }
+        println!("Output: {}", config.output.display());
+        println!("Report: {}", report.markdown.display());
     }
-    println!("Output: {}", config.output.display());
-    println!("Report: {}", report.markdown.display());
 
     Ok(())
 }

--- a/crates/bookforge-cli/src/performance.rs
+++ b/crates/bookforge-cli/src/performance.rs
@@ -67,23 +67,28 @@ pub(crate) fn performance_summary_from_events(
                     latencies.push(latency);
                 }
                 let status = payload.get("status").and_then(Value::as_str).unwrap_or("");
+                let status_lower = status.to_ascii_lowercase();
                 let code = payload.get("status_code").and_then(Value::as_u64);
                 let error_kind = payload
                     .get("error_kind")
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                if code == Some(429) || status.contains("rate") {
+                let error_kind_lower = error_kind.to_ascii_lowercase();
+                if code == Some(429) || status_lower.contains("rate") {
                     summary.rate_limited += 1;
                 }
-                if status.contains("timeout") || error_kind.contains("timeout") {
+                if status_lower.contains("timeout") || error_kind_lower.contains("timeout") {
                     summary.timeouts += 1;
                 }
-                if code.is_some_and(|code| (500..600).contains(&code)) {
+                if code.is_some_and(|code| (500..600).contains(&code))
+                    || status_lower.contains("server")
+                {
                     summary.server_errors += 1;
                 }
-                if error_kind.contains("json")
-                    || error_kind.contains("invalid")
-                    || status.contains("invalid")
+                if error_kind_lower.contains("json")
+                    || error_kind_lower.contains("invalid")
+                    || status_lower.contains("invalid")
+                    || status_lower.contains("json")
                 {
                     summary.invalid_responses += 1;
                 }
@@ -91,6 +96,8 @@ pub(crate) fn performance_summary_from_events(
                     .get("finish_reason")
                     .and_then(Value::as_str)
                     .is_some_and(|reason| reason.eq_ignore_ascii_case("length"))
+                    || status_lower.contains("truncated")
+                    || error_kind_lower.contains("truncated")
                 {
                     summary.truncations += 1;
                 }
@@ -171,10 +178,197 @@ fn percentile(values: &[u64], percentile: f64) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bookforge_core::ProgressEvent;
     use std::{
         fs,
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    #[test]
+    fn performance_summary_from_events_counts_requests() {
+        let path = temp_path("requests.jsonl");
+        write_events(
+            &path,
+            &[
+                ProgressEvent::RequestFinished {
+                    request_id: "r1".to_string(),
+                    batch_id: None,
+                    segment_id: Some("s1".to_string()),
+                    status: "ok".to_string(),
+                    latency_ms: 10,
+                    status_code: None,
+                    finish_reason: None,
+                    retry_count: 0,
+                    input_tokens: Some(11),
+                    output_tokens: Some(7),
+                    error_kind: None,
+                    timestamp_ms: 1,
+                },
+                ProgressEvent::RequestFinished {
+                    request_id: "r2".to_string(),
+                    batch_id: None,
+                    segment_id: Some("s2".to_string()),
+                    status: "ok".to_string(),
+                    latency_ms: 20,
+                    status_code: None,
+                    finish_reason: None,
+                    retry_count: 1,
+                    input_tokens: Some(13),
+                    output_tokens: Some(5),
+                    error_kind: None,
+                    timestamp_ms: 2,
+                },
+            ],
+        );
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.request_count, 2);
+        assert_eq!(summary.retries, 1);
+        assert_eq!(summary.input_tokens, 24);
+        assert_eq!(summary.output_tokens, 12);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn performance_summary_from_events_computes_latency_percentiles() {
+        let path = temp_path("latencies.jsonl");
+        write_events(
+            &path,
+            &[10, 20, 30, 40, 50]
+                .into_iter()
+                .enumerate()
+                .map(|(index, latency_ms)| ProgressEvent::RequestFinished {
+                    request_id: format!("r{index}"),
+                    batch_id: None,
+                    segment_id: Some(format!("s{index}")),
+                    status: "ok".to_string(),
+                    latency_ms,
+                    status_code: None,
+                    finish_reason: None,
+                    retry_count: 0,
+                    input_tokens: None,
+                    output_tokens: None,
+                    error_kind: None,
+                    timestamp_ms: index as u64,
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.p50_latency_ms, Some(30));
+        assert_eq!(summary.p95_latency_ms, Some(50));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn performance_summary_from_events_counts_rate_limits_timeouts_server_errors() {
+        let path = temp_path("errors.jsonl");
+        write_events(
+            &path,
+            &[
+                request_finished("rate", "rate_limited", Some(429), None),
+                request_finished("timeout", "timeout", None, Some("Http timeout")),
+                request_finished("server", "server_error", None, None),
+            ],
+        );
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.rate_limited, 1);
+        assert_eq!(summary.timeouts, 1);
+        assert_eq!(summary.server_errors, 1);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn performance_summary_from_events_counts_invalid_responses_and_truncations() {
+        let path = temp_path("invalid-truncated.jsonl");
+        write_events(
+            &path,
+            &[
+                request_finished(
+                    "invalid",
+                    "invalid_response",
+                    None,
+                    Some("InvalidResponse(\"bad json\")"),
+                ),
+                request_finished(
+                    "truncated",
+                    "truncated",
+                    None,
+                    Some("InvalidResponse(\"truncated response\")"),
+                ),
+                ProgressEvent::RequestFinished {
+                    request_id: "length".to_string(),
+                    batch_id: None,
+                    segment_id: Some("s_length".to_string()),
+                    status: "ok".to_string(),
+                    latency_ms: 5,
+                    status_code: None,
+                    finish_reason: Some("length".to_string()),
+                    retry_count: 0,
+                    input_tokens: None,
+                    output_tokens: None,
+                    error_kind: None,
+                    timestamp_ms: 3,
+                },
+            ],
+        );
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.invalid_responses, 2);
+        assert_eq!(summary.truncations, 2);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn performance_summary_from_events_counts_checkpoint_flushes() {
+        let path = temp_path("checkpoint-flushes.jsonl");
+        write_events(
+            &path,
+            &[
+                ProgressEvent::CheckpointFlushed {
+                    segment_id: Some("s1".to_string()),
+                    flushed_count: 1,
+                    latency_ms: Some(2),
+                    timestamp_ms: 1,
+                },
+                ProgressEvent::CheckpointFlushed {
+                    segment_id: Some("s2".to_string()),
+                    flushed_count: 2,
+                    latency_ms: Some(3),
+                    timestamp_ms: 2,
+                },
+            ],
+        );
+
+        let summary = performance_summary_from_events(&path)
+            .expect("summary should parse")
+            .expect("summary should exist");
+
+        assert_eq!(summary.checkpoint_flushes, 2);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn performance_summary_from_events_returns_none_for_missing_file() {
+        let path = temp_path("missing.jsonl");
+
+        let summary = performance_summary_from_events(&path).expect("missing file should not fail");
+
+        assert!(summary.is_none());
+    }
 
     #[test]
     fn request_and_segment_tokens_are_not_double_counted() {
@@ -229,5 +423,36 @@ mod tests {
             "bookforge-performance-test-{}-{nanos}-{name}",
             std::process::id()
         ))
+    }
+
+    fn write_events(path: &std::path::Path, events: &[ProgressEvent]) {
+        let jsonl = events
+            .iter()
+            .map(|event| serde_json::to_string(event).expect("event should serialize"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(path, jsonl).expect("fixture should be written");
+    }
+
+    fn request_finished(
+        request_id: &str,
+        status: &str,
+        status_code: Option<u16>,
+        error_kind: Option<&str>,
+    ) -> ProgressEvent {
+        ProgressEvent::RequestFinished {
+            request_id: request_id.to_string(),
+            batch_id: None,
+            segment_id: Some(format!("segment_{request_id}")),
+            status: status.to_string(),
+            latency_ms: 5,
+            status_code,
+            finish_reason: None,
+            retry_count: 0,
+            input_tokens: None,
+            output_tokens: None,
+            error_kind: error_kind.map(ToOwned::to_owned),
+            timestamp_ms: 1,
+        }
     }
 }

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -1,13 +1,11 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::path::{Path, PathBuf};
 
+use assert_cmd::Command;
 use bookforge_store::JobStore;
+use tempfile::TempDir;
 
-fn bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_bookforge"))
+fn bookforge() -> Command {
+    Command::cargo_bin("bookforge").expect("bookforge binary should be built")
 }
 
 fn workspace_root() -> PathBuf {
@@ -18,34 +16,217 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn temp_dir(name: &str) -> PathBuf {
-    let path = std::env::temp_dir().join(format!(
-        "bookforge-cli-{name}-{}-{}",
-        std::process::id(),
-        now_nanos()
-    ));
-    fs::create_dir_all(&path).expect("temp dir should be created");
-    path
+fn fixture_input() -> PathBuf {
+    workspace_root().join("test/test.epub")
 }
 
 #[test]
-fn mock_translate_status_and_tail_lifecycle() {
-    let cwd = temp_dir("lifecycle");
-    let input = workspace_root().join("test/test.epub");
-    let output = cwd.join("translated.epub");
-    let events = cwd.join("events.jsonl");
+fn cli_translate_mock_quiet_writes_output_report_and_events() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let run = translate_quiet(&temp, "mock-prefix-target");
 
-    let translate = Command::new(bin())
-        .current_dir(&cwd)
+    assert!(run.output.exists(), "translated EPUB should exist");
+    assert!(run.events.exists(), "event log should exist");
+    assert!(run.report.exists(), "markdown report should exist");
+}
+
+#[test]
+fn cli_translate_json_mode_emits_valid_jsonl_stdout_and_file_log() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let output = temp.path().join("json.epub");
+    let events = temp.path().join("json-events.jsonl");
+    let assert = bookforge()
+        .current_dir(temp.path())
         .args([
             "translate",
-            input.to_str().unwrap(),
+            fixture_input().to_str().unwrap(),
             "--target",
             "Italian",
             "--provider",
             "mock",
             "--model",
             "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--ui",
+            "json",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stdout_events = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(serde_json::from_str::<serde_json::Value>)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("stdout should be valid JSONL");
+    assert!(
+        stdout_events
+            .iter()
+            .any(|event| event.get("JobCreated").is_some()),
+        "stdout JSONL should include job creation"
+    );
+
+    let file_events = read_jsonl(&events);
+    assert!(
+        file_events
+            .iter()
+            .any(|event| event.get("TranslationFinished").is_some()),
+        "file JSONL should include completion"
+    );
+}
+
+#[test]
+fn cli_status_after_translate_reports_succeeded_job() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let run = translate_quiet(&temp, "mock-prefix-target");
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args(["status", &run.job_id])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    assert!(stdout.contains(&format!("Job: {}", run.job_id)));
+    assert!(stdout.contains("Status: succeeded"));
+    assert!(stdout.contains("Segments:"));
+    assert!(stdout.contains("Output:"));
+    assert!(stdout.contains("Event log:"));
+    assert!(stdout.contains("Report:"));
+    assert!(stdout.contains("Performance:"));
+}
+
+#[test]
+fn cli_tail_after_translate_prints_recent_events() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let run = translate_quiet(&temp, "mock-prefix-target");
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args(["tail", &run.job_id, "--last", "3"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    assert!(stdout.contains("Last "));
+    assert!(stdout.contains("Reconstructed state:"));
+}
+
+#[test]
+fn cli_tail_json_outputs_valid_jsonl() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let run = translate_quiet(&temp, "mock-prefix-target");
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args(["tail", &run.job_id, "--last", "5", "--json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    assert!(!stdout.contains("Last "));
+    let events = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(serde_json::from_str::<serde_json::Value>)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("tail --json should emit valid JSONL");
+    assert!(!events.is_empty(), "tail --json should emit recent events");
+}
+
+#[test]
+fn cli_resume_missing_job_fails_clearly() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args(["resume", "job_missing"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(stderr.contains("job 'job_missing' was not found"));
+}
+
+#[test]
+fn cli_resume_reuses_checkpointed_segments() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let run = translate_quiet(&temp, "mock-prefix-target");
+    let resume_events = temp.path().join("resume-events.jsonl");
+    let store = JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store opens");
+    let segment_ids = store
+        .segment_records(&run.job_id)
+        .expect("segments should load")
+        .into_iter()
+        .map(|record| record.id)
+        .collect::<Vec<_>>();
+    assert!(!segment_ids.is_empty(), "fixture should produce segments");
+    let retry_id = segment_ids[0].clone();
+    store
+        .mark_segment_failed(&run.job_id, &retry_id, "force resume")
+        .expect("segment should be marked failed");
+
+    let resume = bookforge()
+        .current_dir(temp.path())
+        .args([
+            "resume",
+            &run.job_id,
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            resume_events.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(
+        resume.get_output().stdout.is_empty(),
+        "resume --ui quiet should not write human stdout"
+    );
+
+    let events = read_jsonl(&resume_events);
+    let segment_finished = events
+        .iter()
+        .filter_map(|event| event.get("SegmentFinished"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        segment_finished.len(),
+        1,
+        "resume should translate only the failed segment"
+    );
+    assert_eq!(
+        segment_finished[0]
+            .get("segment_id")
+            .and_then(|value| value.as_str()),
+        Some(retry_id.as_str())
+    );
+}
+
+struct TranslateRun {
+    job_id: String,
+    output: PathBuf,
+    events: PathBuf,
+    report: PathBuf,
+}
+
+fn translate_quiet(temp: &TempDir, model: &str) -> TranslateRun {
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            fixture_input().to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            model,
             "--profile",
             "v1-fast",
             "--ui",
@@ -55,291 +236,40 @@ fn mock_translate_status_and_tail_lifecycle() {
             "--out",
             output.to_str().unwrap(),
         ])
-        .output()
-        .expect("translate command should run");
+        .assert()
+        .success();
     assert!(
-        translate.status.success(),
-        "translate failed: {}",
-        String::from_utf8_lossy(&translate.stderr)
+        assert.get_output().stdout.is_empty(),
+        "translate --ui quiet should not write human stdout"
     );
-    assert!(output.exists(), "translated EPUB should exist");
-    assert!(events.exists(), "event log should exist");
-    assert!(
-        cwd.join("translated.report.md").exists(),
-        "report should exist"
-    );
+    let job_id = job_id_from_events(&events);
 
-    let stdout = String::from_utf8_lossy(&translate.stdout);
-    let job_id = stdout
-        .lines()
-        .find_map(|line| line.strip_prefix("Job: "))
-        .expect("translate should print job id")
-        .to_string();
-
-    let status = Command::new(bin())
-        .current_dir(&cwd)
-        .args(["status", &job_id])
-        .output()
-        .expect("status command should run");
-    assert!(status.status.success());
-    let status_stdout = String::from_utf8_lossy(&status.stdout);
-    assert!(status_stdout.contains("Status: succeeded"));
-    assert!(status_stdout.contains("Event log:"));
-    assert!(status_stdout.contains("Report:"));
-    assert!(status_stdout.contains("Performance:"));
-
-    let tail = Command::new(bin())
-        .current_dir(&cwd)
-        .args(["tail", &job_id, "--last", "3"])
-        .output()
-        .expect("tail command should run");
-    assert!(tail.status.success());
-    assert!(String::from_utf8_lossy(&tail.stdout).contains("Last "));
-
-    let tail_json = Command::new(bin())
-        .current_dir(&cwd)
-        .args(["tail", &job_id, "--last", "3", "--json"])
-        .output()
-        .expect("tail json command should run");
-    assert!(tail_json.status.success());
-    for line in String::from_utf8_lossy(&tail_json.stdout).lines() {
-        serde_json::from_str::<serde_json::Value>(line).expect("tail --json should emit JSONL");
+    TranslateRun {
+        job_id,
+        report: temp.path().join("out.report.md"),
+        output,
+        events,
     }
 }
 
-#[test]
-fn resume_missing_job_fails_clearly() {
-    let cwd = temp_dir("resume-missing");
-    let output = Command::new(bin())
-        .current_dir(&cwd)
-        .args(["resume", "job_missing"])
-        .output()
-        .expect("resume command should run");
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("job 'job_missing' was not found"));
-}
-
-#[test]
-fn cli_resume_writes_progress_events_and_uses_batch_snapshot_mode() {
-    let cwd = temp_dir("resume-batch");
-    let input = workspace_root().join("test/test.epub");
-    let output = cwd.join("translated.epub");
-    let translate_events = cwd.join("translate-events.jsonl");
-    let resume_events = cwd.join("resume-events.jsonl");
-
-    let translate = Command::new(bin())
-        .current_dir(&cwd)
-        .args([
-            "translate",
-            input.to_str().unwrap(),
-            "--target",
-            "Italian",
-            "--provider",
-            "mock",
-            "--model",
-            "mock-prefix-target",
-            "--profile",
-            "v1-fast",
-            "--ui",
-            "quiet",
-            "--progress-jsonl",
-            translate_events.to_str().unwrap(),
-            "--out",
-            output.to_str().unwrap(),
-        ])
-        .output()
-        .expect("translate command should run");
-    assert!(
-        translate.status.success(),
-        "translate failed: {}",
-        String::from_utf8_lossy(&translate.stderr)
-    );
-    let job_id = job_id_from_stdout(&translate.stdout);
-
-    let store = JobStore::open(cwd.join(".bookforge/jobs.sqlite")).expect("store should open");
-    let segment_ids = store
-        .segment_records(&job_id)
-        .expect("segments should load")
+fn job_id_from_events(path: &Path) -> String {
+    read_jsonl(path)
         .into_iter()
-        .map(|record| record.id)
-        .collect::<Vec<_>>();
-    assert!(!segment_ids.is_empty(), "fixture should have segments");
-    for segment_id in segment_ids {
-        store
-            .mark_segment_failed(&job_id, &segment_id, "force resume")
-            .expect("segment should be marked failed");
-    }
-
-    let resume = Command::new(bin())
-        .current_dir(&cwd)
-        .args([
-            "resume",
-            &job_id,
-            "--ui",
-            "quiet",
-            "--progress-jsonl",
-            resume_events.to_str().unwrap(),
-        ])
-        .output()
-        .expect("resume command should run");
-    assert!(
-        resume.status.success(),
-        "resume failed: {}\nstdout: {}",
-        String::from_utf8_lossy(&resume.stderr),
-        String::from_utf8_lossy(&resume.stdout)
-    );
-
-    let events = read_jsonl(&resume_events);
-    assert!(events.iter().any(|event| {
-        event
-            .get("StageStarted")
-            .and_then(|payload| payload.get("stage"))
-            .and_then(|stage| stage.as_str())
-            == Some("resume")
-    }));
-    assert!(
-        events
-            .iter()
-            .any(|event| event.get("CacheScanFinished").is_some())
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| event.get("BatchQueued").is_some())
-            || events.iter().any(|event| event
-                .get("RequestStarted")
-                .and_then(|payload| payload.get("batch_id"))
-                .is_some_and(|batch_id| !batch_id.is_null())),
-        "resume should use batch progress events when the snapshot has batch enabled"
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| event.get("ArtifactWritten").is_some())
-    );
-    assert!(
-        events
-            .iter()
-            .any(|event| event.get("TranslationFinished").is_some())
-    );
-
-    let summary = store
-        .summary(&job_id)
-        .expect("summary should load")
-        .expect("job should exist");
-    assert_eq!(summary.failed, 0);
-    assert_eq!(
-        summary.succeeded + summary.cached + summary.needs_review,
-        summary.total_segments
-    );
-
-    let tail = Command::new(bin())
-        .current_dir(&cwd)
-        .args(["tail", &job_id, "--last", "200", "--json"])
-        .output()
-        .expect("tail command should run");
-    assert!(tail.status.success());
-    let resume_lines = fs::read_to_string(&resume_events).expect("resume events should exist");
-    let resume_lines = resume_lines.lines().collect::<Vec<_>>();
-    let tail_stdout = String::from_utf8_lossy(&tail.stdout);
-    let tail_lines = tail_stdout.lines().collect::<Vec<_>>();
-    assert!(!tail_lines.is_empty(), "tail should emit JSONL events");
-    let expected_start = resume_lines.len().saturating_sub(tail_lines.len());
-    assert_eq!(
-        tail_lines[0], resume_lines[expected_start],
-        "tail should read the resume event path stored by --progress-jsonl"
-    );
-}
-
-#[test]
-fn resume_preserves_needs_review_segments_by_default() {
-    let cwd = temp_dir("resume-needs-review");
-    let input = workspace_root().join("test/test.epub");
-    let output = cwd.join("translated.epub");
-    let resume_events = cwd.join("resume-events.jsonl");
-
-    let translate = Command::new(bin())
-        .current_dir(&cwd)
-        .args([
-            "translate",
-            input.to_str().unwrap(),
-            "--target",
-            "Italian",
-            "--provider",
-            "mock",
-            "--model",
-            "mock-malformed-json",
-            "--profile",
-            "v1-fast",
-            "--ui",
-            "quiet",
-            "--out",
-            output.to_str().unwrap(),
-        ])
-        .output()
-        .expect("translate command should run");
-    assert!(
-        translate.status.success(),
-        "translate failed: {}",
-        String::from_utf8_lossy(&translate.stderr)
-    );
-    let job_id = job_id_from_stdout(&translate.stdout);
-
-    let resume = Command::new(bin())
-        .current_dir(&cwd)
-        .args([
-            "resume",
-            &job_id,
-            "--ui",
-            "quiet",
-            "--progress-jsonl",
-            resume_events.to_str().unwrap(),
-        ])
-        .output()
-        .expect("resume command should run");
-    assert!(
-        resume.status.success(),
-        "resume failed: {}",
-        String::from_utf8_lossy(&resume.stderr)
-    );
-
-    let store = JobStore::open(cwd.join(".bookforge/jobs.sqlite")).expect("store should open");
-    let summary = store
-        .summary(&job_id)
-        .expect("summary should load")
-        .expect("job should exist");
-    assert_eq!(summary.needs_review, summary.total_segments);
-    assert_eq!(summary.failed, 0);
-
-    let events = read_jsonl(&resume_events);
-    assert!(
-        events
-            .iter()
-            .all(|event| event.get("SegmentFinished").is_none()),
-        "resume should not reprocess needs_review segments by default"
-    );
-}
-
-fn job_id_from_stdout(stdout: &[u8]) -> String {
-    String::from_utf8_lossy(stdout)
-        .lines()
-        .find_map(|line| line.strip_prefix("Job: "))
-        .expect("command should print job id")
-        .to_string()
+        .find_map(|event| {
+            event
+                .get("JobCreated")
+                .and_then(|payload| payload.get("job_id"))
+                .and_then(|value| value.as_str())
+                .map(ToOwned::to_owned)
+        })
+        .expect("event log should include job id")
 }
 
 fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
-    fs::read_to_string(path)
+    std::fs::read_to_string(path)
         .expect("JSONL file should exist")
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str(line).expect("line should be valid JSON"))
         .collect()
-}
-
-fn now_nanos() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos()
 }

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -1447,7 +1447,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_round_trips_and_excludes_api_key_values() {
+    fn job_config_snapshot_round_trips_through_store() {
         let db_path = temp_path("snapshot.sqlite");
         let input_path = temp_path("input.epub");
         fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
@@ -1492,9 +1492,6 @@ mod tests {
             .expect("snapshot should load")
             .expect("snapshot should exist");
         assert_eq!(loaded, snapshot);
-        let json = serde_json::to_string(&loaded).expect("snapshot should serialize");
-        assert!(json.contains("OPENROUTER_API_KEY"));
-        assert!(!json.contains("sk-live-secret"));
 
         let reloaded_job = store
             .get_job(&job.id)
@@ -1507,6 +1504,75 @@ mod tests {
             snapshot.report_markdown_path
         );
 
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn job_config_snapshot_does_not_store_api_key_value() {
+        let db_path = temp_path("snapshot_secret.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let api_key_env = "BOOKFORGE_TEST_API_KEY_VALUE_NOT_STORED";
+        let api_key_value = "sk-live-secret-that-must-not-be-persisted";
+        // This test uses a unique process-local env var and verifies snapshot
+        // serialization never reads the value.
+        unsafe {
+            std::env::set_var(api_key_env, api_key_value);
+        }
+
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "openrouter",
+                model: "model",
+                base_url: Some("https://example.test/v1"),
+                api_key_env: Some(api_key_env),
+            })
+            .expect("job should be created");
+        let settings = bookforge_core::TranslationProfile::Balanced.resolve();
+        let snapshot = RunConfigSnapshot {
+            input_path: input_path.clone(),
+            output_path: temp_path("translated.epub"),
+            events_path: Some(temp_path("events.jsonl")),
+            report_json_path: Some(temp_path("report.json")),
+            report_markdown_path: Some(temp_path("report.md")),
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "openrouter".to_string(),
+            model: "model".to_string(),
+            base_url: Some("https://example.test/v1".to_string()),
+            api_key_env: Some(api_key_env.to_string()),
+            profile: settings.profile,
+            provider_preset: None,
+            prompt_version: "batch_v1".to_string(),
+            cache_namespace: "cache_ns".to_string(),
+            settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+        };
+
+        store
+            .update_job_config_snapshot(&job.id, &snapshot)
+            .expect("snapshot should persist");
+        let raw_json = {
+            let conn = store.conn.borrow();
+            conn.query_row(
+                "SELECT config_json FROM jobs WHERE id = ?1",
+                params![job.id],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("raw snapshot JSON should load")
+        };
+
+        assert!(raw_json.contains(api_key_env));
+        assert!(!raw_json.contains(api_key_value));
+
+        unsafe {
+            std::env::remove_var(api_key_env);
+        }
         let _ = fs::remove_file(db_path);
         let _ = fs::remove_file(input_path);
     }
@@ -1717,6 +1783,178 @@ mod tests {
         assert_eq!(statuses["seg_queued"], "failed");
         assert_eq!(statuses["seg_retry"], "failed");
 
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn mark_unfinished_segments_failed_marks_only_resumable_segments() {
+        let db_path = temp_path("unfinished_resumable_only.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let segments = vec![
+            segment("seg_succeeded", 0),
+            segment("seg_cached", 1),
+            segment("seg_review", 2),
+            segment("seg_failed", 3),
+            segment("seg_retry", 4),
+            segment("seg_queued", 5),
+        ];
+        store
+            .insert_segments(&job.id, &segments, "v1", "mock", "mock-prefix", "test_ns")
+            .expect("segments should insert");
+        {
+            let conn = store.conn.borrow();
+            for (id, status) in [
+                ("seg_succeeded", "succeeded"),
+                ("seg_cached", "skipped_cached"),
+                ("seg_review", "needs_review"),
+                ("seg_failed", "failed"),
+                ("seg_retry", "retry_pending"),
+                ("seg_queued", "queued"),
+            ] {
+                conn.execute(
+                    "UPDATE segments SET status = ?1 WHERE job_id = ?2 AND id = ?3",
+                    params![status, job.id, id],
+                )
+                .expect("status should update");
+            }
+        }
+
+        let candidate_ids = segments
+            .iter()
+            .map(|segment| segment.id.0.clone())
+            .collect::<Vec<_>>();
+        let changed = store
+            .mark_unfinished_segments_failed(&job.id, &candidate_ids, "run failed")
+            .expect("unfinished segments should be marked failed");
+
+        assert_eq!(changed, 3);
+        let records = store.segment_records(&job.id).expect("records should load");
+        let statuses = records
+            .into_iter()
+            .map(|record| (record.id, record.status))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(statuses["seg_succeeded"], "succeeded");
+        assert_eq!(statuses["seg_cached"], "skipped_cached");
+        assert_eq!(statuses["seg_review"], "needs_review");
+        assert_eq!(statuses["seg_failed"], "failed");
+        assert_eq!(statuses["seg_retry"], "failed");
+        assert_eq!(statuses["seg_queued"], "failed");
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn resumable_segment_ids_excludes_succeeded_cached_and_needs_review() {
+        let db_path = temp_path("resumable_excludes.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let segments = vec![
+            segment("seg_succeeded", 0),
+            segment("seg_cached", 1),
+            segment("seg_review", 2),
+        ];
+        store
+            .insert_segments(&job.id, &segments, "v1", "mock", "mock-prefix", "test_ns")
+            .expect("segments should insert");
+        {
+            let conn = store.conn.borrow();
+            for (id, status) in [
+                ("seg_succeeded", "succeeded"),
+                ("seg_cached", "skipped_cached"),
+                ("seg_review", "needs_review"),
+            ] {
+                conn.execute(
+                    "UPDATE segments SET status = ?1 WHERE job_id = ?2 AND id = ?3",
+                    params![status, job.id, id],
+                )
+                .expect("status should update");
+            }
+        }
+
+        let ids = store
+            .resumable_segment_ids(&job.id)
+            .expect("resumable ids should load");
+
+        assert!(ids.is_empty());
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn resumable_segment_ids_includes_failed_retry_pending_and_pending() {
+        let db_path = temp_path("resumable_includes.sqlite");
+        let input_path = temp_path("input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+            })
+            .expect("job should be created");
+        let segments = vec![
+            segment("seg_failed", 0),
+            segment("seg_retry", 1),
+            segment("seg_queued", 2),
+        ];
+        store
+            .insert_segments(&job.id, &segments, "v1", "mock", "mock-prefix", "test_ns")
+            .expect("segments should insert");
+        {
+            let conn = store.conn.borrow();
+            for (id, status) in [
+                ("seg_failed", "failed"),
+                ("seg_retry", "retry_pending"),
+                ("seg_queued", "queued"),
+            ] {
+                conn.execute(
+                    "UPDATE segments SET status = ?1 WHERE job_id = ?2 AND id = ?3",
+                    params![status, job.id, id],
+                )
+                .expect("status should update");
+            }
+        }
+
+        let ids = store
+            .resumable_segment_ids(&job.id)
+            .expect("resumable ids should load");
+
+        assert_eq!(ids, vec!["seg_failed", "seg_retry", "seg_queued"]);
         let _ = fs::remove_file(db_path);
         let _ = fs::remove_file(input_path);
     }


### PR DESCRIPTION
## Summary

Post-merge audit and hardening for v1 lifecycle resume/status/tail behavior.

## Tests and fixes

- Snapshot resume tests for durable run config snapshots, no API key value persistence, snapshot segmentation/profile/compact prompt/json mode/provider attempts, missing snapshots, cache namespace mismatch, needs-review skipping, and original-order output rebuilds.
- CLI lifecycle smoke tests for mock translate output/report/events, quiet stdout suppression, JSON UI stdout/file JSONL, status, tail, tail JSON, missing resume job, and checkpointed resume reuse.
- Status/tail path and JSON behavior tests for stored/snapshot/default event paths, output-adjacent report paths, resume vs review guidance, `--last`, `--lines`, raw `--json`, and missing event logs.
- Performance summary event reconstruction tests for requests, latency percentiles, retry/error classes, invalid/truncated responses, checkpoint flushes, and missing logs.
- Small fixes discovered by tests: keep `--ui quiet` silent for translate/resume human stdout, keep translate `--ui json` stdout as raw JSONL only, route batch/telemetry human output to stderr, and classify status/error strings case-insensitively when reconstructing performance metrics.