### PR TITLE
fix: harden real EPUB translation lifecycle

### DIFF
--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -308,8 +308,19 @@ async fn run_inner(
             cache_namespace
         );
     }
+    let retry_pending_ids = store
+        .segment_records(&job.id)?
+        .into_iter()
+        .filter(|record| record.status == "retry_pending")
+        .map(|record| record.id)
+        .collect::<HashSet<_>>();
+    let cacheable_pending_segments = pending_segments
+        .iter()
+        .filter(|segment| !retry_pending_ids.contains(&segment.id.0))
+        .cloned()
+        .collect::<Vec<_>>();
     let mut cached_translations = apply_cached_translations(
-        &pending_segments,
+        &cacheable_pending_segments,
         CacheContext {
             store: &store,
             job_id: &job.id,
@@ -1058,6 +1069,74 @@ mod tests {
             .expect("job should exist");
         assert_eq!(summary.succeeded, 2);
         assert_eq!(summary.failed, 0);
+    }
+
+    #[tokio::test]
+    async fn resume_retry_pending_bypasses_cache() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        let mut fixture = resume_fixture(settings, 1);
+        let cache_job = fixture
+            .store
+            .create_job(CreateJob {
+                input: &fixture.snapshot.input_path,
+                output: &fixture._tempdir.path().join("cache-output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix-target",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("cache job should be created");
+        fixture
+            .store
+            .insert_segments(
+                &cache_job.id,
+                &fixture.segments,
+                fixture.snapshot.prompt_version.as_str(),
+                "mock",
+                "mock-prefix-target",
+                fixture.snapshot.cache_namespace.as_str(),
+            )
+            .expect("cache job segments should insert");
+        save_succeeded(
+            &fixture.store,
+            &cache_job.id,
+            &fixture.segments[0],
+            "stale cached text",
+        );
+        fixture
+            .store
+            .mark_segment_failed(&fixture.job.id, &fixture.segments[0].id.0, "retry")
+            .expect("segment should be failed");
+        fixture
+            .store
+            .retry_segments(&fixture.job.id, bookforge_store::RetryScope::Failed)
+            .expect("segment should become retry-pending");
+
+        let events = run_fixture(&mut fixture)
+            .await
+            .expect("resume should freshly translate retry-pending segments");
+        let finished = segment_finished_ids(&events);
+
+        assert_eq!(finished, vec![fixture.segments[0].id.0.clone()]);
+        let stored = fixture
+            .store
+            .load_block_translations(&fixture.job.id)
+            .expect("stored blocks should load");
+        assert!(
+            stored
+                .iter()
+                .all(|block| block.text.as_str() != "stale cached text")
+        );
+        assert!(
+            stored
+                .iter()
+                .any(|block| block.text.starts_with("[Italian]"))
+        );
     }
 
     #[tokio::test]

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -21,7 +21,7 @@ use bookforge_llm::{
     run_double_check, telemetry_summary, translate_batches_with_callback,
     translate_segments_with_callback,
 };
-use bookforge_store::{CreateJob, JobRecord, JobStore};
+use bookforge_store::{CreateJob, JobRecord, JobStore, SaveTranslation};
 use clap::Args;
 use sha2::{Digest, Sha256};
 use std::{path::PathBuf, sync::Arc};
@@ -1077,15 +1077,17 @@ async fn finish_translation_pipeline(
     .await?;
     *translations = fallback_translations;
 
-    run_double_check_pass(
+    run_double_check_pass(DoubleCheckPass {
         provider,
         cancel_token,
         cli_args,
         segments,
         translations,
-        run_config,
+        store,
+        job_id: &job.id,
+        config: run_config,
         settings,
-    )
+    })
     .await?;
 
     mark_job_finished(store, &job.id, translations)?;
@@ -1433,15 +1435,30 @@ async fn run_fallback_pass(
     Ok(translations)
 }
 
-async fn run_double_check_pass(
-    provider: &OpenAiCompatibleProvider,
-    cancel_token: &tokio_util::sync::CancellationToken,
-    cli_args: &TranslateArgs,
-    segments: &[Segment],
-    translations: &[SegmentTranslation],
-    config: &TranslationRunConfig,
-    settings: &ResolvedRunSettings,
-) -> Result<()> {
+struct DoubleCheckPass<'a> {
+    provider: &'a OpenAiCompatibleProvider,
+    cancel_token: &'a tokio_util::sync::CancellationToken,
+    cli_args: &'a TranslateArgs,
+    segments: &'a [Segment],
+    translations: &'a mut [SegmentTranslation],
+    store: &'a JobStore,
+    job_id: &'a str,
+    config: &'a TranslationRunConfig,
+    settings: &'a ResolvedRunSettings,
+}
+
+async fn run_double_check_pass(pass: DoubleCheckPass<'_>) -> Result<()> {
+    let DoubleCheckPass {
+        provider,
+        cancel_token,
+        cli_args,
+        segments,
+        translations,
+        store,
+        job_id,
+        config,
+        settings,
+    } = pass;
     if settings.double_check.mode == DoubleCheckMode::Off {
         return Ok(());
     }
@@ -1500,7 +1517,81 @@ async fn run_double_check_pass(
         .filter(|c| matches!(c.status, bookforge_llm::CorrectionStatus::Unresolved))
         .count();
 
-    println!("  Corrections: {applied} applied, {rejected} rejected, {unresolved} unresolved");
+    let changed_segment_ids = apply_double_check_corrections(translations, &corrections);
+    persist_corrected_translations(store, job_id, config, translations, &changed_segment_ids)?;
+
+    println!(
+        "  Corrections: {applied} applied, {rejected} rejected, {unresolved} unresolved, {} segments updated",
+        changed_segment_ids.len()
+    );
+
+    Ok(())
+}
+
+pub(crate) fn apply_double_check_corrections(
+    translations: &mut [SegmentTranslation],
+    corrections: &[bookforge_llm::CorrectionRecord],
+) -> Vec<String> {
+    let mut changed_segment_ids = std::collections::BTreeSet::new();
+
+    for correction in corrections {
+        if !matches!(correction.status, bookforge_llm::CorrectionStatus::Applied) {
+            continue;
+        }
+        let Some(corrected) = correction.corrected_translation.as_deref() else {
+            continue;
+        };
+        let Some(translation) = translations
+            .iter_mut()
+            .find(|translation| translation.segment_id == correction.segment_id)
+        else {
+            continue;
+        };
+        let Some(block) = translation
+            .blocks
+            .iter_mut()
+            .find(|block| block.block_id == correction.block_id)
+        else {
+            continue;
+        };
+        if block.text != corrected {
+            block.text = corrected.to_string();
+            changed_segment_ids.insert(translation.segment_id.0.clone());
+        }
+    }
+
+    changed_segment_ids.into_iter().collect()
+}
+
+fn persist_corrected_translations(
+    store: &JobStore,
+    job_id: &str,
+    config: &TranslationRunConfig,
+    translations: &[SegmentTranslation],
+    changed_segment_ids: &[String],
+) -> Result<()> {
+    for segment_id in changed_segment_ids {
+        let Some(translation) = translations
+            .iter()
+            .find(|translation| translation.segment_id.0 == *segment_id)
+        else {
+            continue;
+        };
+        let joined = translation.joined_text();
+        store.save_translation(SaveTranslation {
+            job_id,
+            segment_id: &translation.segment_id.0,
+            translated_text: &joined,
+            blocks: &translation.blocks,
+            provider: &config.provider,
+            model: &config.model,
+            prompt_version: &config.prompt_version,
+            input_tokens: translation.input_tokens,
+            input_cached_tokens: translation.input_cached_tokens,
+            output_tokens: translation.output_tokens,
+            tokens_estimated: translation.tokens_estimated,
+        })?;
+    }
 
     Ok(())
 }
@@ -1900,8 +1991,8 @@ mod tests {
     use bookforge_core::{
         ir::{BlockId, SectionId},
         segment::{
-            SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
-            SegmentSource, SegmentTextRun,
+            BlockTranslation, SegmentBlock, SegmentConstraints, SegmentContext, SegmentId,
+            SegmentMetadata, SegmentSource, SegmentTextRun,
         },
     };
     use std::{fs, time::SystemTime};
@@ -2117,6 +2208,52 @@ case_sensitive = true
         let prose = glossary_fingerprint(GlossaryFormat::Prose, 800, None, &[term]);
 
         assert_ne!(json, prose);
+    }
+
+    #[test]
+    fn applied_double_check_corrections_update_matching_blocks() {
+        let mut translations = vec![SegmentTranslation {
+            segment_id: SegmentId("seg_a".to_string()),
+            ordinal: 0,
+            block_ids: vec![BlockId("b_000000".to_string())],
+            blocks: vec![BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "vecchio testo".to_string(),
+            }],
+            checksum: "checksum".to_string(),
+            status: SegmentStatus::Succeeded,
+            template: "translate_segment".to_string(),
+            error: None,
+            input_tokens: Some(10),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(12),
+            tokens_estimated: false,
+        }];
+        let corrections = vec![
+            bookforge_llm::CorrectionRecord {
+                item_id: "seg_a:b_000000".to_string(),
+                segment_id: SegmentId("seg_a".to_string()),
+                block_id: BlockId("b_000000".to_string()),
+                original_translation: "vecchio testo".to_string(),
+                corrected_translation: Some("testo corretto".to_string()),
+                status: bookforge_llm::CorrectionStatus::Applied,
+                issues: Vec::new(),
+            },
+            bookforge_llm::CorrectionRecord {
+                item_id: "seg_a:b_000000".to_string(),
+                segment_id: SegmentId("seg_a".to_string()),
+                block_id: BlockId("b_000000".to_string()),
+                original_translation: "testo corretto".to_string(),
+                corrected_translation: Some("non applicato".to_string()),
+                status: bookforge_llm::CorrectionStatus::Unresolved,
+                issues: Vec::new(),
+            },
+        ];
+
+        let changed = apply_double_check_corrections(&mut translations, &corrections);
+
+        assert_eq!(changed, vec!["seg_a".to_string()]);
+        assert_eq!(translations[0].blocks[0].text, "testo corretto");
     }
 
     fn segment(id: &str, ordinal: usize) -> Segment {

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -8,7 +8,10 @@ use serde::Deserialize;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::{sync::mpsc, task::JoinSet};
+use tokio::{
+    sync::{Semaphore, mpsc},
+    task::JoinSet,
+};
 
 use crate::{
     CompletionRequest, FinishReason, LlmError, LlmProvider, PromptLibrary, ProviderRateController,
@@ -1229,6 +1232,7 @@ where
     let provider = Arc::new(provider);
     let config = Arc::new(config.clone());
     let concurrency = config.scheduler.concurrency.max(1);
+    let request_semaphore = Arc::new(Semaphore::new(concurrency));
 
     let all_items: HashMap<String, TranslationBatchItem> = batches
         .iter()
@@ -1254,23 +1258,22 @@ where
     let mut all_results: Vec<BatchTranslationResult> = Vec::new();
     let mut pending: Vec<TranslationBatch> = batches;
     let max_rounds = 3usize;
+    let mut single_invalid_attempts: HashMap<String, usize> = HashMap::new();
 
     for _round in 0..max_rounds {
         if pending.is_empty() {
             break;
         }
 
-        // Keep one spawned task per in-flight batch. This avoids the
-        // persistent-worker/result-channel deadlock class where a worker logs
-        // request completion but the coordinator never observes a result.
+        // Spawn one task per queued batch, but gate provider calls below with
+        // request_semaphore. Context waiters must not consume provider
+        // concurrency, otherwise a split prerequisite batch can be stranded
+        // behind later batches that are waiting for its context.
         let mut pending_queue: VecDeque<TranslationBatch> = pending.drain(..).collect();
         let mut tasks = JoinSet::<BatchWorkerOutput>::new();
 
         while !pending_queue.is_empty() || !tasks.is_empty() {
-            while tasks.len() < concurrency {
-                let Some(batch) = pending_queue.pop_front() else {
-                    break;
-                };
+            while let Some(batch) = pending_queue.pop_front() {
                 let mut normalized = normalize_batch_for_current_sizer(
                     batch,
                     batch_sizer.as_deref(),
@@ -1291,8 +1294,25 @@ where
                 let config = config.clone();
                 let rate_controller = rate_controller.clone();
                 let progress = progress.clone();
+                let request_semaphore = request_semaphore.clone();
 
                 tasks.spawn(async move {
+                    let context_pairs = context_pairs_for_batch(&batch, &config).await;
+                    let request_permit = match request_semaphore.acquire_owned().await {
+                        Ok(permit) => permit,
+                        Err(_) => {
+                            return BatchWorkerOutput {
+                                batch,
+                                result: Err(LlmError::Provider(
+                                    "batch request semaphore closed".to_string(),
+                                )),
+                                request_status: RequestStatus::OtherError,
+                                latency_ms: 0,
+                                max_output_tokens: 0,
+                            };
+                        }
+                    };
+
                     let permit = match rate_controller.as_ref() {
                         Some(controller) => match controller.acquire().await {
                             Ok(permit) => Some(permit),
@@ -1341,6 +1361,7 @@ where
                         library.clone(),
                         batch.clone(),
                         &config,
+                        context_pairs,
                     )
                     .await;
                     let latency_ms = started.elapsed().as_millis() as u64;
@@ -1348,6 +1369,7 @@ where
                     let request_status = request_status_for_controller(&result);
 
                     drop(permit);
+                    drop(request_permit);
                     BatchWorkerOutput {
                         batch,
                         result,
@@ -1505,40 +1527,56 @@ where
                         output_tokens: None,
                     });
                 }
-                Err(LlmError::InvalidResponse(_)) if batch.items.len() == 1 => {
-                    progress.emit(bookforge_core::ProgressEvent::Warning {
-                        kind: "single_item_batch_invalid_response".to_string(),
-                        message: format!(
-                            "single-item batch {} failed; not splitting further",
-                            batch.id
-                        ),
-                        timestamp_ms: bookforge_core::progress::now_ms(),
-                    });
-                    unblock_fence_for_batch_failure(
-                        config.context_registry.as_deref(),
-                        &segments_by_id,
-                        &batch.items,
-                    );
-                    all_results.push(BatchTranslationResult {
-                        batch_id: batch.id.clone(),
-                        translations: Vec::new(),
-                        failures: batch
-                            .items
-                            .iter()
-                            .map(|item| BatchItemFailure {
-                                item_id: item.item_id.clone(),
-                                segment_id: item.segment_id.clone(),
-                                error: "single-item batch invalid response".to_string(),
-                                input_tokens: None,
-                                input_cached_tokens: None,
-                                output_tokens: None,
-                                tokens_estimated: false,
-                            })
-                            .collect(),
-                        input_tokens: None,
-                        input_cached_tokens: None,
-                        output_tokens: None,
-                    });
+                Err(error @ LlmError::InvalidResponse(_)) if batch.items.len() == 1 => {
+                    let attempts = single_invalid_attempts
+                        .entry(batch.id.clone())
+                        .and_modify(|count| *count += 1)
+                        .or_insert(1);
+                    if *attempts < config.scheduler.max_attempts.max(1) {
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "single_item_batch_invalid_response_retry".to_string(),
+                            message: format!(
+                                "single-item batch {} returned invalid response on attempt {}; retrying: {error}",
+                                batch.id, attempts
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                        pending_queue.push_back(batch);
+                    } else {
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "single_item_batch_invalid_response".to_string(),
+                            message: format!(
+                                "single-item batch {} failed after {} attempts; not splitting further",
+                                batch.id, attempts
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                        unblock_fence_for_batch_failure(
+                            config.context_registry.as_deref(),
+                            &segments_by_id,
+                            &batch.items,
+                        );
+                        all_results.push(BatchTranslationResult {
+                            batch_id: batch.id.clone(),
+                            translations: Vec::new(),
+                            failures: batch
+                                .items
+                                .iter()
+                                .map(|item| BatchItemFailure {
+                                    item_id: item.item_id.clone(),
+                                    segment_id: item.segment_id.clone(),
+                                    error: format!("single-item batch invalid response: {error}"),
+                                    input_tokens: None,
+                                    input_cached_tokens: None,
+                                    output_tokens: None,
+                                    tokens_estimated: false,
+                                })
+                                .collect(),
+                            input_tokens: None,
+                            input_cached_tokens: None,
+                            output_tokens: None,
+                        });
+                    }
                 }
                 Err(LlmError::InvalidResponse(_)) if batch.items.len() > 1 => {
                     if let Some(ref mut sizer) = batch_sizer {
@@ -2096,31 +2134,8 @@ async fn translate_one_batch(
     library: Arc<PromptLibrary>,
     batch: TranslationBatch,
     config: &TranslationRunConfig,
+    context_pairs: Vec<crate::scheduler::CompletedContext>,
 ) -> Result<BatchTranslationResult, LlmError> {
-    // Sliding-context fence (ROADMAP §6.4 — PR5 makes this work in batch
-    // mode). build_translation_batches guarantees no batch crosses a
-    // section boundary, so awaiting the batch's earliest segment is safe:
-    // its prior-N dependencies are necessarily in *earlier* batches of
-    // the same section (or earlier sections, depending on scope) and
-    // can't deadlock on a sibling item in this same batch.
-    let context_pairs = match (config.context_registry.as_deref(), batch.kind) {
-        (Some(registry), BatchKind::Translation) if config.context.enabled() => {
-            let earliest = batch
-                .items
-                .iter()
-                .min_by_key(|item| item.ordinal)
-                .map(|item| item.segment_id.clone());
-            match earliest {
-                Some(segment_id) => {
-                    registry
-                        .await_context_for(&segment_id, config.context)
-                        .await
-                }
-                None => Vec::new(),
-            }
-        }
-        _ => Vec::new(),
-    };
     let context_block = crate::scheduler::render_context_pairs(&context_pairs);
     let items_json = render_batch_items(&batch, config);
     let template = if config.compact_prompts {
@@ -2211,6 +2226,38 @@ async fn translate_one_batch(
             Ok(result)
         }
         Err(e) => Err(e),
+    }
+}
+
+async fn context_pairs_for_batch(
+    batch: &TranslationBatch,
+    config: &TranslationRunConfig,
+) -> Vec<crate::scheduler::CompletedContext> {
+    // Sliding-context fence (ROADMAP §6.4 — PR5 makes this work in batch
+    // mode). build_translation_batches guarantees no batch crosses a
+    // section boundary, so awaiting the batch's earliest segment is safe:
+    // its prior-N dependencies are necessarily in *earlier* batches of
+    // the same section (or earlier sections, depending on scope) and
+    // can't deadlock on a sibling item in this same batch. The scheduler
+    // calls this before acquiring request concurrency so context waiters
+    // cannot starve prerequisite split batches.
+    match (config.context_registry.as_deref(), batch.kind) {
+        (Some(registry), BatchKind::Translation) if config.context.enabled() => {
+            let earliest = batch
+                .items
+                .iter()
+                .min_by_key(|item| item.ordinal)
+                .map(|item| item.segment_id.clone());
+            match earliest {
+                Some(segment_id) => {
+                    registry
+                        .await_context_for(&segment_id, config.context)
+                        .await
+                }
+                None => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
     }
 }
 
@@ -3090,7 +3137,7 @@ mod tests {
         let library = Arc::new(PromptLibrary::global().clone());
         let config = test_run_config();
 
-        let result = translate_one_batch(provider, library, batch, &config).await;
+        let result = translate_one_batch(provider, library, batch, &config, Vec::new()).await;
         match result {
             Err(LlmError::InvalidResponse(msg)) => {
                 assert!(msg.contains("truncated"), "unexpected msg: {msg}")
@@ -3108,7 +3155,7 @@ mod tests {
         let library = Arc::new(PromptLibrary::global().clone());
         let config = test_run_config();
 
-        let result = translate_one_batch(provider, library, batch, &config).await;
+        let result = translate_one_batch(provider, library, batch, &config, Vec::new()).await;
         match result {
             Err(LlmError::InvalidResponse(msg)) => {
                 assert!(msg.contains("truncated"), "unexpected msg: {msg}")
@@ -3211,6 +3258,78 @@ mod tests {
         }
     }
 
+    struct FirstInvalidThenPromptEchoProvider {
+        calls: Mutex<usize>,
+    }
+
+    impl FirstInvalidThenPromptEchoProvider {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(0),
+            }
+        }
+    }
+
+    impl LlmProviderTrait for FirstInvalidThenPromptEchoProvider {
+        async fn complete(&self, request: CompletionRequest) -> ProviderResult<CompletionResponse> {
+            let mut calls = self.calls.lock().unwrap();
+            let call = *calls;
+            *calls += 1;
+            drop(calls);
+
+            let content = if call == 0 {
+                "{not valid json".to_string()
+            } else {
+                let item_ids = item_ids_from_batch_prompt(&request.user);
+                serde_json::json!({
+                    "items": item_ids
+                        .into_iter()
+                        .map(|id| serde_json::json!({
+                            "id": id,
+                            "translation": format!("[it] {id}"),
+                        }))
+                        .collect::<Vec<_>>(),
+                })
+                .to_string()
+            };
+
+            Ok(CompletionResponse {
+                content,
+                input_tokens: Some(1),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(1),
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 0,
+                raw: serde_json::json!({}),
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
+            }
+        }
+    }
+
+    fn item_ids_from_batch_prompt(user_prompt: &str) -> Vec<String> {
+        let Some(after_input) = user_prompt.split("Input:\n").nth(1) else {
+            return Vec::new();
+        };
+        let json_text = after_input
+            .split("\n\nReturn JSON only.")
+            .next()
+            .unwrap_or(after_input)
+            .trim();
+        let Ok(items) = serde_json::from_str::<Vec<serde_json::Value>>(json_text) else {
+            return Vec::new();
+        };
+        items
+            .into_iter()
+            .filter_map(|item| item.get("id")?.as_str().map(ToString::to_string))
+            .collect()
+    }
+
     #[tokio::test]
     async fn partial_batch_failure_without_successful_repair_marks_segment_needs_review() {
         let seg = make_segment(
@@ -3274,6 +3393,111 @@ mod tests {
         assert!(
             error.contains(&missing_block_id),
             "error must name missing block id {missing_block_id}, got: {error}",
+        );
+    }
+
+    #[tokio::test]
+    async fn single_item_invalid_response_retries_before_needs_review() {
+        let segment = make_segment("seg1", vec![plain_block("Hello")], vec![]);
+        let segments = vec![segment];
+        let cfg = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 1,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+        assert_eq!(batches.len(), 1);
+        let item_id = batches[0].items[0].item_id.clone();
+        let provider = SequenceProvider::new(vec![
+            "{not valid json".to_string(),
+            serde_json::json!({
+                "items": [
+                    {"id": item_id, "translation": "[it] Hello"},
+                ],
+            })
+            .to_string(),
+        ]);
+        let telemetry = Arc::new(TelemetryLog::new());
+        let mut config = test_run_config();
+        config.scheduler.max_attempts = 2;
+
+        let translations = translate_batches_with_callback(
+            provider,
+            batches,
+            &segments,
+            &config,
+            telemetry,
+            None,
+            None,
+            Arc::new(bookforge_core::NullProgressSink),
+            None,
+            |_| Ok(()),
+        )
+        .await
+        .expect("single-item invalid response should retry and succeed");
+
+        assert_eq!(translations.len(), 1);
+        assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+        assert_eq!(translations[0].joined_text(), "[it] Hello");
+    }
+
+    #[tokio::test]
+    async fn split_prerequisite_batch_unblocks_book_scoped_context_waiters() {
+        let segments = vec![
+            make_segment_in_section("seg0", "sec0", 0, vec![plain_block("Alpha")], vec![]),
+            make_segment_in_section("seg1", "sec0", 1, vec![plain_block("Beta")], vec![]),
+            make_segment_in_section("seg2", "sec1", 2, vec![plain_block("Gamma")], vec![]),
+            make_segment_in_section("seg3", "sec2", 3, vec![plain_block("Delta")], vec![]),
+        ];
+        let cfg = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 64,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+        assert!(batches.len() >= 3, "expected section-partitioned batches");
+        assert!(batches[0].items.len() > 1, "first batch must be splittable");
+
+        let provider = FirstInvalidThenPromptEchoProvider::new();
+        let telemetry = Arc::new(TelemetryLog::new());
+        let mut config = test_run_config();
+        config.scheduler.concurrency = 4;
+        config.context = crate::ContextRunConfig {
+            window: 1,
+            budget_tokens: 1000,
+            scope: bookforge_core::config::ContextScope::Book,
+        };
+        config.context_registry = Some(Arc::new(crate::ContextRegistry::new(&segments)));
+
+        let run = translate_batches_with_callback(
+            provider,
+            batches,
+            &segments,
+            &config,
+            telemetry,
+            None,
+            None,
+            Arc::new(bookforge_core::NullProgressSink),
+            None,
+            |_| Ok(()),
+        );
+
+        let translations = tokio::time::timeout(std::time::Duration::from_secs(5), run)
+            .await
+            .expect("split prerequisite batch must not deadlock context waiters")
+            .expect("translation should complete");
+
+        assert_eq!(translations.len(), segments.len());
+        assert!(
+            translations
+                .iter()
+                .all(|translation| translation.status == SegmentStatus::Succeeded)
         );
     }
 

--- a/crates/bookforge-llm/src/double_check.rs
+++ b/crates/bookforge-llm/src/double_check.rs
@@ -4,6 +4,7 @@ use bookforge_core::{
     segment::{Segment, SegmentId, SegmentStatus},
 };
 use serde::Deserialize;
+use std::collections::{BTreeSet, HashMap, VecDeque};
 
 use crate::{
     CompletionRequest, LlmError, LlmProvider, PromptLibrary, RequestMetadata, ResponseFormat,
@@ -82,6 +83,8 @@ pub enum CorrectionStatus {
 
 pub struct CorrectionRecord {
     pub item_id: String,
+    pub segment_id: SegmentId,
+    pub block_id: BlockId,
     pub original_translation: String,
     pub corrected_translation: Option<String>,
     pub status: CorrectionStatus,
@@ -135,15 +138,13 @@ where
     }
 
     let chunk_size = double_check_config.batch_target_tokens.max(1);
-    let chunks: Vec<Vec<DoubleCheckItem>> = items
-        .chunks(chunk_size.max(1))
-        .map(|c| c.to_vec())
-        .collect();
+    let chunks = chunk_double_check_items(&items, chunk_size);
 
     let mut all_issues = Vec::new();
     for chunk in &chunks {
         let audit_result =
-            run_audit_chunk(&provider, library, chunk, config, double_check_config).await?;
+            run_audit_chunk_resilient(&provider, library, chunk, config, double_check_config)
+                .await?;
         all_issues.extend(audit_result);
     }
 
@@ -152,6 +153,8 @@ where
             .into_iter()
             .map(|item| CorrectionRecord {
                 item_id: item.item_id,
+                segment_id: item.segment_id,
+                block_id: item.block_id,
                 original_translation: item.current_translation,
                 corrected_translation: None,
                 status: CorrectionStatus::Unresolved,
@@ -161,28 +164,224 @@ where
         return Ok(records);
     }
 
+    let mut records: Vec<CorrectionRecord> = all_issues
+        .iter()
+        .filter(|item| is_audit_unresolved_item(item))
+        .map(|item| CorrectionRecord {
+            item_id: item.item_id.clone(),
+            segment_id: item.segment_id.clone(),
+            block_id: item.block_id.clone(),
+            original_translation: item.current_translation.clone(),
+            corrected_translation: None,
+            status: CorrectionStatus::Unresolved,
+            issues: item.issues.clone(),
+        })
+        .collect();
+
     let correction_items: Vec<CorrectionItem> = all_issues
         .into_iter()
         .filter(|item| item.issues.iter().any(|i| i.needs_correction))
         .collect();
 
-    let mut records = Vec::new();
-    for corr_chunk in correction_items.chunks(chunk_size.max(1)) {
-        let corr_results = run_correction_chunk(&provider, library, corr_chunk, config).await?;
+    for corr_chunk in chunk_correction_items(&correction_items, chunk_size) {
+        let original_by_id: HashMap<&str, &CorrectionItem> = corr_chunk
+            .iter()
+            .map(|item| (item.item_id.as_str(), item))
+            .collect();
+        let corr_results =
+            run_correction_chunk_resilient(&provider, library, &corr_chunk, config).await?;
+        let mut returned_ids = BTreeSet::new();
 
         for result in corr_results {
+            returned_ids.insert(result.item_id.clone());
+            let Some(original) = original_by_id.get(result.item_id.as_str()) else {
+                continue;
+            };
             let valid = validate_correction(&result);
             records.push(CorrectionRecord {
                 item_id: result.item_id.clone(),
-                original_translation: result.current_translation.clone(),
+                segment_id: result.segment_id.clone(),
+                block_id: result.block_id.clone(),
+                original_translation: original.current_translation.clone(),
                 corrected_translation: Some(result.current_translation.clone()),
                 status: valid,
                 issues: result.issues.clone(),
             });
         }
+
+        for original in &corr_chunk {
+            if !returned_ids.contains(&original.item_id) {
+                records.push(CorrectionRecord {
+                    item_id: original.item_id.clone(),
+                    segment_id: original.segment_id.clone(),
+                    block_id: original.block_id.clone(),
+                    original_translation: original.current_translation.clone(),
+                    corrected_translation: None,
+                    status: CorrectionStatus::Unresolved,
+                    issues: original.issues.clone(),
+                });
+            }
+        }
     }
 
     Ok(records)
+}
+
+fn chunk_double_check_items(
+    items: &[DoubleCheckItem],
+    budget_tokens: usize,
+) -> Vec<Vec<DoubleCheckItem>> {
+    chunk_by_budget(items, budget_tokens, estimate_double_check_item_tokens)
+}
+
+fn chunk_correction_items(
+    items: &[CorrectionItem],
+    budget_tokens: usize,
+) -> Vec<Vec<CorrectionItem>> {
+    chunk_by_budget(items, budget_tokens, estimate_correction_item_tokens)
+}
+
+fn chunk_by_budget<T: Clone>(
+    items: &[T],
+    budget_tokens: usize,
+    estimate: impl Fn(&T) -> usize,
+) -> Vec<Vec<T>> {
+    let budget_tokens = budget_tokens.max(1);
+    let mut chunks: Vec<Vec<T>> = Vec::new();
+    let mut current: Vec<T> = Vec::new();
+    let mut current_tokens = 0usize;
+
+    for item in items {
+        let item_tokens = estimate(item).max(1);
+        if !current.is_empty() && current_tokens.saturating_add(item_tokens) > budget_tokens {
+            chunks.push(std::mem::take(&mut current));
+            current_tokens = 0;
+        }
+        current.push(item.clone());
+        current_tokens = current_tokens.saturating_add(item_tokens);
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    chunks
+}
+
+fn estimate_double_check_item_tokens(item: &DoubleCheckItem) -> usize {
+    96 + estimate_text_tokens(&item.id)
+        + estimate_text_tokens(&item.section_title.clone().unwrap_or_default())
+        + estimate_text_tokens(&item.kind)
+        + estimate_text_tokens(&item.source)
+        + estimate_text_tokens(&item.translation)
+        + item
+            .required_markers
+            .iter()
+            .map(|value| estimate_text_tokens(value))
+            .sum::<usize>()
+        + item
+            .protected_spans
+            .iter()
+            .map(|value| estimate_text_tokens(value))
+            .sum::<usize>()
+        + item
+            .deterministic_warnings
+            .iter()
+            .map(|value| estimate_text_tokens(value))
+            .sum::<usize>()
+}
+
+fn estimate_correction_item_tokens(item: &CorrectionItem) -> usize {
+    96 + estimate_text_tokens(&item.item_id)
+        + estimate_text_tokens(&item.source)
+        + estimate_text_tokens(&item.current_translation)
+        + item
+            .required_markers
+            .iter()
+            .map(|value| estimate_text_tokens(value))
+            .sum::<usize>()
+        + item
+            .protected_spans
+            .iter()
+            .map(|value| estimate_text_tokens(value))
+            .sum::<usize>()
+        + item
+            .issues
+            .iter()
+            .map(|issue| {
+                estimate_text_tokens(&issue.severity)
+                    + estimate_text_tokens(&issue.kind)
+                    + estimate_text_tokens(&issue.message)
+            })
+            .sum::<usize>()
+}
+
+fn estimate_text_tokens(text: &str) -> usize {
+    (text.chars().count() / 4).max(1)
+}
+
+fn is_json_shape_error(error: &LlmError) -> bool {
+    matches!(error, LlmError::Json(_) | LlmError::InvalidResponse(_))
+}
+
+const AUDIT_UNRESOLVED_KIND: &str = "audit_unavailable";
+
+fn audit_unresolved_issue(error: &LlmError) -> DoubleCheckIssue {
+    DoubleCheckIssue {
+        severity: "minor".to_string(),
+        kind: AUDIT_UNRESOLVED_KIND.to_string(),
+        message: format!("double-check audit could not parse provider response: {error}"),
+        source_excerpt: None,
+        translation_excerpt: None,
+        needs_correction: false,
+    }
+}
+
+fn is_audit_unresolved_item(item: &CorrectionItem) -> bool {
+    item.issues
+        .iter()
+        .any(|issue| issue.kind == AUDIT_UNRESOLVED_KIND)
+}
+
+async fn run_audit_chunk_resilient<P>(
+    provider: &P,
+    library: &PromptLibrary,
+    items: &[DoubleCheckItem],
+    config: &TranslationRunConfig,
+    double_check_config: &DoubleCheckConfig,
+) -> Result<Vec<CorrectionItem>, LlmError>
+where
+    P: LlmProvider,
+{
+    let mut queue = VecDeque::from([items.to_vec()]);
+    let mut corrections = Vec::new();
+
+    while let Some(chunk) = queue.pop_front() {
+        match run_audit_chunk(provider, library, &chunk, config, double_check_config).await {
+            Ok(mut result) => corrections.append(&mut result),
+            Err(error) if is_json_shape_error(&error) && chunk.len() > 1 => {
+                let mid = chunk.len() / 2;
+                queue.push_front(chunk[mid..].to_vec());
+                queue.push_front(chunk[..mid].to_vec());
+            }
+            Err(error) if is_json_shape_error(&error) => {
+                let item = &chunk[0];
+                corrections.push(CorrectionItem {
+                    item_id: item.id.clone(),
+                    segment_id: SegmentId(item.segment_id.clone()),
+                    block_id: BlockId(item.block_id.clone()),
+                    source: item.source.clone(),
+                    current_translation: item.translation.clone(),
+                    required_markers: item.required_markers.clone(),
+                    protected_spans: item.protected_spans.clone(),
+                    issues: vec![audit_unresolved_issue(&error)],
+                });
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(corrections)
 }
 
 async fn run_audit_chunk<P>(
@@ -359,6 +558,34 @@ where
     Ok(result_items)
 }
 
+async fn run_correction_chunk_resilient<P>(
+    provider: &P,
+    library: &PromptLibrary,
+    items: &[CorrectionItem],
+    config: &TranslationRunConfig,
+) -> Result<Vec<CorrectionItem>, LlmError>
+where
+    P: LlmProvider,
+{
+    let mut queue = VecDeque::from([items.to_vec()]);
+    let mut corrected = Vec::new();
+
+    while let Some(chunk) = queue.pop_front() {
+        match run_correction_chunk(provider, library, &chunk, config).await {
+            Ok(mut result) => corrected.append(&mut result),
+            Err(error) if is_json_shape_error(&error) && chunk.len() > 1 => {
+                let mid = chunk.len() / 2;
+                queue.push_front(chunk[mid..].to_vec());
+                queue.push_front(chunk[..mid].to_vec());
+            }
+            Err(error) if is_json_shape_error(&error) => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(corrected)
+}
+
 fn validate_correction(item: &CorrectionItem) -> CorrectionStatus {
     let text = &item.current_translation;
 
@@ -393,5 +620,327 @@ fn double_check_mode_str(mode: bookforge_core::config::DoubleCheckMode) -> &'sta
         bookforge_core::config::DoubleCheckMode::Formatting => "formatting",
         bookforge_core::config::DoubleCheckMode::Semantic => "semantic",
         bookforge_core::config::DoubleCheckMode::Full => "full",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::{CorrectionStatus, DoubleCheckItem, chunk_double_check_items, run_double_check};
+    use bookforge_core::{
+        config::{DoubleCheckConfig, DoubleCheckMode, TranslationProfile},
+        ir::{BlockId, SectionId},
+        scheduler::SchedulerConfig,
+        segment::{
+            BlockTranslation, Segment, SegmentBlock, SegmentConstraints, SegmentContext, SegmentId,
+            SegmentMetadata, SegmentSource, SegmentStatus, SegmentTextRun,
+        },
+    };
+    use serde_json::json;
+
+    use crate::{
+        CompletionRequest, CompletionResponse, FinishReason, GlossaryRunConfig, LlmProvider,
+        ProviderCapabilities, SegmentTranslation, TranslationRunConfig,
+    };
+
+    #[derive(Clone)]
+    struct SequenceProvider {
+        responses: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl SequenceProvider {
+        fn new(responses: Vec<String>) -> Self {
+            let mut responses = responses;
+            responses.reverse();
+            Self {
+                responses: Arc::new(Mutex::new(responses)),
+            }
+        }
+    }
+
+    impl LlmProvider for SequenceProvider {
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> crate::provider::Result<CompletionResponse> {
+            let content = self
+                .responses
+                .lock()
+                .expect("responses mutex should not be poisoned")
+                .pop()
+                .expect("provider response should be queued");
+            Ok(CompletionResponse {
+                content,
+                input_tokens: Some(1),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(1),
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 0,
+                raw: json!({}),
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
+            }
+        }
+    }
+
+    fn segment() -> Segment {
+        Segment {
+            id: SegmentId("seg".to_string()),
+            section_id: SectionId("sec".to_string()),
+            ordinal: 0,
+            block_ids: vec![BlockId("b".to_string())],
+            source: SegmentSource {
+                text: "source".to_string(),
+                blocks: vec![SegmentBlock {
+                    block_id: BlockId("b".to_string()),
+                    kind: "paragraph".to_string(),
+                    text: "source".to_string(),
+                    text_runs: vec![SegmentTextRun {
+                        id: "r".to_string(),
+                        text: "source".to_string(),
+                    }],
+                    protected_spans: Vec::new(),
+                }],
+                token_estimate: 1,
+            },
+            context: SegmentContext::default(),
+            metadata: SegmentMetadata::default(),
+            constraints: SegmentConstraints::default(),
+            checksum: "checksum".to_string(),
+        }
+    }
+
+    fn translation() -> SegmentTranslation {
+        SegmentTranslation {
+            segment_id: SegmentId("seg".to_string()),
+            ordinal: 0,
+            block_ids: vec![BlockId("b".to_string())],
+            blocks: vec![BlockTranslation {
+                block_id: BlockId("b".to_string()),
+                text: "errato".to_string(),
+            }],
+            checksum: "checksum".to_string(),
+            status: SegmentStatus::Succeeded,
+            template: "translate_segment".to_string(),
+            error: None,
+            input_tokens: Some(5),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(6),
+            tokens_estimated: false,
+        }
+    }
+
+    fn segment_with_id(segment_id: &str, block_id: &str) -> Segment {
+        let mut segment = segment();
+        segment.id = SegmentId(segment_id.to_string());
+        segment.block_ids = vec![BlockId(block_id.to_string())];
+        segment.source.blocks[0].block_id = BlockId(block_id.to_string());
+        segment.checksum = format!("checksum-{segment_id}");
+        segment
+    }
+
+    fn translation_with_id(segment_id: &str, block_id: &str, text: &str) -> SegmentTranslation {
+        let mut translation = translation();
+        translation.segment_id = SegmentId(segment_id.to_string());
+        translation.block_ids = vec![BlockId(block_id.to_string())];
+        translation.blocks[0].block_id = BlockId(block_id.to_string());
+        translation.blocks[0].text = text.to_string();
+        translation.checksum = format!("checksum-{segment_id}");
+        translation
+    }
+
+    fn run_config() -> TranslationRunConfig {
+        TranslationRunConfig {
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            provider: "test".to_string(),
+            model: "test".to_string(),
+            prompt_version: "v1".to_string(),
+            temperature: 0.0,
+            scheduler: SchedulerConfig {
+                concurrency: 1,
+                max_attempts: 1,
+            },
+            profile: TranslationProfile::Balanced,
+            model_context_tokens: None,
+            max_output_tokens: None,
+            batch_max_output_tokens: None,
+            compact_prompts: false,
+            glossary: GlossaryRunConfig::default(),
+            context: crate::ContextRunConfig::default(),
+            context_registry: None,
+            style: None,
+            entities: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_correct_records_original_and_corrected_text() {
+        let provider = SequenceProvider::new(vec![
+            r#"{"items":[{"id":"seg:b","verdict":"fail","issues":[{"severity":"major","kind":"formatting","message":"fix it","source_excerpt":null,"translation_excerpt":null,"needs_correction":true}]}]}"#.to_string(),
+            r#"{"items":[{"id":"seg:b","corrected_translation":"corretto"}]}"#.to_string(),
+        ]);
+        let double_check = DoubleCheckConfig {
+            mode: DoubleCheckMode::Formatting,
+            model: None,
+            provider: None,
+            base_url: None,
+            api_key_env: None,
+            concurrency: 1,
+            batch_target_tokens: 8_000,
+            auto_correct: true,
+            correction_rounds: 1,
+        };
+
+        let records = run_double_check(
+            provider,
+            &[segment()],
+            &[translation()],
+            &run_config(),
+            &double_check,
+        )
+        .await
+        .expect("double-check should succeed");
+
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.segment_id.0, "seg");
+        assert_eq!(record.block_id.0, "b");
+        assert_eq!(record.original_translation, "errato");
+        assert_eq!(record.corrected_translation.as_deref(), Some("corretto"));
+        assert!(matches!(record.status, CorrectionStatus::Applied));
+    }
+
+    #[tokio::test]
+    async fn auto_correct_marks_missing_correction_unresolved() {
+        let provider = SequenceProvider::new(vec![
+            r#"{"items":[{"id":"seg:b","verdict":"fail","issues":[{"severity":"major","kind":"formatting","message":"fix it","source_excerpt":null,"translation_excerpt":null,"needs_correction":true}]}]}"#.to_string(),
+            r#"{"items":[]}"#.to_string(),
+        ]);
+        let double_check = DoubleCheckConfig {
+            mode: DoubleCheckMode::Formatting,
+            model: None,
+            provider: None,
+            base_url: None,
+            api_key_env: None,
+            concurrency: 1,
+            batch_target_tokens: 8_000,
+            auto_correct: true,
+            correction_rounds: 1,
+        };
+
+        let records = run_double_check(
+            provider,
+            &[segment()],
+            &[translation()],
+            &run_config(),
+            &double_check,
+        )
+        .await
+        .expect("double-check should succeed");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].corrected_translation, None);
+        assert!(matches!(records[0].status, CorrectionStatus::Unresolved));
+    }
+
+    #[tokio::test]
+    async fn audit_json_error_splits_chunk_and_continues() {
+        let provider = SequenceProvider::new(vec![
+            "{".to_string(),
+            r#"{"items":[{"id":"seg_a:a","verdict":"fail","issues":[{"severity":"minor","kind":"formatting","message":"spacing","source_excerpt":null,"translation_excerpt":null,"needs_correction":false}]}]}"#.to_string(),
+            r#"{"items":[{"id":"seg_b:b","verdict":"pass","issues":[]}]}"#.to_string(),
+        ]);
+        let double_check = DoubleCheckConfig {
+            mode: DoubleCheckMode::Formatting,
+            model: None,
+            provider: None,
+            base_url: None,
+            api_key_env: None,
+            concurrency: 1,
+            batch_target_tokens: 8_000,
+            auto_correct: false,
+            correction_rounds: 1,
+        };
+
+        let records = run_double_check(
+            provider,
+            &[segment_with_id("seg_a", "a"), segment_with_id("seg_b", "b")],
+            &[
+                translation_with_id("seg_a", "a", "errato a"),
+                translation_with_id("seg_b", "b", "corretto b"),
+            ],
+            &run_config(),
+            &double_check,
+        )
+        .await
+        .expect("double-check should split malformed audit chunks");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].item_id, "seg_a:a");
+        assert_eq!(records[0].original_translation, "errato a");
+        assert!(matches!(records[0].status, CorrectionStatus::Unresolved));
+    }
+
+    #[tokio::test]
+    async fn single_item_audit_json_error_is_recorded_unresolved() {
+        let provider = SequenceProvider::new(vec!["{".to_string()]);
+        let double_check = DoubleCheckConfig {
+            mode: DoubleCheckMode::Formatting,
+            model: None,
+            provider: None,
+            base_url: None,
+            api_key_env: None,
+            concurrency: 1,
+            batch_target_tokens: 8_000,
+            auto_correct: true,
+            correction_rounds: 1,
+        };
+
+        let records = run_double_check(
+            provider,
+            &[segment()],
+            &[translation()],
+            &run_config(),
+            &double_check,
+        )
+        .await
+        .expect("single malformed audit response should not fail the run");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].item_id, "seg:b");
+        assert_eq!(records[0].corrected_translation, None);
+        assert!(matches!(records[0].status, CorrectionStatus::Unresolved));
+        assert_eq!(records[0].issues[0].kind, "audit_unavailable");
+    }
+
+    #[test]
+    fn double_check_chunks_use_token_budget() {
+        let item = |id: &str, source_len: usize, translation_len: usize| DoubleCheckItem {
+            id: id.to_string(),
+            segment_id: "seg".to_string(),
+            block_id: "b".to_string(),
+            section_title: None,
+            kind: "paragraph".to_string(),
+            source: "s".repeat(source_len),
+            translation: "t".repeat(translation_len),
+            required_markers: Vec::new(),
+            protected_spans: Vec::new(),
+            deterministic_warnings: Vec::new(),
+        };
+        let items = vec![item("a", 800, 800), item("b", 800, 800), item("c", 10, 10)];
+
+        let chunks = chunk_double_check_items(&items, 550);
+
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0][0].id, "a");
+        assert_eq!(chunks[1][0].id, "b");
+        assert_eq!(chunks[2][0].id, "c");
     }
 }

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -485,7 +485,8 @@ where
     let semaphore = Arc::new(Semaphore::new(config.scheduler.concurrency));
     let mut tasks = JoinSet::new();
 
-    for segment in segments.iter().cloned() {
+    for segment in segments {
+        let segment = segment.clone();
         let provider = provider.clone();
         let config = config.clone();
         let library = library.clone();
@@ -493,6 +494,7 @@ where
 
         tasks.spawn(async move {
             let mode = select_mode(&segment);
+            let context_pairs = context_pairs_for_segment(&segment, &config).await;
             let Ok(_permit) = semaphore.acquire_owned().await else {
                 let failed = failed_translation_with_tokens(
                     &segment,
@@ -507,7 +509,8 @@ where
                 }
                 return failed;
             };
-            let translation = translate_one(provider, library, segment.clone(), &config).await;
+            let translation =
+                translate_one(provider, library, segment.clone(), &config, context_pairs).await;
             if let Some(registry) = config.context_registry.as_deref() {
                 registry.pre_populate(&segment, &translation);
             }
@@ -677,6 +680,7 @@ async fn translate_one<P>(
     library: Arc<PromptLibrary>,
     segment: Segment,
     config: &TranslationRunConfig,
+    context_pairs: Vec<CompletedContext>,
 ) -> SegmentTranslation
 where
     P: LlmProvider,
@@ -687,14 +691,6 @@ where
     let mut accum_in: u64 = 0;
     let mut accum_cached_in: u64 = 0;
     let mut accum_out: u64 = 0;
-    let context_pairs = match config.context_registry.as_deref() {
-        Some(registry) if config.context.enabled() => {
-            registry
-                .await_context_for(&segment.id, config.context)
-                .await
-        }
-        _ => Vec::new(),
-    };
 
     for _ in 0..attempts {
         let retry_context = last_error.as_ref().map(ToString::to_string);
@@ -818,6 +814,20 @@ where
         cached_in,
         tokens_out,
     )
+}
+
+async fn context_pairs_for_segment(
+    segment: &Segment,
+    config: &TranslationRunConfig,
+) -> Vec<CompletedContext> {
+    match config.context_registry.as_deref() {
+        Some(registry) if config.context.enabled() => {
+            registry
+                .await_context_for(&segment.id, config.context)
+                .await
+        }
+        _ => Vec::new(),
+    }
 }
 
 fn select_mode(segment: &Segment) -> TranslationMode {
@@ -1622,6 +1632,47 @@ mod tests {
 
         assert_eq!(translations[0].segment_id.0, "seg_a");
         assert_eq!(translations[1].segment_id.0, "seg_b");
+    }
+
+    #[tokio::test]
+    async fn non_batch_context_waiters_do_not_consume_scheduler_permits() {
+        let segments = vec![
+            segment("seg_d", 3, vec![("b0", "Fourth")]),
+            segment("seg_c", 2, vec![("b0", "Third")]),
+            segment("seg_b", 1, vec![("b0", "Second")]),
+            segment("seg_a", 0, vec![("b0", "First")]),
+        ];
+        let mut cfg = config();
+        cfg.scheduler.concurrency = 1;
+        cfg.context = ContextRunConfig {
+            window: 1,
+            budget_tokens: 1000,
+            scope: ContextScope::Book,
+        };
+        cfg.context_registry = Some(Arc::new(ContextRegistry::new(&segments)));
+
+        let run = translate_segments(
+            MockProvider::new(MockMode::PrefixTarget, "Italian"),
+            &segments,
+            &cfg,
+        );
+        let translations = tokio::time::timeout(std::time::Duration::from_secs(5), run)
+            .await
+            .expect("context waiters must not starve predecessor segments")
+            .expect("mock translation should succeed");
+
+        assert_eq!(
+            translations
+                .iter()
+                .map(|translation| translation.segment_id.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["seg_a", "seg_b", "seg_c", "seg_d"]
+        );
+        assert!(
+            translations
+                .iter()
+                .all(|translation| translation.status == SegmentStatus::Succeeded)
+        );
     }
 
     #[tokio::test]

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -1779,7 +1779,9 @@ impl JobStore {
                    AND j.target_lang = ?6
                    AND s.cache_namespace = ?7
                    AND s.status IN ('succeeded', 'skipped_cached')
-                 ORDER BY t.created_at DESC
+                 ORDER BY CASE s.status WHEN 'succeeded' THEN 0 ELSE 1 END,
+                          CAST(t.created_at AS INTEGER) DESC,
+                          t.rowid DESC
                  LIMIT 1",
                 params![
                     segment.checksum,
@@ -1871,7 +1873,9 @@ impl JobStore {
                    AND j.target_lang = ?{}
                    AND s.cache_namespace = ?{}
                    AND s.status IN ('succeeded', 'skipped_cached')
-                 ORDER BY t.created_at DESC",
+                 ORDER BY CASE s.status WHEN 'succeeded' THEN 0 ELSE 1 END,
+                          CAST(t.created_at AS INTEGER) DESC,
+                          t.rowid DESC",
                 hashes.len() + 1,
                 hashes.len() + 2,
                 hashes.len() + 3,
@@ -2596,7 +2600,7 @@ mod tests {
         store
             .insert_segments(
                 &job.id,
-                &[seg.clone()],
+                std::slice::from_ref(&seg),
                 "v1",
                 "mock",
                 "mock-prefix",
@@ -3251,6 +3255,134 @@ mod tests {
         );
 
         let _ = fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn cached_translation_prefers_repaired_succeeded_rows_over_cached_clones() {
+        let db_path = temp_path("cache_prefers_repaired.sqlite");
+        let (store, _stale_job, seg) =
+            build_seeded_store_with_translation(&db_path, "cache_ns", &["b_000000"]);
+        let cached_input = temp_path("cached-input.epub");
+        let repaired_input = temp_path("repaired-input.epub");
+        fs::write(&cached_input, b"cached input").expect("cached input should be writable");
+        fs::write(&repaired_input, b"repaired input").expect("repaired input should be writable");
+
+        let cached_job = store
+            .create_job(CreateJob {
+                input: &cached_input,
+                output: &temp_path("cached-output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("cached job should be created");
+        store
+            .insert_segments(
+                &cached_job.id,
+                std::slice::from_ref(&seg),
+                "v1",
+                "mock",
+                "mock-prefix",
+                "cache_ns",
+            )
+            .expect("cached job segment should insert");
+        store
+            .save_cached_translation(SaveCachedTranslation {
+                job_id: &cached_job.id,
+                segment_id: "seg_a",
+                translated_text: "stale cached clone",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000000".to_string()),
+                    text: "stale cached clone".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+            })
+            .expect("cached clone should save");
+
+        let repaired_job = store
+            .create_job(CreateJob {
+                input: &repaired_input,
+                output: &temp_path("repaired-output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("repaired job should be created");
+        store
+            .insert_segments(
+                &repaired_job.id,
+                std::slice::from_ref(&seg),
+                "v1",
+                "mock",
+                "mock-prefix",
+                "cache_ns",
+            )
+            .expect("repaired job segment should insert");
+        store
+            .save_translation(SaveTranslation {
+                job_id: &repaired_job.id,
+                segment_id: "seg_a",
+                translated_text: "repaired translation",
+                blocks: &[BlockTranslation {
+                    block_id: BlockId("b_000000".to_string()),
+                    text: "repaired translation".to_string(),
+                }],
+                provider: "mock",
+                model: "mock-prefix",
+                prompt_version: "v1",
+                input_tokens: Some(12),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(8),
+                tokens_estimated: false,
+            })
+            .expect("repaired translation should save");
+
+        let request = CacheLookupRequest {
+            prompt_version: "v1",
+            provider: "mock",
+            model: "mock-prefix",
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            cache_namespace: "cache_ns",
+        };
+        let single_hit = store
+            .find_cached_translation(
+                &seg,
+                request.prompt_version,
+                request.provider,
+                request.model,
+                request.source_lang,
+                request.target_lang,
+                request.cache_namespace,
+            )
+            .expect("single lookup should succeed")
+            .expect("single lookup should hit");
+        let batch_hit = store
+            .find_cached_translations_batch(std::slice::from_ref(&seg), request)
+            .expect("batch lookup should succeed")
+            .remove(&seg.id.0)
+            .expect("batch lookup should hit");
+
+        assert_eq!(single_hit.translated_text, "repaired translation");
+        assert_eq!(single_hit.blocks[0].text, "repaired translation");
+        assert_eq!(batch_hit.translated_text, "repaired translation");
+        assert_eq!(batch_hit.blocks[0].text, "repaired translation");
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(cached_input);
+        let _ = fs::remove_file(repaired_input);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix batch and non-batch sliding-context deadlocks by keeping context waiters out of provider request concurrency.
- Retry single-item invalid batch responses before marking them needs-review.
- Make double-check chunking token-budget based, resilient to malformed JSON, and persist applied corrections back to checkpoints/output.
- Ensure resume retry-pending segments bypass stale cache and cache lookup prefers repaired succeeded rows over cached clones.

## Real EPUB Verification
- Source: `test/test.epub`
- Model/provider: `deepseek-v4-flash` via DeepSeek paid preset, local key
- Final output: `test/test.it.deepseek-v4-flash.context-style-qa.epub`
- Final run: `job_1780500136906115801_a45096b03bf8`
- Final cache pass: 229 hits, 0 misses; double-check corrections 0 applied / 0 rejected / 0 unresolved
- `bookforge validate test/test.it.deepseek-v4-flash.context-style-qa.epub`: validation ok, 0 failed, 0 needs-review, 0 retry-pending, 6 QA warnings

## Tests
- `cargo test -p bookforge-core`
- `cargo test -p bookforge-epub`
- `cargo test -p bookforge-store`
- `cargo test -p bookforge-llm` (outside sandbox for loopback provider test)
- `timeout 360 cargo test -p bookforge-cli`
- `cargo clippy --all-targets --all-features` (passes with pre-existing warnings)
- `git diff --cached --check`