### PR TITLE
feat: add v1.2 manual glossary workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -181,13 +181,14 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "bookforge-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "quick-xml",
@@ -199,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-epub"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bookforge-core",
  "quick-xml",
@@ -209,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-llm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bookforge-core",
  "reqwest",
@@ -223,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-store"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bookforge-core",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1496,6 +1497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1782,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2240,6 +2291,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+toml = "0.8"
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync", "signal"] }
 tokio-util = "0.7"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ cargo run -p bookforge-cli -- translate book.epub \
   --out book.it.epub
 ```
 
+Translate with a glossary:
+
+```bash
+cargo run -p bookforge-cli -- glossary import glossary.series.toml
+cargo run -p bookforge-cli -- translate book.epub \
+  --source English \
+  --target Italian \
+  --provider-preset openrouter-paid-fast \
+  --book-id fellowship \
+  --series-id lord-of-the-rings \
+  --glossary glossary.series.toml \
+  --glossary-budget-tokens 800 \
+  --glossary-format json \
+  --prompt-extra "Maintain a literary register." \
+  --out book.it.epub
+```
+
 Check provider and storage health:
 
 ```bash
@@ -142,6 +159,23 @@ Ingest exported review flags and mark bad translations for retry:
 ```bash
 cargo run -p bookforge-cli -- ingest-flags <job-id> --flags flags.json
 cargo run -p bookforge-cli -- retry <job-id> --only needs-review
+```
+
+Manage glossary terms:
+
+```bash
+cargo run -p bookforge-cli -- glossary list --language 'English->Italian'
+cargo run -p bookforge-cli -- glossary add "Aragorn" "Aragorn" \
+  --category person \
+  --scope series \
+  --scope-id lord-of-the-rings \
+  --source-lang English \
+  --target-lang Italian \
+  --case-sensitive
+cargo run -p bookforge-cli -- glossary export glossary.series.toml \
+  --scope series \
+  --scope-id lord-of-the-rings \
+  --language 'English->Italian'
 ```
 
 Inspect persisted job state and recent events:

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-cli"
-version = "1.1.0"
+version = "1.2.0"
 description = "CLI-first EPUB translation engine with deterministic structure rebuild and review loop."
 readme = "../../README.md"
 edition.workspace = true
@@ -14,10 +14,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-bookforge-core = { version = "1.1.0", path = "../bookforge-core", features = ["cli"] }
-bookforge-epub = { version = "1.1.0", path = "../bookforge-epub" }
-bookforge-llm = { version = "1.1.0", path = "../bookforge-llm" }
-bookforge-store = { version = "1.1.0", path = "../bookforge-store" }
+bookforge-core = { version = "1.2.0", path = "../bookforge-core", features = ["cli"] }
+bookforge-epub = { version = "1.2.0", path = "../bookforge-epub" }
+bookforge-llm = { version = "1.2.0", path = "../bookforge-llm" }
+bookforge-store = { version = "1.2.0", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true
 indicatif.workspace = true
@@ -26,6 +26,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/bookforge-cli/src/checkpoint.rs
+++ b/crates/bookforge-cli/src/checkpoint.rs
@@ -344,6 +344,8 @@ mod tests {
                 model: "mock-model",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job created");
         store
@@ -458,6 +460,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job created");
         store

--- a/crates/bookforge-cli/src/checkpoint.rs
+++ b/crates/bookforge-cli/src/checkpoint.rs
@@ -344,7 +344,7 @@ mod tests {
                 model: "mock-model",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job created");
@@ -460,7 +460,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job created");

--- a/crates/bookforge-cli/src/commands/glossary.rs
+++ b/crates/bookforge-cli/src/commands/glossary.rs
@@ -1,0 +1,458 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use bookforge_core::{GlossaryCategory, GlossaryScopeKind, GlossaryStatus, GlossaryTerm};
+use bookforge_store::{GlossaryFilter, JobStore};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Args)]
+pub struct GlossaryArgs {
+    #[command(subcommand)]
+    command: GlossaryCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum GlossaryCommand {
+    List(ListArgs),
+    Add(AddArgs),
+    Remove(RemoveArgs),
+    Clear(ClearArgs),
+    Import(ImportArgs),
+    Export(ExportArgs),
+}
+
+#[derive(Debug, Args)]
+struct ListArgs {
+    #[arg(long)]
+    book: Option<String>,
+
+    #[arg(long)]
+    series: Option<String>,
+
+    #[arg(long)]
+    language: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct AddArgs {
+    source: String,
+    target: String,
+
+    #[arg(long, value_enum)]
+    category: GlossaryCategory,
+
+    #[arg(long, value_enum, default_value_t = GlossaryScopeKind::Global)]
+    scope: GlossaryScopeKind,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+
+    #[arg(long)]
+    source_lang: Option<String>,
+
+    #[arg(long)]
+    target_lang: Option<String>,
+
+    #[arg(long)]
+    case_sensitive: bool,
+
+    #[arg(long)]
+    always_active: bool,
+
+    #[arg(long)]
+    notes: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct RemoveArgs {
+    id: i64,
+}
+
+#[derive(Debug, Args)]
+struct ClearArgs {
+    #[arg(long, value_enum)]
+    scope: GlossaryScopeKind,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ImportArgs {
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct ExportArgs {
+    file: PathBuf,
+
+    #[arg(long, value_enum)]
+    scope: Option<GlossaryScopeKind>,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+
+    #[arg(long)]
+    language: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GlossaryToml {
+    meta: GlossaryTomlMeta,
+    #[serde(default, rename = "term")]
+    terms: Vec<GlossaryTomlTerm>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GlossaryTomlMeta {
+    schema_version: u32,
+    source_language: String,
+    target_language: String,
+    scope: GlossaryTomlScope,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GlossaryTomlScope {
+    kind: GlossaryScopeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GlossaryTomlTerm {
+    source: String,
+    target: String,
+    category: GlossaryCategory,
+    #[serde(default)]
+    case_sensitive: bool,
+    #[serde(default)]
+    always_active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notes: Option<String>,
+    #[serde(default = "default_user_seeded")]
+    status: GlossaryStatus,
+    #[serde(default)]
+    source_count: usize,
+}
+
+pub async fn run(args: GlossaryArgs) -> Result<()> {
+    let store = JobStore::open_default()?;
+    match args.command {
+        GlossaryCommand::List(args) => list_terms(&store, args),
+        GlossaryCommand::Add(args) => add_term(&store, args),
+        GlossaryCommand::Remove(args) => remove_term(&store, args),
+        GlossaryCommand::Clear(args) => clear_terms(&store, args),
+        GlossaryCommand::Import(args) => import_terms(&store, args),
+        GlossaryCommand::Export(args) => export_terms(&store, args),
+    }
+}
+
+pub(crate) fn read_glossary_file(path: &PathBuf) -> Result<Vec<GlossaryTerm>> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read glossary file {}", path.display()))?;
+    let parsed: GlossaryToml = toml::from_str(&raw)
+        .with_context(|| format!("failed to parse glossary TOML {}", path.display()))?;
+    glossary_toml_to_terms(parsed)
+}
+
+fn import_terms(store: &JobStore, args: ImportArgs) -> Result<()> {
+    let terms = read_glossary_file(&args.file)?;
+    let imported = store.upsert_glossary_terms(&terms)?;
+    println!("Imported {imported} glossary terms.");
+    Ok(())
+}
+
+fn export_terms(store: &JobStore, args: ExportArgs) -> Result<()> {
+    let (source_language, target_language) = match args.language.as_deref() {
+        Some(language) => {
+            let (source, target) = parse_language_pair(language)?;
+            (Some(source), Some(target))
+        }
+        None => (None, None),
+    };
+    let terms = store.list_glossary_terms(GlossaryFilter {
+        scope_kind: args.scope,
+        scope_id: args.scope_id.as_deref(),
+        source_language: source_language.as_deref(),
+        target_language: target_language.as_deref(),
+        active_only: false,
+    })?;
+    if terms.is_empty() {
+        anyhow::bail!("no glossary terms matched the export filters");
+    }
+
+    let output = terms_to_glossary_toml(&terms)?;
+    fs::write(&args.file, toml::to_string_pretty(&output)?)?;
+    println!("Exported {} glossary terms.", output.terms.len());
+    Ok(())
+}
+
+fn list_terms(store: &JobStore, args: ListArgs) -> Result<()> {
+    let (source_language, target_language) = match args.language.as_deref() {
+        Some(language) => {
+            let (source, target) = parse_language_pair(language)?;
+            (Some(source), Some(target))
+        }
+        None => (None, None),
+    };
+    let (scope_kind, scope_id) = if let Some(book) = args.book.as_deref() {
+        (Some(GlossaryScopeKind::Book), Some(book))
+    } else if let Some(series) = args.series.as_deref() {
+        (Some(GlossaryScopeKind::Series), Some(series))
+    } else {
+        (None, None)
+    };
+    let terms = store.list_glossary_terms(GlossaryFilter {
+        scope_kind,
+        scope_id,
+        source_language: source_language.as_deref(),
+        target_language: target_language.as_deref(),
+        active_only: false,
+    })?;
+    if terms.is_empty() {
+        println!("No glossary terms.");
+        return Ok(());
+    }
+    for term in terms {
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{} -> {}",
+            term.id.unwrap_or_default(),
+            term.source_language,
+            term.target_language,
+            term.scope_kind,
+            term.scope_id.as_deref().unwrap_or("-"),
+            term.source_text,
+            term.target_text
+        );
+    }
+    Ok(())
+}
+
+fn add_term(store: &JobStore, args: AddArgs) -> Result<()> {
+    let source_language = args
+        .source_lang
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--source-lang is required for glossary add"))?;
+    let target_language = args
+        .target_lang
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--target-lang is required for glossary add"))?;
+    validate_scope(args.scope, args.scope_id.as_deref())?;
+    let term = GlossaryTerm {
+        id: None,
+        scope_kind: args.scope,
+        scope_id: normalized_scope_id(args.scope, args.scope_id),
+        source_text: args.source,
+        target_text: args.target,
+        category: args.category,
+        notes: args.notes,
+        case_sensitive: args.case_sensitive,
+        always_active: args.always_active,
+        status: GlossaryStatus::UserSeeded,
+        source_language: source_language.to_string(),
+        target_language: target_language.to_string(),
+        source_count: 0,
+    };
+    let id = store.add_glossary_term(&term)?;
+    println!("Glossary term {id} saved.");
+    Ok(())
+}
+
+fn remove_term(store: &JobStore, args: RemoveArgs) -> Result<()> {
+    let removed = store.remove_glossary_term(args.id)?;
+    println!("Removed {removed} glossary terms.");
+    Ok(())
+}
+
+fn clear_terms(store: &JobStore, args: ClearArgs) -> Result<()> {
+    validate_scope(args.scope, args.scope_id.as_deref())?;
+    let removed = store.clear_glossary_scope(args.scope, args.scope_id.as_deref())?;
+    println!("Removed {removed} glossary terms.");
+    Ok(())
+}
+
+fn glossary_toml_to_terms(parsed: GlossaryToml) -> Result<Vec<GlossaryTerm>> {
+    if parsed.meta.schema_version != 1 {
+        anyhow::bail!(
+            "unsupported glossary schema_version {}; expected 1",
+            parsed.meta.schema_version
+        );
+    }
+    validate_scope(parsed.meta.scope.kind, parsed.meta.scope.id.as_deref())?;
+    let scope_id = normalized_scope_id(parsed.meta.scope.kind, parsed.meta.scope.id);
+    let terms = parsed
+        .terms
+        .into_iter()
+        .map(|term| GlossaryTerm {
+            id: None,
+            scope_kind: parsed.meta.scope.kind,
+            scope_id: scope_id.clone(),
+            source_text: term.source,
+            target_text: term.target,
+            category: term.category,
+            notes: term.notes,
+            case_sensitive: term.case_sensitive,
+            always_active: term.always_active,
+            status: term.status,
+            source_language: parsed.meta.source_language.clone(),
+            target_language: parsed.meta.target_language.clone(),
+            source_count: term.source_count,
+        })
+        .collect::<Vec<_>>();
+    Ok(terms)
+}
+
+fn terms_to_glossary_toml(terms: &[GlossaryTerm]) -> Result<GlossaryToml> {
+    let Some(first) = terms.first() else {
+        anyhow::bail!("cannot export an empty glossary");
+    };
+    let same_tuple = terms.iter().all(|term| {
+        term.scope_kind == first.scope_kind
+            && term.scope_id == first.scope_id
+            && term.source_language == first.source_language
+            && term.target_language == first.target_language
+    });
+    if !same_tuple {
+        anyhow::bail!(
+            "export matched multiple scope/language tuples; narrow with --scope, --scope-id, and --language"
+        );
+    }
+    Ok(GlossaryToml {
+        meta: GlossaryTomlMeta {
+            schema_version: 1,
+            source_language: first.source_language.clone(),
+            target_language: first.target_language.clone(),
+            scope: GlossaryTomlScope {
+                kind: first.scope_kind,
+                id: first.scope_id.clone(),
+            },
+        },
+        terms: terms
+            .iter()
+            .map(|term| GlossaryTomlTerm {
+                source: term.source_text.clone(),
+                target: term.target_text.clone(),
+                category: term.category,
+                case_sensitive: term.case_sensitive,
+                always_active: term.always_active,
+                notes: term.notes.clone(),
+                status: term.status,
+                source_count: term.source_count,
+            })
+            .collect(),
+    })
+}
+
+fn validate_scope(scope: GlossaryScopeKind, scope_id: Option<&str>) -> Result<()> {
+    match scope {
+        GlossaryScopeKind::Global => Ok(()),
+        GlossaryScopeKind::Series | GlossaryScopeKind::Book => {
+            if scope_id.is_some_and(|id| !id.trim().is_empty()) {
+                Ok(())
+            } else {
+                anyhow::bail!("--scope-id is required for {scope} glossary terms")
+            }
+        }
+    }
+}
+
+fn normalized_scope_id(scope: GlossaryScopeKind, scope_id: Option<String>) -> Option<String> {
+    if scope == GlossaryScopeKind::Global {
+        None
+    } else {
+        scope_id
+    }
+}
+
+fn parse_language_pair(value: &str) -> Result<(String, String)> {
+    for delimiter in ["->", ":", "/"] {
+        if let Some((source, target)) = value.split_once(delimiter) {
+            let source = source.trim();
+            let target = target.trim();
+            if !source.is_empty() && !target.is_empty() {
+                return Ok((source.to_string(), target.to_string()));
+            }
+        }
+    }
+    anyhow::bail!("language must be formatted as SOURCE->TARGET, SOURCE:TARGET, or SOURCE/TARGET")
+}
+
+fn default_user_seeded() -> GlossaryStatus {
+    GlossaryStatus::UserSeeded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_glossary_toml() {
+        let parsed: GlossaryToml = toml::from_str(
+            r#"
+[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[[term]]
+source = "Aragorn"
+target = "Aragorn"
+category = "person"
+case_sensitive = true
+"#,
+        )
+        .expect("TOML should parse");
+
+        let terms = glossary_toml_to_terms(parsed).expect("terms should convert");
+        assert_eq!(terms.len(), 1);
+        assert_eq!(terms[0].scope_kind, GlossaryScopeKind::Book);
+        assert_eq!(terms[0].scope_id.as_deref(), Some("fellowship"));
+        assert!(terms[0].case_sensitive);
+    }
+
+    #[test]
+    fn parses_language_pair() {
+        assert_eq!(
+            parse_language_pair("English->Italian").expect("pair"),
+            ("English".to_string(), "Italian".to_string())
+        );
+    }
+
+    #[test]
+    fn exported_toml_reimports_same_term_fields() {
+        let terms = vec![GlossaryTerm {
+            id: Some(7),
+            scope_kind: GlossaryScopeKind::Series,
+            scope_id: Some("lotr".to_string()),
+            source_text: "the One Ring".to_string(),
+            target_text: "l'Unico Anello".to_string(),
+            category: GlossaryCategory::Object,
+            notes: Some("canonical series term".to_string()),
+            case_sensitive: false,
+            always_active: false,
+            status: GlossaryStatus::UserSeeded,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+            source_count: 12,
+        }];
+
+        let exported = terms_to_glossary_toml(&terms).expect("terms should export");
+        let encoded = toml::to_string_pretty(&exported).expect("TOML should encode");
+        let reparsed: GlossaryToml = toml::from_str(&encoded).expect("TOML should parse");
+        let imported = glossary_toml_to_terms(reparsed).expect("terms should import");
+
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].scope_kind, terms[0].scope_kind);
+        assert_eq!(imported[0].scope_id, terms[0].scope_id);
+        assert_eq!(imported[0].source_text, terms[0].source_text);
+        assert_eq!(imported[0].target_text, terms[0].target_text);
+        assert_eq!(imported[0].category, terms[0].category);
+        assert_eq!(imported[0].notes, terms[0].notes);
+        assert_eq!(imported[0].source_count, terms[0].source_count);
+    }
+}

--- a/crates/bookforge-cli/src/commands/ingest_flags.rs
+++ b/crates/bookforge-cli/src/commands/ingest_flags.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeSet, fs, path::PathBuf};
 
 use anyhow::Result;
-use bookforge_store::{JobStore, NewSegmentFlag};
+use bookforge_core::{GlossaryCategory, GlossaryScopeKind, GlossaryStatus, GlossaryTerm};
+use bookforge_store::{JobRecord, JobStore, NewSegmentFlag};
 use clap::Args;
 use serde::Deserialize;
 
@@ -11,6 +12,9 @@ pub struct IngestFlagsArgs {
 
     #[arg(long)]
     pub flags: PathBuf,
+
+    #[arg(long, value_enum)]
+    pub default_scope: Option<GlossaryScopeKind>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -33,9 +37,9 @@ struct FlagEntry {
 
 pub async fn run(args: IngestFlagsArgs) -> Result<()> {
     let store = JobStore::open_default()?;
-    if store.get_job(&args.job_id)?.is_none() {
+    let Some(job) = store.get_job(&args.job_id)? else {
         anyhow::bail!("job '{}' was not found", args.job_id);
-    }
+    };
 
     let parsed: FlagsFile = serde_json::from_str(&fs::read_to_string(&args.flags)?)
         .map_err(|err| anyhow::anyhow!("invalid flags JSON: {err}"))?;
@@ -62,6 +66,7 @@ pub async fn run(args: IngestFlagsArgs) -> Result<()> {
         .filter(|flag| flag.kind == "wrong_translation")
         .map(|flag| flag.segment_id.clone())
         .collect::<BTreeSet<_>>();
+    let glossary_terms = glossary_terms_from_flags(&job, args.default_scope, &parsed.flags)?;
 
     let new_flags = parsed
         .flags
@@ -73,11 +78,14 @@ pub async fn run(args: IngestFlagsArgs) -> Result<()> {
             note: flag.note.as_deref(),
             suggested_source: flag.suggested_source.as_deref(),
             suggested_target: flag.suggested_target.as_deref(),
-            consumed: flag.kind == "wrong_translation",
+            consumed: flag.kind == "wrong_translation"
+                || (flag.kind == "name" && flag.suggested_target.is_some())
+                || flag.kind == "register",
         })
         .collect::<Vec<_>>();
 
     let inserted = store.insert_segment_flags(&new_flags)?;
+    let glossary_added = store.upsert_glossary_terms(&glossary_terms)?;
     let wrong_translation_ids = wrong_translation_ids.into_iter().collect::<Vec<_>>();
     let marked = store.mark_segments_needs_review(
         &args.job_id,
@@ -86,10 +94,94 @@ pub async fn run(args: IngestFlagsArgs) -> Result<()> {
     )?;
 
     println!(
-        "Ingested {inserted} flags. {marked} segments marked needs-review. Glossary integration will be available in v1.2."
+        "Ingested {inserted} flags. {marked} segments marked needs-review. {glossary_added} glossary terms saved."
     );
 
     Ok(())
+}
+
+fn glossary_terms_from_flags(
+    job: &JobRecord,
+    default_scope: Option<GlossaryScopeKind>,
+    flags: &[FlagEntry],
+) -> Result<Vec<GlossaryTerm>> {
+    let scope_kind = default_scope.unwrap_or(GlossaryScopeKind::Book);
+    let scope_id = match scope_kind {
+        GlossaryScopeKind::Global => None,
+        GlossaryScopeKind::Book => Some(job.book_id.clone().unwrap_or_else(|| job.id.clone())),
+        GlossaryScopeKind::Series => Some(job.series_id.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "--default-scope series requires job '{}' to have a series_id",
+                job.id
+            )
+        })?),
+    };
+    let source_language = job
+        .source_lang
+        .clone()
+        .unwrap_or_else(|| "auto".to_string());
+    let mut terms = Vec::new();
+    for flag in flags {
+        match flag.kind.as_str() {
+            "name"
+                if flag
+                    .suggested_target
+                    .as_deref()
+                    .is_some_and(|value| !value.trim().is_empty()) =>
+            {
+                let target = flag.suggested_target.clone().unwrap_or_default();
+                let source = flag
+                    .suggested_source
+                    .clone()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|| target.clone());
+                terms.push(GlossaryTerm {
+                    id: None,
+                    scope_kind,
+                    scope_id: scope_id.clone(),
+                    source_text: source,
+                    target_text: target,
+                    category: GlossaryCategory::Person,
+                    notes: flag.note.clone(),
+                    case_sensitive: true,
+                    always_active: false,
+                    status: GlossaryStatus::UserSeeded,
+                    source_language: source_language.clone(),
+                    target_language: job.target_lang.clone(),
+                    source_count: 0,
+                });
+            }
+            "register" => {
+                let source = flag
+                    .suggested_source
+                    .clone()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|| format!("__register:{}", flag.segment_id));
+                let target = flag
+                    .suggested_target
+                    .clone()
+                    .or_else(|| flag.note.clone())
+                    .unwrap_or_else(|| "register".to_string());
+                terms.push(GlossaryTerm {
+                    id: None,
+                    scope_kind,
+                    scope_id: scope_id.clone(),
+                    source_text: source,
+                    target_text: target,
+                    category: GlossaryCategory::Style,
+                    notes: flag.note.clone(),
+                    case_sensitive: false,
+                    always_active: true,
+                    status: GlossaryStatus::UserSeeded,
+                    source_language: source_language.clone(),
+                    target_language: job.target_lang.clone(),
+                    source_count: 0,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(terms)
 }
 
 fn validate_flags(job_id: &str, parsed: &FlagsFile) -> Result<()> {
@@ -159,5 +251,46 @@ mod tests {
         };
         let error = validate_flags("job_1", &parsed).expect_err("should reject kind");
         assert!(error.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn name_flags_seed_book_scoped_glossary_terms() {
+        let job = JobRecord {
+            id: "job_1".to_string(),
+            input_path: "input.epub".into(),
+            input_snapshot_path: None,
+            input_sha256: None,
+            output_path: "out.epub".into(),
+            input_hash: "hash".to_string(),
+            source_lang: Some("English".to_string()),
+            target_lang: "Italian".to_string(),
+            provider: "mock".to_string(),
+            model: "mock".to_string(),
+            base_url: None,
+            api_key_env: None,
+            status: "succeeded".to_string(),
+            events_path: None,
+            report_json_path: None,
+            report_markdown_path: None,
+            book_id: Some("fellowship".to_string()),
+            series_id: Some("lotr".to_string()),
+        };
+        let terms = glossary_terms_from_flags(
+            &job,
+            None,
+            &[FlagEntry {
+                segment_id: "seg_1".to_string(),
+                kind: "name".to_string(),
+                note: Some("preserve".to_string()),
+                suggested_source: Some("Aragorn".to_string()),
+                suggested_target: Some("Aragorn".to_string()),
+            }],
+        )
+        .expect("terms should build");
+
+        assert_eq!(terms.len(), 1);
+        assert_eq!(terms[0].scope_kind, GlossaryScopeKind::Book);
+        assert_eq!(terms[0].scope_id.as_deref(), Some("fellowship"));
+        assert_eq!(terms[0].category, GlossaryCategory::Person);
     }
 }

--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod doctor;
 pub mod estimate;
+pub mod glossary;
 pub mod ingest_flags;
 pub mod inspect;
 pub mod resume;

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -883,6 +883,8 @@ mod tests {
                 model: "mock-prefix-target",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
 
@@ -1047,6 +1049,8 @@ mod tests {
                 model: "mock-prefix-target",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let book = read_epub(&input).expect("fixture EPUB should read");

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -6,14 +6,18 @@ use std::{
 
 use anyhow::Result;
 use bookforge_core::{
-    ProgressEvent, ProgressSink, ResolvedRunSettings, RunConfigSnapshot,
+    ProgressEvent, ProgressSink, ResolvedRunSettings, RunConfigSnapshot, merge_scope_terms,
     progress::now_ms,
-    segment::{BlockTranslation, Segment, SegmentStatus, build_segments, compute_cache_namespace},
+    segment::{
+        BlockTranslation, Segment, SegmentStatus, build_segments, compute_cache_namespace,
+        compute_cache_namespace_v1,
+    },
+    select_glossary_for_segments,
 };
 use bookforge_epub::{read_epub, rebuild_epub};
 use bookforge_llm::{
-    MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider, QaSegmentReview,
-    SegmentTranslation, TranslationRunConfig,
+    GlossaryRunConfig, MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
+    QaSegmentReview, SegmentTranslation, TranslationRunConfig,
 };
 use bookforge_store::{JobRecord, JobStore, StoredBlockTranslation};
 use clap::Args;
@@ -206,6 +210,33 @@ async fn run_inner(
 
     let pending_segments = select_pending_segments(&segments, &pending_ids)?;
     let prompt_version = snapshot.prompt_version.as_str();
+    let legacy_cache_namespace = snapshot.glossary_fingerprint.is_empty();
+    let glossary = if legacy_cache_namespace {
+        crate::commands::translate::PreparedGlossary {
+            run_config: GlossaryRunConfig::default(),
+            fingerprint: String::new(),
+            active_terms: Vec::new(),
+        }
+    } else {
+        let active_terms = merge_scope_terms(&snapshot.glossary_terms);
+        let selected =
+            select_glossary_for_segments(&segments, &active_terms, snapshot.glossary_budget_tokens);
+        let fingerprint = crate::commands::translate::glossary_fingerprint(
+            snapshot.glossary_format,
+            snapshot.glossary_budget_tokens,
+            snapshot.prompt_extra.as_deref(),
+            &active_terms,
+        );
+        crate::commands::translate::PreparedGlossary {
+            run_config: GlossaryRunConfig {
+                format: snapshot.glossary_format,
+                entries_by_segment: selected.entries_by_segment,
+                prompt_extra: snapshot.prompt_extra.clone(),
+            },
+            fingerprint,
+            active_terms,
+        }
+    };
     let run_config = TranslationRunConfig {
         source_language: snapshot.source_language.clone(),
         target_language: snapshot.target_language.clone(),
@@ -219,15 +250,27 @@ async fn run_inner(
         max_output_tokens: settings.provider.max_output_tokens,
         batch_max_output_tokens: settings.provider.batch_max_output_tokens,
         compact_prompts: settings.compact_prompts,
+        glossary: glossary.run_config.clone(),
     };
 
-    let cache_namespace = compute_cache_namespace(
-        settings.segmentation.max_segment_tokens,
-        settings.segmentation.context_tokens,
-        run_config.profile.namespace_str(),
-        settings.batch.enabled,
-        prompt_version,
-    );
+    let cache_namespace = if legacy_cache_namespace {
+        compute_cache_namespace_v1(
+            settings.segmentation.max_segment_tokens,
+            settings.segmentation.context_tokens,
+            run_config.profile.namespace_str(),
+            settings.batch.enabled,
+            prompt_version,
+        )
+    } else {
+        compute_cache_namespace(
+            settings.segmentation.max_segment_tokens,
+            settings.segmentation.context_tokens,
+            run_config.profile.namespace_str(),
+            settings.batch.enabled,
+            prompt_version,
+            &glossary.fingerprint,
+        )
+    };
     if cache_namespace != snapshot.cache_namespace {
         anyhow::bail!(
             "resume cache namespace mismatch for job '{}': snapshot={}, recomputed={}",
@@ -607,6 +650,7 @@ fn batch_run_config(
         max_output_tokens: settings.provider.max_output_tokens,
         batch_max_output_tokens: settings.provider.batch_max_output_tokens,
         compact_prompts: settings.compact_prompts,
+        glossary: run_config.glossary.clone(),
     }
 }
 
@@ -883,7 +927,7 @@ mod tests {
                 model: "mock-prefix-target",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1018,6 +1062,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resume_accepts_legacy_v1_snapshot_without_glossary_metadata() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        let mut fixture = resume_fixture(settings.clone(), 1);
+        fixture.snapshot.glossary_fingerprint.clear();
+        fixture.snapshot.glossary_terms.clear();
+        fixture.snapshot.cache_namespace = compute_cache_namespace_v1(
+            settings.segmentation.max_segment_tokens,
+            settings.segmentation.context_tokens,
+            settings.profile.namespace_str(),
+            settings.batch.enabled,
+            fixture.snapshot.prompt_version.as_str(),
+        );
+        fixture
+            .store
+            .update_job_config_snapshot(&fixture.job.id, &fixture.snapshot)
+            .expect("legacy snapshot should persist");
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("legacy v1 snapshot should resume");
+
+        assert!(!segment_finished_ids(&events).is_empty());
+    }
+
+    #[tokio::test]
     async fn resume_errors_when_rebuilt_segments_do_not_match_stored_pending_ids() {
         let segments = vec![test_segment("seg_a", 0)];
         let pending_ids = vec!["seg_missing".to_string()];
@@ -1049,7 +1119,7 @@ mod tests {
                 model: "mock-prefix-target",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1065,12 +1135,19 @@ mod tests {
             .take(segment_count)
             .collect::<Vec<_>>();
         let prompt_version = "v1";
+        let glossary_fingerprint = crate::commands::translate::glossary_fingerprint(
+            bookforge_core::GlossaryFormat::Json,
+            800,
+            None,
+            &[],
+        );
         let cache_namespace = compute_cache_namespace(
             settings.segmentation.max_segment_tokens,
             settings.segmentation.context_tokens,
             settings.profile.namespace_str(),
             settings.batch.enabled,
             prompt_version,
+            &glossary_fingerprint,
         );
         store
             .insert_segments(
@@ -1100,6 +1177,13 @@ mod tests {
             provider_preset: None,
             prompt_version: prompt_version.to_string(),
             cache_namespace,
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: bookforge_core::GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint,
+            glossary_terms: Vec::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
         store

--- a/crates/bookforge-cli/src/commands/review.rs
+++ b/crates/bookforge-cli/src/commands/review.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use anyhow::Result;
-use bookforge_core::{RunConfigSnapshot, segment::build_segments};
+use bookforge_core::{
+    GlossaryTerm, RunConfigSnapshot, segment::build_segments, target_matches, term_matches,
+};
 use bookforge_epub::read_epub;
 use bookforge_store::{JobRecord, JobStore};
 use clap::Args;
@@ -70,6 +72,14 @@ struct ReviewSegment {
 struct ReviewWarning {
     kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    term_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    found_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     threshold: Option<f64>,
@@ -110,6 +120,16 @@ pub async fn run(args: ReviewArgs) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("job '{}' summary unavailable", job.id))?;
     let records = store.segment_records(&job.id)?;
     let translations = store.load_terminal_segment_translations(&job.id)?;
+    let glossary_terms = if snapshot.glossary_fingerprint.is_empty() {
+        store.load_active_glossary_terms(
+            job.source_lang.as_deref().unwrap_or("auto"),
+            &job.target_lang,
+            job.book_id.as_deref(),
+            job.series_id.as_deref(),
+        )?
+    } else {
+        snapshot.glossary_terms.clone()
+    };
 
     let document = build_review_document(
         &job,
@@ -119,6 +139,7 @@ pub async fn run(args: ReviewArgs) -> Result<()> {
         &records,
         &translations,
         &summary,
+        &glossary_terms,
     );
 
     let out_dir = args.out.unwrap_or_else(|| {
@@ -191,6 +212,7 @@ fn build_review_document(
     records: &[bookforge_store::SegmentRecord],
     translations: &[bookforge_store::StoredSegmentTranslation],
     summary: &bookforge_store::JobSummary,
+    glossary_terms: &[GlossaryTerm],
 ) -> ReviewDocument {
     let records_by_id = records
         .iter()
@@ -223,7 +245,12 @@ fn build_review_document(
                     .flatten(),
                 ordinal: segment.ordinal + 1,
                 source_text: segment.source.text.clone(),
-                soft_warnings: soft_warnings(record, &segment.source.text, &target_text),
+                soft_warnings: soft_warnings(
+                    record,
+                    &segment.source.text,
+                    &target_text,
+                    glossary_terms,
+                ),
                 target_text,
                 tokens: ReviewTokens {
                     input: record.input_tokens.unwrap_or(0),
@@ -271,6 +298,7 @@ fn soft_warnings(
     record: &bookforge_store::SegmentRecord,
     source: &str,
     target: &str,
+    glossary_terms: &[GlossaryTerm],
 ) -> Vec<ReviewWarning> {
     let mut warnings = Vec::new();
     match record.status.as_str() {
@@ -299,6 +327,10 @@ fn soft_warnings(
         if !(0.33..=3.0).contains(&ratio) {
             warnings.push(ReviewWarning {
                 kind: "length_ratio".to_string(),
+                term_id: None,
+                source: None,
+                expected_target: None,
+                found_target: None,
                 value: Some((ratio * 100.0).round() / 100.0),
                 threshold: Some(3.0),
                 from: None,
@@ -328,12 +360,44 @@ fn soft_warnings(
             "translation appears to include model commentary",
         ));
     }
+    warnings.extend(glossary_warnings(source, target, glossary_terms));
     warnings
+}
+
+fn glossary_warnings(
+    source: &str,
+    target: &str,
+    glossary_terms: &[GlossaryTerm],
+) -> Vec<ReviewWarning> {
+    glossary_terms
+        .iter()
+        .filter(|term| term_matches(source, term))
+        .filter(|term| !target_matches(target, term))
+        .map(|term| ReviewWarning {
+            kind: "glossary_mismatch".to_string(),
+            term_id: term.id,
+            source: Some(term.source_text.clone()),
+            expected_target: Some(term.target_text.clone()),
+            found_target: None,
+            value: None,
+            threshold: None,
+            from: None,
+            to: None,
+            message: Some(format!(
+                "expected glossary target '{}' for source '{}'",
+                term.target_text, term.source_text
+            )),
+        })
+        .collect()
 }
 
 fn warning_message(kind: &str, message: &str) -> ReviewWarning {
     ReviewWarning {
         kind: kind.to_string(),
+        term_id: None,
+        source: None,
+        expected_target: None,
+        found_target: None,
         value: None,
         threshold: None,
         from: None,
@@ -348,6 +412,10 @@ fn missing_tokens(kind: &str, source: &[String], target: &[String]) -> Vec<Revie
         .filter(|token| !target.contains(token))
         .map(|token| ReviewWarning {
             kind: kind.to_string(),
+            term_id: None,
+            source: None,
+            expected_target: None,
+            found_target: None,
             value: None,
             threshold: None,
             from: Some(token.clone()),
@@ -564,7 +632,11 @@ input[type="search"] {
   padding: 1px 7px;
   font-size: 11px;
 }
-.badge.status-needs_review, .badge.status-failed { border-color: #fecaca; background: #fef2f2; color: var(--bad); }
+.badge.status-needs_review, .badge.status-failed, .badge.glossary-mismatch {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: var(--bad);
+}
 .flag-panel {
   display: none;
   margin-top: 10px;
@@ -675,6 +747,7 @@ function warningLabel(w) {
   if (w.kind === "length_ratio" && w.value) return `length ${w.value}x`;
   if (w.kind === "url_changed") return "url";
   if (w.kind === "number_changed") return "number";
+  if (w.kind === "glossary_mismatch") return `glossary: ${w.source || ""}`;
   return w.kind.replaceAll("_", " ");
 }
 
@@ -711,7 +784,7 @@ function renderSegment(segment, side) {
   }
   for (const warning of segment.soft_warnings) {
     const b = document.createElement("span");
-    b.className = "badge";
+    b.className = warning.kind === "glossary_mismatch" ? "badge glossary-mismatch" : "badge";
     b.textContent = warningLabel(warning);
     b.title = warning.message || warning.kind;
     badges.appendChild(b);
@@ -894,5 +967,33 @@ mod tests {
         let html = render_html(&json!({"schema_version": 1, "x": "<tag>"}).to_string());
         assert!(html.contains("embedded-review-json"));
         assert!(html.contains("\\u003ctag\\u003e"));
+    }
+
+    #[test]
+    fn glossary_warning_reports_expected_target() {
+        let warnings = glossary_warnings(
+            "Aragorn arrived.",
+            "Granpasso arrivo.",
+            &[GlossaryTerm {
+                id: Some(42),
+                scope_kind: bookforge_core::GlossaryScopeKind::Book,
+                scope_id: Some("fellowship".to_string()),
+                source_text: "Aragorn".to_string(),
+                target_text: "Aragorn".to_string(),
+                category: bookforge_core::GlossaryCategory::Person,
+                notes: None,
+                case_sensitive: true,
+                always_active: false,
+                status: bookforge_core::GlossaryStatus::UserSeeded,
+                source_language: "English".to_string(),
+                target_language: "Italian".to_string(),
+                source_count: 0,
+            }],
+        );
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].kind, "glossary_mismatch");
+        assert_eq!(warnings[0].term_id, Some(42));
+        assert_eq!(warnings[0].expected_target.as_deref(), Some("Aragorn"));
     }
 }

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -201,6 +201,13 @@ mod tests {
             provider_preset: None,
             prompt_version: "v1".to_string(),
             cache_namespace: "cache".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: bookforge_core::GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: String::new(),
+            glossary_terms: Vec::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -173,6 +173,8 @@ mod tests {
             events_path: None,
             report_json_path: None,
             report_markdown_path: None,
+            book_id: None,
+            series_id: None,
         }
     }
 

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -195,6 +195,8 @@ mod tests {
             events_path,
             report_json_path: None,
             report_markdown_path: None,
+            book_id: None,
+            series_id: None,
         }
     }
 

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -220,6 +220,13 @@ mod tests {
             provider_preset: None,
             prompt_version: "v1".to_string(),
             cache_namespace: "cache".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: bookforge_core::GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: String::new(),
+            glossary_terms: Vec::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bookforge_core::{
-    JsonMode, ProviderPreset,
+    GlossaryFormat, JsonMode, ProviderPreset,
     config::{DoubleCheckMode, FallbackScope, TranslationProfile},
 };
 use clap::Args;
@@ -59,6 +59,24 @@ pub struct TranslateArgs {
 
     #[arg(long)]
     pub out: Option<PathBuf>,
+
+    #[arg(long)]
+    pub book_id: Option<String>,
+
+    #[arg(long)]
+    pub series_id: Option<String>,
+
+    #[arg(long = "glossary")]
+    pub glossary: Vec<PathBuf>,
+
+    #[arg(long, default_value_t = 800)]
+    pub glossary_budget_tokens: usize,
+
+    #[arg(long, value_enum, default_value_t = GlossaryFormat::Json)]
+    pub glossary_format: GlossaryFormat,
+
+    #[arg(long)]
+    pub prompt_extra: Option<String>,
 
     #[arg(long, value_enum, default_value_t = QaMode::Off)]
     pub qa: QaMode,

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -198,6 +198,8 @@ async fn run_mock_translation(
         model: &model,
         base_url: None,
         api_key_env: None,
+        book_id: None,
+        series_id: None,
     })?;
     if human_stdout_enabled(cli_args.ui) {
         println!("Job: {}", job.id);
@@ -438,6 +440,8 @@ async fn run_openai_compatible_translation(
         model: &model,
         base_url: Some(&provider_config.base_url),
         api_key_env: Some(&provider_config.api_key_env),
+        book_id: None,
+        series_id: None,
     })?;
     if human_stdout_enabled(cli_args.ui) {
         println!("Job: {}", job.id);
@@ -1519,6 +1523,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![segment("seg_a", 0), segment("seg_b", 1)];

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -2,23 +2,27 @@ use anyhow::Result;
 #[cfg(test)]
 use bookforge_core::config::TranslationProfile;
 use bookforge_core::{
-    NullProgressSink,
+    GlossaryFormat, GlossaryTerm, NullProgressSink,
     config::{DoubleCheckMode, FallbackScope, ResolvedRunSettings, TranslationConfig},
+    merge_scope_terms,
     scheduler::SchedulerConfig,
     segment::{Segment, SegmentStatus, build_segments, compute_cache_namespace},
+    select_glossary_for_segments,
 };
 use bookforge_epub::read_epub;
 #[cfg(test)]
 use bookforge_llm::translate_segments;
 use bookforge_llm::{
-    AdaptiveLimiter, LlmError, LlmProvider, MockMode, MockProvider, OpenAiCompatibleConfig,
-    OpenAiCompatibleProvider, ProviderRateController, QaSegmentReview, RateControllerConfig,
-    SegmentTranslation, TelemetryLog, TranslationRunConfig, build_translation_batches,
-    qa_segments_parallel, run_double_check, telemetry_summary, translate_batches_with_callback,
+    AdaptiveLimiter, GlossaryRunConfig, LlmError, LlmProvider, MockMode, MockProvider,
+    OpenAiCompatibleConfig, OpenAiCompatibleProvider, ProviderRateController, QaSegmentReview,
+    RateControllerConfig, SegmentTranslation, TelemetryLog, TranslationRunConfig,
+    account_for_batch_prompt_overhead, build_translation_batches, qa_segments_parallel,
+    run_double_check, telemetry_summary, translate_batches_with_callback,
     translate_segments_with_callback,
 };
 use bookforge_store::{CreateJob, JobRecord, JobStore};
 use clap::Args;
+use sha2::{Digest, Sha256};
 use std::{path::PathBuf, sync::Arc};
 
 #[cfg(test)]
@@ -26,6 +30,7 @@ use crate::LanguageArgs;
 use crate::{
     ProviderArgs as CliProviderArgs, QaMode,
     checkpoint::{CheckpointCommand, CheckpointSender, CheckpointWriter},
+    commands::glossary::read_glossary_file,
     default_output_path,
 };
 
@@ -141,6 +146,109 @@ fn human_stdout_enabled(ui: crate::progress::UiMode) -> bool {
     )
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedGlossary {
+    pub run_config: GlossaryRunConfig,
+    pub fingerprint: String,
+    pub active_terms: Vec<GlossaryTerm>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_glossary_run_config(
+    store: &JobStore,
+    glossary_files: &[PathBuf],
+    source_language: Option<&str>,
+    target_language: &str,
+    book_id: Option<&str>,
+    series_id: Option<&str>,
+    format: GlossaryFormat,
+    budget_tokens: usize,
+    prompt_extra: Option<String>,
+    segments: &[Segment],
+) -> Result<PreparedGlossary> {
+    let imported_terms = import_glossary_files(store, glossary_files)?;
+    let source_key = source_language.unwrap_or("auto");
+    let mut active_terms =
+        store.load_active_glossary_terms(source_key, target_language, book_id, series_id)?;
+    active_terms.extend(imported_terms.into_iter().filter(|term| {
+        term.active()
+            && term.target_language == target_language
+            && source_language.is_none_or(|source| term.source_language == source)
+    }));
+    active_terms = merge_scope_terms(&active_terms);
+    let selected = select_glossary_for_segments(segments, &active_terms, budget_tokens);
+    if selected.truncated_authoritative_entries > 0 {
+        tracing::warn!(
+            count = selected.truncated_authoritative_entries,
+            "glossary token budget dropped authoritative entries"
+        );
+    }
+    let fingerprint = glossary_fingerprint(
+        format,
+        budget_tokens,
+        prompt_extra.as_deref(),
+        &active_terms,
+    );
+    Ok(PreparedGlossary {
+        run_config: GlossaryRunConfig {
+            format,
+            entries_by_segment: selected.entries_by_segment,
+            prompt_extra,
+        },
+        fingerprint,
+        active_terms,
+    })
+}
+
+fn import_glossary_files(
+    store: &JobStore,
+    glossary_files: &[PathBuf],
+) -> Result<Vec<GlossaryTerm>> {
+    let mut imported = Vec::new();
+    for path in glossary_files {
+        let terms = read_glossary_file(path)?;
+        store.upsert_glossary_terms(&terms)?;
+        imported.extend(terms);
+    }
+    Ok(imported)
+}
+
+pub(crate) fn glossary_fingerprint(
+    format: GlossaryFormat,
+    budget_tokens: usize,
+    prompt_extra: Option<&str>,
+    terms: &[GlossaryTerm],
+) -> String {
+    let mut normalized = terms.to_vec();
+    for term in &mut normalized {
+        term.id = None;
+    }
+    normalized.sort_by(|a, b| {
+        a.source_language
+            .cmp(&b.source_language)
+            .then_with(|| a.target_language.cmp(&b.target_language))
+            .then_with(|| a.scope_kind.priority().cmp(&b.scope_kind.priority()))
+            .then_with(|| a.scope_id.cmp(&b.scope_id))
+            .then_with(|| a.source_text.cmp(&b.source_text))
+            .then_with(|| a.target_text.cmp(&b.target_text))
+    });
+    let payload = serde_json::json!({
+        "schema": 1,
+        "format": format.as_str(),
+        "budget_tokens": budget_tokens,
+        "prompt_extra": prompt_extra.unwrap_or(""),
+        "terms": normalized,
+    });
+    let serialized = serde_json::to_vec(&payload).unwrap_or_default();
+    let digest = Sha256::digest(serialized);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut hex, "{byte:02x}").expect("writing to string cannot fail");
+    }
+    hex
+}
+
 async fn finalize_reporter<T>(
     result: Result<T, anyhow::Error>,
     reporter: crate::progress::ProgressReporter,
@@ -189,6 +297,18 @@ async fn run_mock_translation(
         .unwrap_or_else(|| "mock-prefix-target".to_string());
     let prompt_version = "v1";
     let store = JobStore::open_default()?;
+    let glossary = prepare_glossary_run_config(
+        &store,
+        &cli_args.glossary,
+        config.source_language.as_deref(),
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+        cli_args.glossary_format,
+        cli_args.glossary_budget_tokens,
+        cli_args.prompt_extra.clone(),
+        &segments,
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -198,8 +318,8 @@ async fn run_mock_translation(
         model: &model,
         base_url: None,
         api_key_env: None,
-        book_id: None,
-        series_id: None,
+        book_id: cli_args.book_id.as_deref(),
+        series_id: cli_args.series_id.as_deref(),
     })?;
     if human_stdout_enabled(cli_args.ui) {
         println!("Job: {}", job.id);
@@ -216,6 +336,7 @@ async fn run_mock_translation(
         settings.profile.namespace_str(),
         settings.batch.enabled,
         prompt_version,
+        &glossary.fingerprint,
     );
     persist_snapshot(
         &store,
@@ -227,6 +348,8 @@ async fn run_mock_translation(
         settings,
         prompt_version,
         &cache_namespace,
+        &glossary.fingerprint,
+        &glossary.active_terms,
         &model,
         None,
         None,
@@ -252,6 +375,7 @@ async fn run_mock_translation(
         max_output_tokens: None,
         batch_max_output_tokens: None,
         compact_prompts: false,
+        glossary: glossary.run_config.clone(),
     }; // mock
     let provider = MockProvider::new(mock_mode(&model), &config.target_language);
     let mut translations = apply_cached_translations(
@@ -431,6 +555,18 @@ async fn run_openai_compatible_translation(
         "v1"
     };
     let store = JobStore::open_default()?;
+    let glossary = prepare_glossary_run_config(
+        &store,
+        &cli_args.glossary,
+        config.source_language.as_deref(),
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+        cli_args.glossary_format,
+        cli_args.glossary_budget_tokens,
+        cli_args.prompt_extra.clone(),
+        &segments,
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -440,8 +576,8 @@ async fn run_openai_compatible_translation(
         model: &model,
         base_url: Some(&provider_config.base_url),
         api_key_env: Some(&provider_config.api_key_env),
-        book_id: None,
-        series_id: None,
+        book_id: cli_args.book_id.as_deref(),
+        series_id: cli_args.series_id.as_deref(),
     })?;
     if human_stdout_enabled(cli_args.ui) {
         println!("Job: {}", job.id);
@@ -458,6 +594,7 @@ async fn run_openai_compatible_translation(
         settings.profile.namespace_str(),
         settings.batch.enabled,
         run_prompt_version,
+        &glossary.fingerprint,
     );
     persist_snapshot(
         &store,
@@ -469,6 +606,8 @@ async fn run_openai_compatible_translation(
         settings,
         run_prompt_version,
         &cache_namespace,
+        &glossary.fingerprint,
+        &glossary.active_terms,
         &model,
         Some(provider_config.base_url.clone()),
         Some(provider_config.api_key_env.clone()),
@@ -494,6 +633,7 @@ async fn run_openai_compatible_translation(
         max_output_tokens: settings.provider.max_output_tokens,
         batch_max_output_tokens: settings.provider.batch_max_output_tokens,
         compact_prompts: settings.compact_prompts,
+        glossary: glossary.run_config.clone(),
     };
     // batch_run_config
 
@@ -514,6 +654,7 @@ async fn run_openai_compatible_translation(
             max_output_tokens: settings.provider.max_output_tokens,
             batch_max_output_tokens: settings.provider.batch_max_output_tokens,
             compact_prompts: settings.compact_prompts,
+            glossary: run_config.glossary.clone(),
         };
         let mut translations = apply_cached_translations(
             &segments,
@@ -688,6 +829,7 @@ async fn finish_translation_pipeline(
         &job.id,
         run_prompt_version,
         settings,
+        run_config,
     )
     .await?;
     *translations = fallback_translations;
@@ -799,7 +941,11 @@ pub(crate) async fn translate_and_checkpoint_batch<P>(
 where
     P: LlmProvider,
 {
-    let batches = build_translation_batches(segments, &settings.batch, settings.profile);
+    let batches = account_for_batch_prompt_overhead(
+        build_translation_batches(segments, &settings.batch, settings.profile),
+        &settings.batch,
+        config,
+    );
 
     if batches.is_empty() {
         return translate_and_checkpoint(provider, segments, config, checkpoint).await;
@@ -929,6 +1075,7 @@ async fn run_fallback_pass(
     job_id: &str,
     prompt_version: &str,
     settings: &ResolvedRunSettings,
+    primary_run_config: &TranslationRunConfig,
 ) -> Result<Vec<SegmentTranslation>> {
     if cli_args.fallback_provider.is_none() && cli_args.fallback_model.is_none() {
         return Ok(translations);
@@ -994,8 +1141,8 @@ async fn run_fallback_pass(
     );
 
     let run_config = TranslationRunConfig {
-        source_language: None,
-        target_language: String::new(),
+        source_language: primary_run_config.source_language.clone(),
+        target_language: primary_run_config.target_language.clone(),
         provider: provider_str.to_string(),
         model: fallback_model.clone(),
         prompt_version: prompt_version.to_string(),
@@ -1009,6 +1156,7 @@ async fn run_fallback_pass(
         max_output_tokens: settings.provider.max_output_tokens,
         batch_max_output_tokens: settings.provider.batch_max_output_tokens,
         compact_prompts: settings.compact_prompts,
+        glossary: primary_run_config.glossary.clone(),
     }; // fallback_run_config
 
     let writer = CheckpointWriter::spawn(store.path().to_path_buf(), Arc::new(NullProgressSink));
@@ -1523,7 +1671,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1562,6 +1710,7 @@ mod tests {
             max_output_tokens: None,
             batch_max_output_tokens: None,
             compact_prompts: false,
+            glossary: GlossaryRunConfig::default(),
         };
 
         let error = translate_with_scheduler_guard(
@@ -1588,6 +1737,83 @@ mod tests {
 
         let _ = fs::remove_file(db_path);
         let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn glossary_file_is_selected_for_matching_segment() {
+        let db_path = temp_path("glossary_prepare.sqlite");
+        let glossary_path = temp_path("glossary.toml");
+        fs::write(
+            &glossary_path,
+            r#"
+[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[[term]]
+source = "Aragorn"
+target = "Aragorn"
+category = "person"
+case_sensitive = true
+"#,
+        )
+        .expect("glossary fixture should write");
+        let store = JobStore::open(&db_path).expect("store should open");
+        let mut segment = segment("seg_a", 0);
+        segment.source.text = "Aragorn entered the room.".to_string();
+        segment.source.blocks[0].text = segment.source.text.clone();
+
+        let prepared = prepare_glossary_run_config(
+            &store,
+            std::slice::from_ref(&glossary_path),
+            Some("English"),
+            "Italian",
+            Some("fellowship"),
+            None,
+            GlossaryFormat::Json,
+            800,
+            None,
+            &[segment],
+        )
+        .expect("glossary should prepare");
+
+        let entries = &prepared.run_config.entries_by_segment["seg_a"];
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source, "Aragorn");
+        assert_eq!(entries[0].target, "Aragorn");
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(glossary_path);
+    }
+
+    #[test]
+    fn glossary_format_changes_cache_fingerprint() {
+        let term = GlossaryTerm {
+            id: Some(1),
+            scope_kind: bookforge_core::GlossaryScopeKind::Book,
+            scope_id: Some("fellowship".to_string()),
+            source_text: "Aragorn".to_string(),
+            target_text: "Aragorn".to_string(),
+            category: bookforge_core::GlossaryCategory::Person,
+            notes: None,
+            case_sensitive: true,
+            always_active: false,
+            status: bookforge_core::GlossaryStatus::UserSeeded,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+            source_count: 0,
+        };
+
+        let json =
+            glossary_fingerprint(GlossaryFormat::Json, 800, None, std::slice::from_ref(&term));
+        let prose = glossary_fingerprint(GlossaryFormat::Prose, 800, None, &[term]);
+
+        assert_ne!(json, prose);
     }
 
     fn segment(id: &str, ordinal: usize) -> Segment {
@@ -1727,6 +1953,12 @@ mod tests {
             provider_max_attempts: None,
             validation_max_attempts: None,
             out: None,
+            book_id: None,
+            series_id: None,
+            glossary: Vec::new(),
+            glossary_budget_tokens: 800,
+            glossary_format: GlossaryFormat::Json,
+            prompt_extra: None,
             qa: QaMode::Off,
             qa_concurrency: 8,
             qa_batch_target_tokens: None,

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -4,7 +4,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bookforge_core::{ResolvedRunSettings, ResolvedRunSettingsSnapshot, RunConfigSnapshot};
+use bookforge_core::{
+    GlossaryTerm, ResolvedRunSettings, ResolvedRunSettingsSnapshot, RunConfigSnapshot,
+};
 use bookforge_store::{JobRecord, JobStore};
 use sha2::{Digest, Sha256};
 
@@ -29,6 +31,8 @@ pub(crate) fn persist_snapshot(
     settings: &ResolvedRunSettings,
     prompt_version: &str,
     cache_namespace: &str,
+    glossary_fingerprint: &str,
+    glossary_terms: &[GlossaryTerm],
     model: &str,
     base_url: Option<String>,
     api_key_env: Option<String>,
@@ -57,6 +61,13 @@ pub(crate) fn persist_snapshot(
         provider_preset: cli_args.provider_preset,
         prompt_version: prompt_version.to_string(),
         cache_namespace: cache_namespace.to_string(),
+        book_id: cli_args.book_id.clone(),
+        series_id: cli_args.series_id.clone(),
+        glossary_budget_tokens: cli_args.glossary_budget_tokens,
+        glossary_format: cli_args.glossary_format,
+        prompt_extra: cli_args.prompt_extra.clone(),
+        glossary_fingerprint: glossary_fingerprint.to_string(),
+        glossary_terms: glossary_terms.to_vec(),
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),
     };
     store.update_job_config_snapshot(&job.id, &snapshot)?;

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -8,8 +8,8 @@ mod report;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use commands::{
-    doctor, estimate, ingest_flags, inspect, resume, retry, review, status, tail, translate,
-    validate,
+    doctor, estimate, glossary, ingest_flags, inspect, resume, retry, review, status, tail,
+    translate, validate,
 };
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -34,6 +34,7 @@ enum Command {
     Resume(resume::ResumeArgs),
     Review(review::ReviewArgs),
     IngestFlags(ingest_flags::IngestFlagsArgs),
+    Glossary(glossary::GlossaryArgs),
     Retry(retry::RetryArgs),
     Validate(validate::ValidateArgs),
     Benchmark(Box<translate::BenchmarkArgs>),
@@ -61,6 +62,7 @@ async fn main() -> Result<()> {
         Command::Resume(args) => resume::run(args).await,
         Command::Review(args) => review::run(args).await,
         Command::IngestFlags(args) => ingest_flags::run(args).await,
+        Command::Glossary(args) => glossary::run(args).await,
         Command::Retry(args) => retry::run(args).await,
         Command::Validate(args) => validate::run(args).await,
         Command::Benchmark(args) => translate::run_benchmark(*args).await,

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use assert_cmd::Command;
-use bookforge_store::JobStore;
+use bookforge_core::GlossaryTerm;
+use bookforge_store::{GlossaryFilter, JobStore};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
@@ -32,6 +33,173 @@ fn cli_translate_mock_quiet_writes_output_report_and_events() {
     assert!(run.output.exists(), "translated EPUB should exist");
     assert!(run.events.exists(), "event log should exist");
     assert!(run.report.exists(), "markdown report should exist");
+}
+
+#[test]
+fn cli_translate_mock_with_same_glossary_is_bit_identical() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let glossary = temp.path().join("glossary.toml");
+    fs::write(
+        &glossary,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "smoke"
+
+[[term]]
+source = "Aragorn"
+target = "Aragorn"
+category = "person"
+case_sensitive = true
+"#,
+    )
+    .expect("glossary should write");
+
+    let first = temp.path().join("a.epub");
+    let second = temp.path().join("b.epub");
+    for output in [&first, &second] {
+        bookforge()
+            .current_dir(temp.path())
+            .args([
+                "translate",
+                input.to_str().unwrap(),
+                "--source",
+                "English",
+                "--target",
+                "Italian",
+                "--provider",
+                "mock",
+                "--model",
+                "mock-prefix-target",
+                "--profile",
+                "v1-fast",
+                "--ui",
+                "quiet",
+                "--book-id",
+                "smoke",
+                "--glossary",
+                glossary.to_str().unwrap(),
+                "--out",
+                output.to_str().unwrap(),
+            ])
+            .assert()
+            .success();
+    }
+
+    assert_eq!(
+        fs::read(&first).expect("first EPUB should read"),
+        fs::read(&second).expect("second EPUB should read"),
+        "same input and glossary should produce bit-identical EPUBs"
+    );
+}
+
+#[test]
+fn cli_glossary_import_export_reimports_identical_terms() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let imported = temp.path().join("imported.toml");
+    let exported = temp.path().join("exported.toml");
+    fs::write(
+        &imported,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "roundtrip"
+
+[[term]]
+source = "Aragorn"
+target = "Aragorn"
+category = "person"
+case_sensitive = true
+status = "user_seeded"
+source_count = 4
+
+[[term]]
+source = "Shire"
+target = "Contea"
+category = "place"
+notes = "Canonical place name."
+status = "accepted"
+source_count = 2
+"#,
+    )
+    .expect("glossary should write");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args(["glossary", "import", imported.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let store_path = temp.path().join(".bookforge/jobs.sqlite");
+    let store = JobStore::open(&store_path).expect("store opens");
+    let original = store
+        .list_glossary_terms(roundtrip_filter())
+        .expect("terms should list");
+    assert_eq!(original.len(), 2);
+    assert!(
+        original
+            .iter()
+            .any(|term| term.status == bookforge_core::GlossaryStatus::UserSeeded)
+    );
+    assert!(
+        original
+            .iter()
+            .any(|term| term.status == bookforge_core::GlossaryStatus::Accepted)
+    );
+    drop(store);
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "glossary",
+            "export",
+            exported.to_str().unwrap(),
+            "--scope",
+            "book",
+            "--scope-id",
+            "roundtrip",
+            "--language",
+            "English->Italian",
+        ])
+        .assert()
+        .success();
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "glossary",
+            "clear",
+            "--scope",
+            "book",
+            "--scope-id",
+            "roundtrip",
+        ])
+        .assert()
+        .success();
+    bookforge()
+        .current_dir(temp.path())
+        .args(["glossary", "import", exported.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let store = JobStore::open(&store_path).expect("store opens");
+    let roundtripped = store
+        .list_glossary_terms(roundtrip_filter())
+        .expect("terms should list");
+    assert_eq!(
+        normalized_terms(original),
+        normalized_terms(roundtripped),
+        "exported TOML should reimport to the same glossary term fields"
+    );
 }
 
 #[test]
@@ -83,6 +251,39 @@ fn cli_translate_json_mode_emits_valid_jsonl_stdout_and_file_log() {
             .any(|event| event.get("TranslationFinished").is_some()),
         "file JSONL should include completion"
     );
+}
+
+fn roundtrip_filter<'a>() -> GlossaryFilter<'a> {
+    GlossaryFilter {
+        scope_kind: Some(bookforge_core::GlossaryScopeKind::Book),
+        scope_id: Some("roundtrip"),
+        source_language: Some("English"),
+        target_language: Some("Italian"),
+        active_only: false,
+    }
+}
+
+fn normalized_terms(mut terms: Vec<GlossaryTerm>) -> Vec<GlossaryTerm> {
+    for term in &mut terms {
+        term.id = None;
+    }
+    terms.sort_by(|a, b| {
+        (
+            a.scope_kind.as_str(),
+            a.scope_id.as_deref(),
+            a.source_text.as_str(),
+            a.source_language.as_str(),
+            a.target_language.as_str(),
+        )
+            .cmp(&(
+                b.scope_kind.as_str(),
+                b.scope_id.as_deref(),
+                b.source_text.as_str(),
+                b.source_language.as_str(),
+                b.target_language.as_str(),
+            ))
+    });
+    terms
 }
 
 #[test]

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-core"
-version = "1.1.0"
+version = "1.2.0"
 description = "Core IR, segmentation, configuration, and progress types for BookForge."
 edition.workspace = true
 license.workspace = true

--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -1,0 +1,550 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::segment::Segment;
+
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlossaryScopeKind {
+    Global,
+    Series,
+    Book,
+}
+
+impl GlossaryScopeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Series => "series",
+            Self::Book => "book",
+        }
+    }
+
+    pub fn priority(self) -> usize {
+        match self {
+            Self::Global => 0,
+            Self::Series => 1,
+            Self::Book => 2,
+        }
+    }
+}
+
+impl std::str::FromStr for GlossaryScopeKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "global" => Ok(Self::Global),
+            "series" => Ok(Self::Series),
+            "book" => Ok(Self::Book),
+            other => Err(format!(
+                "invalid glossary scope '{other}'; expected global, series, or book"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for GlossaryScopeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlossaryCategory {
+    Person,
+    Place,
+    Object,
+    Invented,
+    Style,
+    Phrase,
+    Other,
+}
+
+impl GlossaryCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Person => "person",
+            Self::Place => "place",
+            Self::Object => "object",
+            Self::Invented => "invented",
+            Self::Style => "style",
+            Self::Phrase => "phrase",
+            Self::Other => "other",
+        }
+    }
+
+    pub fn is_high_frequency_anchor(self) -> bool {
+        matches!(
+            self,
+            Self::Person | Self::Place | Self::Object | Self::Invented
+        )
+    }
+}
+
+impl std::str::FromStr for GlossaryCategory {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "person" => Ok(Self::Person),
+            "place" => Ok(Self::Place),
+            "object" => Ok(Self::Object),
+            "invented" => Ok(Self::Invented),
+            "style" => Ok(Self::Style),
+            "phrase" => Ok(Self::Phrase),
+            "other" => Ok(Self::Other),
+            other => Err(format!(
+                "invalid glossary category '{other}'; expected person, place, object, invented, style, phrase, or other"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for GlossaryCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlossaryStatus {
+    UserSeeded,
+    AutoCandidate,
+    Accepted,
+    Rejected,
+}
+
+impl GlossaryStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserSeeded => "user_seeded",
+            Self::AutoCandidate => "auto_candidate",
+            Self::Accepted => "accepted",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::UserSeeded | Self::Accepted)
+    }
+}
+
+impl std::str::FromStr for GlossaryStatus {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "user_seeded" => Ok(Self::UserSeeded),
+            "auto_candidate" => Ok(Self::AutoCandidate),
+            "accepted" => Ok(Self::Accepted),
+            "rejected" => Ok(Self::Rejected),
+            other => Err(format!(
+                "invalid glossary status '{other}'; expected user_seeded, auto_candidate, accepted, or rejected"
+            )),
+        }
+    }
+}
+
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlossaryFormat {
+    Json,
+    Prose,
+}
+
+impl GlossaryFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Prose => "prose",
+        }
+    }
+}
+
+impl std::fmt::Display for GlossaryFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlossaryTerm {
+    pub id: Option<i64>,
+    pub scope_kind: GlossaryScopeKind,
+    pub scope_id: Option<String>,
+    pub source_text: String,
+    pub target_text: String,
+    pub category: GlossaryCategory,
+    pub notes: Option<String>,
+    pub case_sensitive: bool,
+    pub always_active: bool,
+    pub status: GlossaryStatus,
+    pub source_language: String,
+    pub target_language: String,
+    pub source_count: usize,
+}
+
+impl GlossaryTerm {
+    pub fn active(&self) -> bool {
+        self.status.is_active()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlossaryPromptTerm {
+    pub source: String,
+    pub target: String,
+    pub category: GlossaryCategory,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub term_id: Option<i64>,
+    pub case_sensitive: bool,
+}
+
+impl GlossaryPromptTerm {
+    fn from_term(term: &GlossaryTerm) -> Self {
+        Self {
+            source: term.source_text.clone(),
+            target: term.target_text.clone(),
+            category: term.category,
+            note: term.notes.clone(),
+            term_id: term.id,
+            case_sensitive: term.case_sensitive,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentGlossarySelections {
+    pub entries_by_segment: HashMap<String, Vec<GlossaryPromptTerm>>,
+    pub truncated_authoritative_entries: usize,
+}
+
+pub fn merge_scope_terms(terms: &[GlossaryTerm]) -> Vec<GlossaryTerm> {
+    let mut by_key: HashMap<(String, bool, String, String), GlossaryTerm> = HashMap::new();
+    for term in terms.iter().filter(|term| term.active()) {
+        let key = (
+            if term.case_sensitive {
+                term.source_text.clone()
+            } else {
+                term.source_text.to_lowercase()
+            },
+            term.case_sensitive,
+            term.source_language.clone(),
+            term.target_language.clone(),
+        );
+        match by_key.get(&key) {
+            Some(existing) if existing.scope_kind.priority() > term.scope_kind.priority() => {}
+            _ => {
+                by_key.insert(key, term.clone());
+            }
+        }
+    }
+    let mut merged = by_key.into_values().collect::<Vec<_>>();
+    merged.sort_by(|a, b| {
+        a.scope_kind
+            .priority()
+            .cmp(&b.scope_kind.priority())
+            .then_with(|| a.source_text.cmp(&b.source_text))
+            .then_with(|| a.target_text.cmp(&b.target_text))
+    });
+    merged
+}
+
+pub fn select_glossary_for_segments(
+    segments: &[Segment],
+    terms: &[GlossaryTerm],
+    budget_tokens: usize,
+) -> SegmentGlossarySelections {
+    let terms = merge_scope_terms(terms);
+    let computed_counts = source_counts(segments, &terms);
+    let high_frequency = high_frequency_anchors(&terms, &computed_counts, 20);
+    let mut entries_by_segment = HashMap::new();
+    let mut truncated_authoritative_entries = 0usize;
+
+    for (index, segment) in segments.iter().enumerate() {
+        let mut selected = Vec::<&GlossaryTerm>::new();
+        let mut seen = HashSet::<i64>::new();
+
+        for term in &terms {
+            if term_matches(&segment.source.text, term) {
+                push_term(&mut selected, &mut seen, term);
+            }
+        }
+
+        for term in terms.iter().filter(|term| term.always_active) {
+            push_term(&mut selected, &mut seen, term);
+        }
+
+        let start = index.saturating_sub(5);
+        for previous in &segments[start..index] {
+            if previous.section_id != segment.section_id {
+                continue;
+            }
+            for term in &terms {
+                if term_matches(&previous.source.text, term) {
+                    push_term(&mut selected, &mut seen, term);
+                }
+            }
+        }
+
+        for term in &high_frequency {
+            push_term(&mut selected, &mut seen, term);
+        }
+
+        let (bounded, truncated) = enforce_budget(selected, budget_tokens);
+        truncated_authoritative_entries += truncated;
+        entries_by_segment.insert(
+            segment.id.0.clone(),
+            bounded
+                .into_iter()
+                .map(GlossaryPromptTerm::from_term)
+                .collect(),
+        );
+    }
+
+    SegmentGlossarySelections {
+        entries_by_segment,
+        truncated_authoritative_entries,
+    }
+}
+
+pub fn term_matches(text: &str, term: &GlossaryTerm) -> bool {
+    if term.source_text.is_empty() {
+        return false;
+    }
+    if term.case_sensitive {
+        text.contains(&term.source_text)
+    } else {
+        text.to_lowercase()
+            .contains(&term.source_text.to_lowercase())
+    }
+}
+
+pub fn target_matches(text: &str, term: &GlossaryTerm) -> bool {
+    if term.target_text.is_empty() {
+        return false;
+    }
+    if term.case_sensitive {
+        text.contains(&term.target_text)
+    } else {
+        text.to_lowercase()
+            .contains(&term.target_text.to_lowercase())
+    }
+}
+
+fn push_term<'a>(
+    selected: &mut Vec<&'a GlossaryTerm>,
+    seen: &mut HashSet<i64>,
+    term: &'a GlossaryTerm,
+) {
+    let synthetic = term.synthetic_id();
+    if seen.insert(synthetic) {
+        selected.push(term);
+    }
+}
+
+fn enforce_budget(terms: Vec<&GlossaryTerm>, budget_tokens: usize) -> (Vec<&GlossaryTerm>, usize) {
+    let mut used = 0usize;
+    let mut kept = Vec::new();
+    let mut truncated = 0usize;
+    for term in terms {
+        let estimate = estimate_prompt_tokens(term);
+        if used + estimate <= budget_tokens || kept.is_empty() {
+            used += estimate;
+            kept.push(term);
+        } else if term.status == GlossaryStatus::UserSeeded || term.always_active {
+            truncated += 1;
+        }
+    }
+    (kept, truncated)
+}
+
+fn estimate_prompt_tokens(term: &GlossaryTerm) -> usize {
+    let note = term.notes.as_deref().unwrap_or("");
+    let chars = term.source_text.len()
+        + term.target_text.len()
+        + term.category.as_str().len()
+        + note.len()
+        + 16;
+    chars.div_ceil(3).max(1)
+}
+
+fn source_counts(segments: &[Segment], terms: &[GlossaryTerm]) -> HashMap<i64, usize> {
+    let mut counts = HashMap::new();
+    for term in terms {
+        let count = segments
+            .iter()
+            .filter(|segment| term_matches(&segment.source.text, term))
+            .count();
+        counts.insert(term.synthetic_id(), count);
+    }
+    counts
+}
+
+fn high_frequency_anchors<'a>(
+    terms: &'a [GlossaryTerm],
+    computed_counts: &HashMap<i64, usize>,
+    limit: usize,
+) -> Vec<&'a GlossaryTerm> {
+    let mut anchors = terms
+        .iter()
+        .filter(|term| term.category.is_high_frequency_anchor())
+        .map(|term| {
+            let count = term
+                .source_count
+                .max(*computed_counts.get(&term.synthetic_id()).unwrap_or(&0));
+            (term, count)
+        })
+        .filter(|(_, count)| *count > 0)
+        .collect::<Vec<_>>();
+    anchors.sort_by(|(a, ac), (b, bc)| {
+        bc.cmp(ac)
+            .then_with(|| {
+                a.scope_kind
+                    .priority()
+                    .cmp(&b.scope_kind.priority())
+                    .reverse()
+            })
+            .then_with(|| a.source_text.cmp(&b.source_text))
+    });
+    anchors
+        .into_iter()
+        .take(limit)
+        .map(|(term, _)| term)
+        .collect()
+}
+
+trait SyntheticId {
+    fn synthetic_id(&self) -> i64;
+}
+
+impl SyntheticId for GlossaryTerm {
+    fn synthetic_id(&self) -> i64 {
+        self.id.unwrap_or_else(|| {
+            let mut hash = 0xcbf29ce484222325_u64;
+            for byte in format!(
+                "{}\0{}\0{}\0{}",
+                self.scope_kind.as_str(),
+                self.scope_id.as_deref().unwrap_or(""),
+                self.source_language,
+                self.source_text
+            )
+            .as_bytes()
+            {
+                hash ^= u64::from(*byte);
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+            i64::from_ne_bytes(hash.to_ne_bytes())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ir::{BlockId, SectionId},
+        segment::{
+            Segment, SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
+            SegmentSource,
+        },
+    };
+
+    #[test]
+    fn book_scope_overrides_series_scope() {
+        let terms = vec![
+            term("Aragorn", "Aragorn", GlossaryScopeKind::Series),
+            term("Aragorn", "Granpasso", GlossaryScopeKind::Book),
+        ];
+        let merged = merge_scope_terms(&terms);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].target_text, "Granpasso");
+    }
+
+    #[test]
+    fn merge_preserves_case_sensitive_source_variants() {
+        let mut proper_name = term("Will", "Will", GlossaryScopeKind::Book);
+        proper_name.case_sensitive = true;
+        let mut auxiliary = term("will", "volonta", GlossaryScopeKind::Book);
+        auxiliary.case_sensitive = true;
+
+        let merged = merge_scope_terms(&[proper_name, auxiliary]);
+
+        assert_eq!(merged.len(), 2);
+        assert!(merged.iter().any(|term| term.source_text == "Will"));
+        assert!(merged.iter().any(|term| term.source_text == "will"));
+    }
+
+    #[test]
+    fn selects_matched_always_recent_and_high_frequency_terms() {
+        let mut ring = term("Ring", "Anello", GlossaryScopeKind::Book);
+        ring.category = GlossaryCategory::Object;
+        ring.source_count = 100;
+        let mut style = term("you", "tu", GlossaryScopeKind::Book);
+        style.category = GlossaryCategory::Style;
+        style.always_active = true;
+        let terms = vec![ring, style];
+        let segments = vec![
+            segment("seg_1", 0, "The Ring is here"),
+            segment("seg_2", 1, "He lifted it"),
+        ];
+
+        let selected = select_glossary_for_segments(&segments, &terms, 800);
+        let second = &selected.entries_by_segment["seg_2"];
+        assert!(second.iter().any(|entry| entry.source == "Ring"));
+        assert!(second.iter().any(|entry| entry.source == "you"));
+    }
+
+    fn term(source: &str, target: &str, scope_kind: GlossaryScopeKind) -> GlossaryTerm {
+        GlossaryTerm {
+            id: None,
+            scope_kind,
+            scope_id: Some("scope".to_string()),
+            source_text: source.to_string(),
+            target_text: target.to_string(),
+            category: GlossaryCategory::Person,
+            notes: None,
+            case_sensitive: false,
+            always_active: false,
+            status: GlossaryStatus::UserSeeded,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+            source_count: 0,
+        }
+    }
+
+    fn segment(id: &str, ordinal: usize, text: &str) -> Segment {
+        let block_id = BlockId(format!("b_{ordinal:06}"));
+        Segment {
+            id: SegmentId(id.to_string()),
+            section_id: SectionId("sec_1".to_string()),
+            ordinal,
+            block_ids: vec![block_id.clone()],
+            source: SegmentSource {
+                text: text.to_string(),
+                blocks: vec![SegmentBlock {
+                    block_id,
+                    kind: "paragraph".to_string(),
+                    text: text.to_string(),
+                    text_runs: Vec::new(),
+                    protected_spans: Vec::new(),
+                }],
+                token_estimate: text.len() / 4,
+            },
+            context: SegmentContext::default(),
+            metadata: SegmentMetadata::default(),
+            constraints: SegmentConstraints::default(),
+            checksum: id.to_string(),
+        }
+    }
+}

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod error;
+pub mod glossary;
 pub mod ir;
 pub mod marker;
 pub mod progress;
@@ -15,6 +16,11 @@ pub use config::{
     TranslationProfile, cap_output_tokens,
 };
 pub use error::{BookforgeError, Result};
+pub use glossary::{
+    GlossaryCategory, GlossaryFormat, GlossaryPromptTerm, GlossaryScopeKind, GlossaryStatus,
+    GlossaryTerm, SegmentGlossarySelections, merge_scope_terms, select_glossary_for_segments,
+    target_matches, term_matches,
+};
 pub use progress::{NullProgressSink, ProgressEvent, ProgressSink, now_ms};
 pub use run_snapshot::{ResolvedRunSettingsSnapshot, RunConfigSnapshot};
 pub use scheduler::SchedulerConfig;

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::{
     BatchConfig, DoubleCheckConfig, JsonMode, ProviderPreset, ProviderRuntimeConfig, QaRunConfig,
     ResolvedRunSettings, RetryAfterPolicy, SchedulerConfig, SegmentationConfig, TranslationProfile,
+    glossary::{GlossaryFormat, GlossaryTerm},
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -26,7 +27,29 @@ pub struct RunConfigSnapshot {
     pub provider_preset: Option<ProviderPreset>,
     pub prompt_version: String,
     pub cache_namespace: String,
+    #[serde(default)]
+    pub book_id: Option<String>,
+    #[serde(default)]
+    pub series_id: Option<String>,
+    #[serde(default = "default_glossary_budget_tokens")]
+    pub glossary_budget_tokens: usize,
+    #[serde(default = "default_glossary_format")]
+    pub glossary_format: GlossaryFormat,
+    #[serde(default)]
+    pub prompt_extra: Option<String>,
+    #[serde(default)]
+    pub glossary_fingerprint: String,
+    #[serde(default)]
+    pub glossary_terms: Vec<GlossaryTerm>,
     pub settings: ResolvedRunSettingsSnapshot,
+}
+
+fn default_glossary_budget_tokens() -> usize {
+    800
+}
+
+fn default_glossary_format() -> GlossaryFormat {
+    GlossaryFormat::Json
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Bumped when the cache key derivation changes incompatibly.
-pub const CACHE_KEY_SCHEMA_VERSION: u32 = 1;
+pub const CACHE_KEY_SCHEMA_VERSION: u32 = 2;
 /// Bumped when Segment / SegmentBlock layout changes incompatibly.
 pub const SEGMENT_SCHEMA_VERSION: u32 = 1;
 /// Bumped when inline marker extraction (m/keep/ref) changes incompatibly.
@@ -23,9 +23,48 @@ pub fn compute_cache_namespace(
     profile: &str,
     batch_enabled: bool,
     prompt_version: &str,
+    glossary_fingerprint: &str,
+) -> String {
+    compute_cache_namespace_inner(
+        CACHE_KEY_SCHEMA_VERSION,
+        max_segment_tokens,
+        context_tokens,
+        profile,
+        batch_enabled,
+        prompt_version,
+        Some(glossary_fingerprint),
+    )
+}
+
+pub fn compute_cache_namespace_v1(
+    max_segment_tokens: usize,
+    context_tokens: usize,
+    profile: &str,
+    batch_enabled: bool,
+    prompt_version: &str,
+) -> String {
+    compute_cache_namespace_inner(
+        1,
+        max_segment_tokens,
+        context_tokens,
+        profile,
+        batch_enabled,
+        prompt_version,
+        None,
+    )
+}
+
+fn compute_cache_namespace_inner(
+    cache_key_schema_version: u32,
+    max_segment_tokens: usize,
+    context_tokens: usize,
+    profile: &str,
+    batch_enabled: bool,
+    prompt_version: &str,
+    glossary_fingerprint: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(CACHE_KEY_SCHEMA_VERSION.to_le_bytes());
+    hasher.update(cache_key_schema_version.to_le_bytes());
     hasher.update(SEGMENT_SCHEMA_VERSION.to_le_bytes());
     hasher.update(INLINE_MARKER_SCHEMA_VERSION.to_le_bytes());
     hasher.update((max_segment_tokens as u64).to_le_bytes());
@@ -33,6 +72,9 @@ pub fn compute_cache_namespace(
     hasher.update(profile.as_bytes());
     hasher.update([batch_enabled as u8]);
     hasher.update(prompt_version.as_bytes());
+    if let Some(glossary_fingerprint) = glossary_fingerprint {
+        hasher.update(glossary_fingerprint.as_bytes());
+    }
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(digest.len() * 2);
     for byte in digest {
@@ -409,16 +451,33 @@ mod tests {
 
     #[test]
     fn cache_namespace_changes_when_segmentation_settings_change() {
-        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1");
-        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1");
-        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1");
-        let d = compute_cache_namespace(1200, 160, "Balanced", false, "batch_v1");
-        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1");
+        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
+        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1", "glossary:a");
+        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a");
+        let d = compute_cache_namespace(1200, 160, "Balanced", false, "batch_v1", "glossary:a");
+        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
+        let f = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:b");
 
         assert_ne!(a, b, "max_segment_tokens must affect namespace");
         assert_ne!(a, c, "batch_enabled must affect namespace");
         assert_ne!(a, d, "prompt_version must affect namespace");
+        assert_ne!(a, f, "glossary fingerprint must affect namespace");
         assert_eq!(a, e, "namespace is deterministic for identical inputs");
+    }
+
+    #[test]
+    fn legacy_cache_namespace_v1_ignores_glossary_fingerprint() {
+        let current_without_terms = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "");
+        let current_with_terms =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
+        let legacy = compute_cache_namespace_v1(1200, 160, "Balanced", false, "v1");
+
+        assert_ne!(legacy, current_without_terms);
+        assert_ne!(legacy, current_with_terms);
+        assert_eq!(
+            legacy,
+            compute_cache_namespace_v1(1200, 160, "Balanced", false, "v1")
+        );
     }
 
     fn book_with_two_sections() -> Book {

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-epub"
-version = "1.1.0"
+version = "1.2.0"
 description = "EPUB reading, validation, and deterministic rebuild support for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.1.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.2.0", path = "../bookforge-core" }
 quick-xml.workspace = true
 tracing.workspace = true
 zip.workspace = true

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -15,7 +15,7 @@ use quick_xml::{
     Reader, Writer,
     events::{BytesEnd, BytesText, Event},
 };
-use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
+use zip::{CompressionMethod, DateTime, ZipArchive, ZipWriter, write::SimpleFileOptions};
 
 pub fn rebuild_epub(book: &Book, translations: &[BlockTranslation], output: &Path) -> Result<()> {
     let source_path = book.source_path.as_deref().ok_or_else(|| {
@@ -43,7 +43,9 @@ pub fn rebuild_epub(book: &Book, translations: &[BlockTranslation], output: &Pat
 
     write_mimetype_first(&mut archive, &mut writer)?;
 
-    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    let deflated = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .last_modified_time(deterministic_zip_time());
     let mut total_skipped = 0usize;
     for index in 0..archive.len() {
         let mut file = archive.by_index(index)?;
@@ -101,10 +103,16 @@ fn write_mimetype_first(source: &mut ZipArchive<File>, writer: &mut ZipWriter<Fi
         ));
     }
 
-    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let stored = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .last_modified_time(deterministic_zip_time());
     writer.start_file("mimetype", stored)?;
     writer.write_all(b"application/epub+zip")?;
     Ok(())
+}
+
+fn deterministic_zip_time() -> DateTime {
+    DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).expect("DOS epoch timestamp should be valid")
 }
 
 fn patches_by_href<'a>(

--- a/crates/bookforge-llm/Cargo.toml
+++ b/crates/bookforge-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-llm"
-version = "1.1.0"
+version = "1.2.0"
 description = "Prompting, providers, batching, and validation for BookForge translation runs."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.1.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.2.0", path = "../bookforge-core" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
@@ -55,6 +55,12 @@ Return exactly:
 
 Translate every structured item. Preserve ALL markers exactly.
 
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Input:
 {{items_json}}
 

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
@@ -17,5 +17,6 @@ Return exactly:
 ## User
 
 Translate every item, preserving all markers.
+Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
@@ -21,6 +21,12 @@ Return exactly:
 
 Translate every item.
 
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Input:
 {{items_json}}
 

--- a/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
@@ -11,5 +11,6 @@ Return exactly:
 ## User
 
 Translate every item.
+Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
@@ -22,6 +22,12 @@ Return exactly:
 
 Translate every item.
 
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Input:
 {{items_json}}
 

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
@@ -17,5 +17,6 @@ Return exactly:
 ## User
 
 Translate every item.
+Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
@@ -95,6 +95,18 @@ Glossary and fixed terminology:
 {{glossary_json}}
 ```
 
+Glossary prose constraints:
+
+```txt
+{{glossary_block_prose}}
+```
+
+Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Protected spans that must not be changed:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
@@ -75,6 +75,18 @@ Glossary and fixed terminology:
 {{glossary_json}}
 ```
 
+Glossary prose constraints:
+
+```txt
+{{glossary_block_prose}}
+```
+
+Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Protected spans that must not be changed:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_segment.v1.md
+++ b/crates/bookforge-llm/prompts/translate_segment.v1.md
@@ -67,6 +67,18 @@ Glossary and fixed terminology:
 {{glossary_json}}
 ```
 
+Glossary prose constraints:
+
+```txt
+{{glossary_block_prose}}
+```
+
+Additional instructions:
+
+```txt
+{{prompt_extra}}
+```
+
 Protected spans that must not be changed:
 
 ```json

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1,5 +1,6 @@
 use bookforge_core::{
     config::{BatchConfig, ProviderRequestMetric, TranslationProfile},
+    glossary::GlossaryFormat,
     ir::BlockId,
     segment::{BlockTranslation, Segment, SegmentId, SegmentStatus, SegmentTextRun},
 };
@@ -557,6 +558,24 @@ pub fn build_translation_batches(
     group_batches(items, config)
 }
 
+pub fn account_for_batch_prompt_overhead(
+    batches: Vec<TranslationBatch>,
+    config: &BatchConfig,
+    run_config: &TranslationRunConfig,
+) -> Vec<TranslationBatch> {
+    let target_tokens = mode_target_tokens(config.target_tokens);
+    batches
+        .into_iter()
+        .flat_map(|batch| {
+            let token_limit = target_tokens
+                .get(&batch.mode)
+                .copied()
+                .unwrap_or(config.target_tokens);
+            repack_batch_with_config(batch, token_limit, config.max_items, Some(run_config))
+        })
+        .collect()
+}
+
 fn group_batches(items: Vec<TranslationBatchItem>, config: &BatchConfig) -> Vec<TranslationBatch> {
     let mut mode_groups: HashMap<BatchMode, Vec<TranslationBatchItem>> = HashMap::new();
     for item in items {
@@ -648,6 +667,55 @@ fn token_estimate(text: &str) -> usize {
         return 0;
     }
     (chars / 4).max(1)
+}
+
+fn item_token_estimate(
+    item: &TranslationBatchItem,
+    config: Option<&TranslationRunConfig>,
+) -> usize {
+    let mut estimate = token_estimate(&item.source_text).max(1);
+    let Some(config) = config else {
+        return estimate;
+    };
+
+    let entries = config
+        .glossary
+        .entries_by_segment
+        .get(&item.segment_id.0)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if entries.is_empty() {
+        return estimate;
+    }
+    estimate += match config.glossary.format {
+        GlossaryFormat::Json => {
+            let rendered = serde_json::to_string(entries).unwrap_or_else(|_| "[]".to_string());
+            token_estimate("glossary") + token_estimate(&rendered)
+        }
+        GlossaryFormat::Prose => {
+            let rendered = crate::scheduler::render_glossary_prose(entries);
+            token_estimate("glossary_prose") + token_estimate(&rendered)
+        }
+    };
+    estimate
+}
+
+fn batch_fixed_token_estimate(config: Option<&TranslationRunConfig>) -> usize {
+    config
+        .and_then(|config| config.glossary.prompt_extra.as_deref())
+        .map(token_estimate)
+        .unwrap_or(0)
+}
+
+fn batch_token_estimate(
+    items: &[TranslationBatchItem],
+    config: Option<&TranslationRunConfig>,
+) -> usize {
+    batch_fixed_token_estimate(config)
+        + items
+            .iter()
+            .map(|item| item_token_estimate(item, config))
+            .sum::<usize>()
 }
 
 fn restore_missing_tokens(mut translation: String, required: &[String]) -> String {
@@ -926,6 +994,13 @@ fn is_transient(err: &LlmError) -> bool {
 }
 
 pub fn split_batch(batch: &TranslationBatch) -> Vec<TranslationBatch> {
+    split_batch_with_config(batch, None)
+}
+
+fn split_batch_with_config(
+    batch: &TranslationBatch,
+    config: Option<&TranslationRunConfig>,
+) -> Vec<TranslationBatch> {
     if batch.items.len() <= 1 {
         return vec![batch.clone()];
     }
@@ -938,7 +1013,7 @@ pub fn split_batch(batch: &TranslationBatch) -> Vec<TranslationBatch> {
             batch.ordinal * 2,
             batch.mode,
             left.to_vec(),
-            left.iter().map(|i| token_estimate(&i.source_text)).sum(),
+            batch_token_estimate(left, config),
         ));
     }
     if !right.is_empty() {
@@ -947,7 +1022,7 @@ pub fn split_batch(batch: &TranslationBatch) -> Vec<TranslationBatch> {
             batch.ordinal * 2 + 1,
             batch.mode,
             right.to_vec(),
-            right.iter().map(|i| token_estimate(&i.source_text)).sum(),
+            batch_token_estimate(right, config),
         ));
     }
     batches
@@ -956,28 +1031,41 @@ pub fn split_batch(batch: &TranslationBatch) -> Vec<TranslationBatch> {
 fn normalize_batch_for_current_sizer(
     batch: TranslationBatch,
     sizer: Option<&BatchSizer>,
+    config: Option<&TranslationRunConfig>,
 ) -> Vec<TranslationBatch> {
     let Some(sizer) = sizer else {
-        return vec![batch];
+        return vec![with_configured_token_estimate(batch, config)];
     };
     let target_tokens = sizer.target_tokens_for_mode(batch.mode);
     let max_items = sizer.max_items_for_mode(batch.mode);
+    let batch = with_configured_token_estimate(batch, config);
     if batch.token_estimate <= target_tokens && batch.items.len() <= max_items {
         return vec![batch];
     }
-    repack_batch(batch, target_tokens, max_items)
+    repack_batch_with_config(batch, target_tokens, max_items, config)
 }
 
+#[cfg(test)]
 fn repack_batch(
     batch: TranslationBatch,
     target_tokens: usize,
     max_items: usize,
 ) -> Vec<TranslationBatch> {
+    repack_batch_with_config(batch, target_tokens, max_items, None)
+}
+
+fn repack_batch_with_config(
+    batch: TranslationBatch,
+    target_tokens: usize,
+    max_items: usize,
+    config: Option<&TranslationRunConfig>,
+) -> Vec<TranslationBatch> {
     let target_tokens = target_tokens.max(1);
     let max_items = max_items.max(1);
     let mut out = Vec::new();
     let mut current_items = Vec::new();
-    let mut current_tokens = 0usize;
+    let fixed_tokens = batch_fixed_token_estimate(config);
+    let mut current_tokens = fixed_tokens;
     let mut part = 0usize;
     let base_id = batch.id;
     let base_ordinal = batch.ordinal;
@@ -985,7 +1073,7 @@ fn repack_batch(
     let kind = batch.kind;
 
     for item in batch.items {
-        let item_tokens = token_estimate(&item.source_text).max(1);
+        let item_tokens = item_token_estimate(&item, config).max(1);
         let would_exceed_items = current_items.len() >= max_items;
         let would_exceed_tokens =
             !current_items.is_empty() && current_tokens + item_tokens > target_tokens;
@@ -998,7 +1086,7 @@ fn repack_batch(
                 items: std::mem::take(&mut current_items),
                 token_estimate: current_tokens,
             });
-            current_tokens = 0;
+            current_tokens = fixed_tokens;
             part += 1;
         }
         current_tokens += item_tokens;
@@ -1016,6 +1104,14 @@ fn repack_batch(
         });
     }
     out
+}
+
+fn with_configured_token_estimate(
+    mut batch: TranslationBatch,
+    config: Option<&TranslationRunConfig>,
+) -> TranslationBatch {
+    batch.token_estimate = batch_token_estimate(&batch.items, config);
+    batch
 }
 
 pub fn collect_repair_items(result: &BatchTranslationResult) -> Vec<TranslationBatchItem> {
@@ -1085,8 +1181,11 @@ where
                 let Some(batch) = pending_queue.pop_front() else {
                     break;
                 };
-                let mut normalized =
-                    normalize_batch_for_current_sizer(batch, batch_sizer.as_deref());
+                let mut normalized = normalize_batch_for_current_sizer(
+                    batch,
+                    batch_sizer.as_deref(),
+                    Some(config.as_ref()),
+                );
                 let batch = normalized.remove(0);
                 for extra in normalized.into_iter().rev() {
                     pending_queue.push_front(extra);
@@ -1303,7 +1402,7 @@ where
                             sizer.on_invalid_json_for_mode(batch.mode);
                         }
                     }
-                    let split = split_batch(&batch);
+                    let split = split_batch_with_config(&batch, Some(config.as_ref()));
                     if split.len() == 2 {
                         progress.emit(bookforge_core::ProgressEvent::BatchSplit {
                             batch_id: batch.id.clone(),
@@ -1843,7 +1942,7 @@ async fn translate_one_batch(
     batch: TranslationBatch,
     config: &TranslationRunConfig,
 ) -> Result<BatchTranslationResult, LlmError> {
-    let items_json = render_batch_items(&batch);
+    let items_json = render_batch_items(&batch, config);
     let template = if config.compact_prompts {
         match batch.mode {
             BatchMode::Plain | BatchMode::TurboTextOnly => &library.batch_plain_compact,
@@ -1867,6 +1966,10 @@ async fn translate_one_batch(
             .unwrap_or("the source language"),
     )
     .string("target_language", &config.target_language)
+    .raw(
+        "prompt_extra",
+        config.glossary.prompt_extra.clone().unwrap_or_default(),
+    )
     .raw("items_json", items_json);
 
     let rendered = template
@@ -1914,31 +2017,53 @@ async fn translate_one_batch(
     }
 }
 
-fn render_batch_items(batch: &TranslationBatch) -> String {
+fn render_batch_items(batch: &TranslationBatch, config: &TranslationRunConfig) -> String {
     let items: Vec<serde_json::Value> = batch
         .items
         .iter()
         .map(|item| {
-            let base = serde_json::json!({
+            let mut obj = serde_json::json!({
                 "id": item.item_id,
                 "kind": item.kind,
                 "text": item.source_text,
                 "required_markers": item.required_markers,
                 "protected": item.protected_spans,
-            });
+            })
+            .as_object()
+            .cloned()
+            .unwrap_or_default();
+
+            let entries = config
+                .glossary
+                .entries_by_segment
+                .get(&item.segment_id.0)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            match config.glossary.format {
+                GlossaryFormat::Json => {
+                    obj.insert(
+                        "glossary".to_string(),
+                        serde_json::to_value(entries)
+                            .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
+                    );
+                }
+                GlossaryFormat::Prose => {
+                    obj.insert(
+                        "glossary_prose".to_string(),
+                        serde_json::Value::String(crate::scheduler::render_glossary_prose(entries)),
+                    );
+                }
+            }
 
             if batch.mode == BatchMode::RunPreserving {
-                let mut obj = base.as_object().cloned().unwrap_or_default();
                 let runs: Vec<serde_json::Value> = item
                     .text_runs
                     .iter()
                     .map(|r| serde_json::json!({"id": r.id, "text": r.text}))
                     .collect();
                 obj.insert("runs".to_string(), serde_json::Value::Array(runs));
-                serde_json::Value::Object(obj)
-            } else {
-                base
             }
+            serde_json::Value::Object(obj)
         })
         .collect();
 
@@ -2333,7 +2458,7 @@ mod tests {
                 .collect(),
         };
 
-        let normalized = normalize_batch_for_current_sizer(batch, Some(&sizer));
+        let normalized = normalize_batch_for_current_sizer(batch, Some(&sizer), None);
         assert!(normalized.len() > 1);
         assert!(normalized.iter().all(|part| {
             part.token_estimate <= sizer.target_tokens_for_mode(BatchMode::MarkerSafe)
@@ -2587,6 +2712,7 @@ mod tests {
             max_output_tokens: None,
             batch_max_output_tokens: None,
             compact_prompts: false,
+            glossary: crate::GlossaryRunConfig::default(),
         }
     }
 
@@ -2605,6 +2731,69 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
+    }
+
+    #[test]
+    fn batch_items_include_segment_glossary() {
+        let batch = make_two_item_batch();
+        let mut config = test_run_config();
+        config.glossary.entries_by_segment.insert(
+            "seg1".to_string(),
+            vec![bookforge_core::GlossaryPromptTerm {
+                source: "Hello".to_string(),
+                target: "Ciao".to_string(),
+                category: bookforge_core::GlossaryCategory::Phrase,
+                note: None,
+                term_id: Some(7),
+                case_sensitive: false,
+            }],
+        );
+        config.glossary.prompt_extra = Some("Use informal register.".to_string());
+
+        let rendered = render_batch_items(&batch, &config);
+        assert!(rendered.contains("\"glossary\""));
+        assert!(rendered.contains("\"source\":\"Hello\""));
+        assert!(!rendered.contains("Use informal register."));
+    }
+
+    #[test]
+    fn batch_prompt_overhead_repacks_glossary_heavy_items() {
+        let seg1 = make_segment("seg1", vec![plain_block("Hello")], vec![]);
+        let seg2 = make_segment("seg2", vec![plain_block("Goodbye")], vec![]);
+        let batch_config = BatchConfig {
+            enabled: true,
+            target_tokens: 120,
+            max_items: 64,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches =
+            build_translation_batches(&[seg1, seg2], &batch_config, TranslationProfile::Balanced);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].items.len(), 2);
+
+        let mut config = test_run_config();
+        for segment_id in ["seg1", "seg2"] {
+            config.glossary.entries_by_segment.insert(
+                segment_id.to_string(),
+                vec![bookforge_core::GlossaryPromptTerm {
+                    source: format!("{segment_id}_source"),
+                    target: format!("{segment_id}_target"),
+                    category: bookforge_core::GlossaryCategory::Phrase,
+                    note: Some("x".repeat(480)),
+                    term_id: None,
+                    case_sensitive: false,
+                }],
+            );
+        }
+        config.glossary.prompt_extra = Some("y".repeat(160));
+
+        let adjusted = account_for_batch_prompt_overhead(batches, &batch_config, &config);
+
+        assert_eq!(adjusted.len(), 2);
+        assert!(adjusted.iter().all(|batch| batch.items.len() == 1));
+        assert!(adjusted.iter().all(|batch| batch.token_estimate > 120));
     }
 
     #[tokio::test]

--- a/crates/bookforge-llm/src/lib.rs
+++ b/crates/bookforge-llm/src/lib.rs
@@ -10,8 +10,9 @@ pub mod telemetry;
 
 pub use batch::{
     BatchItemFailure, BatchItemTranslation, BatchKind, BatchMode, BatchSizer,
-    BatchTranslationResult, TranslationBatch, TranslationBatchItem, build_translation_batches,
-    collect_repair_items, parse_batch_response, split_batch, translate_batches_with_callback,
+    BatchTranslationResult, TranslationBatch, TranslationBatchItem,
+    account_for_batch_prompt_overhead, build_translation_batches, collect_repair_items,
+    parse_batch_response, split_batch, translate_batches_with_callback,
 };
 pub use concurrency::AdaptiveLimiter;
 pub use double_check::{
@@ -28,7 +29,7 @@ pub use rate_controller::{
     ProviderRateController, RateControllerConfig, RequestObservation, RequestStatus,
 };
 pub use scheduler::{
-    QaIssue, QaSegmentReview, SegmentTranslation, TranslationRunConfig, qa_segments,
-    translate_segments, translate_segments_with_callback,
+    GlossaryRunConfig, QaIssue, QaSegmentReview, SegmentTranslation, TranslationRunConfig,
+    qa_segments, translate_segments, translate_segments_with_callback,
 };
 pub use telemetry::{TelemetryLog, telemetry_summary};

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -170,20 +170,17 @@ fn json_escape_inner(value: &str) -> String {
 }
 
 const PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_segment.v1.md");
-const MARKER_SAFE_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_marker_safe.v1.md");
+const MARKER_SAFE_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_marker_safe.v1.md");
 const RUN_PRESERVING_TEMPLATE_SOURCE: &str =
     include_str!("../prompts/translate_run_preserving.v1.md");
 const QA_TEMPLATE_SOURCE: &str = include_str!("../prompts/qa_segment.v1.md");
 
-const BATCH_PLAIN_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_plain.v1.md");
+const BATCH_PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_plain.v1.md");
 const BATCH_MARKER_SAFE_TEMPLATE_SOURCE: &str =
     include_str!("../prompts/translate_batch_marker_safe.v1.md");
 const BATCH_RUN_PRESERVING_TEMPLATE_SOURCE: &str =
     include_str!("../prompts/translate_batch_run_preserving.v1.md");
-const BATCH_REPAIR_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_repair.v1.md");
+const BATCH_REPAIR_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_repair.v1.md");
 const BATCH_PLAIN_COMPACT_TEMPLATE_SOURCE: &str =
     include_str!("../prompts/translate_batch_plain_compact.v1.md");
 const BATCH_MARKER_SAFE_COMPACT_TEMPLATE_SOURCE: &str =

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use bookforge_core::{
     config::TranslationProfile,
+    glossary::{GlossaryFormat, GlossaryPromptTerm},
     ir::BlockId,
     scheduler::SchedulerConfig,
     segment::{BlockTranslation, Segment, SegmentBlock, SegmentId, SegmentStatus},
@@ -35,6 +37,24 @@ pub struct TranslationRunConfig {
     pub max_output_tokens: Option<u32>,
     pub batch_max_output_tokens: Option<u32>,
     pub compact_prompts: bool,
+    pub glossary: GlossaryRunConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlossaryRunConfig {
+    pub format: GlossaryFormat,
+    pub entries_by_segment: HashMap<String, Vec<GlossaryPromptTerm>>,
+    pub prompt_extra: Option<String>,
+}
+
+impl Default for GlossaryRunConfig {
+    fn default() -> Self {
+        Self {
+            format: GlossaryFormat::Json,
+            entries_by_segment: HashMap::new(),
+            prompt_extra: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -330,6 +350,8 @@ fn render_qa_prompt(
         segment.metadata.section_title.as_deref().unwrap_or(""),
     )
     .json("glossary_json", &Value::Array(Vec::new()))
+    .raw("glossary_block_prose", "")
+    .raw("prompt_extra", "")
     .raw("source_text", &segment.source.text)
     .raw("translation_text", translation.joined_text());
 
@@ -586,6 +608,7 @@ fn render_prompt(
     config: &TranslationRunConfig,
     mode: TranslationMode,
 ) -> Result<crate::prompt::Rendered> {
+    let (glossary_json, glossary_prose) = glossary_for_segment(config, &segment.id.0);
     let mut vars = Substitutions::new();
     vars.string(
         "source_language",
@@ -615,7 +638,12 @@ fn render_prompt(
         "context_after",
         segment.context.after.clone().unwrap_or_default(),
     )
-    .json("glossary_json", &Value::Array(Vec::new()))
+    .json("glossary_json", &glossary_json)
+    .raw("glossary_block_prose", glossary_prose)
+    .raw(
+        "prompt_extra",
+        config.glossary.prompt_extra.clone().unwrap_or_default(),
+    )
     .json(
         "protected_spans_json",
         &Value::Array(
@@ -674,6 +702,47 @@ fn render_prompt(
     template
         .render(&vars)
         .map_err(|err| LlmError::Provider(format!("prompt render failed: {err}")))
+}
+
+pub(crate) fn glossary_for_segment(
+    config: &TranslationRunConfig,
+    segment_id: &str,
+) -> (Value, String) {
+    let entries = config
+        .glossary
+        .entries_by_segment
+        .get(segment_id)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    match config.glossary.format {
+        GlossaryFormat::Json => (
+            serde_json::to_value(entries).unwrap_or(Value::Array(vec![])),
+            String::new(),
+        ),
+        GlossaryFormat::Prose => (Value::Array(vec![]), render_glossary_prose(entries)),
+    }
+}
+
+pub(crate) fn render_glossary_prose(entries: &[GlossaryPromptTerm]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("Active glossary constraints (must be honored):\n");
+    for entry in entries {
+        out.push_str("- \"");
+        out.push_str(&entry.source);
+        out.push_str("\" -> \"");
+        out.push_str(&entry.target);
+        out.push_str("\" (");
+        out.push_str(entry.category.as_str());
+        out.push(')');
+        if let Some(note) = entry.note.as_deref().filter(|note| !note.is_empty()) {
+            out.push_str(": ");
+            out.push_str(note);
+        }
+        out.push('\n');
+    }
+    out
 }
 
 fn segment_block_to_json(block: &SegmentBlock) -> Value {
@@ -1420,6 +1489,46 @@ mod tests {
         assert!(translations[0].error.is_some());
     }
 
+    #[test]
+    fn prompt_renders_glossary_json_prose_and_prompt_extra() {
+        let segment = segment("seg_a", 0, vec![("b0", "Aragorn enters.")]);
+        let mut json_config = config();
+        json_config.glossary.entries_by_segment.insert(
+            "seg_a".to_string(),
+            vec![GlossaryPromptTerm {
+                source: "Aragorn".to_string(),
+                target: "Aragorn".to_string(),
+                category: bookforge_core::GlossaryCategory::Person,
+                note: Some("Preserve name".to_string()),
+                term_id: Some(42),
+                case_sensitive: true,
+            }],
+        );
+        json_config.glossary.prompt_extra = Some("Maintain a literary register.".to_string());
+
+        let rendered = render_prompt(
+            &PromptLibrary::global().plain,
+            &segment,
+            &json_config,
+            TranslationMode::Plain,
+        )
+        .expect("prompt should render");
+        assert!(rendered.user.contains("\"source\": \"Aragorn\""));
+        assert!(rendered.user.contains("Maintain a literary register."));
+
+        let mut prose_config = json_config.clone();
+        prose_config.glossary.format = bookforge_core::GlossaryFormat::Prose;
+        let rendered = render_prompt(
+            &PromptLibrary::global().plain,
+            &segment,
+            &prose_config,
+            TranslationMode::Plain,
+        )
+        .expect("prompt should render");
+        assert!(rendered.user.contains("Active glossary constraints"));
+        assert!(rendered.user.contains("\"Aragorn\" -> \"Aragorn\""));
+    }
+
     fn config() -> TranslationRunConfig {
         TranslationRunConfig {
             source_language: Some("English".to_string()),
@@ -1437,6 +1546,7 @@ mod tests {
             max_output_tokens: None,
             batch_max_output_tokens: None,
             compact_prompts: false,
+            glossary: GlossaryRunConfig::default(),
         }
     }
 

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -14,3 +14,4 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+toml.workspace = true

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-store"
-version = "1.1.0"
+version = "1.2.0"
 description = "SQLite checkpoint and job store for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.1.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.2.0", path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-store/migrations/0004_v1_2_glossary_terms.sql
+++ b/crates/bookforge-store/migrations/0004_v1_2_glossary_terms.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS glossary_terms (
+  id INTEGER PRIMARY KEY,
+  scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+  scope_id TEXT,
+  source_text TEXT NOT NULL,
+  target_text TEXT NOT NULL,
+  category TEXT NOT NULL CHECK(category IN
+    ('person', 'place', 'object', 'invented', 'style', 'phrase', 'other')),
+  notes TEXT,
+  case_sensitive INTEGER NOT NULL DEFAULT 0,
+  always_active INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK(status IN
+    ('user_seeded', 'auto_candidate', 'accepted', 'rejected'))
+    DEFAULT 'user_seeded',
+  source_language TEXT NOT NULL,
+  target_language TEXT NOT NULL,
+  source_count INTEGER DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(scope_kind, scope_id, source_text, source_language, target_language)
+);
+
+CREATE INDEX IF NOT EXISTS idx_glossary_lookup
+  ON glossary_terms(source_language, target_language, scope_kind, scope_id, status);
+
+ALTER TABLE jobs ADD COLUMN book_id TEXT;
+ALTER TABLE jobs ADD COLUMN series_id TEXT;

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -8,12 +8,14 @@ use std::{
 
 use bookforge_core::{
     Result as CoreResult,
+    glossary::{GlossaryScopeKind, GlossaryTerm},
     ir::BlockId,
     run_snapshot::RunConfigSnapshot,
     segment::{BlockTranslation, Segment},
 };
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, types::Type};
 use sha2::{Digest, Sha256};
+use std::str::FromStr;
 
 pub type Result<T> = std::result::Result<T, StoreError>;
 
@@ -185,6 +187,15 @@ pub struct NewSegmentFlag<'a> {
     pub suggested_source: Option<&'a str>,
     pub suggested_target: Option<&'a str>,
     pub consumed: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GlossaryFilter<'a> {
+    pub scope_kind: Option<GlossaryScopeKind>,
+    pub scope_id: Option<&'a str>,
+    pub source_language: Option<&'a str>,
+    pub target_language: Option<&'a str>,
+    pub active_only: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -900,6 +911,201 @@ impl JobStore {
         Ok(count as usize)
     }
 
+    pub fn upsert_glossary_terms(&self, terms: &[GlossaryTerm]) -> Result<usize> {
+        let mut conn = self.conn.borrow_mut();
+        let tx = conn.transaction()?;
+        let now = timestamp_string();
+        let mut changed = 0usize;
+        for term in terms {
+            let existing_id = tx
+                .query_row(
+                    "SELECT id FROM glossary_terms
+                     WHERE scope_kind = ?1
+                       AND ((?2 IS NULL AND scope_id IS NULL) OR scope_id = ?2)
+                       AND source_text = ?3
+                       AND source_language = ?4
+                       AND target_language = ?5",
+                    params![
+                        term.scope_kind.as_str(),
+                        term.scope_id.as_deref(),
+                        term.source_text,
+                        term.source_language,
+                        term.target_language,
+                    ],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?;
+            if let Some(id) = existing_id {
+                changed += tx.execute(
+                    "UPDATE glossary_terms
+                     SET target_text = ?1,
+                         category = ?2,
+                         notes = ?3,
+                         case_sensitive = ?4,
+                         always_active = ?5,
+                         status = ?6,
+                         source_count = ?7,
+                         updated_at = ?8
+                     WHERE id = ?9",
+                    params![
+                        term.target_text,
+                        term.category.as_str(),
+                        term.notes.as_deref(),
+                        if term.case_sensitive { 1_i64 } else { 0_i64 },
+                        if term.always_active { 1_i64 } else { 0_i64 },
+                        term.status.as_str(),
+                        term.source_count as i64,
+                        now,
+                        id,
+                    ],
+                )?;
+            } else {
+                changed += tx.execute(
+                    "INSERT INTO glossary_terms
+                     (scope_kind, scope_id, source_text, target_text, category, notes,
+                      case_sensitive, always_active, status, source_language, target_language,
+                      source_count, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13)",
+                    params![
+                        term.scope_kind.as_str(),
+                        term.scope_id.as_deref(),
+                        term.source_text,
+                        term.target_text,
+                        term.category.as_str(),
+                        term.notes.as_deref(),
+                        if term.case_sensitive { 1_i64 } else { 0_i64 },
+                        if term.always_active { 1_i64 } else { 0_i64 },
+                        term.status.as_str(),
+                        term.source_language,
+                        term.target_language,
+                        term.source_count as i64,
+                        now,
+                    ],
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(changed)
+    }
+
+    pub fn add_glossary_term(&self, term: &GlossaryTerm) -> Result<i64> {
+        self.upsert_glossary_terms(std::slice::from_ref(term))?;
+        let conn = self.conn.borrow();
+        let id = conn.query_row(
+            "SELECT id FROM glossary_terms
+             WHERE scope_kind = ?1
+               AND ((?2 IS NULL AND scope_id IS NULL) OR scope_id = ?2)
+               AND source_text = ?3
+               AND source_language = ?4
+               AND target_language = ?5",
+            params![
+                term.scope_kind.as_str(),
+                term.scope_id.as_deref(),
+                term.source_text,
+                term.source_language,
+                term.target_language,
+            ],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(id)
+    }
+
+    pub fn list_glossary_terms(&self, filter: GlossaryFilter<'_>) -> Result<Vec<GlossaryTerm>> {
+        let conn = self.conn.borrow();
+        let mut sql = String::from(
+            "SELECT id, scope_kind, scope_id, source_text, target_text, category, notes,
+                    case_sensitive, always_active, status, source_language, target_language,
+                    source_count
+             FROM glossary_terms
+             WHERE 1 = 1",
+        );
+        let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        if let Some(scope_kind) = filter.scope_kind {
+            sql.push_str(" AND scope_kind = ?");
+            values.push(Box::new(scope_kind.as_str().to_string()));
+        }
+        if let Some(scope_id) = filter.scope_id {
+            sql.push_str(" AND scope_id = ?");
+            values.push(Box::new(scope_id.to_string()));
+        }
+        if let Some(source_language) = filter.source_language {
+            sql.push_str(" AND source_language = ?");
+            values.push(Box::new(source_language.to_string()));
+        }
+        if let Some(target_language) = filter.target_language {
+            sql.push_str(" AND target_language = ?");
+            values.push(Box::new(target_language.to_string()));
+        }
+        if filter.active_only {
+            sql.push_str(" AND status IN ('user_seeded', 'accepted')");
+        }
+        sql.push_str(
+            " ORDER BY source_language, target_language, scope_kind, scope_id, source_text",
+        );
+        let param_refs = values
+            .iter()
+            .map(|value| value.as_ref())
+            .collect::<Vec<&dyn rusqlite::types::ToSql>>();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(param_refs.as_slice(), glossary_term_from_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn load_active_glossary_terms(
+        &self,
+        source_language: &str,
+        target_language: &str,
+        book_id: Option<&str>,
+        series_id: Option<&str>,
+    ) -> Result<Vec<GlossaryTerm>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, scope_kind, scope_id, source_text, target_text, category, notes,
+                    case_sensitive, always_active, status, source_language, target_language,
+                    source_count
+             FROM glossary_terms
+             WHERE source_language = ?1
+               AND target_language = ?2
+               AND status IN ('user_seeded', 'accepted')
+               AND (
+                    scope_kind = 'global'
+                    OR (scope_kind = 'series' AND scope_id = ?3)
+                    OR (scope_kind = 'book' AND scope_id = ?4)
+               )
+             ORDER BY scope_kind, scope_id, source_text",
+        )?;
+        let rows = stmt.query_map(
+            params![source_language, target_language, series_id, book_id],
+            glossary_term_from_row,
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn remove_glossary_term(&self, id: i64) -> Result<usize> {
+        let conn = self.conn.borrow();
+        conn.execute("DELETE FROM glossary_terms WHERE id = ?1", params![id])
+            .map_err(StoreError::from)
+    }
+
+    pub fn clear_glossary_scope(
+        &self,
+        scope_kind: GlossaryScopeKind,
+        scope_id: Option<&str>,
+    ) -> Result<usize> {
+        let conn = self.conn.borrow();
+        let count = if scope_kind == GlossaryScopeKind::Global {
+            conn.execute("DELETE FROM glossary_terms WHERE scope_kind = 'global'", [])?
+        } else {
+            conn.execute(
+                "DELETE FROM glossary_terms WHERE scope_kind = ?1 AND scope_id = ?2",
+                params![scope_kind.as_str(), scope_id],
+            )?
+        };
+        Ok(count)
+    }
+
     pub fn pending_segment_ids(&self, job_id: &str) -> Result<Vec<String>> {
         let conn = self.conn.borrow();
         let mut stmt = conn.prepare(
@@ -1475,6 +1681,47 @@ fn record_migration(conn: &Connection, version: i64, name: &str) -> rusqlite::Re
     Ok(())
 }
 
+fn glossary_term_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GlossaryTerm> {
+    let scope_kind_text: String = row.get(1)?;
+    let category_text: String = row.get(5)?;
+    let status_text: String = row.get(9)?;
+    Ok(GlossaryTerm {
+        id: Some(row.get(0)?),
+        scope_kind: parse_row_enum(&scope_kind_text, 1)?,
+        scope_id: row.get(2)?,
+        source_text: row.get(3)?,
+        target_text: row.get(4)?,
+        category: parse_row_enum(&category_text, 5)?,
+        notes: row.get(6)?,
+        case_sensitive: row.get::<_, i64>(7)? != 0,
+        always_active: row.get::<_, i64>(8)? != 0,
+        status: parse_row_enum(&status_text, 9)?,
+        source_language: row.get(10)?,
+        target_language: row.get(11)?,
+        source_count: row.get::<_, Option<i64>>(12)?.unwrap_or(0).max(0) as usize,
+    })
+}
+
+fn parse_row_enum<T>(value: &str, column: usize) -> rusqlite::Result<T>
+where
+    T: FromStr<Err = String>,
+{
+    value.parse::<T>().map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(RowEnumError(err)))
+    })
+}
+
+#[derive(Debug)]
+struct RowEnumError(String);
+
+impl std::fmt::Display for RowEnumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for RowEnumError {}
+
 fn replace_block_translations(
     conn: &Connection,
     job_id: &str,
@@ -1572,7 +1819,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1677,7 +1924,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1738,7 +1985,7 @@ mod tests {
                 model: "model",
                 base_url: Some("https://example.test/v1"),
                 api_key_env: Some("OPENROUTER_API_KEY"),
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1761,6 +2008,13 @@ mod tests {
             provider_preset: None,
             prompt_version: "batch_v1".to_string(),
             cache_namespace: "cache_ns".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: bookforge_core::GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: String::new(),
+            glossary_terms: Vec::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 
@@ -1812,7 +2066,7 @@ mod tests {
                 model: "model",
                 base_url: Some("https://example.test/v1"),
                 api_key_env: Some(api_key_env),
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1835,6 +2089,13 @@ mod tests {
             provider_preset: None,
             prompt_version: "batch_v1".to_string(),
             cache_namespace: "cache_ns".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: bookforge_core::GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: String::new(),
+            glossary_terms: Vec::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 
@@ -1877,7 +2138,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -1982,7 +2243,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -2099,7 +2360,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -2173,7 +2434,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -2225,7 +2486,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job should be created");
@@ -2417,7 +2678,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job created");
@@ -2469,7 +2730,7 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
-                            book_id: None,
+                book_id: None,
                 series_id: None,
             })
             .expect("job created");
@@ -2547,6 +2808,53 @@ mod tests {
     }
 
     #[test]
+    fn glossary_terms_upsert_list_and_active_lookup() {
+        let db_path = temp_path("glossary_terms.sqlite");
+        let store = JobStore::open(&db_path).expect("store opens");
+        let mut global = glossary_term(
+            bookforge_core::GlossaryScopeKind::Global,
+            None,
+            "Aragorn",
+            "Aragorn",
+        );
+        let book = glossary_term(
+            bookforge_core::GlossaryScopeKind::Book,
+            Some("fellowship"),
+            "Aragorn",
+            "Granpasso",
+        );
+
+        assert_eq!(
+            store
+                .upsert_glossary_terms(&[global.clone(), book.clone()])
+                .expect("terms upsert"),
+            2
+        );
+        global.target_text = "Aragorn II".to_string();
+        store
+            .upsert_glossary_terms(&[global.clone()])
+            .expect("global term updates instead of duplicating");
+
+        let all = store
+            .list_glossary_terms(GlossaryFilter::default())
+            .expect("terms list");
+        assert_eq!(all.len(), 2);
+
+        let active = store
+            .load_active_glossary_terms("English", "Italian", Some("fellowship"), Some("lotr"))
+            .expect("active terms");
+        assert_eq!(active.len(), 2);
+        assert!(active.iter().any(|term| term.target_text == "Granpasso"));
+
+        let removed = store
+            .clear_glossary_scope(bookforge_core::GlossaryScopeKind::Global, None)
+            .expect("global clear");
+        assert_eq!(removed, 1);
+
+        let _ = fs::remove_file(&db_path);
+    }
+
+    #[test]
     fn create_job_persists_book_and_series_ids() {
         let db_path = temp_path("glossary_jobids.sqlite");
         let input_path = temp_path("input_jobids.epub");
@@ -2576,5 +2884,28 @@ mod tests {
         assert_eq!(loaded.series_id.as_deref(), Some("lord-of-the-rings"));
         let _ = fs::remove_file(&db_path);
         let _ = fs::remove_file(input_path);
+    }
+
+    fn glossary_term(
+        scope_kind: bookforge_core::GlossaryScopeKind,
+        scope_id: Option<&str>,
+        source: &str,
+        target: &str,
+    ) -> bookforge_core::GlossaryTerm {
+        bookforge_core::GlossaryTerm {
+            id: None,
+            scope_kind,
+            scope_id: scope_id.map(ToOwned::to_owned),
+            source_text: source.to_string(),
+            target_text: target.to_string(),
+            category: bookforge_core::GlossaryCategory::Person,
+            notes: None,
+            case_sensitive: true,
+            always_active: false,
+            status: bookforge_core::GlossaryStatus::UserSeeded,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+            source_count: 0,
+        }
     }
 }

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -55,6 +55,8 @@ pub struct JobRecord {
     pub events_path: Option<PathBuf>,
     pub report_json_path: Option<PathBuf>,
     pub report_markdown_path: Option<PathBuf>,
+    pub book_id: Option<String>,
+    pub series_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -83,6 +85,8 @@ pub struct CreateJob<'a> {
     pub model: &'a str,
     pub base_url: Option<&'a str>,
     pub api_key_env: Option<&'a str>,
+    pub book_id: Option<&'a str>,
+    pub series_id: Option<&'a str>,
 }
 
 #[derive(Debug, Clone)]
@@ -282,8 +286,8 @@ impl JobStore {
         let conn = self.conn.borrow();
         conn.execute(
             "INSERT INTO jobs
-             (id, input_path, output_path, input_hash, source_lang, target_lang, provider, model, base_url, api_key_env, status, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'running', ?11, ?11)",
+             (id, input_path, output_path, input_hash, source_lang, target_lang, provider, model, base_url, api_key_env, book_id, series_id, status, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 'running', ?13, ?13)",
             params![
                 id,
                 input_path.to_string_lossy(),
@@ -295,6 +299,8 @@ impl JobStore {
                 request.model,
                 request.base_url,
                 request.api_key_env,
+                request.book_id,
+                request.series_id,
                 now,
             ],
         )?;
@@ -316,6 +322,8 @@ impl JobStore {
             events_path: None,
             report_json_path: None,
             report_markdown_path: None,
+            book_id: request.book_id.map(ToOwned::to_owned),
+            series_id: request.series_id.map(ToOwned::to_owned),
         })
     }
 
@@ -717,7 +725,7 @@ impl JobStore {
         let conn = self.conn.borrow();
         conn.query_row(
             "SELECT id, input_path, input_snapshot_path, input_sha256, output_path, input_hash, source_lang, target_lang, provider, model, base_url, api_key_env, status,
-                    events_path, report_json_path, report_markdown_path
+                    events_path, report_json_path, report_markdown_path, book_id, series_id
              FROM jobs WHERE id = ?1",
             params![job_id],
             |row| {
@@ -738,6 +746,8 @@ impl JobStore {
                     events_path: row.get::<_, Option<String>>(13)?.map(PathBuf::from),
                     report_json_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
                     report_markdown_path: row.get::<_, Option<String>>(15)?.map(PathBuf::from),
+                    book_id: row.get(16)?,
+                    series_id: row.get(17)?,
                 })
             },
         )
@@ -1263,6 +1273,8 @@ impl JobStore {
               events_path TEXT,
               report_json_path TEXT,
               report_markdown_path TEXT,
+              book_id TEXT,
+              series_id TEXT,
               created_at TEXT NOT NULL,
               updated_at TEXT NOT NULL
             );
@@ -1334,6 +1346,28 @@ impl JobStore {
               consumed INTEGER NOT NULL DEFAULT 0,
               FOREIGN KEY(job_id) REFERENCES jobs(id) ON DELETE CASCADE
             );
+
+            CREATE TABLE IF NOT EXISTS glossary_terms (
+              id INTEGER PRIMARY KEY,
+              scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+              scope_id TEXT,
+              source_text TEXT NOT NULL,
+              target_text TEXT NOT NULL,
+              category TEXT NOT NULL CHECK(category IN
+                ('person', 'place', 'object', 'invented', 'style', 'phrase', 'other')),
+              notes TEXT,
+              case_sensitive INTEGER NOT NULL DEFAULT 0,
+              always_active INTEGER NOT NULL DEFAULT 0,
+              status TEXT NOT NULL CHECK(status IN
+                ('user_seeded', 'auto_candidate', 'accepted', 'rejected'))
+                DEFAULT 'user_seeded',
+              source_language TEXT NOT NULL,
+              target_language TEXT NOT NULL,
+              source_count INTEGER DEFAULT 0,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              UNIQUE(scope_kind, scope_id, source_text, source_language, target_language)
+            );
             ",
         )?;
         ensure_column(&conn, "jobs", "input_path", "TEXT NOT NULL DEFAULT ''")?;
@@ -1346,6 +1380,8 @@ impl JobStore {
         ensure_column(&conn, "jobs", "events_path", "TEXT")?;
         ensure_column(&conn, "jobs", "report_json_path", "TEXT")?;
         ensure_column(&conn, "jobs", "report_markdown_path", "TEXT")?;
+        ensure_column(&conn, "jobs", "book_id", "TEXT")?;
+        ensure_column(&conn, "jobs", "series_id", "TEXT")?;
         ensure_column(
             &conn,
             "segments",
@@ -1365,11 +1401,14 @@ impl JobStore {
             "CREATE INDEX IF NOT EXISTS idx_segments_cache_lookup
              ON segments(source_hash, cache_namespace, prompt_version, provider, model, status);
              CREATE INDEX IF NOT EXISTS idx_segment_flags_job
-             ON segment_flags(job_id, consumed);",
+             ON segment_flags(job_id, consumed);
+             CREATE INDEX IF NOT EXISTS idx_glossary_lookup
+             ON glossary_terms(source_language, target_language, scope_kind, scope_id, status);",
         )?;
         record_migration(&conn, 1, "initial")?;
         record_migration(&conn, 2, "v1_0_1_input_snapshot")?;
         record_migration(&conn, 3, "v1_1_segment_flags")?;
+        record_migration(&conn, 4, "v1_2_glossary_terms")?;
         Ok(())
     }
 
@@ -1533,6 +1572,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![segment("seg_a", 0), segment("seg_b", 1)];
@@ -1636,6 +1677,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
 
@@ -1695,6 +1738,8 @@ mod tests {
                 model: "model",
                 base_url: Some("https://example.test/v1"),
                 api_key_env: Some("OPENROUTER_API_KEY"),
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let settings = bookforge_core::TranslationProfile::Balanced.resolve();
@@ -1767,6 +1812,8 @@ mod tests {
                 model: "model",
                 base_url: Some("https://example.test/v1"),
                 api_key_env: Some(api_key_env),
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let settings = bookforge_core::TranslationProfile::Balanced.resolve();
@@ -1830,6 +1877,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![
@@ -1933,6 +1982,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![
@@ -2048,6 +2099,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![
@@ -2120,6 +2173,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![
@@ -2170,6 +2225,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job should be created");
         let segments = vec![
@@ -2360,6 +2417,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job created");
         drop(store);
@@ -2410,6 +2469,8 @@ mod tests {
                 model: "mock-prefix",
                 base_url: None,
                 api_key_env: None,
+                            book_id: None,
+                series_id: None,
             })
             .expect("job created");
         store_w
@@ -2437,5 +2498,83 @@ mod tests {
         let _ = fs::remove_file(input_path);
         let _ = fs::remove_file(wal_path);
         let _ = fs::remove_file(shm_path);
+    }
+
+    #[test]
+    fn migrate_creates_glossary_terms_table() {
+        let db_path = temp_path("glossary_migrate.sqlite");
+        let store = JobStore::open(&db_path).expect("store opens");
+        let conn = store.conn.borrow();
+        let table: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'glossary_terms'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("glossary_terms table exists");
+        assert_eq!(table, "glossary_terms");
+        let index: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_glossary_lookup'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("idx_glossary_lookup exists");
+        assert_eq!(index, "idx_glossary_lookup");
+        let version: i64 = conn
+            .query_row(
+                "SELECT version FROM _migrations WHERE name = 'v1_2_glossary_terms'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("v1_2 migration recorded");
+        assert_eq!(version, 4);
+        drop(conn);
+        let _ = fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn migrate_is_idempotent_v1_2() {
+        let db_path = temp_path("glossary_idem.sqlite");
+        // Open twice; second open re-runs migrate() and must not error.
+        {
+            let _store = JobStore::open(&db_path).expect("first open");
+        }
+        {
+            let _store = JobStore::open(&db_path).expect("second open");
+        }
+        let _ = fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn create_job_persists_book_and_series_ids() {
+        let db_path = temp_path("glossary_jobids.sqlite");
+        let input_path = temp_path("input_jobids.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture");
+        let store = JobStore::open(&db_path).expect("store opens");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("out_jobids.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock",
+                base_url: None,
+                api_key_env: None,
+                book_id: Some("fellowship"),
+                series_id: Some("lord-of-the-rings"),
+            })
+            .expect("job created");
+        assert_eq!(job.book_id.as_deref(), Some("fellowship"));
+        assert_eq!(job.series_id.as_deref(), Some("lord-of-the-rings"));
+        let loaded = store
+            .get_job(&job.id)
+            .expect("get_job ok")
+            .expect("job present");
+        assert_eq!(loaded.book_id.as_deref(), Some("fellowship"));
+        assert_eq!(loaded.series_id.as_deref(), Some("lord-of-the-rings"));
+        let _ = fs::remove_file(&db_path);
+        let _ = fs::remove_file(input_path);
     }
 }

--- a/crates/bookforge-store/src/lib.rs
+++ b/crates/bookforge-store/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod db;
 
 pub use db::{
-    CacheLookupRequest, CachedTranslation, CreateJob, JobRecord, JobStore, JobSummary,
-    NewSegmentFlag, RetryScope, SaveCachedTranslation, SaveNeedsReview, SaveTranslation,
-    SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation, StoredSegmentTranslation,
-    run_doctor,
+    CacheLookupRequest, CachedTranslation, CreateJob, GlossaryFilter, JobRecord, JobStore,
+    JobSummary, NewSegmentFlag, RetryScope, SaveCachedTranslation, SaveNeedsReview,
+    SaveTranslation, SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation,
+    StoredSegmentTranslation, run_doctor,
 };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # BookForge — Technical Roadmap, v1.0.1 through v2
 
-**Document version:** 1.0
-**Last updated:** 2026-05-06
+**Document version:** 1.1
+**Last updated:** 2026-05-12
 **Status:** active planning document
 **Audience:** project maintainer + Claude Code (or any other coding agent) implementing
 the milestones below.
@@ -91,17 +91,17 @@ via `java`, but the BookForge binary itself does not need Java to run.
 
 ## 2. Roadmap overview
 
-| Version | Theme | Estimated effort | Marketing posture |
-|---------|-------|------------------|-------------------|
-| v1.0.1 | Snapshot patch | 0.5–1 day | none (silent patch) |
-| v1.1 | Review loop | 5–8 days | minimal (README rewrite, GitHub topics, crates.io publish) |
-| v1.2 | Glossary, manual | 8–12 days | none (development quiet) |
-| v1.2.x | Glossary, auto-extraction | 4–6 days | none |
-| v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) |
-| v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here |
-| v1.5 | Structural credibility | 10–14 days | README final rewrite citing corpus |
-| v1.6 | Bilingual output | 5–8 days | passive (release notes only) |
-| v2 | Open-ended | not committed | recompute from v1.4/v1.5 feedback |
+| Version | Theme | Estimated effort | Marketing posture | Status |
+|---------|-------|------------------|-------------------|--------|
+| v1.0.1 | Snapshot patch | 0.5–1 day | none (silent patch) | shipped |
+| v1.1 | Review loop | 5–8 days | minimal (README rewrite, GitHub topics, crates.io publish) | shipped |
+| v1.2 | Glossary, manual | 8–12 days | none (development quiet) | shipped |
+| v1.2.x | Glossary, auto-extraction | 4–6 days | none | planned |
+| v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) | planned |
+| v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here | planned |
+| v1.5 | Structural credibility | 10–14 days | README final rewrite citing corpus | planned |
+| v1.6 | Bilingual output | 5–8 days | passive (release notes only) | planned |
+| v2 | Open-ended | not committed | recompute from v1.4/v1.5 feedback | planned |
 
 Total v1.x roadmap is roughly 45–70 person-days of focused work; in calendar
 terms, with a maintainer who has limited evenings and weekends and a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -605,7 +605,10 @@ book" to "translates her books."
 - `glossary_terms` table in SQLite.
 - TOML import/export format (§5.5).
 - CLI commands for glossary management (§5.7).
-- Prompt injection during translation, token-budgeted (§5.8).
+- Prompt injection during translation, token-budgeted (§5.8). Two
+  render formats — structured JSON and prose bullets — selectable via
+  `--glossary-format`; both ship in v1.2 so we can A/B which the model
+  honors better.
 - Review UI updated to highlight glossary mismatches (§5.9).
 - `--prompt-extra` flag for ad-hoc instructions (oomol-lab inspiration, §5.10).
 - ingest-flags from v1.1 lights up: flags of kind `name` with
@@ -744,12 +747,16 @@ bookforge translate book.epub \
     --glossary ~/Books/lord-of-the-rings/glossary.series.toml \
     --glossary ~/Books/lord-of-the-rings/glossary.fellowship.toml \
     --glossary-budget-tokens 800 \
+    --glossary-format json \
     --prompt-extra "Maintain a literary register typical of Tolkien translation."
 ```
 
 `--book-id` and `--series-id` associate the job with scope identifiers,
 which become the default scope for `bookforge glossary add` if invoked
 during the same session.
+
+`--glossary-format` accepts `json` (default) or `prose`. Both inject the
+same selected entries; only the rendered shape differs. See §5.8.
 
 ### 5.8 Prompt injection (token-budgeted)
 
@@ -799,7 +806,36 @@ order and truncated at the token budget (default 800 tokens, configurable
 via `--glossary-budget-tokens`). A `tracing::warn!()` line fires if
 truncation drops any `user_seeded` or `always_active` entries.
 
-The injected block in the prompt looks like:
+**Token estimator.** v1.2 uses a conservative `chars / 3` heuristic
+(rounded up) instead of a real BPE tokenizer. The heuristic over-counts
+slightly on Latin scripts and under-counts on Asian scripts; both
+directions stay safely inside the budget for our purposes. A real
+tokenizer (`tiktoken-rs` or per-provider equivalent) is deferred to v1.3
+once style sheets land and per-segment token accounting becomes a more
+load-bearing concern. Code carries a `// TODO(v1.3): real tokenizer`
+marker.
+
+**Render format (selectable).** The injected block has two shapes,
+selected per-job via `--glossary-format`. Both inject the same selected
+entries; we ship both so users can A/B which the model honors better in
+their language pair and against their model. The format choice is
+hashed into the segment cache namespace so switching formats does not
+silently mix cached translations from different shapes.
+
+`--glossary-format json` (default) populates the existing
+`{{glossary_json}}` template placeholder with a structured array:
+
+```json
+[
+  {"source":"Aragorn","target":"Aragorn","category":"person"},
+  {"source":"the One Ring","target":"l'Unico Anello","category":"object"},
+  {"source":"you","target":"tu","category":"style",
+   "note":"informal in hobbit dialogue"}
+]
+```
+
+`--glossary-format prose` populates a sibling `{{glossary_block_prose}}`
+placeholder with a human-readable bullet list:
 
 ```
 Active glossary constraints (must be honored):
@@ -903,6 +939,16 @@ When ingesting `flags.json`:
    request log in tests).
 8. Translating a book without any `--glossary` flag works exactly as
    in v1.1 (no regressions).
+9. Switching `--glossary-format` between `json` and `prose` for the same
+   `(book, glossary)` pair produces a different cache namespace and
+   re-translates rather than reusing the prior format's cache.
+
+**Cache compatibility note.** v1.2 bumps `CACHE_KEY_SCHEMA_VERSION` from
+1 to 2 unconditionally so that glossary content and format always factor
+into the cache key. The first v1.2 run on a v1.1 book will re-translate
+even with no `--glossary`. This one-time cost is preferred over the
+footgun where adding one term mid-job silently mixes glossary-aware and
+glossary-blind cached segments.
 
 ### 5.14 Effort
 


### PR DESCRIPTION
## Summary
- add the v1.2 manual glossary model, SQLite storage, TOML import/export, and `bookforge glossary` CLI
- wire glossary selection into translate/resume/review/ingest-flags, including prompt-extra and JSON/prose formats
- fix review findings: legacy v1.1 resume cache namespaces, glossary-aware batch packing, and case-sensitive glossary merge variants
- make EPUB rebuild ZIP metadata deterministic and bump the CLI/workspace crates to 1.2.0

## Verification
- `cargo fmt`
- `cargo check -q`
- `cargo test -q -p bookforge-core`
- `cargo test -q -p bookforge-llm -- --skip json_mode_auto_fallback_works_with_one_provider_attempt`
- `cargo test -q -p bookforge-cli`
- `cargo test -q -p bookforge-store`
- `cargo test -q -p bookforge-epub`
- `git diff --check`
- `cargo test -q` outside the sandbox so the loopback-binding provider test can run