### PR TITLE
feat(v1.3): style sheet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "clap",
  "quick-xml",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror",
  "zip",

--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod resume;
 pub mod retry;
 pub mod review;
 pub mod status;
+pub mod style;
 pub mod tail;
 pub mod translate;
 pub mod validate;

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -261,6 +261,7 @@ async fn run_inner(
         glossary: glossary.run_config.clone(),
         context: context_cfg,
         context_registry: context_registry.clone(),
+        style: style_run_config_from_snapshot(snapshot),
     };
 
     let cache_namespace = if legacy_cache_namespace {
@@ -663,6 +664,7 @@ fn batch_run_config(
         glossary: run_config.glossary.clone(),
         context: run_config.context,
         context_registry: run_config.context_registry.clone(),
+        style: run_config.style.clone(),
     }
 }
 

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -17,7 +17,8 @@ use bookforge_core::{
 use bookforge_epub::{read_epub, rebuild_epub};
 use bookforge_llm::{
     ContextRegistry, ContextRunConfig, GlossaryRunConfig, MockProvider, OpenAiCompatibleConfig,
-    OpenAiCompatibleProvider, QaSegmentReview, SegmentTranslation, TranslationRunConfig,
+    OpenAiCompatibleProvider, QaSegmentReview, SegmentTranslation, StyleRunConfig,
+    TranslationRunConfig,
 };
 use bookforge_store::{JobRecord, JobStore, StoredBlockTranslation};
 use clap::Args;
@@ -280,6 +281,11 @@ async fn run_inner(
             settings.batch.enabled,
             prompt_version,
             &glossary.fingerprint,
+            if snapshot.style_rendered_block.is_empty() {
+                ""
+            } else {
+                snapshot.style_fingerprint.as_str()
+            },
         )
     };
     if cache_namespace != snapshot.cache_namespace {
@@ -673,6 +679,17 @@ fn snapshot_context_run_config(snapshot: &RunConfigSnapshot) -> ContextRunConfig
         window: snapshot.context_window,
         budget_tokens: snapshot.context_budget_tokens,
         scope: snapshot.context_scope,
+    }
+}
+
+fn style_run_config_from_snapshot(snapshot: &RunConfigSnapshot) -> Option<StyleRunConfig> {
+    if snapshot.style_rendered_block.is_empty() {
+        None
+    } else {
+        Some(StyleRunConfig {
+            rendered_block: snapshot.style_rendered_block.clone(),
+            fingerprint: snapshot.style_fingerprint.clone(),
+        })
     }
 }
 
@@ -1193,6 +1210,7 @@ mod tests {
             settings.batch.enabled,
             prompt_version,
             &glossary_fingerprint,
+            "",
         );
         store
             .insert_segments(
@@ -1232,6 +1250,8 @@ mod tests {
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
         store

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -211,6 +211,8 @@ mod tests {
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/style.rs
+++ b/crates/bookforge-cli/src/commands/style.rs
@@ -184,8 +184,11 @@ fn import_style(store: &JobStore, args: ImportArgs) -> Result<()> {
 }
 
 fn list_styles(store: &JobStore, args: ListArgs) -> Result<()> {
-    let stored =
-        store.list_style_sheets(args.language.as_deref(), args.scope, args.scope_id.as_deref())?;
+    let stored = store.list_style_sheets(
+        args.language.as_deref(),
+        args.scope,
+        args.scope_id.as_deref(),
+    )?;
     if stored.is_empty() {
         println!("No style sheets matched.");
         return Ok(());
@@ -214,7 +217,11 @@ fn export_style(store: &JobStore, args: ExportArgs) -> Result<()> {
         .next()
         .ok_or_else(|| anyhow::anyhow!("no style sheet matched the export filters"))?;
     fs::write(&args.file, record.content_toml)?;
-    println!("Exported style sheet id={} to {}", record.id, args.file.display());
+    println!(
+        "Exported style sheet id={} to {}",
+        record.id,
+        args.file.display()
+    );
     Ok(())
 }
 
@@ -238,7 +245,10 @@ fn show_style(store: &JobStore, args: ShowArgs) -> Result<()> {
     for record in &records {
         match parse_style_toml(&record.content_toml) {
             Ok(s) => sheets.push(s),
-            Err(err) => eprintln!("warn: skipping malformed style sheet id={}: {err}", record.id),
+            Err(err) => eprintln!(
+                "warn: skipping malformed style sheet id={}: {err}",
+                record.id
+            ),
         }
     }
     let merged = merge_style_sheets(&sheets);

--- a/crates/bookforge-cli/src/commands/style.rs
+++ b/crates/bookforge-cli/src/commands/style.rs
@@ -1,0 +1,252 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use bookforge_core::{
+    GlossaryScopeKind,
+    style::{
+        DoNotFields, RegisterFields, StyleSheet, VoiceFields, merge_style_sheets,
+        render_style_block, style_fingerprint,
+    },
+};
+use bookforge_store::{JobStore, NewStyleSheet};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Args)]
+pub struct StyleArgs {
+    #[command(subcommand)]
+    command: StyleCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum StyleCommand {
+    List(ListArgs),
+    Import(ImportArgs),
+    Export(ExportArgs),
+    Clear(ClearArgs),
+    Show(ShowArgs),
+}
+
+#[derive(Debug, Args)]
+struct ListArgs {
+    #[arg(long)]
+    language: Option<String>,
+
+    #[arg(long, value_enum)]
+    scope: Option<GlossaryScopeKind>,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ImportArgs {
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct ExportArgs {
+    file: PathBuf,
+
+    #[arg(long, value_enum)]
+    scope: GlossaryScopeKind,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+
+    #[arg(long)]
+    language: String,
+}
+
+#[derive(Debug, Args)]
+struct ClearArgs {
+    #[arg(long, value_enum)]
+    scope: GlossaryScopeKind,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ShowArgs {
+    #[arg(long)]
+    language: String,
+
+    #[arg(long)]
+    book_id: Option<String>,
+
+    #[arg(long)]
+    series_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct StyleToml {
+    meta: StyleTomlMeta,
+    #[serde(default)]
+    register: RegisterFields,
+    #[serde(default)]
+    voice: VoiceFields,
+    #[serde(default)]
+    do_not: DoNotFields,
+    #[serde(default)]
+    free_text: Option<FreeText>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct StyleTomlMeta {
+    schema_version: u32,
+    target_language: String,
+    scope: StyleTomlScope,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct StyleTomlScope {
+    kind: GlossaryScopeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FreeText {
+    #[serde(default)]
+    instructions: Option<String>,
+}
+
+pub async fn run(args: StyleArgs) -> Result<()> {
+    let store = JobStore::open_default()?;
+    match args.command {
+        StyleCommand::List(args) => list_styles(&store, args),
+        StyleCommand::Import(args) => import_style(&store, args),
+        StyleCommand::Export(args) => export_style(&store, args),
+        StyleCommand::Clear(args) => clear_style(&store, args),
+        StyleCommand::Show(args) => show_style(&store, args),
+    }
+}
+
+pub(crate) fn read_style_file(path: &PathBuf) -> Result<StyleSheet> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read style sheet {}", path.display()))?;
+    parse_style_toml(&raw)
+        .with_context(|| format!("failed to parse style sheet {}", path.display()))
+}
+
+pub(crate) fn parse_style_toml(raw: &str) -> Result<StyleSheet> {
+    let parsed: StyleToml = toml::from_str(raw)?;
+    if parsed.meta.schema_version != 1 {
+        anyhow::bail!(
+            "style sheet schema_version {} is not supported (expected 1)",
+            parsed.meta.schema_version
+        );
+    }
+    validate_scope(parsed.meta.scope.kind, parsed.meta.scope.id.as_deref())?;
+    let free_text_instructions = parsed.free_text.and_then(|f| f.instructions);
+    Ok(StyleSheet {
+        scope_kind: parsed.meta.scope.kind,
+        scope_id: parsed.meta.scope.id,
+        target_language: parsed.meta.target_language,
+        register: parsed.register,
+        voice: parsed.voice,
+        free_text_instructions,
+        do_not: parsed.do_not,
+    })
+}
+
+fn validate_scope(scope: GlossaryScopeKind, scope_id: Option<&str>) -> Result<()> {
+    match scope {
+        GlossaryScopeKind::Global => Ok(()),
+        GlossaryScopeKind::Series | GlossaryScopeKind::Book => {
+            if scope_id.is_none() || scope_id.is_some_and(|id| id.is_empty()) {
+                anyhow::bail!(
+                    "style sheet with scope.kind = {:?} requires a non-empty scope.id",
+                    scope
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn import_style(store: &JobStore, args: ImportArgs) -> Result<()> {
+    let sheet = read_style_file(&args.file)?;
+    let content_toml = fs::read_to_string(&args.file)?;
+    let one = vec![sheet.clone()];
+    let merged = merge_style_sheets(&one);
+    let fp = style_fingerprint(merged.as_ref());
+    store.upsert_style_sheet(&NewStyleSheet {
+        scope_kind: sheet.scope_kind,
+        scope_id: sheet.scope_id.as_deref(),
+        target_language: &sheet.target_language,
+        content_toml: &content_toml,
+        fingerprint: &fp,
+    })?;
+    println!("Imported style sheet for {}.", sheet.target_language);
+    Ok(())
+}
+
+fn list_styles(store: &JobStore, args: ListArgs) -> Result<()> {
+    let stored =
+        store.list_style_sheets(args.language.as_deref(), args.scope, args.scope_id.as_deref())?;
+    if stored.is_empty() {
+        println!("No style sheets matched.");
+        return Ok(());
+    }
+    for record in stored {
+        println!(
+            "id={} scope={:?} scope_id={:?} target={} fingerprint={}",
+            record.id,
+            record.scope_kind,
+            record.scope_id,
+            record.target_language,
+            &record.fingerprint[..16]
+        );
+    }
+    Ok(())
+}
+
+fn export_style(store: &JobStore, args: ExportArgs) -> Result<()> {
+    let records = store.list_style_sheets(
+        Some(&args.language),
+        Some(args.scope),
+        args.scope_id.as_deref(),
+    )?;
+    let record = records
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no style sheet matched the export filters"))?;
+    fs::write(&args.file, record.content_toml)?;
+    println!("Exported style sheet id={} to {}", record.id, args.file.display());
+    Ok(())
+}
+
+fn clear_style(store: &JobStore, args: ClearArgs) -> Result<()> {
+    let count = store.clear_style_scope(args.scope, args.scope_id.as_deref())?;
+    println!("Cleared {count} style sheets.");
+    Ok(())
+}
+
+fn show_style(store: &JobStore, args: ShowArgs) -> Result<()> {
+    let records = store.load_active_style_sheets(
+        &args.language,
+        args.book_id.as_deref(),
+        args.series_id.as_deref(),
+    )?;
+    if records.is_empty() {
+        println!("No active style sheets for the requested scope.");
+        return Ok(());
+    }
+    let mut sheets: Vec<StyleSheet> = Vec::new();
+    for record in &records {
+        match parse_style_toml(&record.content_toml) {
+            Ok(s) => sheets.push(s),
+            Err(err) => eprintln!("warn: skipping malformed style sheet id={}: {err}", record.id),
+        }
+    }
+    let merged = merge_style_sheets(&sheets);
+    let block = render_style_block(merged.as_ref());
+    if block.is_empty() {
+        println!("Active sheets parsed but produced no content.");
+    } else {
+        print!("{block}");
+    }
+    Ok(())
+}

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -230,6 +230,8 @@ mod tests {
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -94,6 +94,11 @@ pub struct TranslateArgs {
     #[arg(long, value_enum, default_value_t = ContextScope::Chapter)]
     pub context_scope: ContextScope,
 
+    /// Style sheet TOML to merge into prompts (repeatable). Sheets merge
+    /// with `book > series > global` precedence.
+    #[arg(long = "style")]
+    pub style: Vec<PathBuf>,
+
     #[arg(long, value_enum, default_value_t = QaMode::Off)]
     pub qa: QaMode,
 

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -16,7 +16,7 @@ use bookforge_llm::{
     AdaptiveLimiter, ContextRegistry, ContextRunConfig, GlossaryRunConfig, LlmError, LlmProvider,
     MockMode, MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
     ProviderRateController, QaSegmentReview, RateControllerConfig, SegmentTranslation,
-    TelemetryLog, TranslationRunConfig, account_for_batch_prompt_overhead,
+    StyleRunConfig, TelemetryLog, TranslationRunConfig, account_for_batch_prompt_overhead,
     build_translation_batches, qa_segments_parallel, run_double_check, telemetry_summary,
     translate_batches_with_callback, translate_segments_with_callback,
 };
@@ -160,6 +160,66 @@ pub(crate) fn context_run_config_from_args(cli_args: &TranslateArgs) -> ContextR
         budget_tokens: cli_args.context_budget_tokens,
         scope: cli_args.context_scope,
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedStyle {
+    pub run_config: Option<StyleRunConfig>,
+    pub fingerprint: String,
+    pub rendered_block: String,
+}
+
+/// Load `--style` files into the store, merge all sheets for the active
+/// scope, render the prompt block, and produce both the run-time
+/// injection bundle and the snapshot-capture fields.
+pub(crate) fn prepare_style_run_config(
+    store: &JobStore,
+    style_files: &[PathBuf],
+    target_language: &str,
+    book_id: Option<&str>,
+    series_id: Option<&str>,
+) -> Result<PreparedStyle> {
+    for path in style_files {
+        let sheet = crate::commands::style::read_style_file(path)?;
+        let content_toml = std::fs::read_to_string(path)?;
+        let one_sheet = vec![sheet.clone()];
+        let merged_for_one = bookforge_core::style::merge_style_sheets(&one_sheet);
+        let fp = bookforge_core::style::style_fingerprint(merged_for_one.as_ref());
+        store.upsert_style_sheet(&bookforge_store::NewStyleSheet {
+            scope_kind: sheet.scope_kind,
+            scope_id: sheet.scope_id.as_deref(),
+            target_language: &sheet.target_language,
+            content_toml: &content_toml,
+            fingerprint: &fp,
+        })?;
+    }
+    let stored = store.load_active_style_sheets(target_language, book_id, series_id)?;
+    let mut parsed: Vec<bookforge_core::style::StyleSheet> = Vec::new();
+    for record in &stored {
+        match crate::commands::style::parse_style_toml(&record.content_toml) {
+            Ok(sheet) => parsed.push(sheet),
+            Err(err) => tracing::warn!(
+                style_id = record.id,
+                "skipping stored style sheet that failed to parse: {err}"
+            ),
+        }
+    }
+    let merged = bookforge_core::style::merge_style_sheets(&parsed);
+    let rendered_block = bookforge_core::style::render_style_block(merged.as_ref());
+    let fingerprint = bookforge_core::style::style_fingerprint(merged.as_ref());
+    let run_config = if rendered_block.is_empty() {
+        None
+    } else {
+        Some(StyleRunConfig {
+            rendered_block: rendered_block.clone(),
+            fingerprint: fingerprint.clone(),
+        })
+    };
+    Ok(PreparedStyle {
+        run_config,
+        fingerprint,
+        rendered_block,
+    })
 }
 
 /// Seed the in-memory completion fence from already-completed translations
@@ -344,6 +404,13 @@ async fn run_mock_translation(
     } else {
         None
     };
+    let style = prepare_style_run_config(
+        &store,
+        &cli_args.style,
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -385,6 +452,8 @@ async fn run_mock_translation(
         &cache_namespace,
         &glossary.fingerprint,
         &glossary.active_terms,
+        &style.fingerprint,
+        &style.rendered_block,
         &model,
         None,
         None,
@@ -413,6 +482,7 @@ async fn run_mock_translation(
         glossary: glossary.run_config.clone(),
         context: context_run_config,
         context_registry: context_registry.clone(),
+        style: style.run_config.clone(),
     }; // mock
     let provider = MockProvider::new(mock_mode(&model), &config.target_language);
     let mut translations = apply_cached_translations(
@@ -611,6 +681,13 @@ async fn run_openai_compatible_translation(
     } else {
         None
     };
+    let style = prepare_style_run_config(
+        &store,
+        &cli_args.style,
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -652,6 +729,8 @@ async fn run_openai_compatible_translation(
         &cache_namespace,
         &glossary.fingerprint,
         &glossary.active_terms,
+        &style.fingerprint,
+        &style.rendered_block,
         &model,
         Some(provider_config.base_url.clone()),
         Some(provider_config.api_key_env.clone()),
@@ -680,6 +759,7 @@ async fn run_openai_compatible_translation(
         glossary: glossary.run_config.clone(),
         context: context_run_config,
         context_registry: context_registry.clone(),
+        style: style.run_config.clone(),
     };
     // batch_run_config
 
@@ -703,6 +783,7 @@ async fn run_openai_compatible_translation(
             glossary: run_config.glossary.clone(),
             context: run_config.context,
             context_registry: run_config.context_registry.clone(),
+            style: run_config.style.clone(),
         };
         let mut translations = apply_cached_translations(
             &segments,
@@ -1209,6 +1290,7 @@ async fn run_fallback_pass(
         glossary: primary_run_config.glossary.clone(),
         context: primary_run_config.context,
         context_registry: primary_run_config.context_registry.clone(),
+        style: primary_run_config.style.clone(),
     }; // fallback_run_config
 
     let writer = CheckpointWriter::spawn(store.path().to_path_buf(), Arc::new(NullProgressSink));
@@ -1765,6 +1847,7 @@ mod tests {
             glossary: GlossaryRunConfig::default(),
             context: ContextRunConfig::default(),
             context_registry: None,
+            style: None,
         };
 
         let error = translate_with_scheduler_guard(

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -439,6 +439,11 @@ async fn run_mock_translation(
         settings.batch.enabled,
         prompt_version,
         &glossary.fingerprint,
+        if style.run_config.is_some() {
+            &style.fingerprint
+        } else {
+            ""
+        },
     );
     persist_snapshot(
         &store,
@@ -716,6 +721,11 @@ async fn run_openai_compatible_translation(
         settings.batch.enabled,
         run_prompt_version,
         &glossary.fingerprint,
+        if style.run_config.is_some() {
+            &style.fingerprint
+        } else {
+            ""
+        },
     );
     persist_snapshot(
         &store,
@@ -2146,6 +2156,7 @@ case_sensitive = true
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style: Vec::new(),
             qa: QaMode::Off,
             qa_concurrency: 8,
             qa_batch_target_tokens: None,

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -33,6 +33,8 @@ pub(crate) fn persist_snapshot(
     cache_namespace: &str,
     glossary_fingerprint: &str,
     glossary_terms: &[GlossaryTerm],
+    style_fingerprint: &str,
+    style_rendered_block: &str,
     model: &str,
     base_url: Option<String>,
     api_key_env: Option<String>,
@@ -71,6 +73,8 @@ pub(crate) fn persist_snapshot(
         context_window: cli_args.context_window,
         context_budget_tokens: cli_args.context_budget_tokens,
         context_scope: cli_args.context_scope,
+        style_fingerprint: style_fingerprint.to_string(),
+        style_rendered_block: style_rendered_block.to_string(),
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),
     };
     store.update_job_config_snapshot(&job.id, &snapshot)?;

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -8,7 +8,7 @@ mod report;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use commands::{
-    doctor, estimate, glossary, ingest_flags, inspect, resume, retry, review, status, tail,
+    doctor, estimate, glossary, ingest_flags, inspect, resume, retry, review, status, style, tail,
     translate, validate,
 };
 use std::path::PathBuf;
@@ -40,6 +40,7 @@ enum Command {
     Benchmark(Box<translate::BenchmarkArgs>),
     Doctor(doctor::DoctorArgs),
     Status(status::StatusArgs),
+    Style(style::StyleArgs),
     Tail(tail::TailArgs),
 }
 
@@ -68,6 +69,7 @@ async fn main() -> Result<()> {
         Command::Benchmark(args) => translate::run_benchmark(*args).await,
         Command::Doctor(args) => doctor::run(args).await,
         Command::Status(args) => status::run(args).await,
+        Command::Style(args) => style::run(args).await,
         Command::Tail(args) => tail::run(args).await,
     }
 }

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -84,6 +84,129 @@ fn cli_translate_context_window_persists_snapshot_settings() {
 }
 
 #[test]
+fn cli_translate_with_style_sheet_persists_rendered_block_in_snapshot() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let style_path = temp.path().join("style.toml");
+    fs::write(
+        &style_path,
+        r#"[meta]
+schema_version = 1
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "smoke"
+
+[register]
+narration = "literary"
+dialogue_default = "tu"
+
+[free_text]
+instructions = "Maintain a literary register typical of Italian fiction translation."
+"#,
+    )
+    .expect("style sheet should write");
+
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            fixture_input().to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--book-id",
+            "smoke",
+            "--style",
+            style_path.to_str().unwrap(),
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let job_id = job_id_from_events(&events);
+    let store =
+        JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store should open");
+    let snapshot = store
+        .load_job_config_snapshot(&job_id)
+        .expect("snapshot load")
+        .expect("snapshot present");
+    assert!(
+        !snapshot.style_rendered_block.is_empty(),
+        "snapshot should capture a non-empty style block when --style is supplied"
+    );
+    assert!(
+        snapshot.style_rendered_block.contains("Register: literary"),
+        "rendered block must include configured register"
+    );
+    assert!(
+        snapshot
+            .style_rendered_block
+            .contains("Dialogue default: tu"),
+        "rendered block must include configured dialogue default"
+    );
+    assert!(
+        snapshot
+            .style_rendered_block
+            .contains("Maintain a literary register"),
+        "rendered block must include free-text instructions"
+    );
+    assert!(
+        !snapshot.style_fingerprint.is_empty(),
+        "snapshot should record a style fingerprint when style is active"
+    );
+}
+
+#[test]
+fn cli_style_import_then_show_matches_input() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let style_path = temp.path().join("style.toml");
+    fs::write(
+        &style_path,
+        r#"[meta]
+schema_version = 1
+target_language = "Italian"
+
+[meta.scope]
+kind = "global"
+
+[register]
+narration = "neutral"
+"#,
+    )
+    .expect("style sheet should write");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args(["style", "import", style_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args(["style", "show", "--language", "Italian"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("Register: neutral"),
+        "show output should render the imported register; got: {stdout}"
+    );
+}
+
+#[test]
 fn cli_translate_mock_with_same_glossary_is_bit_identical() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let input = fixture_input();

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 quick-xml.workspace = true
 sha2.workspace = true

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod progress;
 pub mod run_snapshot;
 pub mod scheduler;
 pub mod segment;
+pub mod style;
 
 pub use config::{
     BatchConfig, DoubleCheckConfig, DoubleCheckMode, FallbackScope, JsonMode, ModelEndpoint,
@@ -24,3 +25,7 @@ pub use glossary::{
 pub use progress::{NullProgressSink, ProgressEvent, ProgressSink, now_ms};
 pub use run_snapshot::{ResolvedRunSettingsSnapshot, RunConfigSnapshot};
 pub use scheduler::SchedulerConfig;
+pub use style::{
+    DoNotFields, RegisterFields, StyleSheet, VoiceFields, merge_style_sheets, render_style_block,
+    style_fingerprint,
+};

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -48,6 +48,15 @@ pub struct RunConfigSnapshot {
     pub context_budget_tokens: usize,
     #[serde(default)]
     pub context_scope: ContextScope,
+    /// SHA-256 of the merged style sheet's normalized JSON form. Stable
+    /// for users without `--style` (fingerprint of `None`).
+    #[serde(default)]
+    pub style_fingerprint: String,
+    /// Pre-rendered style guide block — captured so resume reproduces the
+    /// exact prompt the original run sent, even if the source TOML files
+    /// have moved or been edited.
+    #[serde(default)]
+    pub style_rendered_block: String,
     pub settings: ResolvedRunSettingsSnapshot,
 }
 

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -17,6 +17,11 @@ pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 1;
 /// Compute a cache namespace that scopes lookups to a single set of
 /// schema and segmentation parameters. Cached rows from a different
 /// namespace are not eligible for reuse.
+///
+/// `style_fingerprint` is an opt-in mixin: pass an empty string to
+/// preserve cache compatibility with runs that didn't use style sheets;
+/// pass a non-empty fingerprint when a sheet is active and the rendered
+/// prompt is materially different.
 pub fn compute_cache_namespace(
     max_segment_tokens: usize,
     context_tokens: usize,
@@ -24,6 +29,7 @@ pub fn compute_cache_namespace(
     batch_enabled: bool,
     prompt_version: &str,
     glossary_fingerprint: &str,
+    style_fingerprint: &str,
 ) -> String {
     compute_cache_namespace_inner(
         CACHE_KEY_SCHEMA_VERSION,
@@ -33,6 +39,11 @@ pub fn compute_cache_namespace(
         batch_enabled,
         prompt_version,
         Some(glossary_fingerprint),
+        if style_fingerprint.is_empty() {
+            None
+        } else {
+            Some(style_fingerprint)
+        },
     )
 }
 
@@ -51,6 +62,7 @@ pub fn compute_cache_namespace_v1(
         batch_enabled,
         prompt_version,
         None,
+        None,
     )
 }
 
@@ -62,6 +74,7 @@ fn compute_cache_namespace_inner(
     batch_enabled: bool,
     prompt_version: &str,
     glossary_fingerprint: Option<&str>,
+    style_fingerprint: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
     hasher.update(cache_key_schema_version.to_le_bytes());
@@ -74,6 +87,11 @@ fn compute_cache_namespace_inner(
     hasher.update(prompt_version.as_bytes());
     if let Some(glossary_fingerprint) = glossary_fingerprint {
         hasher.update(glossary_fingerprint.as_bytes());
+    }
+    if let Some(style_fingerprint) = style_fingerprint {
+        // Domain separator so glossary and style fingerprints can never collide.
+        hasher.update(b"|style|");
+        hasher.update(style_fingerprint.as_bytes());
     }
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(digest.len() * 2);
@@ -451,12 +469,12 @@ mod tests {
 
     #[test]
     fn cache_namespace_changes_when_segmentation_settings_change() {
-        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
-        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1", "glossary:a");
-        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a");
-        let d = compute_cache_namespace(1200, 160, "Balanced", false, "batch_v1", "glossary:a");
-        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
-        let f = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:b");
+        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1", "glossary:a", "");
+        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a", "");
+        let d = compute_cache_namespace(1200, 160, "Balanced", false, "batch_v1", "glossary:a", "");
+        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+        let f = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:b", "");
 
         assert_ne!(a, b, "max_segment_tokens must affect namespace");
         assert_ne!(a, c, "batch_enabled must affect namespace");
@@ -467,9 +485,10 @@ mod tests {
 
     #[test]
     fn legacy_cache_namespace_v1_ignores_glossary_fingerprint() {
-        let current_without_terms = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "");
+        let current_without_terms =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "", "");
         let current_with_terms =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
         let legacy = compute_cache_namespace_v1(1200, 160, "Balanced", false, "v1");
 
         assert_ne!(legacy, current_without_terms);
@@ -477,6 +496,36 @@ mod tests {
         assert_eq!(
             legacy,
             compute_cache_namespace_v1(1200, 160, "Balanced", false, "v1")
+        );
+    }
+
+    #[test]
+    fn cache_namespace_is_stable_when_style_fingerprint_is_empty() {
+        // Users who don't use --style must see no cache invalidation when
+        // they upgrade to a build that supports style sheets.
+        let without_style =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+        let still_without_style =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+        assert_eq!(without_style, still_without_style);
+    }
+
+    #[test]
+    fn cache_namespace_changes_when_style_fingerprint_changes() {
+        let baseline =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+        let with_style =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "style:a");
+        let with_other_style =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "style:b");
+
+        assert_ne!(
+            baseline, with_style,
+            "switching on a style sheet must invalidate cache"
+        );
+        assert_ne!(
+            with_style, with_other_style,
+            "different style fingerprints must yield different namespaces"
         );
     }
 

--- a/crates/bookforge-core/src/style.rs
+++ b/crates/bookforge-core/src/style.rs
@@ -1,0 +1,375 @@
+//! Style sheets — per-book/series/global rendering hints injected into
+//! the translation prompt.
+//!
+//! A style sheet captures the per-book stylistic decisions that
+//! `--prompt-extra` was a thin proxy for: narrative register, dialogue
+//! formality, loanword policy, and free-form custom instructions. Several
+//! sheets at different scopes can be active simultaneously; they merge
+//! `book > series > global` with the same precedence as glossary terms
+//! (see [`merge_style_sheets`]).
+//!
+//! The merged sheet renders as a single prompt block; the prompt
+//! template references it via `{{style_guide_block}}`. When no sheet is
+//! active, the block renders to an empty string.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::glossary::GlossaryScopeKind;
+
+/// Narrative register: maps to source-language → target-language voice
+/// conventions. Values are strings so the user can pick conventions
+/// outside this enum (`passato_remoto` etc.) without us pre-enumerating
+/// every target-language idiom.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisterFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub narration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub narration_tense: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dialogue_default: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loanword_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoiceFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub narrator_register: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preserve_anglicisms: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_audience: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gender_of_unspecified_narrator: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DoNotFields {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub translate_terms: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub preserve_punctuation: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StyleSheet {
+    pub scope_kind: GlossaryScopeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_id: Option<String>,
+    pub target_language: String,
+    #[serde(default)]
+    pub register: RegisterFields,
+    #[serde(default)]
+    pub voice: VoiceFields,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub free_text_instructions: Option<String>,
+    #[serde(default)]
+    pub do_not: DoNotFields,
+}
+
+/// Merge multiple style sheets following `book > series > global`
+/// precedence (mirrors [`crate::glossary::merge_scope_terms`]). For
+/// scalar Optional fields, the highest-priority non-`None` wins. For
+/// `do_not.translate_terms` and `do_not.preserve_punctuation`, vectors
+/// concatenate with deduplication. `free_text_instructions` concatenates
+/// global-first → book-last so book-level instructions appear most
+/// prominently to the model. Returns `None` if no input sheets carry any
+/// content.
+pub fn merge_style_sheets(sheets: &[StyleSheet]) -> Option<StyleSheet> {
+    if sheets.is_empty() {
+        return None;
+    }
+    let target_language = sheets[0].target_language.clone();
+    let mut ordered: Vec<&StyleSheet> = sheets.iter().collect();
+    ordered.sort_by_key(|sheet| sheet.scope_kind.priority());
+
+    let mut merged = StyleSheet {
+        scope_kind: GlossaryScopeKind::Global,
+        scope_id: None,
+        target_language,
+        register: RegisterFields::default(),
+        voice: VoiceFields::default(),
+        free_text_instructions: None,
+        do_not: DoNotFields::default(),
+    };
+    let mut instructions: Vec<String> = Vec::new();
+    let mut translate_seen: std::collections::BTreeSet<String> =
+        std::collections::BTreeSet::new();
+    let mut punct_seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for sheet in ordered {
+        if let Some(value) = sheet.register.narration.as_ref() {
+            merged.register.narration = Some(value.clone());
+        }
+        if let Some(value) = sheet.register.narration_tense.as_ref() {
+            merged.register.narration_tense = Some(value.clone());
+        }
+        if let Some(value) = sheet.register.dialogue_default.as_ref() {
+            merged.register.dialogue_default = Some(value.clone());
+        }
+        if let Some(value) = sheet.register.loanword_policy.as_ref() {
+            merged.register.loanword_policy = Some(value.clone());
+        }
+        if let Some(value) = sheet.voice.narrator_register.as_ref() {
+            merged.voice.narrator_register = Some(value.clone());
+        }
+        if let Some(value) = sheet.voice.preserve_anglicisms {
+            merged.voice.preserve_anglicisms = Some(value);
+        }
+        if let Some(value) = sheet.voice.target_audience.as_ref() {
+            merged.voice.target_audience = Some(value.clone());
+        }
+        if let Some(value) = sheet.voice.gender_of_unspecified_narrator.as_ref() {
+            merged.voice.gender_of_unspecified_narrator = Some(value.clone());
+        }
+        if let Some(value) = sheet
+            .free_text_instructions
+            .as_ref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            instructions.push(value.trim().to_string());
+        }
+        for term in &sheet.do_not.translate_terms {
+            if translate_seen.insert(term.clone()) {
+                merged.do_not.translate_terms.push(term.clone());
+            }
+        }
+        for token in &sheet.do_not.preserve_punctuation {
+            if punct_seen.insert(token.clone()) {
+                merged.do_not.preserve_punctuation.push(token.clone());
+            }
+        }
+    }
+    if !instructions.is_empty() {
+        merged.free_text_instructions = Some(instructions.join("\n\n"));
+    }
+    if has_content(&merged) {
+        Some(merged)
+    } else {
+        None
+    }
+}
+
+fn has_content(s: &StyleSheet) -> bool {
+    let RegisterFields {
+        narration,
+        narration_tense,
+        dialogue_default,
+        loanword_policy,
+    } = &s.register;
+    let VoiceFields {
+        narrator_register,
+        preserve_anglicisms,
+        target_audience,
+        gender_of_unspecified_narrator,
+    } = &s.voice;
+    narration.is_some()
+        || narration_tense.is_some()
+        || dialogue_default.is_some()
+        || loanword_policy.is_some()
+        || narrator_register.is_some()
+        || preserve_anglicisms.is_some()
+        || target_audience.is_some()
+        || gender_of_unspecified_narrator.is_some()
+        || s.free_text_instructions.is_some()
+        || !s.do_not.translate_terms.is_empty()
+        || !s.do_not.preserve_punctuation.is_empty()
+}
+
+/// Render the merged style sheet as a prompt block. Empty input returns
+/// an empty string so the placeholder substitutes to nothing in
+/// templates that don't reference style guides.
+pub fn render_style_block(merged: Option<&StyleSheet>) -> String {
+    let Some(sheet) = merged else {
+        return String::new();
+    };
+    let mut out = String::from("=== Active style guide ===\n");
+    if let Some(narration) = &sheet.register.narration {
+        let mut line = format!("Register: {narration}");
+        if let Some(tense) = &sheet.register.narration_tense {
+            line.push_str(&format!(", narration in {tense}"));
+        }
+        out.push_str(&line);
+        out.push_str(".\n");
+    } else if let Some(tense) = &sheet.register.narration_tense {
+        out.push_str(&format!("Narration tense: {tense}.\n"));
+    }
+    if let Some(dialogue) = &sheet.register.dialogue_default {
+        out.push_str(&format!("Dialogue default: {dialogue}.\n"));
+    }
+    if let Some(policy) = &sheet.register.loanword_policy {
+        out.push_str(&format!("Loanword policy: {policy}.\n"));
+    }
+    if let Some(voice) = &sheet.voice.narrator_register {
+        out.push_str(&format!("Narrator voice: {voice}.\n"));
+    }
+    if let Some(audience) = &sheet.voice.target_audience {
+        out.push_str(&format!("Target audience: {audience}.\n"));
+    }
+    if let Some(gender) = &sheet.voice.gender_of_unspecified_narrator {
+        out.push_str(&format!("Unspecified-narrator gender: {gender}.\n"));
+    }
+    if let Some(preserve) = sheet.voice.preserve_anglicisms {
+        out.push_str(&format!("Preserve anglicisms: {preserve}.\n"));
+    }
+    if !sheet.do_not.preserve_punctuation.is_empty() {
+        out.push_str(&format!(
+            "Preserve punctuation: {}.\n",
+            sheet.do_not.preserve_punctuation.join(" ")
+        ));
+    }
+    if !sheet.do_not.translate_terms.is_empty() {
+        out.push_str(&format!(
+            "Do not translate: {}.\n",
+            sheet.do_not.translate_terms.join(", ")
+        ));
+    }
+    if let Some(instructions) = sheet
+        .free_text_instructions
+        .as_ref()
+        .filter(|s| !s.trim().is_empty())
+    {
+        out.push_str("\nCustom instructions:\n");
+        out.push_str(instructions.trim());
+        out.push('\n');
+    }
+    out.push_str("=== End style guide ===\n");
+    out
+}
+
+/// Stable fingerprint of the merged style sheet for cache namespacing
+/// and snapshot integrity. When `merged` is `None`, returns the
+/// fingerprint of the empty payload — stable across runs and across
+/// upgrades, so users without `--style` see no cache invalidation.
+pub fn style_fingerprint(merged: Option<&StyleSheet>) -> String {
+    let payload = serde_json::json!({
+        "schema": 1,
+        "merged": merged,
+    });
+    let serialized = serde_json::to_vec(&payload).unwrap_or_default();
+    let digest = Sha256::digest(serialized);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut hex, "{byte:02x}").expect("write to string");
+    }
+    hex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sheet(scope: GlossaryScopeKind, target: &str) -> StyleSheet {
+        StyleSheet {
+            scope_kind: scope,
+            scope_id: Some("test".to_string()),
+            target_language: target.to_string(),
+            register: RegisterFields::default(),
+            voice: VoiceFields::default(),
+            free_text_instructions: None,
+            do_not: DoNotFields::default(),
+        }
+    }
+
+    #[test]
+    fn merge_returns_none_for_empty_input() {
+        assert!(merge_style_sheets(&[]).is_none());
+    }
+
+    #[test]
+    fn merge_returns_none_when_all_sheets_are_empty() {
+        let sheets = vec![sheet(GlossaryScopeKind::Global, "Italian")];
+        assert!(merge_style_sheets(&sheets).is_none());
+    }
+
+    #[test]
+    fn merge_applies_book_over_series_over_global_precedence_for_scalars() {
+        let mut global = sheet(GlossaryScopeKind::Global, "Italian");
+        global.register.narration = Some("neutral".to_string());
+        global.register.dialogue_default = Some("Lei".to_string());
+        let mut series = sheet(GlossaryScopeKind::Series, "Italian");
+        series.register.narration = Some("literary".to_string());
+        let mut book = sheet(GlossaryScopeKind::Book, "Italian");
+        book.register.dialogue_default = Some("tu".to_string());
+
+        let merged = merge_style_sheets(&[global, series, book]).expect("merged");
+        assert_eq!(merged.register.narration.as_deref(), Some("literary"));
+        assert_eq!(merged.register.dialogue_default.as_deref(), Some("tu"));
+    }
+
+    #[test]
+    fn merge_concatenates_free_text_global_first_book_last() {
+        let mut global = sheet(GlossaryScopeKind::Global, "Italian");
+        global.free_text_instructions = Some("global hint".to_string());
+        let mut book = sheet(GlossaryScopeKind::Book, "Italian");
+        book.free_text_instructions = Some("book hint".to_string());
+
+        let merged = merge_style_sheets(&[book, global]).expect("merged");
+        let text = merged.free_text_instructions.expect("instructions");
+        let g = text.find("global hint").expect("global");
+        let b = text.find("book hint").expect("book");
+        assert!(g < b, "global instructions render before book-level ones");
+    }
+
+    #[test]
+    fn merge_dedupes_do_not_translate_terms() {
+        let mut global = sheet(GlossaryScopeKind::Global, "Italian");
+        global.do_not.translate_terms = vec!["mithril".to_string()];
+        let mut book = sheet(GlossaryScopeKind::Book, "Italian");
+        book.do_not.translate_terms = vec!["mithril".to_string(), "lembas".to_string()];
+        let merged = merge_style_sheets(&[global, book]).expect("merged");
+        assert_eq!(merged.do_not.translate_terms.len(), 2);
+        assert!(merged.do_not.translate_terms.contains(&"mithril".to_string()));
+        assert!(merged.do_not.translate_terms.contains(&"lembas".to_string()));
+    }
+
+    #[test]
+    fn render_block_returns_empty_when_no_sheet() {
+        assert_eq!(render_style_block(None), "");
+    }
+
+    #[test]
+    fn render_block_skips_unset_fields() {
+        let mut s = sheet(GlossaryScopeKind::Book, "Italian");
+        s.register.dialogue_default = Some("tu".to_string());
+        let rendered = render_style_block(Some(&s));
+        assert!(rendered.contains("Dialogue default: tu."));
+        assert!(!rendered.contains("Register:"));
+        assert!(!rendered.contains("Narrator voice:"));
+    }
+
+    #[test]
+    fn render_block_includes_free_text_instructions_after_structured_fields() {
+        let mut s = sheet(GlossaryScopeKind::Book, "Italian");
+        s.register.narration = Some("literary".to_string());
+        s.free_text_instructions = Some("Maintain a literary register.".to_string());
+        let rendered = render_style_block(Some(&s));
+        let reg = rendered.find("Register:").expect("register present");
+        let instr = rendered
+            .find("Maintain a literary register.")
+            .expect("instructions present");
+        assert!(reg < instr);
+    }
+
+    #[test]
+    fn style_fingerprint_is_stable_across_field_order() {
+        let mut a = sheet(GlossaryScopeKind::Book, "Italian");
+        a.register.narration = Some("literary".to_string());
+        a.register.dialogue_default = Some("tu".to_string());
+        let mut b = sheet(GlossaryScopeKind::Book, "Italian");
+        b.register.dialogue_default = Some("tu".to_string());
+        b.register.narration = Some("literary".to_string());
+        assert_eq!(style_fingerprint(Some(&a)), style_fingerprint(Some(&b)));
+    }
+
+    #[test]
+    fn style_fingerprint_of_none_is_stable() {
+        let f1 = style_fingerprint(None);
+        let f2 = style_fingerprint(None);
+        assert_eq!(f1, f2);
+        assert_ne!(f1, "");
+    }
+}

--- a/crates/bookforge-core/src/style.rs
+++ b/crates/bookforge-core/src/style.rs
@@ -95,8 +95,7 @@ pub fn merge_style_sheets(sheets: &[StyleSheet]) -> Option<StyleSheet> {
         do_not: DoNotFields::default(),
     };
     let mut instructions: Vec<String> = Vec::new();
-    let mut translate_seen: std::collections::BTreeSet<String> =
-        std::collections::BTreeSet::new();
+    let mut translate_seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut punct_seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
     for sheet in ordered {
@@ -322,8 +321,18 @@ mod tests {
         book.do_not.translate_terms = vec!["mithril".to_string(), "lembas".to_string()];
         let merged = merge_style_sheets(&[global, book]).expect("merged");
         assert_eq!(merged.do_not.translate_terms.len(), 2);
-        assert!(merged.do_not.translate_terms.contains(&"mithril".to_string()));
-        assert!(merged.do_not.translate_terms.contains(&"lembas".to_string()));
+        assert!(
+            merged
+                .do_not
+                .translate_terms
+                .contains(&"mithril".to_string())
+        );
+        assert!(
+            merged
+                .do_not
+                .translate_terms
+                .contains(&"lembas".to_string())
+        );
     }
 
     #[test]

--- a/crates/bookforge-llm/prompts/qa_segment.v1.md
+++ b/crates/bookforge-llm/prompts/qa_segment.v1.md
@@ -66,6 +66,12 @@ Glossary and fixed terminology:
 {{glossary_json}}
 ```
 
+Active style guide (review for adherence to register and dialogue conventions):
+
+```txt
+{{style_guide_block}}
+```
+
 Source:
 
 ```txt

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
@@ -55,7 +55,15 @@ Return exactly:
 
 Translate every structured item. Preserve ALL markers exactly.
 
-Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item.
+
+Active style guide (apply consistently to every item):
+
+```txt
+{{style_guide_block}}
+```
+
+Additional instructions:
 
 ```txt
 {{prompt_extra}}

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
@@ -17,6 +17,7 @@ Return exactly:
 ## User
 
 Translate every item, preserving all markers.
-Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
+Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
@@ -21,7 +21,15 @@ Return exactly:
 
 Translate every item.
 
-Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item.
+
+Active style guide (apply consistently to every item):
+
+```txt
+{{style_guide_block}}
+```
+
+Additional instructions:
 
 ```txt
 {{prompt_extra}}

--- a/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
@@ -11,6 +11,7 @@ Return exactly:
 ## User
 
 Translate every item.
-Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
+Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
@@ -22,7 +22,15 @@ Return exactly:
 
 Translate every item.
 
-Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item. Additional instructions:
+Each input item may include `glossary` or `glossary_prose`; honor those constraints for that item.
+
+Active style guide (apply consistently to every item):
+
+```txt
+{{style_guide_block}}
+```
+
+Additional instructions:
 
 ```txt
 {{prompt_extra}}

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
@@ -17,6 +17,7 @@ Return exactly:
 ## User
 
 Translate every item.
-Honor item `glossary`/`glossary_prose` constraints. Extra: {{prompt_extra}}
+Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
@@ -95,6 +95,12 @@ Already-translated prior segments (use for pronoun, gender, and voice consistenc
 {{context_translation_pairs}}
 ```
 
+Active style guide (apply consistently throughout):
+
+```txt
+{{style_guide_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
@@ -75,6 +75,12 @@ Already-translated prior segments (use for pronoun, gender, and voice consistenc
 {{context_translation_pairs}}
 ```
 
+Active style guide (apply consistently throughout):
+
+```txt
+{{style_guide_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_segment.v1.md
+++ b/crates/bookforge-llm/prompts/translate_segment.v1.md
@@ -67,6 +67,12 @@ Already-translated prior segments (use for pronoun, gender, and voice consistenc
 {{context_translation_pairs}}
 ```
 
+Active style guide (apply consistently throughout):
+
+```txt
+{{style_guide_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1977,6 +1977,14 @@ async fn translate_one_batch(
     )
     .string("target_language", &config.target_language)
     .raw(
+        "style_guide_block",
+        config
+            .style
+            .as_ref()
+            .map(|s| s.rendered_block.clone())
+            .unwrap_or_default(),
+    )
+    .raw(
         "prompt_extra",
         config.glossary.prompt_extra.clone().unwrap_or_default(),
     )
@@ -2725,6 +2733,7 @@ mod tests {
             glossary: crate::GlossaryRunConfig::default(),
             context: crate::ContextRunConfig::default(),
             context_registry: None,
+            style: None,
         }
     }
 

--- a/crates/bookforge-llm/src/lib.rs
+++ b/crates/bookforge-llm/src/lib.rs
@@ -30,7 +30,7 @@ pub use rate_controller::{
 };
 pub use scheduler::{
     CompletedContext, ContextRegistry, ContextRunConfig, GlossaryRunConfig, QaIssue,
-    QaSegmentReview, SegmentTranslation, TranslationRunConfig, qa_segments, translate_segments,
-    translate_segments_with_callback,
+    QaSegmentReview, SegmentTranslation, StyleRunConfig, TranslationRunConfig, qa_segments,
+    translate_segments, translate_segments_with_callback,
 };
 pub use telemetry::{TelemetryLog, telemetry_summary};

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -45,6 +45,17 @@ pub struct TranslationRunConfig {
     /// scheduler runs without context injection even if `context.window`
     /// is non-zero (degrades silently with a `tracing::warn!`).
     pub context_registry: Option<Arc<ContextRegistry>>,
+    /// Merged style sheet pre-rendered as a prompt block. The scheduler
+    /// substitutes `rendered_block` into the `{{style_guide_block}}`
+    /// placeholder in per-segment and batch prompts. `None` = no style
+    /// sheet active; renders to empty string.
+    pub style: Option<StyleRunConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyleRunConfig {
+    pub rendered_block: String,
+    pub fingerprint: String,
 }
 
 /// Sliding-context injection settings. `window == 0` disables the feature
@@ -626,6 +637,14 @@ fn render_qa_prompt(
     )
     .json("glossary_json", &Value::Array(Vec::new()))
     .raw("glossary_block_prose", "")
+    .raw(
+        "style_guide_block",
+        config
+            .style
+            .as_ref()
+            .map(|s| s.rendered_block.clone())
+            .unwrap_or_default(),
+    )
     .raw("prompt_extra", "")
     .raw("source_text", &segment.source.text)
     .raw("translation_text", translation.joined_text());
@@ -929,6 +948,14 @@ fn render_prompt(
     .json("glossary_json", &glossary_json)
     .raw("glossary_block_prose", glossary_prose)
     .raw("context_translation_pairs", context_block)
+    .raw(
+        "style_guide_block",
+        config
+            .style
+            .as_ref()
+            .map(|s| s.rendered_block.clone())
+            .unwrap_or_default(),
+    )
     .raw(
         "prompt_extra",
         config.glossary.prompt_extra.clone().unwrap_or_default(),
@@ -1864,6 +1891,7 @@ mod tests {
             glossary: GlossaryRunConfig::default(),
             context: ContextRunConfig::default(),
             context_registry: None,
+            style: None,
         }
     }
 

--- a/crates/bookforge-store/migrations/0006_v1_3_context_styles_entities.sql
+++ b/crates/bookforge-store/migrations/0006_v1_3_context_styles_entities.sql
@@ -1,0 +1,41 @@
+-- v1.3 milestone (ROADMAP §6): style sheets and entity sheets.
+--
+-- style_sheets keeps the full TOML body verbatim: the rendered prompt
+-- block is recomputed from TOML at run time, and the schema is small
+-- enough that a normalized column-per-field layout would churn faster
+-- than the data evolves.
+
+CREATE TABLE IF NOT EXISTS style_sheets (
+  id INTEGER PRIMARY KEY,
+  scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+  scope_id TEXT,
+  target_language TEXT NOT NULL,
+  content_toml TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(scope_kind, scope_id, target_language)
+);
+
+CREATE INDEX IF NOT EXISTS idx_style_lookup
+  ON style_sheets(target_language, scope_kind, scope_id);
+
+-- Entities (PR3) — schema from ROADMAP §6.6.
+CREATE TABLE IF NOT EXISTS entities (
+  id INTEGER PRIMARY KEY,
+  scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+  scope_id TEXT,
+  source_name TEXT NOT NULL,
+  target_name TEXT NOT NULL,
+  gender_target TEXT CHECK(gender_target IS NULL OR gender_target IN ('m', 'f', 'n')),
+  role TEXT,
+  notes TEXT,
+  source_language TEXT NOT NULL,
+  target_language TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(scope_kind, scope_id, source_name, source_language, target_language)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_lookup
+  ON entities(source_language, target_language, scope_kind, scope_id);

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -1433,19 +1433,16 @@ impl JobStore {
              ORDER BY scope_kind, scope_id",
         )?;
         let scope_text = scope_kind.map(|s| s.as_str().to_string());
-        let rows = stmt.query_map(
-            params![target_language, scope_text, scope_id],
-            |row| {
-                Ok(StoredStyleSheet {
-                    id: row.get(0)?,
-                    scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
-                    scope_id: row.get(2)?,
-                    target_language: row.get(3)?,
-                    content_toml: row.get(4)?,
-                    fingerprint: row.get(5)?,
-                })
-            },
-        )?;
+        let rows = stmt.query_map(params![target_language, scope_text, scope_id], |row| {
+            Ok(StoredStyleSheet {
+                id: row.get(0)?,
+                scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
+                scope_id: row.get(2)?,
+                target_language: row.get(3)?,
+                content_toml: row.get(4)?,
+                fingerprint: row.get(5)?,
+            })
+        })?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(StoreError::from)
     }
@@ -2499,6 +2496,8 @@ mod tests {
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 
@@ -2583,6 +2582,8 @@ mod tests {
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -227,6 +227,25 @@ pub struct StoredGlossaryCandidate {
     pub source_count: usize,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct NewStyleSheet<'a> {
+    pub scope_kind: GlossaryScopeKind,
+    pub scope_id: Option<&'a str>,
+    pub target_language: &'a str,
+    pub content_toml: &'a str,
+    pub fingerprint: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredStyleSheet {
+    pub id: i64,
+    pub scope_kind: GlossaryScopeKind,
+    pub scope_id: Option<String>,
+    pub target_language: String,
+    pub content_toml: String,
+    pub fingerprint: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct StorageDoctor {
     pub database_path: PathBuf,
@@ -1330,6 +1349,124 @@ impl JobStore {
         Ok(count)
     }
 
+    /// Upsert a style sheet for a (scope, target_language) tuple. Returns
+    /// the row id of the inserted/updated row.
+    pub fn upsert_style_sheet(&self, record: &NewStyleSheet<'_>) -> Result<i64> {
+        let conn = self.conn.borrow();
+        let now = timestamp_string();
+        conn.execute(
+            "INSERT INTO style_sheets
+                (scope_kind, scope_id, target_language, content_toml, fingerprint, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
+             ON CONFLICT(scope_kind, scope_id, target_language) DO UPDATE SET
+                content_toml = excluded.content_toml,
+                fingerprint = excluded.fingerprint,
+                updated_at = excluded.updated_at",
+            params![
+                record.scope_kind.as_str(),
+                record.scope_id,
+                record.target_language,
+                record.content_toml,
+                record.fingerprint,
+                now,
+            ],
+        )?;
+        let id: i64 = conn.query_row(
+            "SELECT id FROM style_sheets
+                WHERE scope_kind = ?1 AND IFNULL(scope_id, '') = IFNULL(?2, '')
+                  AND target_language = ?3",
+            params![
+                record.scope_kind.as_str(),
+                record.scope_id,
+                record.target_language
+            ],
+            |row| row.get(0),
+        )?;
+        Ok(id)
+    }
+
+    /// Load all style sheets that apply for a given language pair and
+    /// optional book/series scopes. Caller is responsible for merging via
+    /// [`bookforge_core::style::merge_style_sheets`].
+    pub fn load_active_style_sheets(
+        &self,
+        target_language: &str,
+        book_id: Option<&str>,
+        series_id: Option<&str>,
+    ) -> Result<Vec<StoredStyleSheet>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, scope_kind, scope_id, target_language, content_toml, fingerprint
+             FROM style_sheets
+             WHERE target_language = ?1
+               AND ( (scope_kind = 'global')
+                  OR (scope_kind = 'series' AND scope_id = ?2)
+                  OR (scope_kind = 'book' AND scope_id = ?3) )",
+        )?;
+        let rows = stmt.query_map(params![target_language, series_id, book_id], |row| {
+            Ok(StoredStyleSheet {
+                id: row.get(0)?,
+                scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
+                scope_id: row.get(2)?,
+                target_language: row.get(3)?,
+                content_toml: row.get(4)?,
+                fingerprint: row.get(5)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn list_style_sheets(
+        &self,
+        target_language: Option<&str>,
+        scope_kind: Option<GlossaryScopeKind>,
+        scope_id: Option<&str>,
+    ) -> Result<Vec<StoredStyleSheet>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, scope_kind, scope_id, target_language, content_toml, fingerprint
+             FROM style_sheets
+             WHERE (?1 IS NULL OR target_language = ?1)
+               AND (?2 IS NULL OR scope_kind = ?2)
+               AND (?3 IS NULL OR scope_id = ?3)
+             ORDER BY scope_kind, scope_id",
+        )?;
+        let scope_text = scope_kind.map(|s| s.as_str().to_string());
+        let rows = stmt.query_map(
+            params![target_language, scope_text, scope_id],
+            |row| {
+                Ok(StoredStyleSheet {
+                    id: row.get(0)?,
+                    scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
+                    scope_id: row.get(2)?,
+                    target_language: row.get(3)?,
+                    content_toml: row.get(4)?,
+                    fingerprint: row.get(5)?,
+                })
+            },
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn clear_style_scope(
+        &self,
+        scope_kind: GlossaryScopeKind,
+        scope_id: Option<&str>,
+    ) -> Result<usize> {
+        let conn = self.conn.borrow();
+        let count = if scope_kind == GlossaryScopeKind::Global {
+            conn.execute("DELETE FROM style_sheets WHERE scope_kind = 'global'", [])?
+        } else {
+            conn.execute(
+                "DELETE FROM style_sheets WHERE scope_kind = ?1 AND scope_id = ?2",
+                params![scope_kind.as_str(), scope_id],
+            )?
+        };
+        Ok(count)
+    }
+
     pub fn pending_segment_ids(&self, job_id: &str) -> Result<Vec<String>> {
         let conn = self.conn.borrow();
         let mut stmt = conn.prepare(
@@ -1798,6 +1935,35 @@ impl JobStore {
               updated_at TEXT NOT NULL,
               UNIQUE(scope_kind, scope_id, source_text, source_language, target_language)
             );
+
+            CREATE TABLE IF NOT EXISTS style_sheets (
+              id INTEGER PRIMARY KEY,
+              scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+              scope_id TEXT,
+              target_language TEXT NOT NULL,
+              content_toml TEXT NOT NULL,
+              fingerprint TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              UNIQUE(scope_kind, scope_id, target_language)
+            );
+
+            CREATE TABLE IF NOT EXISTS entities (
+              id INTEGER PRIMARY KEY,
+              scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
+              scope_id TEXT,
+              source_name TEXT NOT NULL,
+              target_name TEXT NOT NULL,
+              gender_target TEXT
+                CHECK(gender_target IS NULL OR gender_target IN ('m', 'f', 'n')),
+              role TEXT,
+              notes TEXT,
+              source_language TEXT NOT NULL,
+              target_language TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              UNIQUE(scope_kind, scope_id, source_name, source_language, target_language)
+            );
             ",
         )?;
         ensure_glossary_target_nullable(&conn)?;
@@ -1834,13 +2000,18 @@ impl JobStore {
              CREATE INDEX IF NOT EXISTS idx_segment_flags_job
              ON segment_flags(job_id, consumed);
              CREATE INDEX IF NOT EXISTS idx_glossary_lookup
-             ON glossary_terms(source_language, target_language, scope_kind, scope_id, status);",
+             ON glossary_terms(source_language, target_language, scope_kind, scope_id, status);
+             CREATE INDEX IF NOT EXISTS idx_style_lookup
+             ON style_sheets(target_language, scope_kind, scope_id);
+             CREATE INDEX IF NOT EXISTS idx_entity_lookup
+             ON entities(source_language, target_language, scope_kind, scope_id);",
         )?;
         record_migration(&conn, 1, "initial")?;
         record_migration(&conn, 2, "v1_0_1_input_snapshot")?;
         record_migration(&conn, 3, "v1_1_segment_flags")?;
         record_migration(&conn, 4, "v1_2_glossary_terms")?;
         record_migration(&conn, 5, "v1_2_1_nullable_glossary_candidate_targets")?;
+        record_migration(&conn, 6, "v1_3_context_styles_entities")?;
         Ok(())
     }
 

--- a/crates/bookforge-store/src/lib.rs
+++ b/crates/bookforge-store/src/lib.rs
@@ -3,7 +3,7 @@ pub mod db;
 pub use db::{
     CacheLookupRequest, CachedTranslation, CreateJob, GlossaryCandidateUpsertResult,
     GlossaryFilter, JobRecord, JobStore, JobSummary, NewGlossaryCandidate, NewSegmentFlag,
-    RetryScope, SaveCachedTranslation, SaveNeedsReview, SaveTranslation, SegmentRecord,
-    StorageDoctor, StoreError, StoredBlockTranslation, StoredGlossaryCandidate,
-    StoredSegmentTranslation, run_doctor,
+    NewStyleSheet, RetryScope, SaveCachedTranslation, SaveNeedsReview, SaveTranslation,
+    SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation, StoredGlossaryCandidate,
+    StoredSegmentTranslation, StoredStyleSheet, run_doctor,
 };


### PR DESCRIPTION
## Summary
- Second of three v1.3 deliverables (ROADMAP §6.5). Adds per-book/series/global TOML style sheets that merge with `book > series > global` precedence and render into a `{{style_guide_block}}` prompt placeholder on per-segment + batch + QA templates.
- New CLI: `bookforge style {import,list,export,clear,show}` for managing sheets; `--style <file.toml>` (repeatable) on `bookforge translate`.
- New migration `0006_v1_3_context_styles_entities.sql` adds `style_sheets` and (pre-emptively for PR3) `entities` tables.
- Cache namespace mixes in `style_fingerprint` only when a sheet is active — users without `--style` see no cache invalidation; users with `--style` get a fresh namespace because the rendered prompt actually changes.

## Stacked on PR1
This branch targets `feat/v1-3-pr1-sliding-context` (PR #9). Merge order: #9 → this PR. Once #9 lands the base will auto-update to `main`.

## Scope
- `bookforge-core::style` module with `StyleSheet` / `RegisterFields` / `VoiceFields` / `DoNotFields`, `merge_style_sheets` (scalar precedence, vector dedup, free-text concatenation global → series → book), `render_style_block`, `style_fingerprint`.
- `bookforge-store`: `NewStyleSheet` / `StoredStyleSheet` types and `upsert_style_sheet` / `load_active_style_sheets` / `list_style_sheets` / `clear_style_scope` methods.
- Snapshot captures `style_fingerprint` + `style_rendered_block`; resume rehydrates the prompt block from those fields, so deleting the source TOML doesn't break resume.
- `{{style_guide_block}}` placeholder added to `translate_segment` / `translate_marker_safe` / `translate_run_preserving` / `qa_segment` and all 6 main batch templates. Repair templates intentionally skipped (own substitution set; style isn't relevant for JSON-repair prompts).

## Test plan
- [x] `cargo build --release`
- [x] `cargo test --workspace` — 248 tests pass (PR1 tip was 234)
- [x] `cargo test -p bookforge-cli --test lifecycle` — 17 pass (15 prior + 2 new style tests)
- [x] `cargo test -p bookforge-core` — 27 pass (was 25; +9 style module tests, +2 cache-namespace tests)
- [x] `scripts/bench-mock.sh` — green
- [x] `cargo fmt`

## What to look at first
- `crates/bookforge-core/src/style.rs` — the merge precedence and rendering shape.
- `crates/bookforge-core/src/segment.rs::compute_cache_namespace` — the opt-in style fingerprint with the `|style|` domain separator and the new tests that prove it's a no-op for users who don't pass `--style`.
- `crates/bookforge-cli/src/commands/translate/mod.rs::prepare_style_run_config` — imports `--style` files into the store, loads active sheets for the language/book/series scope, merges, and produces both the runtime injection bundle and the snapshot fields.
- `crates/bookforge-cli/src/commands/resume.rs::style_run_config_from_snapshot` — proves resume reproduces the original prompt without touching the source TOML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)