### PR TITLE
feat(v1.3): closing integration sweep + ROADMAP flip

### DIFF
--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -260,6 +260,130 @@ role = "object"
 }
 
 #[test]
+fn cli_translate_with_full_v1_3_stack_persists_all_three_blocks() {
+    // Acceptance §6.9: a single translate run with --context-window,
+    // --style, and --entities together must capture all three blocks in
+    // the persisted snapshot. This is the gate that proves the three
+    // PRs interoperate end-to-end (PR1 sliding context + PR2 style +
+    // PR3 entities + PR4 plumbing).
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let style_path = temp.path().join("style.toml");
+    fs::write(
+        &style_path,
+        r#"[meta]
+schema_version = 1
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[register]
+narration = "literary"
+dialogue_default = "tu"
+
+[free_text]
+instructions = "Preserve em-dashes and ellipses."
+"#,
+    )
+    .expect("style sheet should write");
+
+    let entities_path = temp.path().join("entities.toml");
+    fs::write(
+        &entities_path,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[[entity]]
+source_name = "Galadriel"
+target_name = "Galadriel"
+gender_target = "f"
+
+[[entity]]
+source_name = "the Ring"
+target_name = "l'Anello"
+gender_target = "m"
+"#,
+    )
+    .expect("entities file should write");
+
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            fixture_input().to_str().unwrap(),
+            "--source",
+            "English",
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--book-id",
+            "fellowship",
+            "--context-window",
+            "3",
+            "--context-scope",
+            "chapter",
+            "--style",
+            style_path.to_str().unwrap(),
+            "--entities",
+            entities_path.to_str().unwrap(),
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let job_id = job_id_from_events(&events);
+    let store =
+        JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store should open");
+    let snapshot = store
+        .load_job_config_snapshot(&job_id)
+        .expect("snapshot load")
+        .expect("snapshot present");
+
+    // Sliding context: settings round-trip.
+    assert_eq!(snapshot.context_window, 3);
+    assert_eq!(
+        snapshot.context_scope,
+        bookforge_core::config::ContextScope::Chapter
+    );
+
+    // Style sheet: block + fingerprint present.
+    assert!(!snapshot.style_rendered_block.is_empty());
+    assert!(snapshot.style_rendered_block.contains("Register: literary"));
+    assert!(!snapshot.style_fingerprint.is_empty());
+
+    // Entity sheet: block + fingerprint present.
+    assert!(!snapshot.entities_rendered_block.is_empty());
+    assert!(
+        snapshot
+            .entities_rendered_block
+            .contains("l'Anello (the Ring): masculine")
+    );
+    assert!(!snapshot.entities_fingerprint.is_empty());
+
+    // Style and entity fingerprints are independent — domain-separator test.
+    assert_ne!(snapshot.style_fingerprint, snapshot.entities_fingerprint);
+}
+
+#[test]
 fn cli_entities_import_then_show_matches_input() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let entities_path = temp.path().join("entities.toml");

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,8 +96,8 @@ via `java`, but the BookForge binary itself does not need Java to run.
 | v1.0.1 | Snapshot patch | 0.5–1 day | none (silent patch) | shipped |
 | v1.1 | Review loop | 5–8 days | minimal (README rewrite, GitHub topics, crates.io publish) | shipped |
 | v1.2 | Glossary, manual | 8–12 days | none (development quiet) | shipped |
-| v1.2.x | Glossary, auto-extraction | 4–6 days | none | planned |
-| v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) | planned |
+| v1.2.x | Glossary, auto-extraction | 4–6 days | none | shipped |
+| v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) | shipped |
 | v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here | planned |
 | v1.5 | Structural credibility | 10–14 days | README final rewrite citing corpus | planned |
 | v1.6 | Bilingual output | 5–8 days | passive (release notes only) | planned |


### PR DESCRIPTION
## Summary
- Closes the v1.3 milestone. Adds the cross-feature integration test that exercises sliding context + style sheet + entity sheet in a single translate run, and flips the ROADMAP §2 status table to mark v1.3 (and v1.2.x, already on main) as shipped.

## Stacked on PR3
Targets `feat/v1-3-pr3-entity-sheet` (PR #11). Merge order: #9 → #10 → #11 → this PR. Once #11 lands the base will auto-update to `main`.

## Why one integration test, not three
The three previous PRs each added their own focused tests. What was still missing was proof that the three features compose cleanly — the prompt template variables don't shadow each other, the cache fingerprint uses distinct domain separators (`|style|` vs `|entities|`), the snapshot captures all three blocks, and `--source` is properly threaded so the entity loader can key on the language pair.

## What's still open (intentionally deferred)
- **Section-aware batching** (task #15 / would be PR5): the gating prerequisite for sliding context inside batch mode. Until that lands, `translate_one_batch` continues to emit a `tracing::warn` and skip context injection. This was explicit PR1 scope.
- **v1.2.x table flip**: v1.2.x's "Glossary, auto-extraction" was already on main (commit 269d51c) but the table still said "planned". Updated to "shipped" here so the table matches reality.

## Test plan
- [x] `cargo test --workspace` — 247 tests pass
- [x] `cargo test -p bookforge-cli --test lifecycle` — 20 pass (19 prior + 1 new full-stack test)
- [x] `cargo fmt`
- [x] Acceptance §6.9 items 1–4 are mechanically covered across PR1/2/3/4. Items 5 (visible pronoun-consistency improvement on a real book) and 6 (no regressions in v1.1/v1.2) are human-in-the-loop checks for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)