### PR TITLE
feat(v1.3): entity sheet

### DIFF
--- a/crates/bookforge-cli/src/commands/entity.rs
+++ b/crates/bookforge-cli/src/commands/entity.rs
@@ -1,0 +1,261 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use bookforge_core::{
+    GlossaryScopeKind,
+    entity::{
+        Entity, EntityGender, entities_fingerprint, merge_scope_entities,
+        render_entity_agreement_block,
+    },
+};
+use bookforge_store::{JobStore, NewEntity};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Args)]
+pub struct EntitiesArgs {
+    #[command(subcommand)]
+    command: EntitiesCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum EntitiesCommand {
+    List(ListArgs),
+    Import(ImportArgs),
+    Clear(ClearArgs),
+    Show(ShowArgs),
+}
+
+#[derive(Debug, Args)]
+struct ListArgs {
+    #[arg(long)]
+    language: Option<String>,
+
+    #[arg(long, value_enum)]
+    scope: Option<GlossaryScopeKind>,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ImportArgs {
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct ClearArgs {
+    #[arg(long, value_enum)]
+    scope: GlossaryScopeKind,
+
+    #[arg(long)]
+    scope_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ShowArgs {
+    #[arg(long)]
+    source_language: String,
+
+    #[arg(long)]
+    target_language: String,
+
+    #[arg(long)]
+    book_id: Option<String>,
+
+    #[arg(long)]
+    series_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EntitiesToml {
+    meta: EntitiesTomlMeta,
+    #[serde(default, rename = "entity")]
+    entities: Vec<EntitiesTomlEntity>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EntitiesTomlMeta {
+    schema_version: u32,
+    source_language: String,
+    target_language: String,
+    scope: EntitiesTomlScope,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EntitiesTomlScope {
+    kind: GlossaryScopeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct EntitiesTomlEntity {
+    source_name: String,
+    target_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    gender_target: Option<EntityGender>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    notes: Option<String>,
+}
+
+pub async fn run(args: EntitiesArgs) -> Result<()> {
+    let store = JobStore::open_default()?;
+    match args.command {
+        EntitiesCommand::List(args) => list_entities(&store, args),
+        EntitiesCommand::Import(args) => import_entities(&store, args),
+        EntitiesCommand::Clear(args) => clear_entities(&store, args),
+        EntitiesCommand::Show(args) => show_entities(&store, args),
+    }
+}
+
+pub(crate) fn read_entities_file(path: &PathBuf) -> Result<Vec<Entity>> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read entities file {}", path.display()))?;
+    parse_entities_toml(&raw)
+        .with_context(|| format!("failed to parse entities file {}", path.display()))
+}
+
+pub(crate) fn parse_entities_toml(raw: &str) -> Result<Vec<Entity>> {
+    let parsed: EntitiesToml = toml::from_str(raw)?;
+    if parsed.meta.schema_version != 1 {
+        anyhow::bail!(
+            "entities schema_version {} is not supported (expected 1)",
+            parsed.meta.schema_version
+        );
+    }
+    validate_scope(parsed.meta.scope.kind, parsed.meta.scope.id.as_deref())?;
+    let mut out = Vec::with_capacity(parsed.entities.len());
+    for entity in parsed.entities {
+        if entity.source_name.is_empty() || entity.target_name.is_empty() {
+            anyhow::bail!("each entity requires non-empty source_name and target_name");
+        }
+        out.push(Entity {
+            id: None,
+            scope_kind: parsed.meta.scope.kind,
+            scope_id: parsed.meta.scope.id.clone(),
+            source_name: entity.source_name,
+            target_name: entity.target_name,
+            gender_target: entity.gender_target,
+            role: entity.role,
+            notes: entity.notes,
+            source_language: parsed.meta.source_language.clone(),
+            target_language: parsed.meta.target_language.clone(),
+        });
+    }
+    Ok(out)
+}
+
+fn validate_scope(scope: GlossaryScopeKind, scope_id: Option<&str>) -> Result<()> {
+    match scope {
+        GlossaryScopeKind::Global => Ok(()),
+        GlossaryScopeKind::Series | GlossaryScopeKind::Book => {
+            if scope_id.is_none() || scope_id.is_some_and(|id| id.is_empty()) {
+                anyhow::bail!(
+                    "entities file with scope.kind = {:?} requires a non-empty scope.id",
+                    scope
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+fn import_entities(store: &JobStore, args: ImportArgs) -> Result<()> {
+    let entities = read_entities_file(&args.file)?;
+    let count = upsert_entities(store, &entities)?;
+    println!("Imported {count} entity rows.");
+    Ok(())
+}
+
+pub(crate) fn upsert_entities(store: &JobStore, entities: &[Entity]) -> Result<usize> {
+    let rows: Vec<NewEntity<'_>> = entities
+        .iter()
+        .map(|e| NewEntity {
+            scope_kind: e.scope_kind,
+            scope_id: e.scope_id.as_deref(),
+            source_name: e.source_name.as_str(),
+            target_name: e.target_name.as_str(),
+            gender_target: e.gender_target,
+            role: e.role.as_deref(),
+            notes: e.notes.as_deref(),
+            source_language: e.source_language.as_str(),
+            target_language: e.target_language.as_str(),
+        })
+        .collect();
+    let written = store.upsert_entities(&rows)?;
+    Ok(written)
+}
+
+fn list_entities(store: &JobStore, args: ListArgs) -> Result<()> {
+    let stored = store.list_entities(
+        None,
+        args.language.as_deref(),
+        args.scope,
+        args.scope_id.as_deref(),
+    )?;
+    if stored.is_empty() {
+        println!("No entities matched.");
+        return Ok(());
+    }
+    for record in stored {
+        println!(
+            "id={} scope={:?} scope_id={:?} {} -> {} ({})",
+            record.id,
+            record.scope_kind,
+            record.scope_id,
+            record.source_name,
+            record.target_name,
+            record
+                .gender_target
+                .map(|g| g.as_label())
+                .unwrap_or("unspecified")
+        );
+    }
+    Ok(())
+}
+
+fn clear_entities(store: &JobStore, args: ClearArgs) -> Result<()> {
+    let count = store.clear_entities_scope(args.scope, args.scope_id.as_deref())?;
+    println!("Cleared {count} entity rows.");
+    Ok(())
+}
+
+fn show_entities(store: &JobStore, args: ShowArgs) -> Result<()> {
+    let records = store.load_active_entities(
+        &args.source_language,
+        &args.target_language,
+        args.book_id.as_deref(),
+        args.series_id.as_deref(),
+    )?;
+    if records.is_empty() {
+        println!("No active entities for the requested scope.");
+        return Ok(());
+    }
+    let entities: Vec<Entity> = records
+        .into_iter()
+        .map(|r| Entity {
+            id: Some(r.id),
+            scope_kind: r.scope_kind,
+            scope_id: r.scope_id,
+            source_name: r.source_name,
+            target_name: r.target_name,
+            gender_target: r.gender_target,
+            role: r.role,
+            notes: r.notes,
+            source_language: r.source_language,
+            target_language: r.target_language,
+        })
+        .collect();
+    let merged = merge_scope_entities(&entities);
+    let block = render_entity_agreement_block(&merged);
+    if block.is_empty() {
+        println!("Active entities present but produced no agreement block.");
+    } else {
+        print!("{block}");
+    }
+    let _ = entities_fingerprint(&merged); // exercise the fn for compilation symmetry
+    Ok(())
+}

--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod doctor;
+pub mod entity;
 pub mod estimate;
 pub mod glossary;
 pub mod ingest_flags;

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -16,9 +16,9 @@ use bookforge_core::{
 };
 use bookforge_epub::{read_epub, rebuild_epub};
 use bookforge_llm::{
-    ContextRegistry, ContextRunConfig, GlossaryRunConfig, MockProvider, OpenAiCompatibleConfig,
-    OpenAiCompatibleProvider, QaSegmentReview, SegmentTranslation, StyleRunConfig,
-    TranslationRunConfig,
+    ContextRegistry, ContextRunConfig, EntityRunConfig, GlossaryRunConfig, MockProvider,
+    OpenAiCompatibleConfig, OpenAiCompatibleProvider, QaSegmentReview, SegmentTranslation,
+    StyleRunConfig, TranslationRunConfig,
 };
 use bookforge_store::{JobRecord, JobStore, StoredBlockTranslation};
 use clap::Args;
@@ -263,6 +263,7 @@ async fn run_inner(
         context: context_cfg,
         context_registry: context_registry.clone(),
         style: style_run_config_from_snapshot(snapshot),
+        entities: entities_run_config_from_snapshot(snapshot),
     };
 
     let cache_namespace = if legacy_cache_namespace {
@@ -285,6 +286,11 @@ async fn run_inner(
                 ""
             } else {
                 snapshot.style_fingerprint.as_str()
+            },
+            if snapshot.entities_rendered_block.is_empty() {
+                ""
+            } else {
+                snapshot.entities_fingerprint.as_str()
             },
         )
     };
@@ -671,6 +677,7 @@ fn batch_run_config(
         context: run_config.context,
         context_registry: run_config.context_registry.clone(),
         style: run_config.style.clone(),
+        entities: run_config.entities.clone(),
     }
 }
 
@@ -689,6 +696,17 @@ fn style_run_config_from_snapshot(snapshot: &RunConfigSnapshot) -> Option<StyleR
         Some(StyleRunConfig {
             rendered_block: snapshot.style_rendered_block.clone(),
             fingerprint: snapshot.style_fingerprint.clone(),
+        })
+    }
+}
+
+fn entities_run_config_from_snapshot(snapshot: &RunConfigSnapshot) -> Option<EntityRunConfig> {
+    if snapshot.entities_rendered_block.is_empty() {
+        None
+    } else {
+        Some(EntityRunConfig {
+            rendered_block: snapshot.entities_rendered_block.clone(),
+            fingerprint: snapshot.entities_fingerprint.clone(),
         })
     }
 }
@@ -1211,6 +1229,7 @@ mod tests {
             prompt_version,
             &glossary_fingerprint,
             "",
+            "",
         );
         store
             .insert_segments(
@@ -1252,6 +1271,8 @@ mod tests {
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style_fingerprint: String::new(),
             style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
         store

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -213,6 +213,8 @@ mod tests {
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style_fingerprint: String::new(),
             style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -232,6 +232,8 @@ mod tests {
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style_fingerprint: String::new(),
             style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -99,6 +99,12 @@ pub struct TranslateArgs {
     #[arg(long = "style")]
     pub style: Vec<PathBuf>,
 
+    /// Entities TOML to merge into prompts (repeatable). Entries become
+    /// a grammatical-agreement table; helps the model keep gender concord
+    /// consistent across paragraphs.
+    #[arg(long = "entities")]
+    pub entities: Vec<PathBuf>,
+
     #[arg(long, value_enum, default_value_t = QaMode::Off)]
     pub qa: QaMode,
 

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -13,12 +13,13 @@ use bookforge_epub::read_epub;
 #[cfg(test)]
 use bookforge_llm::translate_segments;
 use bookforge_llm::{
-    AdaptiveLimiter, ContextRegistry, ContextRunConfig, GlossaryRunConfig, LlmError, LlmProvider,
-    MockMode, MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
-    ProviderRateController, QaSegmentReview, RateControllerConfig, SegmentTranslation,
-    StyleRunConfig, TelemetryLog, TranslationRunConfig, account_for_batch_prompt_overhead,
-    build_translation_batches, qa_segments_parallel, run_double_check, telemetry_summary,
-    translate_batches_with_callback, translate_segments_with_callback,
+    AdaptiveLimiter, ContextRegistry, ContextRunConfig, EntityRunConfig, GlossaryRunConfig,
+    LlmError, LlmProvider, MockMode, MockProvider, OpenAiCompatibleConfig,
+    OpenAiCompatibleProvider, ProviderRateController, QaSegmentReview, RateControllerConfig,
+    SegmentTranslation, StyleRunConfig, TelemetryLog, TranslationRunConfig,
+    account_for_batch_prompt_overhead, build_translation_batches, qa_segments_parallel,
+    run_double_check, telemetry_summary, translate_batches_with_callback,
+    translate_segments_with_callback,
 };
 use bookforge_store::{CreateJob, JobRecord, JobStore};
 use clap::Args;
@@ -167,6 +168,74 @@ pub(crate) struct PreparedStyle {
     pub run_config: Option<StyleRunConfig>,
     pub fingerprint: String,
     pub rendered_block: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedEntities {
+    pub run_config: Option<EntityRunConfig>,
+    pub fingerprint: String,
+    pub rendered_block: String,
+}
+
+/// Import `--entities` files into the store, then load all entities
+/// applicable to the current (source_language, target_language, book_id,
+/// series_id) scope and produce both the runtime injection bundle and
+/// the snapshot-capture fields.
+pub(crate) fn prepare_entities_run_config(
+    store: &JobStore,
+    entity_files: &[PathBuf],
+    source_language: Option<&str>,
+    target_language: &str,
+    book_id: Option<&str>,
+    series_id: Option<&str>,
+) -> Result<PreparedEntities> {
+    for path in entity_files {
+        let entities = crate::commands::entity::read_entities_file(path)?;
+        crate::commands::entity::upsert_entities(store, &entities)?;
+    }
+    // Without a source language we can't load entities (they're keyed on
+    // both languages). The run still needs a stable fingerprint.
+    let Some(source_language) = source_language else {
+        let fp = bookforge_core::entity::entities_fingerprint(&[]);
+        return Ok(PreparedEntities {
+            run_config: None,
+            fingerprint: fp,
+            rendered_block: String::new(),
+        });
+    };
+    let stored =
+        store.load_active_entities(source_language, target_language, book_id, series_id)?;
+    let active: Vec<bookforge_core::entity::Entity> = stored
+        .into_iter()
+        .map(|r| bookforge_core::entity::Entity {
+            id: Some(r.id),
+            scope_kind: r.scope_kind,
+            scope_id: r.scope_id,
+            source_name: r.source_name,
+            target_name: r.target_name,
+            gender_target: r.gender_target,
+            role: r.role,
+            notes: r.notes,
+            source_language: r.source_language,
+            target_language: r.target_language,
+        })
+        .collect();
+    let merged = bookforge_core::entity::merge_scope_entities(&active);
+    let rendered_block = bookforge_core::entity::render_entity_agreement_block(&merged);
+    let fingerprint = bookforge_core::entity::entities_fingerprint(&merged);
+    let run_config = if rendered_block.is_empty() {
+        None
+    } else {
+        Some(EntityRunConfig {
+            rendered_block: rendered_block.clone(),
+            fingerprint: fingerprint.clone(),
+        })
+    };
+    Ok(PreparedEntities {
+        run_config,
+        fingerprint,
+        rendered_block,
+    })
 }
 
 /// Load `--style` files into the store, merge all sheets for the active
@@ -411,6 +480,14 @@ async fn run_mock_translation(
         cli_args.book_id.as_deref(),
         cli_args.series_id.as_deref(),
     )?;
+    let entities = prepare_entities_run_config(
+        &store,
+        &cli_args.entities,
+        config.source_language.as_deref(),
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -444,6 +521,11 @@ async fn run_mock_translation(
         } else {
             ""
         },
+        if entities.run_config.is_some() {
+            &entities.fingerprint
+        } else {
+            ""
+        },
     );
     persist_snapshot(
         &store,
@@ -459,6 +541,8 @@ async fn run_mock_translation(
         &glossary.active_terms,
         &style.fingerprint,
         &style.rendered_block,
+        &entities.fingerprint,
+        &entities.rendered_block,
         &model,
         None,
         None,
@@ -488,6 +572,7 @@ async fn run_mock_translation(
         context: context_run_config,
         context_registry: context_registry.clone(),
         style: style.run_config.clone(),
+        entities: entities.run_config.clone(),
     }; // mock
     let provider = MockProvider::new(mock_mode(&model), &config.target_language);
     let mut translations = apply_cached_translations(
@@ -693,6 +778,14 @@ async fn run_openai_compatible_translation(
         cli_args.book_id.as_deref(),
         cli_args.series_id.as_deref(),
     )?;
+    let entities = prepare_entities_run_config(
+        &store,
+        &cli_args.entities,
+        config.source_language.as_deref(),
+        &config.target_language,
+        cli_args.book_id.as_deref(),
+        cli_args.series_id.as_deref(),
+    )?;
     let job = store.create_job(CreateJob {
         input,
         output: &config.output,
@@ -726,6 +819,11 @@ async fn run_openai_compatible_translation(
         } else {
             ""
         },
+        if entities.run_config.is_some() {
+            &entities.fingerprint
+        } else {
+            ""
+        },
     );
     persist_snapshot(
         &store,
@@ -741,6 +839,8 @@ async fn run_openai_compatible_translation(
         &glossary.active_terms,
         &style.fingerprint,
         &style.rendered_block,
+        &entities.fingerprint,
+        &entities.rendered_block,
         &model,
         Some(provider_config.base_url.clone()),
         Some(provider_config.api_key_env.clone()),
@@ -770,6 +870,7 @@ async fn run_openai_compatible_translation(
         context: context_run_config,
         context_registry: context_registry.clone(),
         style: style.run_config.clone(),
+        entities: entities.run_config.clone(),
     };
     // batch_run_config
 
@@ -794,6 +895,7 @@ async fn run_openai_compatible_translation(
             context: run_config.context,
             context_registry: run_config.context_registry.clone(),
             style: run_config.style.clone(),
+            entities: run_config.entities.clone(),
         };
         let mut translations = apply_cached_translations(
             &segments,
@@ -1301,6 +1403,7 @@ async fn run_fallback_pass(
         context: primary_run_config.context,
         context_registry: primary_run_config.context_registry.clone(),
         style: primary_run_config.style.clone(),
+        entities: primary_run_config.entities.clone(),
     }; // fallback_run_config
 
     let writer = CheckpointWriter::spawn(store.path().to_path_buf(), Arc::new(NullProgressSink));
@@ -1858,6 +1961,7 @@ mod tests {
             context: ContextRunConfig::default(),
             context_registry: None,
             style: None,
+            entities: None,
         };
 
         let error = translate_with_scheduler_guard(
@@ -2157,6 +2261,7 @@ case_sensitive = true
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style: Vec::new(),
+            entities: Vec::new(),
             qa: QaMode::Off,
             qa_concurrency: 8,
             qa_batch_target_tokens: None,

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -35,6 +35,8 @@ pub(crate) fn persist_snapshot(
     glossary_terms: &[GlossaryTerm],
     style_fingerprint: &str,
     style_rendered_block: &str,
+    entities_fingerprint: &str,
+    entities_rendered_block: &str,
     model: &str,
     base_url: Option<String>,
     api_key_env: Option<String>,
@@ -75,6 +77,8 @@ pub(crate) fn persist_snapshot(
         context_scope: cli_args.context_scope,
         style_fingerprint: style_fingerprint.to_string(),
         style_rendered_block: style_rendered_block.to_string(),
+        entities_fingerprint: entities_fingerprint.to_string(),
+        entities_rendered_block: entities_rendered_block.to_string(),
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),
     };
     store.update_job_config_snapshot(&job.id, &snapshot)?;

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -8,8 +8,8 @@ mod report;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use commands::{
-    doctor, estimate, glossary, ingest_flags, inspect, resume, retry, review, status, style, tail,
-    translate, validate,
+    doctor, entity, estimate, glossary, ingest_flags, inspect, resume, retry, review, status,
+    style, tail, translate, validate,
 };
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -39,6 +39,7 @@ enum Command {
     Validate(validate::ValidateArgs),
     Benchmark(Box<translate::BenchmarkArgs>),
     Doctor(doctor::DoctorArgs),
+    Entities(entity::EntitiesArgs),
     Status(status::StatusArgs),
     Style(style::StyleArgs),
     Tail(tail::TailArgs),
@@ -68,6 +69,7 @@ async fn main() -> Result<()> {
         Command::Validate(args) => validate::run(args).await,
         Command::Benchmark(args) => translate::run_benchmark(*args).await,
         Command::Doctor(args) => doctor::run(args).await,
+        Command::Entities(args) => entity::run(args).await,
         Command::Status(args) => status::run(args).await,
         Command::Style(args) => style::run(args).await,
         Command::Tail(args) => tail::run(args).await,

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -170,6 +170,143 @@ instructions = "Maintain a literary register typical of Italian fiction translat
 }
 
 #[test]
+fn cli_translate_with_entities_persists_agreement_block_in_snapshot() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let entities_path = temp.path().join("entities.toml");
+    fs::write(
+        &entities_path,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[[entity]]
+source_name = "Galadriel"
+target_name = "Galadriel"
+gender_target = "f"
+role = "elf-queen"
+
+[[entity]]
+source_name = "the Ring"
+target_name = "l'Anello"
+gender_target = "m"
+role = "object"
+"#,
+    )
+    .expect("entities file should write");
+
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            fixture_input().to_str().unwrap(),
+            "--source",
+            "English",
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--book-id",
+            "fellowship",
+            "--entities",
+            entities_path.to_str().unwrap(),
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let job_id = job_id_from_events(&events);
+    let store =
+        JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store should open");
+    let snapshot = store
+        .load_job_config_snapshot(&job_id)
+        .expect("snapshot load")
+        .expect("snapshot present");
+    assert!(
+        !snapshot.entities_rendered_block.is_empty(),
+        "snapshot should capture a non-empty entity block when --entities is supplied"
+    );
+    assert!(
+        snapshot
+            .entities_rendered_block
+            .contains("Galadriel: feminine"),
+        "rendered block must list feminine entities"
+    );
+    assert!(
+        snapshot
+            .entities_rendered_block
+            .contains("l'Anello (the Ring): masculine"),
+        "rendered block must list masculine entities with source-name disambiguation"
+    );
+    assert!(
+        !snapshot.entities_fingerprint.is_empty(),
+        "snapshot should record an entity fingerprint when entities are active"
+    );
+}
+
+#[test]
+fn cli_entities_import_then_show_matches_input() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let entities_path = temp.path().join("entities.toml");
+    fs::write(
+        &entities_path,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "global"
+
+[[entity]]
+source_name = "Gandalf"
+target_name = "Gandalf"
+gender_target = "m"
+"#,
+    )
+    .expect("entities file should write");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args(["entities", "import", entities_path.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .args([
+            "entities",
+            "show",
+            "--source-language",
+            "English",
+            "--target-language",
+            "Italian",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("Gandalf: masculine"),
+        "entities show should render the imported entry; got: {stdout}"
+    );
+}
+
+#[test]
 fn cli_style_import_then_show_matches_input() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let style_path = temp.path().join("style.toml");

--- a/crates/bookforge-core/src/entity.rs
+++ b/crates/bookforge-core/src/entity.rs
@@ -1,0 +1,310 @@
+//! Named entities — a structured extension of the glossary for
+//! characters, places, and named items whose grammatical gender matters
+//! in the target language.
+//!
+//! Glossary terms enforce a source → target substitution; entities go
+//! further and tell the model how to inflect adjectives and articles
+//! around the translated name. The rendered block reads like a
+//! grammatical-agreement table (see [`render_entity_agreement_block`]),
+//! so the model can keep gender concord consistent across paragraphs.
+//!
+//! Italian, French, Spanish, German, etc. all need this; English
+//! doesn't. The feature is purely additive — empty input produces an
+//! empty block.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::glossary::GlossaryScopeKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EntityGender {
+    #[serde(rename = "m")]
+    Masculine,
+    #[serde(rename = "f")]
+    Feminine,
+    #[serde(rename = "n")]
+    Neuter,
+}
+
+impl EntityGender {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            EntityGender::Masculine => "masculine",
+            EntityGender::Feminine => "feminine",
+            EntityGender::Neuter => "neuter",
+        }
+    }
+
+    pub fn as_short(self) -> &'static str {
+        match self {
+            EntityGender::Masculine => "m",
+            EntityGender::Feminine => "f",
+            EntityGender::Neuter => "n",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entity {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
+    pub scope_kind: GlossaryScopeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_id: Option<String>,
+    pub source_name: String,
+    pub target_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gender_target: Option<EntityGender>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub source_language: String,
+    pub target_language: String,
+}
+
+/// Merge entities across scopes with the same `book > series > global`
+/// precedence as glossary terms. Entities are keyed on
+/// `(source_name, source_language, target_language)`; the highest-
+/// priority row wins.
+pub fn merge_scope_entities(entities: &[Entity]) -> Vec<Entity> {
+    let mut by_key: HashMap<(String, String, String), Entity> = HashMap::new();
+    for entity in entities {
+        let key = (
+            entity.source_name.clone(),
+            entity.source_language.clone(),
+            entity.target_language.clone(),
+        );
+        match by_key.get(&key) {
+            Some(existing) if existing.scope_kind.priority() > entity.scope_kind.priority() => {}
+            _ => {
+                by_key.insert(key, entity.clone());
+            }
+        }
+    }
+    let mut merged: Vec<Entity> = by_key.into_values().collect();
+    merged.sort_by(|a, b| {
+        a.source_language
+            .cmp(&b.source_language)
+            .then_with(|| a.target_language.cmp(&b.target_language))
+            .then_with(|| a.source_name.cmp(&b.source_name))
+    });
+    merged
+}
+
+/// Render merged entities as a grammatical-agreement block. Empty input
+/// returns an empty string so the placeholder substitutes to nothing in
+/// templates that don't reference the table.
+pub fn render_entity_agreement_block(entities: &[Entity]) -> String {
+    if entities.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "=== Entity grammatical agreement (use this for adjective/article concord) ===\n",
+    );
+    for entity in entities {
+        let mut line = format!("- {}", entity.target_name);
+        if entity.target_name != entity.source_name {
+            line.push_str(&format!(" ({})", entity.source_name));
+        }
+        if let Some(gender) = entity.gender_target {
+            line.push_str(&format!(": {}", gender.as_label()));
+        } else {
+            line.push_str(": unspecified");
+        }
+        if let Some(role) = entity.role.as_deref().filter(|r| !r.is_empty()) {
+            line.push_str(&format!(" [{role}]"));
+        }
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out.push_str("=== End ===\n");
+    out
+}
+
+/// Stable fingerprint of a merged entity set. Empty input still produces
+/// a stable fingerprint so the cache namespace can ignore-or-include
+/// uniformly.
+pub fn entities_fingerprint(entities: &[Entity]) -> String {
+    let mut normalized: Vec<Entity> = entities.to_vec();
+    // Strip ids and sort for stability — the same logical set must
+    // fingerprint identically regardless of insertion order.
+    for entity in &mut normalized {
+        entity.id = None;
+    }
+    normalized.sort_by(|a, b| {
+        a.scope_kind
+            .priority()
+            .cmp(&b.scope_kind.priority())
+            .then_with(|| a.scope_id.cmp(&b.scope_id))
+            .then_with(|| a.source_language.cmp(&b.source_language))
+            .then_with(|| a.target_language.cmp(&b.target_language))
+            .then_with(|| a.source_name.cmp(&b.source_name))
+            .then_with(|| a.target_name.cmp(&b.target_name))
+    });
+    let payload = serde_json::json!({
+        "schema": 1,
+        "entities": normalized,
+    });
+    let serialized = serde_json::to_vec(&payload).unwrap_or_default();
+    let digest = Sha256::digest(serialized);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut hex, "{byte:02x}").expect("write to string");
+    }
+    hex
+}
+
+/// Convenience: produce both the rendered block and the fingerprint
+/// from a single merge.
+pub fn render_and_fingerprint(merged: &[Entity]) -> (String, String) {
+    (
+        render_entity_agreement_block(merged),
+        entities_fingerprint(merged),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(name: &str, target: &str, scope: GlossaryScopeKind, gender: EntityGender) -> Entity {
+        Entity {
+            id: None,
+            scope_kind: scope,
+            scope_id: Some("test".to_string()),
+            source_name: name.to_string(),
+            target_name: target.to_string(),
+            gender_target: Some(gender),
+            role: None,
+            notes: None,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+        }
+    }
+
+    #[test]
+    fn render_block_returns_empty_for_no_entities() {
+        assert_eq!(render_entity_agreement_block(&[]), "");
+    }
+
+    #[test]
+    fn render_block_includes_source_when_target_differs() {
+        let entities = vec![entity(
+            "the Ring",
+            "l'Anello",
+            GlossaryScopeKind::Book,
+            EntityGender::Masculine,
+        )];
+        let rendered = render_entity_agreement_block(&entities);
+        assert!(rendered.contains("l'Anello (the Ring): masculine"));
+    }
+
+    #[test]
+    fn render_block_omits_source_when_target_matches() {
+        let entities = vec![entity(
+            "Galadriel",
+            "Galadriel",
+            GlossaryScopeKind::Book,
+            EntityGender::Feminine,
+        )];
+        let rendered = render_entity_agreement_block(&entities);
+        assert!(rendered.contains("- Galadriel: feminine"));
+        assert!(!rendered.contains("(Galadriel)"));
+    }
+
+    #[test]
+    fn merge_book_overrides_series_overrides_global() {
+        let global = entity(
+            "Aragorn",
+            "Aragorn-old",
+            GlossaryScopeKind::Global,
+            EntityGender::Masculine,
+        );
+        let series = entity(
+            "Aragorn",
+            "Aragorn-series",
+            GlossaryScopeKind::Series,
+            EntityGender::Masculine,
+        );
+        let book = entity(
+            "Aragorn",
+            "Aragorn",
+            GlossaryScopeKind::Book,
+            EntityGender::Masculine,
+        );
+        let merged = merge_scope_entities(&[global, series, book]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].target_name, "Aragorn");
+        assert_eq!(merged[0].scope_kind, GlossaryScopeKind::Book);
+    }
+
+    #[test]
+    fn merge_keeps_distinct_source_names() {
+        let a = entity(
+            "Galadriel",
+            "Galadriel",
+            GlossaryScopeKind::Book,
+            EntityGender::Feminine,
+        );
+        let b = entity(
+            "Boromir",
+            "Boromir",
+            GlossaryScopeKind::Book,
+            EntityGender::Masculine,
+        );
+        let merged = merge_scope_entities(&[a, b]);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn entities_fingerprint_is_stable_across_input_order() {
+        let a = entity(
+            "Galadriel",
+            "Galadriel",
+            GlossaryScopeKind::Book,
+            EntityGender::Feminine,
+        );
+        let b = entity(
+            "Boromir",
+            "Boromir",
+            GlossaryScopeKind::Book,
+            EntityGender::Masculine,
+        );
+        let fp_ab = entities_fingerprint(&[a.clone(), b.clone()]);
+        let fp_ba = entities_fingerprint(&[b, a]);
+        assert_eq!(fp_ab, fp_ba);
+    }
+
+    #[test]
+    fn entities_fingerprint_changes_when_gender_changes() {
+        let masc = entity("X", "X", GlossaryScopeKind::Book, EntityGender::Masculine);
+        let fem = entity("X", "X", GlossaryScopeKind::Book, EntityGender::Feminine);
+        assert_ne!(entities_fingerprint(&[masc]), entities_fingerprint(&[fem]));
+    }
+
+    #[test]
+    fn entities_fingerprint_of_empty_is_stable() {
+        let a = entities_fingerprint(&[]);
+        let b = entities_fingerprint(&[]);
+        assert_eq!(a, b);
+        assert!(!a.is_empty());
+    }
+
+    #[test]
+    fn render_block_includes_role_when_present() {
+        let mut e = entity(
+            "Galadriel",
+            "Galadriel",
+            GlossaryScopeKind::Book,
+            EntityGender::Feminine,
+        );
+        e.role = Some("elf-queen".to_string());
+        let rendered = render_entity_agreement_block(&[e]);
+        assert!(rendered.contains("[elf-queen]"));
+    }
+}

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod entity;
 pub mod error;
 pub mod glossary;
 pub mod ir;
@@ -15,6 +16,9 @@ pub use config::{
     ProviderPresetRuntimeOverrides, ProviderRequestMetric, ProviderRuntimeConfig, QaRunConfig,
     ResolvedRunSettings, RetryAfterPolicy, SegmentationConfig, TranslationConfig,
     TranslationProfile, cap_output_tokens,
+};
+pub use entity::{
+    Entity, EntityGender, entities_fingerprint, merge_scope_entities, render_entity_agreement_block,
 };
 pub use error::{BookforgeError, Result};
 pub use glossary::{

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -57,6 +57,14 @@ pub struct RunConfigSnapshot {
     /// have moved or been edited.
     #[serde(default)]
     pub style_rendered_block: String,
+    /// SHA-256 of the merged entity set. Same opt-in stance as
+    /// `style_fingerprint`: empty rendered block means the cache
+    /// namespace ignores this field.
+    #[serde(default)]
+    pub entities_fingerprint: String,
+    /// Pre-rendered entity grammatical-agreement block.
+    #[serde(default)]
+    pub entities_rendered_block: String,
     pub settings: ResolvedRunSettingsSnapshot,
 }
 

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -18,10 +18,12 @@ pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 1;
 /// schema and segmentation parameters. Cached rows from a different
 /// namespace are not eligible for reuse.
 ///
-/// `style_fingerprint` is an opt-in mixin: pass an empty string to
-/// preserve cache compatibility with runs that didn't use style sheets;
-/// pass a non-empty fingerprint when a sheet is active and the rendered
-/// prompt is materially different.
+/// `style_fingerprint` and `entities_fingerprint` are opt-in mixins:
+/// pass an empty string to preserve cache compatibility with runs that
+/// didn't use the feature; pass a non-empty fingerprint when the
+/// rendered prompt actually changes. The two slots use distinct domain
+/// separators so a style fingerprint can never collide with an entity
+/// fingerprint of the same content.
 pub fn compute_cache_namespace(
     max_segment_tokens: usize,
     context_tokens: usize,
@@ -30,6 +32,7 @@ pub fn compute_cache_namespace(
     prompt_version: &str,
     glossary_fingerprint: &str,
     style_fingerprint: &str,
+    entities_fingerprint: &str,
 ) -> String {
     compute_cache_namespace_inner(
         CACHE_KEY_SCHEMA_VERSION,
@@ -43,6 +46,11 @@ pub fn compute_cache_namespace(
             None
         } else {
             Some(style_fingerprint)
+        },
+        if entities_fingerprint.is_empty() {
+            None
+        } else {
+            Some(entities_fingerprint)
         },
     )
 }
@@ -63,6 +71,7 @@ pub fn compute_cache_namespace_v1(
         prompt_version,
         None,
         None,
+        None,
     )
 }
 
@@ -75,6 +84,7 @@ fn compute_cache_namespace_inner(
     prompt_version: &str,
     glossary_fingerprint: Option<&str>,
     style_fingerprint: Option<&str>,
+    entities_fingerprint: Option<&str>,
 ) -> String {
     let mut hasher = Sha256::new();
     hasher.update(cache_key_schema_version.to_le_bytes());
@@ -89,9 +99,12 @@ fn compute_cache_namespace_inner(
         hasher.update(glossary_fingerprint.as_bytes());
     }
     if let Some(style_fingerprint) = style_fingerprint {
-        // Domain separator so glossary and style fingerprints can never collide.
         hasher.update(b"|style|");
         hasher.update(style_fingerprint.as_bytes());
+    }
+    if let Some(entities_fingerprint) = entities_fingerprint {
+        hasher.update(b"|entities|");
+        hasher.update(entities_fingerprint.as_bytes());
     }
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(digest.len() * 2);
@@ -469,12 +482,21 @@ mod tests {
 
     #[test]
     fn cache_namespace_changes_when_segmentation_settings_change() {
-        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
-        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1", "glossary:a", "");
-        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a", "");
-        let d = compute_cache_namespace(1200, 160, "Balanced", false, "batch_v1", "glossary:a", "");
-        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
-        let f = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:b", "");
+        let a = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
+        let b = compute_cache_namespace(1201, 160, "Balanced", false, "v1", "glossary:a", "", "");
+        let c = compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a", "", "");
+        let d = compute_cache_namespace(
+            1200,
+            160,
+            "Balanced",
+            false,
+            "batch_v1",
+            "glossary:a",
+            "",
+            "",
+        );
+        let e = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
+        let f = compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:b", "", "");
 
         assert_ne!(a, b, "max_segment_tokens must affect namespace");
         assert_ne!(a, c, "batch_enabled must affect namespace");
@@ -486,9 +508,9 @@ mod tests {
     #[test]
     fn legacy_cache_namespace_v1_ignores_glossary_fingerprint() {
         let current_without_terms =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "", "");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "", "", "");
         let current_with_terms =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
         let legacy = compute_cache_namespace_v1(1200, 160, "Balanced", false, "v1");
 
         assert_ne!(legacy, current_without_terms);
@@ -504,20 +526,36 @@ mod tests {
         // Users who don't use --style must see no cache invalidation when
         // they upgrade to a build that supports style sheets.
         let without_style =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
         let still_without_style =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
         assert_eq!(without_style, still_without_style);
     }
 
     #[test]
     fn cache_namespace_changes_when_style_fingerprint_changes() {
         let baseline =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "");
-        let with_style =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "style:a");
-        let with_other_style =
-            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "style:b");
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
+        let with_style = compute_cache_namespace(
+            1200,
+            160,
+            "Balanced",
+            false,
+            "v1",
+            "glossary:a",
+            "style:a",
+            "",
+        );
+        let with_other_style = compute_cache_namespace(
+            1200,
+            160,
+            "Balanced",
+            false,
+            "v1",
+            "glossary:a",
+            "style:b",
+            "",
+        );
 
         assert_ne!(
             baseline, with_style,
@@ -527,6 +565,51 @@ mod tests {
             with_style, with_other_style,
             "different style fingerprints must yield different namespaces"
         );
+    }
+
+    #[test]
+    fn cache_namespace_changes_when_entities_fingerprint_changes() {
+        let baseline =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "");
+        let with_entities = compute_cache_namespace(
+            1200,
+            160,
+            "Balanced",
+            false,
+            "v1",
+            "glossary:a",
+            "",
+            "entities:a",
+        );
+        let with_other_entities = compute_cache_namespace(
+            1200,
+            160,
+            "Balanced",
+            false,
+            "v1",
+            "glossary:a",
+            "",
+            "entities:b",
+        );
+        assert_ne!(
+            baseline, with_entities,
+            "switching on entities must invalidate cache"
+        );
+        assert_ne!(
+            with_entities, with_other_entities,
+            "different entity fingerprints must yield different namespaces"
+        );
+    }
+
+    #[test]
+    fn style_and_entities_fingerprints_use_distinct_domain_separators() {
+        // The same hex string used as style vs. entities must not produce
+        // the same namespace — domain separators prevent the collision.
+        let as_style =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "ab", "");
+        let as_entities =
+            compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "ab");
+        assert_ne!(as_style, as_entities);
     }
 
     fn book_with_two_sections() -> Book {

--- a/crates/bookforge-llm/prompts/qa_segment.v1.md
+++ b/crates/bookforge-llm/prompts/qa_segment.v1.md
@@ -72,6 +72,12 @@ Active style guide (review for adherence to register and dialogue conventions):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (flag any disagreement on adjective/article concord):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Source:
 
 ```txt

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe.v1.md
@@ -63,6 +63,12 @@ Active style guide (apply consistently to every item):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord across all items):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Additional instructions:
 
 ```txt

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v1.md
@@ -18,6 +18,7 @@ Return exactly:
 
 Translate every item, preserving all markers.
 Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Entities: {{entity_agreement_block}}
 Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain.v1.md
@@ -29,6 +29,12 @@ Active style guide (apply consistently to every item):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord across all items):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Additional instructions:
 
 ```txt

--- a/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain_compact.v1.md
@@ -12,6 +12,7 @@ Return exactly:
 
 Translate every item.
 Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Entities: {{entity_agreement_block}}
 Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving.v1.md
@@ -30,6 +30,12 @@ Active style guide (apply consistently to every item):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord across all items):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Additional instructions:
 
 ```txt

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v1.md
@@ -18,6 +18,7 @@ Return exactly:
 
 Translate every item.
 Honor item `glossary`/`glossary_prose` constraints. Style: {{style_guide_block}}
+Entities: {{entity_agreement_block}}
 Extra: {{prompt_extra}}
 {{items_json}}
 Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
+++ b/crates/bookforge-llm/prompts/translate_marker_safe.v1.md
@@ -101,6 +101,12 @@ Active style guide (apply consistently throughout):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
+++ b/crates/bookforge-llm/prompts/translate_run_preserving.v1.md
@@ -81,6 +81,12 @@ Active style guide (apply consistently throughout):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/prompts/translate_segment.v1.md
+++ b/crates/bookforge-llm/prompts/translate_segment.v1.md
@@ -73,6 +73,12 @@ Active style guide (apply consistently throughout):
 {{style_guide_block}}
 ```
 
+Entity grammatical agreement (use for adjective/article concord):
+
+```txt
+{{entity_agreement_block}}
+```
+
 Glossary and fixed terminology:
 
 ```json

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1985,6 +1985,14 @@ async fn translate_one_batch(
             .unwrap_or_default(),
     )
     .raw(
+        "entity_agreement_block",
+        config
+            .entities
+            .as_ref()
+            .map(|e| e.rendered_block.clone())
+            .unwrap_or_default(),
+    )
+    .raw(
         "prompt_extra",
         config.glossary.prompt_extra.clone().unwrap_or_default(),
     )
@@ -2734,6 +2742,7 @@ mod tests {
             context: crate::ContextRunConfig::default(),
             context_registry: None,
             style: None,
+            entities: None,
         }
     }
 

--- a/crates/bookforge-llm/src/lib.rs
+++ b/crates/bookforge-llm/src/lib.rs
@@ -29,8 +29,8 @@ pub use rate_controller::{
     ProviderRateController, RateControllerConfig, RequestObservation, RequestStatus,
 };
 pub use scheduler::{
-    CompletedContext, ContextRegistry, ContextRunConfig, GlossaryRunConfig, QaIssue,
-    QaSegmentReview, SegmentTranslation, StyleRunConfig, TranslationRunConfig, qa_segments,
-    translate_segments, translate_segments_with_callback,
+    CompletedContext, ContextRegistry, ContextRunConfig, EntityRunConfig, GlossaryRunConfig,
+    QaIssue, QaSegmentReview, SegmentTranslation, StyleRunConfig, TranslationRunConfig,
+    qa_segments, translate_segments, translate_segments_with_callback,
 };
 pub use telemetry::{TelemetryLog, telemetry_summary};

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -50,10 +50,20 @@ pub struct TranslationRunConfig {
     /// placeholder in per-segment and batch prompts. `None` = no style
     /// sheet active; renders to empty string.
     pub style: Option<StyleRunConfig>,
+    /// Merged entity table pre-rendered as a prompt block. The scheduler
+    /// substitutes `rendered_block` into the `{{entity_agreement_block}}`
+    /// placeholder. `None` = no entities active; renders to empty string.
+    pub entities: Option<EntityRunConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StyleRunConfig {
+    pub rendered_block: String,
+    pub fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityRunConfig {
     pub rendered_block: String,
     pub fingerprint: String,
 }
@@ -645,6 +655,14 @@ fn render_qa_prompt(
             .map(|s| s.rendered_block.clone())
             .unwrap_or_default(),
     )
+    .raw(
+        "entity_agreement_block",
+        config
+            .entities
+            .as_ref()
+            .map(|e| e.rendered_block.clone())
+            .unwrap_or_default(),
+    )
     .raw("prompt_extra", "")
     .raw("source_text", &segment.source.text)
     .raw("translation_text", translation.joined_text());
@@ -954,6 +972,14 @@ fn render_prompt(
             .style
             .as_ref()
             .map(|s| s.rendered_block.clone())
+            .unwrap_or_default(),
+    )
+    .raw(
+        "entity_agreement_block",
+        config
+            .entities
+            .as_ref()
+            .map(|e| e.rendered_block.clone())
             .unwrap_or_default(),
     )
     .raw(
@@ -1892,6 +1918,7 @@ mod tests {
             context: ContextRunConfig::default(),
             context_registry: None,
             style: None,
+            entities: None,
         }
     }
 

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -8,6 +8,7 @@ use std::{
 
 use bookforge_core::{
     Result as CoreResult,
+    entity::EntityGender,
     glossary::{GlossaryCategory, GlossaryScopeKind, GlossaryStatus, GlossaryTerm},
     ir::BlockId,
     run_snapshot::RunConfigSnapshot,
@@ -244,6 +245,33 @@ pub struct StoredStyleSheet {
     pub target_language: String,
     pub content_toml: String,
     pub fingerprint: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct NewEntity<'a> {
+    pub scope_kind: GlossaryScopeKind,
+    pub scope_id: Option<&'a str>,
+    pub source_name: &'a str,
+    pub target_name: &'a str,
+    pub gender_target: Option<EntityGender>,
+    pub role: Option<&'a str>,
+    pub notes: Option<&'a str>,
+    pub source_language: &'a str,
+    pub target_language: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredEntity {
+    pub id: i64,
+    pub scope_kind: GlossaryScopeKind,
+    pub scope_id: Option<String>,
+    pub source_name: String,
+    pub target_name: String,
+    pub gender_target: Option<EntityGender>,
+    pub role: Option<String>,
+    pub notes: Option<String>,
+    pub source_language: String,
+    pub target_language: String,
 }
 
 #[derive(Debug, Clone)]
@@ -1464,6 +1492,145 @@ impl JobStore {
         Ok(count)
     }
 
+    pub fn upsert_entities(&self, entities: &[NewEntity<'_>]) -> Result<usize> {
+        if entities.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.conn.borrow();
+        let now = timestamp_string();
+        let mut changed = 0usize;
+        for entity in entities {
+            conn.execute(
+                "INSERT INTO entities
+                    (scope_kind, scope_id, source_name, target_name, gender_target,
+                     role, notes, source_language, target_language, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)
+                 ON CONFLICT(scope_kind, scope_id, source_name, source_language, target_language)
+                 DO UPDATE SET
+                    target_name = excluded.target_name,
+                    gender_target = excluded.gender_target,
+                    role = excluded.role,
+                    notes = excluded.notes,
+                    updated_at = excluded.updated_at",
+                params![
+                    entity.scope_kind.as_str(),
+                    entity.scope_id,
+                    entity.source_name,
+                    entity.target_name,
+                    entity.gender_target.map(|g| g.as_short()),
+                    entity.role,
+                    entity.notes,
+                    entity.source_language,
+                    entity.target_language,
+                    now,
+                ],
+            )?;
+            changed += 1;
+        }
+        Ok(changed)
+    }
+
+    /// Load all entities that apply for a language pair and optional
+    /// book/series scopes. Caller is responsible for merging via
+    /// [`bookforge_core::entity::merge_scope_entities`].
+    pub fn load_active_entities(
+        &self,
+        source_language: &str,
+        target_language: &str,
+        book_id: Option<&str>,
+        series_id: Option<&str>,
+    ) -> Result<Vec<StoredEntity>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, scope_kind, scope_id, source_name, target_name, gender_target,
+                    role, notes, source_language, target_language
+             FROM entities
+             WHERE source_language = ?1
+               AND target_language = ?2
+               AND ( (scope_kind = 'global')
+                  OR (scope_kind = 'series' AND scope_id = ?3)
+                  OR (scope_kind = 'book' AND scope_id = ?4) )",
+        )?;
+        let rows = stmt.query_map(
+            params![source_language, target_language, series_id, book_id],
+            |row| {
+                let gender: Option<String> = row.get(5)?;
+                Ok(StoredEntity {
+                    id: row.get(0)?,
+                    scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
+                    scope_id: row.get(2)?,
+                    source_name: row.get(3)?,
+                    target_name: row.get(4)?,
+                    gender_target: gender.and_then(|g| parse_gender_short(&g)),
+                    role: row.get(6)?,
+                    notes: row.get(7)?,
+                    source_language: row.get(8)?,
+                    target_language: row.get(9)?,
+                })
+            },
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn list_entities(
+        &self,
+        source_language: Option<&str>,
+        target_language: Option<&str>,
+        scope_kind: Option<GlossaryScopeKind>,
+        scope_id: Option<&str>,
+    ) -> Result<Vec<StoredEntity>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, scope_kind, scope_id, source_name, target_name, gender_target,
+                    role, notes, source_language, target_language
+             FROM entities
+             WHERE (?1 IS NULL OR source_language = ?1)
+               AND (?2 IS NULL OR target_language = ?2)
+               AND (?3 IS NULL OR scope_kind = ?3)
+               AND (?4 IS NULL OR scope_id = ?4)
+             ORDER BY scope_kind, scope_id, source_name",
+        )?;
+        let scope_text = scope_kind.map(|s| s.as_str().to_string());
+        let rows = stmt.query_map(
+            params![source_language, target_language, scope_text, scope_id],
+            |row| {
+                let gender: Option<String> = row.get(5)?;
+                Ok(StoredEntity {
+                    id: row.get(0)?,
+                    scope_kind: parse_row_enum(&row.get::<_, String>(1)?, 1)?,
+                    scope_id: row.get(2)?,
+                    source_name: row.get(3)?,
+                    target_name: row.get(4)?,
+                    gender_target: gender.and_then(|g| parse_gender_short(&g)),
+                    role: row.get(6)?,
+                    notes: row.get(7)?,
+                    source_language: row.get(8)?,
+                    target_language: row.get(9)?,
+                })
+            },
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    pub fn clear_entities_scope(
+        &self,
+        scope_kind: GlossaryScopeKind,
+        scope_id: Option<&str>,
+    ) -> Result<usize> {
+        let conn = self.conn.borrow();
+        let count = if scope_kind == GlossaryScopeKind::Global {
+            conn.execute("DELETE FROM entities WHERE scope_kind = 'global'", [])?
+        } else {
+            conn.execute(
+                "DELETE FROM entities WHERE scope_kind = ?1 AND scope_id = ?2",
+                params![scope_kind.as_str(), scope_id],
+            )?
+        };
+        Ok(count)
+    }
+
     pub fn pending_segment_ids(&self, job_id: &str) -> Result<Vec<String>> {
         let conn = self.conn.borrow();
         let mut stmt = conn.prepare(
@@ -2180,6 +2347,15 @@ fn glossary_candidate_from_row(
     })
 }
 
+fn parse_gender_short(value: &str) -> Option<EntityGender> {
+    match value {
+        "m" => Some(EntityGender::Masculine),
+        "f" => Some(EntityGender::Feminine),
+        "n" => Some(EntityGender::Neuter),
+        _ => None,
+    }
+}
+
 fn parse_row_enum<T>(value: &str, column: usize) -> rusqlite::Result<T>
 where
     T: FromStr<Err = String>,
@@ -2498,6 +2674,8 @@ mod tests {
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style_fingerprint: String::new(),
             style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 
@@ -2584,6 +2762,8 @@ mod tests {
             context_scope: bookforge_core::config::ContextScope::Chapter,
             style_fingerprint: String::new(),
             style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 

--- a/crates/bookforge-store/src/lib.rs
+++ b/crates/bookforge-store/src/lib.rs
@@ -2,8 +2,8 @@ pub mod db;
 
 pub use db::{
     CacheLookupRequest, CachedTranslation, CreateJob, GlossaryCandidateUpsertResult,
-    GlossaryFilter, JobRecord, JobStore, JobSummary, NewGlossaryCandidate, NewSegmentFlag,
-    NewStyleSheet, RetryScope, SaveCachedTranslation, SaveNeedsReview, SaveTranslation,
-    SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation, StoredGlossaryCandidate,
-    StoredSegmentTranslation, StoredStyleSheet, run_doctor,
+    GlossaryFilter, JobRecord, JobStore, JobSummary, NewEntity, NewGlossaryCandidate,
+    NewSegmentFlag, NewStyleSheet, RetryScope, SaveCachedTranslation, SaveNeedsReview,
+    SaveTranslation, SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation,
+    StoredEntity, StoredGlossaryCandidate, StoredSegmentTranslation, StoredStyleSheet, run_doctor,
 };


### PR DESCRIPTION
## Summary
- Third of three v1.3 deliverables (ROADMAP §6.6). Adds per-book/series/global TOML entity files that render into a `{{entity_agreement_block}}` prompt placeholder. Each entry maps a source name to a translated name + grammatical gender + optional role; the model uses the table to keep gender concord consistent across paragraphs.
- New CLI: `bookforge entities {import,list,clear,show}`; `--entities <file.toml>` (repeatable) on `bookforge translate`.
- Cache namespace mixes in `entities_fingerprint` only when the run actually has entities — opt-in semantics identical to PR2's style fingerprint, with a distinct `|entities|` domain separator so the two slots can't collide.

## Stacked on PR2
Targets `feat/v1-3-pr2-style-sheet` (PR #10). Merge order: #9 → #10 → this PR. Once #10 lands the base will auto-update.

## Scope
- `bookforge-core::entity` module: `Entity` / `EntityGender` / `merge_scope_entities` / `render_entity_agreement_block` / `entities_fingerprint` / `render_and_fingerprint`. Merge precedence is keyed on `(source_name, source_language, target_language)`.
- `bookforge-store`: `NewEntity` / `StoredEntity` and `upsert_entities` / `load_active_entities` / `list_entities` / `clear_entities_scope`. The `entities` table was created in PR2's migration; this PR adds the access methods.
- Snapshot fields `entities_fingerprint` + `entities_rendered_block` capture the prompt block so resume reproduces the exact prompt even if the source TOML moves.
- `{{entity_agreement_block}}` placeholder added to the same nine templates that received `{{style_guide_block}}` in PR2.

## Test plan
- [x] `cargo build --release`
- [x] `cargo test --workspace` — 246 tests pass (PR2 tip: 233)
- [x] `cargo test -p bookforge-cli --test lifecycle` — 19 tests pass (17 prior + 2 new entity tests)
- [x] `cargo test -p bookforge-core` — 38 tests pass (was 27; +9 entity module tests, +2 cache-namespace tests for entities)
- [x] `cargo fmt`

## What to look at first
- `crates/bookforge-core/src/entity.rs` — the merge key, the rendering shape, and the fingerprint stability tests.
- `crates/bookforge-core/src/segment.rs::compute_cache_namespace` — the `|style|` vs `|entities|` domain separators and the new `style_and_entities_fingerprints_use_distinct_domain_separators` test that proves they don't collide.
- `crates/bookforge-cli/src/commands/translate/mod.rs::prepare_entities_run_config` — imports `--entities` files, loads + merges for the active scope, falls back to empty fingerprint when no source language is provided.
- `crates/bookforge-cli/src/commands/entity.rs` — TOML loader (`[meta]`, `[[entity]]` array, gender encoded as `m`/`f`/`n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)