### PR TITLE
v1.5: extraction and scheduling overhaul + v1.7 PDF ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.codex
 /.claude/
 /test/
+/tests/
 *.tmp
 *.log
 *.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "bookforge-core",
  "bookforge-epub",
  "bookforge-llm",
+ "bookforge-pdf",
  "bookforge-store",
  "clap",
  "console",
@@ -223,6 +224,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "bookforge-pdf"
+version = "1.4.0"
+dependencies = [
+ "bookforge-core",
+ "bookforge-epub",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "clap",
  "console",
  "indicatif",
+ "quick-xml",
  "serde",
  "serde_json",
  "sha2",
@@ -184,6 +185,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ console = "0.16"
 indicatif = "0.18"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-quick-xml = "0.38"
+quick-xml = { version = "0.38", features = ["escape-html"] }
 zip = "6.0"
 rusqlite = { version = "0.37", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "brotli"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/bookforge-core",
     "crates/bookforge-epub",
     "crates/bookforge-llm",
+    "crates/bookforge-pdf",
     "crates/bookforge-store",
 ]
 resolver = "3"

--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@ cargo run -p bookforge-cli -- translate book.epub \
   --out book.it.epub
 ```
 
-Translate with the v1 fast preset:
+Translate with the default fast profile:
 
 ```bash
 cargo run -p bookforge-cli -- translate book.epub \
   --target Italian \
   --provider-preset openrouter-paid-fast \
-  --profile v1-fast \
   --ui progress \
   --out book.it.epub
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Inspect an EPUB:
 cargo run -p bookforge-cli -- inspect book.epub
 ```
 
+The inspect output includes a text-coverage metric: the percentage of
+visible body text that lands in translatable blocks. Files with low
+coverage (text in unsupported markup such as bare `<div>`s) are listed
+individually — that text would ship untranslated, so check coverage
+before spending tokens on a full run.
+
 Estimate tokens and approximate cost:
 
 ```bash
@@ -211,6 +217,16 @@ Translation always runs hard validators before committing a segment. The optiona
 
 `off` is the default. Reports still include deterministic soft warnings such as changed URLs, changed numbers, suspicious length ratios, model commentary, and repeated text.
 
+Two structural defaults to know about:
+
+- `pre`/`code` blocks are never sent to the model. They are copied through
+  to the output byte-for-byte, preserving internal whitespace.
+- The sliding context window (`--context-window`, default 3) is
+  best-effort: a segment uses whichever predecessors have already
+  finished and never waits for them. Pass `--context-strict` to restore
+  the v1.3 fence behavior, which guarantees a complete context block but
+  serializes segments within the context scope.
+
 ## Checkpoints And Cache
 
 Runtime state is stored in:
@@ -288,5 +304,4 @@ crates/bookforge-llm/prompts  Versioned prompt templates
 crates/bookforge-store  SQLite checkpoint store
 crates/bookforge-cli    CLI commands and reports
 docs/                   Architecture notes
-tests/fixtures/         Committed minimal fixture only
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ cargo run -p bookforge-cli -- <command>
 
 ## Commands
 
+Convert a PDF to a translatable EPUB (requires [poppler](https://poppler.freedesktop.org/)
+command-line tools on PATH, or `POPPLER_PATH` pointing at their bin
+directory; on Windows use the poppler-windows release zip):
+
+```bash
+cargo run -p bookforge-cli -- convert paper.pdf --out paper.epub
+```
+
+The converter detects two-column layouts per page (scientific papers),
+repairs hyphenated line breaks, joins paragraphs across pages, and maps
+oversized fonts to headings. It prints a fidelity report comparing the
+reconstructed text against the raw `pdftotext` baseline — check that
+coverage number (and `inspect` on the result) before spending tokens.
+Figures, tables-as-images, and low-confidence page fallbacks are
+roadmap items (ROADMAP §9b, phases P2–P4); for image-heavy PDFs expect
+text-only output for now.
+
 Inspect an EPUB:
 
 ```bash

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -32,4 +32,6 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"
+quick-xml.workspace = true
 tempfile = "3"
+zip.workspace = true

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 bookforge-core = { version = "1.4.0", path = "../bookforge-core", features = ["cli"] }
 bookforge-epub = { version = "1.4.0", path = "../bookforge-epub" }
 bookforge-llm = { version = "1.4.0", path = "../bookforge-llm" }
+bookforge-pdf = { version = "1.4.0", path = "../bookforge-pdf" }
 bookforge-store = { version = "1.4.0", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true

--- a/crates/bookforge-cli/src/commands/convert.rs
+++ b/crates/bookforge-cli/src/commands/convert.rs
@@ -1,0 +1,92 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use bookforge_pdf::{ColumnMode, ConvertOptions, convert_pdf};
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ConvertArgs {
+    /// Input PDF.
+    pub input: PathBuf,
+
+    /// Output EPUB path. Defaults to the input with an .epub extension.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Column handling: detect per page, or force single/two-column.
+    #[arg(long, value_enum, default_value_t = ColumnsArg::Auto)]
+    pub columns: ColumnsArg,
+
+    /// Source language recorded as the EPUB dc:language.
+    #[arg(long, default_value = "en")]
+    pub language: String,
+
+    /// Title for the produced EPUB; defaults to the input file name.
+    #[arg(long)]
+    pub title: Option<String>,
+
+    /// Where to write the JSON conversion report. Defaults to
+    /// `<out>.convert.json`.
+    #[arg(long)]
+    pub report: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ColumnsArg {
+    Auto,
+    #[value(name = "1")]
+    Single,
+    #[value(name = "2")]
+    Two,
+}
+
+impl From<ColumnsArg> for ColumnMode {
+    fn from(value: ColumnsArg) -> Self {
+        match value {
+            ColumnsArg::Auto => ColumnMode::Auto,
+            ColumnsArg::Single => ColumnMode::Single,
+            ColumnsArg::Two => ColumnMode::Two,
+        }
+    }
+}
+
+pub async fn run(args: ConvertArgs) -> Result<()> {
+    if !args.input.exists() {
+        bail!("input PDF does not exist: {}", args.input.display());
+    }
+    let output = args
+        .out
+        .clone()
+        .unwrap_or_else(|| args.input.with_extension("epub"));
+    let report_path = args
+        .report
+        .clone()
+        .unwrap_or_else(|| output.with_extension("convert.json"));
+
+    let options = ConvertOptions {
+        columns: args.columns.into(),
+        language: args.language.clone(),
+        title: args.title.clone().unwrap_or_default(),
+    };
+
+    let outcome = convert_pdf(&args.input, &output, &options)
+        .with_context(|| format!("converting {}", args.input.display()))?;
+
+    let json = serde_json::to_string_pretty(&outcome.report)?;
+    std::fs::write(&report_path, json)
+        .with_context(|| format!("writing report {}", report_path.display()))?;
+
+    println!("Input: {}", args.input.display());
+    println!("Output: {}", outcome.output.display());
+    print!("{}", outcome.report.summary());
+    println!("Report: {}", report_path.display());
+    println!();
+    println!("Check coverage before translating:");
+    println!("  bookforge inspect \"{}\"", outcome.output.display());
+    println!(
+        "  bookforge translate \"{}\" --target <language> ...",
+        outcome.output.display()
+    );
+
+    Ok(())
+}

--- a/crates/bookforge-cli/src/commands/inspect.rs
+++ b/crates/bookforge-cli/src/commands/inspect.rs
@@ -4,7 +4,7 @@ use bookforge_core::{
     ir::{BlockKind, Book},
     segment::{Segment, build_segments},
 };
-use bookforge_epub::{inspect_epub, read_epub};
+use bookforge_epub::{inspect_epub, read_epub, text_coverage};
 use clap::Args;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -42,6 +42,41 @@ pub async fn run(args: InspectArgs) -> Result<()> {
         status(inspection.has_toc)
     );
     println!("Resource count: {}", inspection.resource_count);
+
+    let coverage = text_coverage(&args.input)?;
+    println!(
+        "Text coverage: {:.1}% ({} of {} visible characters in translatable blocks)",
+        coverage.percent(),
+        coverage.captured_chars,
+        coverage.total_chars
+    );
+    let mut low = coverage
+        .files
+        .iter()
+        .filter(|file| file.uncaptured_chars() > 0 && file.percent() < 99.0)
+        .collect::<Vec<_>>();
+    low.sort_by(|left, right| {
+        left.percent()
+            .partial_cmp(&right.percent())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    if !low.is_empty() {
+        println!(
+            "Low-coverage files (text the translator will never see, {} total):",
+            low.len()
+        );
+        for file in low.iter().take(10) {
+            println!(
+                "  {}: {:.1}% ({} uncaptured characters)",
+                file.href,
+                file.percent(),
+                file.uncaptured_chars()
+            );
+        }
+        if low.len() > 10 {
+            println!("  ... and {} more", low.len() - 10);
+        }
+    }
 
     if args.structure || args.segments {
         let book = read_epub(&args.input)?;

--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod convert;
 pub mod doctor;
 pub mod entity;
 pub mod estimate;

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -25,15 +25,14 @@ use clap::Args;
 
 use crate::{
     QaMode,
-    checkpoint::CheckpointWriter,
     cost::estimate_cost_usd,
     performance::performance_summary_from_events,
     report::{ReportInput, write_report},
 };
 
 use super::translate::{
-    CacheContext, CheckpointContext, apply_cached_translations, mock_mode, qa_reviews_for_mode,
-    translate_and_checkpoint, translate_and_checkpoint_batch,
+    CacheContext, CheckpointRunContext, apply_cached_translations, mock_mode, qa_reviews_for_mode,
+    run_checkpointed_translation,
 };
 
 #[derive(Debug, Args)]
@@ -344,90 +343,49 @@ async fn run_inner(
     let fresh_translations = if pending_segments.is_empty() {
         Vec::new()
     } else {
-        let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
-        let sender = writer.sender();
-        let result = match job.provider.as_str() {
+        match job.provider.as_str() {
             "mock" => {
                 let provider =
                     MockProvider::new(mock_mode(&snapshot.model), &snapshot.target_language);
-                if settings.batch.enabled {
-                    let batch_run_config = batch_run_config(&run_config, &settings);
-                    translate_and_checkpoint_batch(
-                        provider.clone(),
-                        &pending_segments,
-                        &batch_run_config,
-                        &settings,
-                        CheckpointContext {
-                            store: &store,
-                            job_id: &job.id,
-                            provider: &snapshot.provider,
-                            model: &snapshot.model,
-                            prompt_version,
-                            sender: &sender,
-                        },
-                        progress.clone(),
-                    )
-                    .await
-                } else {
-                    translate_and_checkpoint(
-                        provider.clone(),
-                        &pending_segments,
-                        &run_config,
-                        CheckpointContext {
-                            store: &store,
-                            job_id: &job.id,
-                            provider: &snapshot.provider,
-                            model: &snapshot.model,
-                            prompt_version,
-                            sender: &sender,
-                        },
-                    )
-                    .await
-                }
+                run_checkpointed_translation(
+                    provider,
+                    &pending_segments,
+                    &run_config,
+                    &settings,
+                    CheckpointRunContext {
+                        store: &store,
+                        job_id: &job.id,
+                        provider: &snapshot.provider,
+                        model: &snapshot.model,
+                        prompt_version,
+                    },
+                    progress.clone(),
+                    settings.batch.enabled,
+                )
+                .await
             }
             "deepseek" | "openrouter" | "openai-compatible" => {
                 let provider_config = openai_compatible_config(&job, snapshot, &settings)?;
                 let provider = OpenAiCompatibleProvider::new(provider_config)?;
-                if settings.batch.enabled {
-                    let batch_run_config = batch_run_config(&run_config, &settings);
-                    translate_and_checkpoint_batch(
-                        provider.clone(),
-                        &pending_segments,
-                        &batch_run_config,
-                        &settings,
-                        CheckpointContext {
-                            store: &store,
-                            job_id: &job.id,
-                            provider: &snapshot.provider,
-                            model: &snapshot.model,
-                            prompt_version,
-                            sender: &sender,
-                        },
-                        progress.clone(),
-                    )
-                    .await
-                } else {
-                    translate_and_checkpoint(
-                        provider.clone(),
-                        &pending_segments,
-                        &run_config,
-                        CheckpointContext {
-                            store: &store,
-                            job_id: &job.id,
-                            provider: &snapshot.provider,
-                            model: &snapshot.model,
-                            prompt_version,
-                            sender: &sender,
-                        },
-                    )
-                    .await
-                }
+                run_checkpointed_translation(
+                    provider,
+                    &pending_segments,
+                    &run_config,
+                    &settings,
+                    CheckpointRunContext {
+                        store: &store,
+                        job_id: &job.id,
+                        provider: &snapshot.provider,
+                        model: &snapshot.model,
+                        prompt_version,
+                    },
+                    progress.clone(),
+                    settings.batch.enabled,
+                )
+                .await
             }
             provider => anyhow::bail!("cannot resume unsupported provider '{provider}'"),
-        };
-        drop(sender);
-        writer.shutdown().await?;
-        result?
+        }?
     };
 
     cached_translations.extend(fresh_translations);
@@ -670,34 +628,6 @@ fn openai_compatible_config_from_parts(
     })
 }
 
-fn batch_run_config(
-    run_config: &TranslationRunConfig,
-    settings: &ResolvedRunSettings,
-) -> TranslationRunConfig {
-    TranslationRunConfig {
-        source_language: run_config.source_language.clone(),
-        target_language: run_config.target_language.clone(),
-        provider: run_config.provider.clone(),
-        model: run_config.model.clone(),
-        prompt_version: run_config.prompt_version.clone(),
-        temperature: run_config.temperature,
-        scheduler: bookforge_core::SchedulerConfig {
-            concurrency: run_config.scheduler.concurrency,
-            max_attempts: settings.provider.provider_max_attempts,
-        },
-        profile: settings.profile,
-        model_context_tokens: settings.provider.model_context_tokens,
-        max_output_tokens: settings.provider.max_output_tokens,
-        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
-        compact_prompts: settings.compact_prompts,
-        glossary: run_config.glossary.clone(),
-        context: run_config.context,
-        context_registry: run_config.context_registry.clone(),
-        style: run_config.style.clone(),
-        entities: run_config.entities.clone(),
-    }
-}
-
 fn snapshot_context_run_config(snapshot: &RunConfigSnapshot) -> ContextRunConfig {
     ContextRunConfig {
         window: snapshot.context_window,
@@ -927,7 +857,13 @@ mod tests {
         },
     };
     use bookforge_store::{CreateJob, SaveNeedsReview, SaveTranslation};
-    use std::sync::Mutex;
+    use std::{
+        io::Write,
+        path::Path,
+        sync::Mutex,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
     struct RecordingSink {
         events: Arc<Mutex<Vec<ProgressEvent>>>,
@@ -953,9 +889,7 @@ mod tests {
         settings.batch.enabled = false;
         settings.segmentation.max_segment_tokens = 1377;
         settings.segmentation.context_tokens = 77;
-        let Some(mut fixture) = resume_fixture(settings, 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 1);
 
         run_fixture(&mut fixture)
             .await
@@ -975,9 +909,7 @@ mod tests {
         let mut settings = TranslationProfile::Safe.resolve();
         settings.batch.enabled = false;
         settings.compact_prompts = true;
-        let Some(mut fixture) = resume_fixture(settings, 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 1);
 
         let events = run_fixture(&mut fixture)
             .await
@@ -994,9 +926,7 @@ mod tests {
         settings.batch.enabled = false;
         settings.provider.json_mode = JsonMode::PromptOnly;
         settings.provider.provider_max_attempts = 4;
-        let Some(mut fixture) = resume_fixture(settings.clone(), 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings.clone(), 1);
 
         let config = openai_compatible_config_from_parts(
             "openrouter",
@@ -1021,9 +951,7 @@ mod tests {
     #[tokio::test]
     async fn resume_missing_config_snapshot_fails_clearly() {
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
-        let Some(input) = fixture_input_or_skip() else {
-            return;
-        };
+        let input = fixture_input();
         let output = tempdir.path().join("out.epub");
         let store = JobStore::open(tempdir.path().join("jobs.sqlite")).expect("store should open");
         let job = store
@@ -1056,9 +984,7 @@ mod tests {
     async fn resume_reuses_checkpointed_segments_and_translates_only_resumable_segments() {
         let mut settings = TranslationProfile::V1Fast.resolve();
         settings.batch.enabled = false;
-        let Some(mut fixture) = resume_fixture(settings, 2) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 2);
         save_succeeded(
             &fixture.store,
             &fixture.job.id,
@@ -1089,9 +1015,7 @@ mod tests {
     async fn resume_retry_pending_bypasses_cache() {
         let mut settings = TranslationProfile::V1Fast.resolve();
         settings.batch.enabled = false;
-        let Some(mut fixture) = resume_fixture(settings, 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 1);
         let cache_job = fixture
             .store
             .create_job(CreateJob {
@@ -1159,9 +1083,7 @@ mod tests {
     async fn resume_skips_needs_review_by_default() {
         let mut settings = TranslationProfile::V1Fast.resolve();
         settings.batch.enabled = false;
-        let Some(mut fixture) = resume_fixture(settings, 2) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 2);
         for segment in &fixture.segments {
             save_needs_review(&fixture.store, &fixture.job.id, segment);
         }
@@ -1230,9 +1152,7 @@ mod tests {
     async fn resume_errors_on_cache_namespace_mismatch() {
         let mut settings = TranslationProfile::V1Fast.resolve();
         settings.batch.enabled = false;
-        let Some(mut fixture) = resume_fixture(settings, 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings, 1);
         fixture.snapshot.cache_namespace = "wrong-cache-namespace".to_string();
 
         let error = run_fixture(&mut fixture)
@@ -1250,9 +1170,7 @@ mod tests {
     async fn resume_accepts_legacy_v1_snapshot_without_glossary_metadata() {
         let mut settings = TranslationProfile::V1Fast.resolve();
         settings.batch.enabled = false;
-        let Some(mut fixture) = resume_fixture(settings.clone(), 1) else {
-            return;
-        };
+        let mut fixture = resume_fixture(settings.clone(), 1);
         fixture.snapshot.glossary_fingerprint.clear();
         fixture.snapshot.glossary_terms.clear();
         fixture.snapshot.cache_namespace = compute_cache_namespace_v1(
@@ -1290,12 +1208,9 @@ mod tests {
         assert!(error.to_string().contains("seg_missing"));
     }
 
-    fn resume_fixture(
-        settings: ResolvedRunSettings,
-        segment_count: usize,
-    ) -> Option<ResumeFixture> {
+    fn resume_fixture(settings: ResolvedRunSettings, segment_count: usize) -> ResumeFixture {
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
-        let input = fixture_input_or_skip()?;
+        let input = fixture_input();
         let output = tempdir.path().join("translated.epub");
         let events = tempdir.path().join("events.jsonl");
         let store = JobStore::open(tempdir.path().join("jobs.sqlite")).expect("store should open");
@@ -1389,13 +1304,13 @@ mod tests {
             .update_job_config_snapshot(&job.id, &snapshot)
             .expect("snapshot should persist");
 
-        Some(ResumeFixture {
+        ResumeFixture {
             _tempdir: tempdir,
             store,
             job,
             snapshot,
             segments,
-        })
+        }
     }
 
     async fn run_fixture(fixture: &mut ResumeFixture) -> Result<Vec<ProgressEvent>> {
@@ -1537,23 +1452,82 @@ mod tests {
             .collect()
     }
 
-    // Returns the path to test/test.epub if present, otherwise prints a skip
-    // line and returns None. The fixture is gitignored (private to the
-    // maintainer), so CI and contributor checkouts must skip these tests
-    // rather than fail. See CLAUDE.md and CONTRIBUTING.md.
-    fn fixture_input_or_skip() -> Option<PathBuf> {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(std::path::Path::parent)
-            .expect("cli crate should be under crates/bookforge-cli")
-            .join("test/test.epub");
-        if !path.exists() {
-            let name = std::thread::current().name().unwrap_or("?").to_string();
-            eprintln!("[skip] {name}: requires test/test.epub fixture");
-            return None;
-        }
-        Some(path)
+    // Builds a synthetic EPUB so resume tests exercise the EPUB path in CI
+    // without relying on local, gitignored book fixtures.
+    fn fixture_input() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "bookforge-resume-fixture-{}-{nanos}.epub",
+            std::process::id()
+        ));
+        build_resume_epub(&path);
+        path
     }
+
+    fn build_resume_epub(path: &Path) {
+        let file = std::fs::File::create(path).expect("fixture EPUB should be creatable");
+        let mut zip = ZipWriter::new(file);
+        let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+        zip.start_file("mimetype", stored).unwrap();
+        zip.write_all(b"application/epub+zip").unwrap();
+        zip.start_file("META-INF/container.xml", deflated).unwrap();
+        zip.write_all(RESUME_CONTAINER_XML.as_bytes()).unwrap();
+        zip.start_file("content.opf", deflated).unwrap();
+        zip.write_all(RESUME_OPF.as_bytes()).unwrap();
+        zip.start_file("chapter1.xhtml", deflated).unwrap();
+        zip.write_all(RESUME_CHAPTER_ONE.as_bytes()).unwrap();
+        zip.start_file("chapter2.xhtml", deflated).unwrap();
+        zip.write_all(RESUME_CHAPTER_TWO.as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+
+    const RESUME_CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    const RESUME_OPF: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">resume-fixture</dc:identifier>
+    <dc:title>Resume Fixture</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="chapter2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>"#;
+
+    const RESUME_CHAPTER_ONE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Resume Chapter One</title></head>
+<body>
+<h1>Resume Chapter One</h1>
+<p>First resume paragraph with <em>inline emphasis</em> and a <a href="https://example.com">link</a>.</p>
+<p>Second resume paragraph gives the fixture enough blocks for retry and cache tests.</p>
+</body>
+</html>"#;
+
+    const RESUME_CHAPTER_TWO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Resume Chapter Two</title></head>
+<body>
+<h1>Resume Chapter Two</h1>
+<p>Another section keeps segmentation boundaries stable across resume tests.</p>
+</body>
+</html>"#;
 
     fn test_segment(id: &str, ordinal: usize) -> Segment {
         let block_id = BlockId(format!("b_{ordinal:06}"));

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -703,6 +703,10 @@ fn snapshot_context_run_config(snapshot: &RunConfigSnapshot) -> ContextRunConfig
         window: snapshot.context_window,
         budget_tokens: snapshot.context_budget_tokens,
         scope: snapshot.context_scope,
+        // Strictness is a scheduling choice, not part of the cached
+        // translation contract, so it is not persisted in the snapshot.
+        // Resumed jobs use the best-effort default.
+        strict: false,
     }
 }
 

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -18,7 +18,7 @@ pub struct TranslateArgs {
     #[command(flatten)]
     pub provider: CliProviderArgs,
 
-    #[arg(long, value_enum, default_value_t = TranslationProfile::Balanced)]
+    #[arg(long, value_enum, default_value_t = TranslationProfile::V1Fast)]
     pub profile: TranslationProfile,
 
     #[arg(long)]

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -89,10 +89,17 @@ pub struct TranslateArgs {
     pub context_budget_tokens: usize,
 
     /// Scope of the sliding context. `chapter` (default) limits context to
-    /// the same chapter; `book` walks the entire book and materially
-    /// reduces cross-chapter concurrency.
+    /// the same chapter; `book` walks the entire book and, in strict mode,
+    /// materially reduces cross-chapter concurrency.
     #[arg(long, value_enum, default_value_t = ContextScope::Chapter)]
     pub context_scope: ContextScope,
+
+    /// Wait for all predecessor segments before translating, guaranteeing
+    /// a complete sliding-context block at the cost of serializing
+    /// segments within the context scope. Off by default: context is
+    /// best-effort and segments never wait on each other.
+    #[arg(long, default_value_t = false)]
+    pub context_strict: bool,
 
     /// Style sheet TOML to merge into prompts (repeatable). Sheets merge
     /// with `book > series > global` precedence.

--- a/crates/bookforge-cli/src/commands/translate/engine.rs
+++ b/crates/bookforge-cli/src/commands/translate/engine.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use bookforge_core::{ResolvedRunSettings, scheduler::SchedulerConfig, segment::Segment};
+use bookforge_llm::{LlmProvider, SegmentTranslation, TranslationRunConfig};
+use bookforge_store::JobStore;
+
+use crate::checkpoint::CheckpointWriter;
+
+use super::{
+    CheckpointContext, checkpointing::finalize_writer, translate_and_checkpoint,
+    translate_and_checkpoint_batch,
+};
+
+pub(crate) struct CheckpointRunContext<'a> {
+    pub store: &'a JobStore,
+    pub job_id: &'a str,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub prompt_version: &'a str,
+}
+
+pub(crate) fn batch_run_config(
+    run_config: &TranslationRunConfig,
+    settings: &ResolvedRunSettings,
+) -> TranslationRunConfig {
+    TranslationRunConfig {
+        source_language: run_config.source_language.clone(),
+        target_language: run_config.target_language.clone(),
+        provider: run_config.provider.clone(),
+        model: run_config.model.clone(),
+        prompt_version: run_config.prompt_version.clone(),
+        temperature: run_config.temperature,
+        scheduler: SchedulerConfig {
+            concurrency: run_config.scheduler.concurrency,
+            max_attempts: settings.provider.provider_max_attempts,
+        },
+        profile: settings.profile,
+        model_context_tokens: settings.provider.model_context_tokens,
+        max_output_tokens: settings.provider.max_output_tokens,
+        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+        compact_prompts: settings.compact_prompts,
+        glossary: run_config.glossary.clone(),
+        context: run_config.context,
+        context_registry: run_config.context_registry.clone(),
+        style: run_config.style.clone(),
+        entities: run_config.entities.clone(),
+    }
+}
+
+pub(crate) async fn run_checkpointed_translation<P>(
+    provider: P,
+    pending_segments: &[Segment],
+    run_config: &TranslationRunConfig,
+    settings: &ResolvedRunSettings,
+    checkpoint: CheckpointRunContext<'_>,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    batch_enabled: bool,
+) -> Result<Vec<SegmentTranslation>>
+where
+    P: LlmProvider,
+{
+    if pending_segments.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let writer = CheckpointWriter::spawn(checkpoint.store.path().to_path_buf(), progress.clone());
+    let sender = writer.sender();
+    let checkpoint_context = CheckpointContext {
+        store: checkpoint.store,
+        job_id: checkpoint.job_id,
+        provider: checkpoint.provider,
+        model: checkpoint.model,
+        prompt_version: checkpoint.prompt_version,
+        sender: &sender,
+    };
+    let translation_result = if batch_enabled {
+        let batch_config = batch_run_config(run_config, settings);
+        translate_and_checkpoint_batch(
+            provider,
+            pending_segments,
+            &batch_config,
+            settings,
+            checkpoint_context,
+            progress,
+        )
+        .await
+    } else {
+        translate_and_checkpoint(provider, pending_segments, run_config, checkpoint_context).await
+    };
+    finalize_writer(translation_result, sender, writer).await
+}

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -3,8 +3,10 @@ use anyhow::Result;
 use bookforge_core::config::TranslationProfile;
 use bookforge_core::{
     GlossaryFormat, GlossaryTerm, NullProgressSink,
-    config::{DoubleCheckMode, FallbackScope, ResolvedRunSettings, TranslationConfig},
-    marker::extract_marker_id,
+    config::{
+        DoubleCheckMode, FallbackScope, PromptVersion, ResolvedRunSettings, TranslationConfig,
+    },
+    marker::{parse_empty_marker, parse_marker_close, parse_paired_marker_open},
     merge_scope_terms,
     scheduler::SchedulerConfig,
     segment::{Segment, SegmentStatus, build_segments, compute_cache_namespace},
@@ -39,6 +41,7 @@ use crate::{
 pub mod args;
 mod cache;
 mod checkpointing;
+mod engine;
 mod reporting;
 mod settings;
 mod snapshot;
@@ -46,6 +49,7 @@ mod snapshot;
 pub use args::TranslateArgs;
 pub(crate) use cache::{CacheContext, apply_cached_translations, pending_segments_for_job};
 use checkpointing::finalize_writer;
+pub(crate) use engine::{CheckpointRunContext, run_checkpointed_translation};
 use reporting::print_summary_rebuild_and_report;
 use settings::{apply_provider_preset, resolve_settings, retry_amplification_warning};
 use snapshot::persist_snapshot;
@@ -455,7 +459,7 @@ async fn run_mock_translation(
         .model
         .clone()
         .unwrap_or_else(|| "mock-prefix-target".to_string());
-    let prompt_version = "v1";
+    let prompt_version = PromptVersion::V2.as_str();
     let store = JobStore::open_default()?;
     let glossary = prepare_glossary_run_config(
         &store,
@@ -597,23 +601,22 @@ async fn run_mock_translation(
         misses: pending_segments.len(),
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
-    let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
-    let sender = writer.sender();
-    let translation_result = translate_and_checkpoint(
+    let fresh_translations = run_checkpointed_translation(
         provider.clone(),
         &pending_segments,
         &run_config,
-        CheckpointContext {
+        settings,
+        CheckpointRunContext {
             store: &store,
             job_id: &job.id,
             provider: "mock",
             model: &model,
             prompt_version,
-            sender: &sender,
         },
+        progress.clone(),
+        false,
     )
-    .await;
-    let fresh_translations = finalize_writer(translation_result, sender, writer).await?;
+    .await?;
     translations.extend(fresh_translations);
     translations.sort_by_key(|translation| translation.ordinal);
     let qa_reviews = qa_reviews_for_mode(
@@ -750,9 +753,9 @@ async fn run_openai_compatible_translation(
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
     let run_prompt_version = if settings.batch.enabled {
-        "batch_v1"
+        PromptVersion::BatchV2.as_str()
     } else {
-        "v1"
+        PromptVersion::V2.as_str()
     };
     let store = JobStore::open_default()?;
     let glossary = prepare_glossary_run_config(
@@ -874,151 +877,63 @@ async fn run_openai_compatible_translation(
         style: style.run_config.clone(),
         entities: entities.run_config.clone(),
     };
-    // batch_run_config
+    let mut translations = apply_cached_translations(
+        &segments,
+        CacheContext {
+            store: &store,
+            job_id: &job.id,
+            prompt_version: run_prompt_version,
+            provider: &config.provider,
+            model: &model,
+            source_lang: config.source_language.as_deref(),
+            target_lang: &config.target_language,
+            cache_namespace: &cache_namespace,
+        },
+    )?;
+    let hits = translations.len();
+    let pending_count = segments.len().saturating_sub(hits);
+    progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
+        hits,
+        misses: pending_count,
+        timestamp_ms: bookforge_core::progress::now_ms(),
+    });
+    let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
+    prepopulate_context_registry(context_registry.as_ref(), &segments, &translations);
+    let fresh_translations = run_checkpointed_translation(
+        provider.clone(),
+        &pending_segments,
+        &run_config,
+        settings,
+        CheckpointRunContext {
+            store: &store,
+            job_id: &job.id,
+            provider: &config.provider,
+            model: &model,
+            prompt_version: run_prompt_version,
+        },
+        progress.clone(),
+        settings.batch.enabled,
+    )
+    .await?;
+    translations.extend(fresh_translations);
 
-    if settings.batch.enabled {
-        let batch_run_config = TranslationRunConfig {
-            source_language: run_config.source_language.clone(),
-            target_language: run_config.target_language.clone(),
-            provider: run_config.provider.clone(),
-            model: run_config.model.clone(),
-            prompt_version: run_prompt_version.to_string(),
-            temperature: run_config.temperature,
-            scheduler: SchedulerConfig {
-                concurrency: run_config.scheduler.concurrency,
-                max_attempts: settings.provider.provider_max_attempts,
-            },
-            profile: settings.profile,
-            model_context_tokens: settings.provider.model_context_tokens,
-            max_output_tokens: settings.provider.max_output_tokens,
-            batch_max_output_tokens: settings.provider.batch_max_output_tokens,
-            compact_prompts: settings.compact_prompts,
-            glossary: run_config.glossary.clone(),
-            context: run_config.context,
-            context_registry: run_config.context_registry.clone(),
-            style: run_config.style.clone(),
-            entities: run_config.entities.clone(),
-        };
-        let mut translations = apply_cached_translations(
-            &segments,
-            CacheContext {
-                store: &store,
-                job_id: &job.id,
-                prompt_version: run_prompt_version,
-                provider: &config.provider,
-                model: &model,
-                source_lang: config.source_language.as_deref(),
-                target_lang: &config.target_language,
-                cache_namespace: &cache_namespace,
-            },
-        )?;
-        let hits = translations.len();
-        let pending_count = segments.len().saturating_sub(hits);
-        progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
-            hits,
-            misses: pending_count,
-            timestamp_ms: bookforge_core::progress::now_ms(),
-        });
-        let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
-        prepopulate_context_registry(context_registry.as_ref(), &segments, &translations);
-        let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
-        let sender = writer.sender();
-        let translation_result = translate_and_checkpoint_batch(
-            provider.clone(),
-            &pending_segments,
-            &batch_run_config,
-            settings,
-            CheckpointContext {
-                store: &store,
-                job_id: &job.id,
-                provider: &config.provider,
-                model: &model,
-                prompt_version: run_prompt_version,
-                sender: &sender,
-            },
-            progress.clone(),
-        )
-        .await;
-        let fresh_translations = finalize_writer(translation_result, sender, writer).await?;
-        translations.extend(fresh_translations);
-
-        finish_translation_pipeline(
-            &provider,
-            cancel_token,
-            cli_args,
-            &segments,
-            &mut translations,
-            &store,
-            &job,
-            run_prompt_version,
-            settings,
-            &run_config,
-            config,
-            &book,
-            progress.clone(),
-            started,
-        )
-        .await?;
-    } else {
-        let mut translations = apply_cached_translations(
-            &segments,
-            CacheContext {
-                store: &store,
-                job_id: &job.id,
-                prompt_version: run_prompt_version,
-                provider: &config.provider,
-                model: &model,
-                source_lang: config.source_language.as_deref(),
-                target_lang: &config.target_language,
-                cache_namespace: &cache_namespace,
-            },
-        )?;
-        let hits = translations.len();
-        let pending_count = segments.len().saturating_sub(hits);
-        progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
-            hits,
-            misses: pending_count,
-            timestamp_ms: bookforge_core::progress::now_ms(),
-        });
-        let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
-        prepopulate_context_registry(context_registry.as_ref(), &segments, &translations);
-        let writer = CheckpointWriter::spawn(store.path().to_path_buf(), progress.clone());
-        let sender = writer.sender();
-        let translation_result = translate_and_checkpoint(
-            provider.clone(),
-            &pending_segments,
-            &run_config,
-            CheckpointContext {
-                store: &store,
-                job_id: &job.id,
-                provider: &config.provider,
-                model: &model,
-                prompt_version: run_prompt_version,
-                sender: &sender,
-            },
-        )
-        .await;
-        let fresh_translations = finalize_writer(translation_result, sender, writer).await?;
-        translations.extend(fresh_translations);
-
-        finish_translation_pipeline(
-            &provider,
-            cancel_token,
-            cli_args,
-            &segments,
-            &mut translations,
-            &store,
-            &job,
-            run_prompt_version,
-            settings,
-            &run_config,
-            config,
-            &book,
-            progress.clone(),
-            started,
-        )
-        .await?;
-    }
+    finish_translation_pipeline(
+        &provider,
+        cancel_token,
+        cli_args,
+        &segments,
+        &mut translations,
+        &store,
+        &job,
+        run_prompt_version,
+        settings,
+        &run_config,
+        config,
+        &book,
+        progress.clone(),
+        started,
+    )
+    .await?;
 
     if cancel_token.is_cancelled() {
         let _ = store.mark_job_interrupted(&job.id);
@@ -1778,6 +1693,7 @@ fn suspicious_qa_candidates(
 
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 struct MarkerSignature {
+    block_index: usize,
     id: String,
     shape: MarkerShape,
 }
@@ -1813,57 +1729,44 @@ fn marker_signatures_for_blocks<'a>(
     blocks: impl Iterator<Item = &'a str>,
 ) -> Option<Vec<MarkerSignature>> {
     let mut signatures = Vec::new();
-    for text in blocks {
-        signatures.extend(marker_signatures_in_text(text)?);
+    for (block_index, text) in blocks.enumerate() {
+        signatures.extend(marker_signatures_in_text(block_index, text)?);
     }
     Some(signatures)
 }
 
-fn marker_signatures_in_text(text: &str) -> Option<Vec<MarkerSignature>> {
+fn marker_signatures_in_text(block_index: usize, text: &str) -> Option<Vec<MarkerSignature>> {
     let mut signatures = Vec::new();
-    let mut open_stack: Vec<&'static str> = Vec::new();
+    let mut open_stack: Vec<String> = Vec::new();
     let mut rest = text;
 
     while let Some(index) = rest.find('<') {
         let tag = &rest[index..];
-        if tag.starts_with("<m ") || tag.starts_with("<keep ") {
-            let end = tag.find('>')?;
-            let open_tag = &tag[..=end];
-            if open_tag.ends_with("/>") {
-                return None;
-            }
-            let (tag_name, shape) = if tag.starts_with("<m ") {
-                ("m", MarkerShape::PairedM)
+        if let Some(open) = parse_paired_marker_open(tag) {
+            let shape = if open.tag_name == "keep" {
+                MarkerShape::PairedKeep
             } else {
-                ("keep", MarkerShape::PairedKeep)
+                MarkerShape::PairedM
             };
             signatures.push(MarkerSignature {
-                id: extract_marker_id(open_tag)?,
+                block_index,
+                id: open.id,
                 shape,
             });
-            open_stack.push(tag_name);
-            rest = &tag[end + 1..];
-        } else if tag.starts_with("<ref ") {
-            let end = tag.find('>')?;
-            let ref_tag = &tag[..=end];
-            if !ref_tag.ends_with("/>") {
-                return None;
-            }
+            open_stack.push(open.tag_name);
+            rest = &tag[open.len..];
+        } else if let Some(empty) = parse_empty_marker(tag) {
             signatures.push(MarkerSignature {
-                id: extract_marker_id(ref_tag)?,
+                block_index,
+                id: empty.id,
                 shape: MarkerShape::EmptyRef,
             });
-            rest = &tag[end + 1..];
-        } else if tag.starts_with("</m>") || tag.starts_with("</keep>") {
-            let expected = if tag.starts_with("</m>") { "m" } else { "keep" };
-            if open_stack.pop() != Some(expected) {
+            rest = &tag[empty.len..];
+        } else if let Some(close) = parse_marker_close(tag) {
+            if open_stack.pop().as_deref() != Some(close.tag_name.as_str()) {
                 return None;
             }
-            rest = if expected == "m" {
-                &tag["</m>".len()..]
-            } else {
-                &tag["</keep>".len()..]
-            };
+            rest = &tag[close.len..];
         } else {
             rest = &tag[1..];
         }
@@ -2360,10 +2263,10 @@ case_sensitive = true
 
     #[test]
     fn suspicious_qa_ignores_matching_inline_markers() {
-        let segment = marked_segment("seg_marker", 0, "<m id=\"m000000_000\">Hello</m>");
+        let segment = marked_segment("seg_marker", 0, "<m1>Hello</m1>");
         let translation = translation_for(
             &segment,
-            "<m id=\"m000000_000\">Ciao</m>",
+            "<m1>Ciao</m1>",
             "stored",
             SegmentStatus::Succeeded,
         );
@@ -2378,10 +2281,10 @@ case_sensitive = true
 
     #[test]
     fn suspicious_qa_includes_marker_id_mismatch() {
-        let segment = marked_segment("seg_marker", 0, "<m id=\"m000000_000\">Hello</m>");
+        let segment = marked_segment("seg_marker", 0, "<m1>Hello</m1>");
         let translation = translation_for(
             &segment,
-            "<m id=\"m000000_999\">Ciao</m>",
+            "<m2>Ciao</m2>",
             "stored",
             SegmentStatus::Succeeded,
         );
@@ -2394,13 +2297,8 @@ case_sensitive = true
 
     #[test]
     fn suspicious_qa_includes_marker_shape_mismatch() {
-        let segment = marked_segment("seg_marker", 0, "<m id=\"m000000_000\">Hello</m>");
-        let translation = translation_for(
-            &segment,
-            "<ref id=\"m000000_000\"/>",
-            "stored",
-            SegmentStatus::Succeeded,
-        );
+        let segment = marked_segment("seg_marker", 0, "<m1>Hello</m1>");
+        let translation = translation_for(&segment, "<m1/>", "stored", SegmentStatus::Succeeded);
 
         let candidates = suspicious_qa_candidates(&[segment], &[translation]);
 
@@ -2410,13 +2308,8 @@ case_sensitive = true
 
     #[test]
     fn suspicious_qa_includes_malformed_marker() {
-        let segment = marked_segment("seg_marker", 0, "<m id=\"m000000_000\">Hello</m>");
-        let translation = translation_for(
-            &segment,
-            "<m id=\"m000000_000\">Ciao",
-            "stored",
-            SegmentStatus::Succeeded,
-        );
+        let segment = marked_segment("seg_marker", 0, "<m1>Hello</m1>");
+        let translation = translation_for(&segment, "<m1>Ciao", "stored", SegmentStatus::Succeeded);
 
         let candidates = suspicious_qa_candidates(&[segment], &[translation]);
 

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -161,6 +161,7 @@ pub(crate) fn context_run_config_from_args(cli_args: &TranslateArgs) -> ContextR
         window: cli_args.context_window,
         budget_tokens: cli_args.context_budget_tokens,
         scope: cli_args.context_scope,
+        strict: cli_args.context_strict,
     }
 }
 
@@ -2602,6 +2603,7 @@ case_sensitive = true
             context_window: 0,
             context_budget_tokens: 1200,
             context_scope: bookforge_core::config::ContextScope::Chapter,
+            context_strict: false,
             style: Vec::new(),
             entities: Vec::new(),
             qa: QaMode::Off,

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -8,8 +8,8 @@ mod report;
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use commands::{
-    doctor, entity, estimate, glossary, ingest_flags, inspect, resume, retry, review, status,
-    style, tail, translate, validate,
+    convert, doctor, entity, estimate, glossary, ingest_flags, inspect, resume, retry, review,
+    status, style, tail, translate, validate,
 };
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -28,6 +28,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    Convert(convert::ConvertArgs),
     Inspect(inspect::InspectArgs),
     Estimate(estimate::EstimateArgs),
     Translate(Box<translate::TranslateArgs>),
@@ -58,6 +59,7 @@ async fn main() -> Result<()> {
     });
 
     match Cli::parse().command {
+        Command::Convert(args) => convert::run(args).await,
         Command::Inspect(args) => inspect::run(args).await,
         Command::Estimate(args) => estimate::run(args).await,
         Command::Translate(args) => translate::run(*args, cancel_token).await,

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -145,3 +145,21 @@ fn default_output_path(input: &std::path::Path, target: &str) -> PathBuf {
     let target = target.trim_matches('-');
     input.with_file_name(format!("{stem}.{target}.epub"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bookforge_core::config::TranslationProfile;
+
+    #[test]
+    fn translate_defaults_to_v1_fast_profile() {
+        let cli = Cli::parse_from(["bookforge", "translate", "book.epub", "--target", "Italian"]);
+
+        match cli.command {
+            Command::Translate(args) => {
+                assert_eq!(args.profile, TranslationProfile::V1Fast);
+            }
+            _ => panic!("expected translate command"),
+        }
+    }
+}

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -1,6 +1,8 @@
 use std::{
     fs,
+    io::Write,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use assert_cmd::Command;
@@ -8,38 +10,95 @@ use bookforge_core::{GlossaryCategory, GlossaryStatus, GlossaryTerm};
 use bookforge_store::{GlossaryFilter, JobStore, NewGlossaryCandidate};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 fn bookforge() -> Command {
     Command::cargo_bin("bookforge").expect("bookforge binary should be built")
 }
 
-fn workspace_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .expect("cli crate should be under crates/bookforge-cli")
-        .to_path_buf()
+// Builds a synthetic EPUB so lifecycle tests run in CI and contributor
+// checkouts without relying on local, gitignored book fixtures.
+fn fixture_input() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "bookforge-lifecycle-fixture-{}-{nanos}.epub",
+        std::process::id()
+    ));
+    build_lifecycle_epub(&path);
+    path
 }
 
-// Returns the path to test/test.epub if present, otherwise prints a skip line
-// and returns None. The fixture is gitignored; CI and contributor checkouts
-// must skip these tests rather than fail. See CLAUDE.md and CONTRIBUTING.md.
-fn fixture_input_or_skip() -> Option<PathBuf> {
-    let path = workspace_root().join("test/test.epub");
-    if !path.exists() {
-        let name = std::thread::current().name().unwrap_or("?").to_string();
-        eprintln!("[skip] {name}: requires test/test.epub fixture");
-        return None;
-    }
-    Some(path)
+fn build_lifecycle_epub(path: &Path) {
+    let file = fs::File::create(path).expect("fixture EPUB should be creatable");
+    let mut zip = ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/epub+zip").unwrap();
+    zip.start_file("META-INF/container.xml", deflated).unwrap();
+    zip.write_all(LIFECYCLE_CONTAINER_XML.as_bytes()).unwrap();
+    zip.start_file("content.opf", deflated).unwrap();
+    zip.write_all(LIFECYCLE_OPF.as_bytes()).unwrap();
+    zip.start_file("chapter1.xhtml", deflated).unwrap();
+    zip.write_all(LIFECYCLE_CHAPTER_ONE.as_bytes()).unwrap();
+    zip.start_file("chapter2.xhtml", deflated).unwrap();
+    zip.write_all(LIFECYCLE_CHAPTER_TWO.as_bytes()).unwrap();
+    zip.finish().unwrap();
 }
+
+const LIFECYCLE_CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+const LIFECYCLE_OPF: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">lifecycle-fixture</dc:identifier>
+    <dc:title>Lifecycle Fixture</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="chapter2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>"#;
+
+const LIFECYCLE_CHAPTER_ONE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Lifecycle Chapter One</title></head>
+<body>
+<h1>Lifecycle Chapter One</h1>
+<p>Ivan Ilych met Peter Ivanovich near Mount Doom. Ivan Ilych carried the Ring while Aragorn watched Mount Doom.</p>
+<p>Galadriel named Ivan Ilych and Ivan Ilych again. Mount Doom appeared, and Mount Doom remained in sight.</p>
+<p>Hello <em>formatted</em> link text with <a href="https://example.com">Example Link</a>.</p>
+</body>
+</html>"#;
+
+const LIFECYCLE_CHAPTER_TWO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Lifecycle Chapter Two</title></head>
+<body>
+<h1>Lifecycle Chapter Two</h1>
+<p>Aragorn and Gandalf returned to Mount Doom. Ivan Ilych remembered Peter Ivanovich and Galadriel.</p>
+<p>The Shire, Mount Doom, and Ivan Ilych are repeated here so glossary extraction has stable candidates.</p>
+</body>
+</html>"#;
 
 #[test]
 fn cli_translate_mock_quiet_writes_output_report_and_events() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
 
     assert!(run.output.exists(), "translated EPUB should exist");
     assert!(run.events.exists(), "event log should exist");
@@ -49,9 +108,7 @@ fn cli_translate_mock_quiet_writes_output_report_and_events() {
 #[test]
 fn cli_translate_context_window_persists_snapshot_settings() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let output = temp.path().join("out.epub");
     let events = temp.path().join("events.jsonl");
     bookforge()
@@ -100,9 +157,7 @@ fn cli_translate_context_window_persists_snapshot_settings() {
 #[test]
 fn cli_translate_with_style_sheet_persists_rendered_block_in_snapshot() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let style_path = temp.path().join("style.toml");
     fs::write(
         &style_path,
@@ -189,9 +244,7 @@ instructions = "Maintain a literary register typical of Italian fiction translat
 #[test]
 fn cli_translate_with_entities_persists_agreement_block_in_snapshot() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let entities_path = temp.path().join("entities.toml");
     fs::write(
         &entities_path,
@@ -290,9 +343,7 @@ fn cli_translate_batch_mode_with_sliding_context_completes_without_deadlock() {
     // happy path completes — the value is "doesn't hang", which the
     // 60-second test timeout enforces by failure.
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let output = temp.path().join("out.epub");
     let events = temp.path().join("events.jsonl");
     bookforge()
@@ -332,9 +383,7 @@ fn cli_translate_with_full_v1_3_stack_persists_all_three_blocks() {
     // PRs interoperate end-to-end (PR1 sliding context + PR2 style +
     // PR3 entities + PR4 plumbing).
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let style_path = temp.path().join("style.toml");
     fs::write(
         &style_path,
@@ -538,9 +587,7 @@ narration = "neutral"
 #[test]
 fn cli_translate_mock_with_same_glossary_is_bit_identical() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let glossary = temp.path().join("glossary.toml");
     fs::write(
         &glossary,
@@ -707,9 +754,7 @@ source_count = 2
 #[test]
 fn cli_glossary_extract_candidates_stores_auto_candidates() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
 
     bookforge()
         .current_dir(temp.path())
@@ -751,9 +796,7 @@ fn cli_glossary_extract_candidates_stores_auto_candidates() {
 #[test]
 fn cli_glossary_review_candidates_accepts_sets_and_rejects() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let store_path = temp.path().join(".bookforge/jobs.sqlite");
     let store = JobStore::open(&store_path).expect("store opens");
     store
@@ -891,9 +934,7 @@ fn cli_glossary_review_candidates_requires_language_when_ambiguous() {
 #[test]
 fn cli_translate_json_mode_emits_valid_jsonl_stdout_and_file_log() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(input) = fixture_input_or_skip() else {
-        return;
-    };
+    let input = fixture_input();
     let output = temp.path().join("json.epub");
     let events = temp.path().join("json-events.jsonl");
     let assert = bookforge()
@@ -978,9 +1019,7 @@ fn normalized_terms(mut terms: Vec<GlossaryTerm>) -> Vec<GlossaryTerm> {
 #[test]
 fn cli_status_after_translate_reports_succeeded_job() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
 
     let assert = bookforge()
         .current_dir(temp.path())
@@ -1001,9 +1040,7 @@ fn cli_status_after_translate_reports_succeeded_job() {
 #[test]
 fn cli_tail_after_translate_prints_recent_events() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
 
     let assert = bookforge()
         .current_dir(temp.path())
@@ -1019,9 +1056,7 @@ fn cli_tail_after_translate_prints_recent_events() {
 #[test]
 fn cli_tail_json_outputs_valid_jsonl() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
 
     let assert = bookforge()
         .current_dir(temp.path())
@@ -1056,9 +1091,7 @@ fn cli_resume_missing_job_fails_clearly() {
 #[test]
 fn cli_resume_reuses_checkpointed_segments() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
     let resume_events = temp.path().join("resume-events.jsonl");
     let store = JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store opens");
     let segment_ids = store
@@ -1111,9 +1144,7 @@ fn cli_resume_reuses_checkpointed_segments() {
 #[test]
 fn cli_resume_uses_input_snapshot_after_original_is_moved() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(fixture) = fixture_input_or_skip() else {
-        return;
-    };
+    let fixture = fixture_input();
     let input = temp.path().join("source.epub");
     let moved = temp.path().join("source-moved.epub");
     fs::copy(&fixture, &input).expect("fixture should copy");
@@ -1161,9 +1192,7 @@ fn cli_resume_uses_input_snapshot_after_original_is_moved() {
 #[test]
 fn cli_review_generates_artifacts_and_ingest_flags_marks_retry() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
-    let Some(run) = translate_quiet(&temp, "mock-prefix-target") else {
-        return;
-    };
+    let run = translate_quiet(&temp, "mock-prefix-target");
     let review_dir = temp.path().join("review-out");
 
     bookforge()
@@ -1274,9 +1303,9 @@ struct TranslateRun {
     report: PathBuf,
 }
 
-fn translate_quiet(temp: &TempDir, model: &str) -> Option<TranslateRun> {
-    let input = fixture_input_or_skip()?;
-    Some(translate_quiet_input(temp, &input, model))
+fn translate_quiet(temp: &TempDir, model: &str) -> TranslateRun {
+    let input = fixture_input();
+    translate_quiet_input(temp, &input, model)
 }
 
 fn translate_quiet_input(temp: &TempDir, input: &Path, model: &str) -> TranslateRun {

--- a/crates/bookforge-cli/tests/roundtrip.rs
+++ b/crates/bookforge-cli/tests/roundtrip.rs
@@ -64,6 +64,67 @@ fn opf(chapter_files: &[&str]) -> String {
     )
 }
 
+fn opf_with_ncx(chapter_files: &[&str]) -> String {
+    let manifest = chapter_files
+        .iter()
+        .enumerate()
+        .map(|(i, href)| {
+            format!(r#"    <item id="ch{i}" href="{href}" media-type="application/xhtml+xml"/>"#)
+        })
+        .chain(std::iter::once(
+            r#"    <item id="toc" href="toc.ncx" media-type="application/x-dtbncx+xml"/>"#
+                .to_string(),
+        ))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let spine = chapter_files
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!(r#"    <itemref idref="ch{i}"/>"#))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">roundtrip-fixture</dc:identifier>
+    <dc:title>Roundtrip Fixture</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+{manifest}
+  </manifest>
+  <spine toc="toc">
+{spine}
+  </spine>
+</package>"#
+    )
+}
+
+fn ncx(chapter_files: &[&str]) -> String {
+    let nav_points = chapter_files
+        .iter()
+        .enumerate()
+        .map(|(i, href)| {
+            format!(
+                r##"    <navPoint id="nav{i}" playOrder="{}"><navLabel><text>Chapter</text></navLabel><content src="{href}"/></navPoint>"##,
+                i + 1
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head><meta name="dtb:uid" content="roundtrip-fixture"/></head>
+  <docTitle><text>Roundtrip Fixture</text></docTitle>
+  <navMap>
+{nav_points}
+  </navMap>
+</ncx>"#
+    )
+}
+
 fn chapter(body: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -100,6 +161,31 @@ fn build_epub(dir: &Path, name: &str, chapters: &[(&str, &str)]) -> PathBuf {
     path
 }
 
+fn build_epub_with_ncx(dir: &Path, name: &str, chapters: &[(&str, &str)]) -> PathBuf {
+    let path = dir.join(name);
+    let file = File::create(&path).expect("fixture EPUB should be creatable");
+    let mut zip = ZipWriter::new(file);
+
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/epub+zip").unwrap();
+    zip.start_file("META-INF/container.xml", deflated).unwrap();
+    zip.write_all(CONTAINER_XML.as_bytes()).unwrap();
+    let hrefs = chapters.iter().map(|(href, _)| *href).collect::<Vec<_>>();
+    zip.start_file("content.opf", deflated).unwrap();
+    zip.write_all(opf_with_ncx(&hrefs).as_bytes()).unwrap();
+    zip.start_file("toc.ncx", deflated).unwrap();
+    zip.write_all(ncx(&hrefs).as_bytes()).unwrap();
+    for (href, body) in chapters {
+        zip.start_file(*href, deflated).unwrap();
+        zip.write_all(chapter(body).as_bytes()).unwrap();
+    }
+    zip.finish().unwrap();
+    path
+}
+
 struct RoundtripRun {
     _temp: TempDir,
     output: PathBuf,
@@ -109,6 +195,38 @@ struct RoundtripRun {
 fn translate(chapters: &[(&str, &str)], model: &str) -> RoundtripRun {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let input = build_epub(temp.path(), "in.epub", chapters);
+    let output = temp.path().join("out.epub");
+    Command::cargo_bin("bookforge")
+        .expect("bookforge binary should be built")
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--source",
+            "English",
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            model,
+            "--ui",
+            "quiet",
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(output.exists(), "translated EPUB should exist");
+    RoundtripRun {
+        _temp: temp,
+        output,
+    }
+}
+
+fn translate_with_ncx(chapters: &[(&str, &str)], model: &str) -> RoundtripRun {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = build_epub_with_ncx(temp.path(), "in.epub", chapters);
     let output = temp.path().join("out.epub");
     Command::cargo_bin("bookforge")
         .expect("bookforge binary should be built")
@@ -386,6 +504,34 @@ fn ingestion_survives_named_html_entities() {
     let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
     let text = body_text(&run.output, "ch1.xhtml");
     assert_translated(&text, "ENTITY_SENTINEL");
+}
+
+#[test]
+fn coverage_opf_ncx_and_head_titles() {
+    let body = r#"<h1>BODY_TITLE_SENTINEL</h1><p>BODY_SENTINEL text.</p>"#;
+    let run = translate_with_ncx(&[("ch1.xhtml", body)], "mock-prefix-target");
+
+    let opf = read_zip_text(&run.output, "content.opf");
+    assert!(
+        opf.contains("<dc:title>[Italian] Roundtrip Fixture</dc:title>"),
+        "OPF dc:title should be translated, got: {opf}"
+    );
+
+    let chapter = read_zip_text(&run.output, "ch1.xhtml");
+    assert!(
+        chapter.contains("<title>[Italian] Chapter</title>"),
+        "XHTML head title should be translated, got: {chapter}"
+    );
+
+    let toc = read_zip_text(&run.output, "toc.ncx");
+    assert!(
+        toc.contains("<text>[Italian] Roundtrip Fixture</text>"),
+        "NCX docTitle should be translated, got: {toc}"
+    );
+    assert!(
+        toc.contains("<text>[Italian] Chapter</text>"),
+        "NCX navLabel should be translated, got: {toc}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bookforge-cli/tests/roundtrip.rs
+++ b/crates/bookforge-cli/tests/roundtrip.rs
@@ -339,7 +339,6 @@ fn coverage_paragraphs_headings_lists_quotes() {
 }
 
 #[test]
-#[ignore = "known bug: text directly inside <div>/<dt>/<dd>/<figure>/naked <body> is never extracted and ships untranslated (block_kind whitelist in bookforge-epub/src/reader.rs)"]
 fn coverage_div_and_naked_body_text() {
     let body = r#"<div class="ccru-fragment">DIV_SENTINEL hyperstition node</div>
 <dl><dt>DT_SENTINEL</dt><dd>DD_SENTINEL definition</dd></dl>
@@ -360,7 +359,6 @@ NAKED_SENTINEL floating in body"#;
 }
 
 #[test]
-#[ignore = "known bug: nested same-name blocks (li>ul>li) close the outer block at the first matching end tag; inner patches are silently dropped (reader.rs End handling vs writer.rs depth-tracked buffering)"]
 fn coverage_nested_lists() {
     let body = r#"<ul>
 <li>OUTER_SENTINEL intro
@@ -383,7 +381,6 @@ tail text TAIL_SENTINEL</li>
 }
 
 #[test]
-#[ignore = "known bug: named HTML entities (&nbsp; &mdash;) are not resolvable by quick-xml without a custom resolver; ingestion fails on books that use them"]
 fn ingestion_survives_named_html_entities() {
     let body = "<p>ENTITY_SENTINEL one&nbsp;two&mdash;three</p>";
     let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");

--- a/crates/bookforge-cli/tests/roundtrip.rs
+++ b/crates/bookforge-cli/tests/roundtrip.rs
@@ -1,0 +1,407 @@
+//! Identity-roundtrip harness over a synthetic EPUB corpus.
+//!
+//! Two oracles, two mock models:
+//!
+//! - `mock-identity` checks **structure preservation**: translating a book
+//!   with the identity transform must leave every byte of visible text and
+//!   whitespace-sensitive content (e.g. `<pre>`) unchanged.
+//! - `mock-prefix-target` checks **coverage**: every piece of prose the
+//!   reader claims to own must come back carrying the `[Italian]` prefix.
+//!   Sentinel words that appear in the output without the prefix were never
+//!   sent to the model — silently untranslated text.
+//!
+//! Tests marked `#[ignore]` document known extraction bugs; un-ignore them
+//! as the corresponding reader fixes land.
+
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+use assert_cmd::Command;
+use quick_xml::{Reader, events::Event};
+use tempfile::TempDir;
+use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
+
+const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+fn opf(chapter_files: &[&str]) -> String {
+    let manifest = chapter_files
+        .iter()
+        .enumerate()
+        .map(|(i, href)| {
+            format!(r#"    <item id="ch{i}" href="{href}" media-type="application/xhtml+xml"/>"#)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let spine = chapter_files
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!(r#"    <itemref idref="ch{i}"/>"#))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">roundtrip-fixture</dc:identifier>
+    <dc:title>Roundtrip Fixture</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+{manifest}
+  </manifest>
+  <spine>
+{spine}
+  </spine>
+</package>"#
+    )
+}
+
+fn chapter(body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Chapter</title></head>
+<body>
+{body}
+</body>
+</html>"#
+    )
+}
+
+/// Build a minimal valid EPUB at `dir/name` from (filename, body-html) pairs.
+fn build_epub(dir: &Path, name: &str, chapters: &[(&str, &str)]) -> PathBuf {
+    let path = dir.join(name);
+    let file = File::create(&path).expect("fixture EPUB should be creatable");
+    let mut zip = ZipWriter::new(file);
+
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/epub+zip").unwrap();
+    zip.start_file("META-INF/container.xml", deflated).unwrap();
+    zip.write_all(CONTAINER_XML.as_bytes()).unwrap();
+    let hrefs = chapters.iter().map(|(href, _)| *href).collect::<Vec<_>>();
+    zip.start_file("content.opf", deflated).unwrap();
+    zip.write_all(opf(&hrefs).as_bytes()).unwrap();
+    for (href, body) in chapters {
+        zip.start_file(*href, deflated).unwrap();
+        zip.write_all(chapter(body).as_bytes()).unwrap();
+    }
+    zip.finish().unwrap();
+    path
+}
+
+struct RoundtripRun {
+    _temp: TempDir,
+    output: PathBuf,
+}
+
+/// Translate `chapters` with the given mock model and return the output EPUB.
+fn translate(chapters: &[(&str, &str)], model: &str) -> RoundtripRun {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = build_epub(temp.path(), "in.epub", chapters);
+    let output = temp.path().join("out.epub");
+    Command::cargo_bin("bookforge")
+        .expect("bookforge binary should be built")
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--source",
+            "English",
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            model,
+            "--ui",
+            "quiet",
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(output.exists(), "translated EPUB should exist");
+    RoundtripRun {
+        _temp: temp,
+        output,
+    }
+}
+
+fn read_zip_text(epub: &Path, member: &str) -> String {
+    let file = File::open(epub).expect("EPUB should open");
+    let mut archive = ZipArchive::new(file).expect("EPUB should be a zip");
+    let mut entry = archive.by_name(member).expect("member should exist");
+    let mut text = String::new();
+    entry
+        .read_to_string(&mut text)
+        .expect("member should be UTF-8");
+    text
+}
+
+/// Whitespace-normalized visible text of `<body>`.
+fn body_text(epub: &Path, member: &str) -> String {
+    let xhtml = read_zip_text(epub, member);
+    extract_text(&xhtml, None)
+}
+
+/// Raw (whitespace-exact) text content of every `<pre>` element, in order.
+fn pre_texts(epub: &Path, member: &str) -> Vec<String> {
+    let xhtml = read_zip_text(epub, member);
+    let mut reader = Reader::from_str(&xhtml);
+    reader.config_mut().trim_text(false);
+    let mut depth = 0usize;
+    let mut current = String::new();
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event().expect("fixture XHTML should parse") {
+            Event::Start(e) if e.local_name().as_ref() == b"pre" => {
+                depth += 1;
+            }
+            Event::End(e) if e.local_name().as_ref() == b"pre" => {
+                depth -= 1;
+                if depth == 0 {
+                    out.push(std::mem::take(&mut current));
+                }
+            }
+            Event::Text(t) if depth > 0 => current.push_str(&t.decode().unwrap()),
+            Event::CData(t) if depth > 0 => {
+                current.push_str(&t.decode().unwrap());
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    out
+}
+
+fn extract_text(xhtml: &str, within: Option<&[u8]>) -> String {
+    let mut reader = Reader::from_str(xhtml);
+    reader.config_mut().trim_text(false);
+    let scope = within.unwrap_or(b"body");
+    let mut in_scope = false;
+    let mut text = String::new();
+    loop {
+        match reader.read_event().expect("XHTML should parse") {
+            Event::Start(e) if e.local_name().as_ref() == scope => in_scope = true,
+            Event::End(e) if e.local_name().as_ref() == scope => in_scope = false,
+            Event::Text(t) if in_scope => text.push_str(&t.decode().unwrap()),
+            Event::CData(t) if in_scope => text.push_str(&t.decode().unwrap()),
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    normalize_ws(&text)
+}
+
+fn normalize_ws(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+const PREFIX: &str = "[Italian]";
+
+/// Assert that `sentinel` appears in the text and is covered by translation:
+/// somewhere in the same output, the prefix marker must precede it within its
+/// block. We approximate "same block" by requiring the sentinel to NOT appear
+/// in any stretch of text that lacks the prefix entirely.
+fn assert_translated(out_text: &str, sentinel: &str) {
+    assert!(
+        out_text.contains(sentinel),
+        "sentinel '{sentinel}' must survive translation, got: {out_text}"
+    );
+    // Identity check on coverage: text reachable by the reader always comes
+    // back as "[Italian] <original block text>". If the sentinel's block was
+    // never sent to the model there is no prefix anywhere before it up to the
+    // previous prefixed block.
+    let position = out_text.find(sentinel).unwrap();
+    let preceding = &out_text[..position];
+    let last_prefix = preceding.rfind(PREFIX);
+    assert!(
+        last_prefix.is_some(),
+        "sentinel '{sentinel}' appears with no '{PREFIX}' marker before it — its block was never translated.\nOutput: {out_text}"
+    );
+}
+
+fn assert_untranslated(out_text: &str, sentinel: &str) {
+    let position = out_text
+        .find(sentinel)
+        .unwrap_or_else(|| panic!("sentinel '{sentinel}' must appear in output: {out_text}"));
+    let between = &out_text[..position];
+    // The block carrying the sentinel must not start with the prefix. Look at
+    // the text from the last prefix to the sentinel: if a prefix immediately
+    // governs this block, the distance is short and within the same block.
+    // For fixture purposes the untranslated sentinel is in its own block, so
+    // it is enough that "[Italian] SENTINEL" never occurs.
+    let _ = between;
+    assert!(
+        !out_text.contains(&format!("{PREFIX} {sentinel}")),
+        "sentinel '{sentinel}' was unexpectedly translated: {out_text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Structure preservation (mock-identity): output visible text == input.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identity_roundtrip_preserves_basic_prose_and_inline_markup() {
+    let body = r#"<h1>Chapter One</h1>
+<p>Plain paragraph with an em dash — and an ellipsis…</p>
+<p>Hello <em>brave new</em> world, with a <a href="https://example.com">link</a>!</p>
+<p>Line one<br/>line two.</p>
+<blockquote>A quote with <strong>bold</strong> text.</blockquote>
+<ul><li>First item</li><li>Second item</li></ul>"#;
+    let chapters = [("ch1.xhtml", body)];
+    let probe_dir = tempfile::tempdir().unwrap();
+    let input = build_epub(probe_dir.path(), "probe.epub", &chapters);
+    let expected = body_text(&input, "ch1.xhtml");
+
+    let run = translate(&chapters, "mock-identity");
+    let actual = body_text(&run.output, "ch1.xhtml");
+
+    assert_eq!(
+        expected, actual,
+        "identity translation must not change visible text"
+    );
+}
+
+#[test]
+fn identity_roundtrip_preserves_pre_block_whitespace_exactly() {
+    let body = "<p>Before the diagram.</p>\n<pre>  col1   col2\n  a      b\n\n  zone:9 ::: gate</pre>\n<p>After the diagram.</p>";
+    let chapters = [("ch1.xhtml", body)];
+    let probe_dir = tempfile::tempdir().unwrap();
+    let input = build_epub(probe_dir.path(), "probe.epub", &chapters);
+    let expected = pre_texts(&input, "ch1.xhtml");
+    assert_eq!(expected.len(), 1, "fixture should contain one pre block");
+
+    let run = translate(&chapters, "mock-identity");
+    let actual = pre_texts(&run.output, "ch1.xhtml");
+
+    assert_eq!(
+        expected, actual,
+        "pre/code content must survive translation byte-for-byte"
+    );
+}
+
+#[test]
+fn identity_roundtrip_does_not_invent_text_in_empty_elements() {
+    let body = r#"<p>Real content.</p>
+<p/>
+<p></p>
+<table><tr><td>cell</td><td/></tr></table>"#;
+    let chapters = [("ch1.xhtml", body)];
+    let run = translate(&chapters, "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+
+    // The only translated text must be the two non-empty blocks. A prefix
+    // with nothing after it means an empty element received hallucinated
+    // model output.
+    let occurrences = text.matches(PREFIX).count();
+    assert_eq!(
+        occurrences, 2,
+        "empty elements must not be sent to the model (expected 2 translated blocks), got: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Coverage (mock-prefix-target): everything readable must carry the prefix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coverage_paragraphs_headings_lists_quotes() {
+    let body = r#"<h2>HEAD_SENTINEL</h2>
+<p>PARA_SENTINEL with prose.</p>
+<ul><li>LIST_SENTINEL entry</li></ul>
+<blockquote>QUOTE_SENTINEL text</blockquote>
+<table><tr><td>CELL_SENTINEL</td></tr></table>"#;
+    let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+
+    for sentinel in [
+        "HEAD_SENTINEL",
+        "PARA_SENTINEL",
+        "LIST_SENTINEL",
+        "QUOTE_SENTINEL",
+        "CELL_SENTINEL",
+    ] {
+        assert_translated(&text, sentinel);
+    }
+}
+
+#[test]
+#[ignore = "known bug: text directly inside <div>/<dt>/<dd>/<figure>/naked <body> is never extracted and ships untranslated (block_kind whitelist in bookforge-epub/src/reader.rs)"]
+fn coverage_div_and_naked_body_text() {
+    let body = r#"<div class="ccru-fragment">DIV_SENTINEL hyperstition node</div>
+<dl><dt>DT_SENTINEL</dt><dd>DD_SENTINEL definition</dd></dl>
+<figure><div>FIGDIV_SENTINEL</div></figure>
+NAKED_SENTINEL floating in body"#;
+    let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+
+    for sentinel in [
+        "DIV_SENTINEL",
+        "DT_SENTINEL",
+        "DD_SENTINEL",
+        "FIGDIV_SENTINEL",
+        "NAKED_SENTINEL",
+    ] {
+        assert_translated(&text, sentinel);
+    }
+}
+
+#[test]
+#[ignore = "known bug: nested same-name blocks (li>ul>li) close the outer block at the first matching end tag; inner patches are silently dropped (reader.rs End handling vs writer.rs depth-tracked buffering)"]
+fn coverage_nested_lists() {
+    let body = r#"<ul>
+<li>OUTER_SENTINEL intro
+  <ul><li>INNER_ONE_SENTINEL</li><li>INNER_TWO_SENTINEL</li></ul>
+tail text TAIL_SENTINEL</li>
+<li>SIBLING_SENTINEL</li>
+</ul>"#;
+    let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+
+    for sentinel in [
+        "OUTER_SENTINEL",
+        "INNER_ONE_SENTINEL",
+        "INNER_TWO_SENTINEL",
+        "TAIL_SENTINEL",
+        "SIBLING_SENTINEL",
+    ] {
+        assert_translated(&text, sentinel);
+    }
+}
+
+#[test]
+#[ignore = "known bug: named HTML entities (&nbsp; &mdash;) are not resolvable by quick-xml without a custom resolver; ingestion fails on books that use them"]
+fn ingestion_survives_named_html_entities() {
+    let body = "<p>ENTITY_SENTINEL one&nbsp;two&mdash;three</p>";
+    let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+    assert_translated(&text, "ENTITY_SENTINEL");
+}
+
+// ---------------------------------------------------------------------------
+// Code blocks must not be translated at all (lands with the Code-skip fix).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn code_blocks_are_not_sent_to_the_model() {
+    let body = r#"<p>PROSE_SENTINEL before.</p>
+<pre>CODE_SENTINEL := numogram(9)</pre>"#;
+    let run = translate(&[("ch1.xhtml", body)], "mock-prefix-target");
+    let text = body_text(&run.output, "ch1.xhtml");
+
+    assert_translated(&text, "PROSE_SENTINEL");
+    assert_untranslated(&text, "CODE_SENTINEL");
+}

--- a/crates/bookforge-core/src/config.rs
+++ b/crates/bookforge-core/src/config.rs
@@ -32,6 +32,8 @@ impl Default for SegmentationConfig {
 pub enum PromptVersion {
     V1,
     BatchV1,
+    V2,
+    BatchV2,
 }
 
 impl PromptVersion {
@@ -39,6 +41,8 @@ impl PromptVersion {
         match self {
             PromptVersion::V1 => "v1",
             PromptVersion::BatchV1 => "batch_v1",
+            PromptVersion::V2 => "v2",
+            PromptVersion::BatchV2 => "batch_v2",
         }
     }
 }

--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ir::Block, marker::extract_marker_id, segment::Segment};
+use crate::{ir::Block, marker::parse_paired_marker_open, segment::Segment};
 
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -541,23 +541,25 @@ fn collect_quoted_italic_candidates(
     let mut sources = HashSet::new();
     let marked = marked_block_text(block);
     let mut offset = 0usize;
-    while let Some(relative_start) = marked[offset..].find("<m ") {
+    while let Some(relative_start) = marked[offset..].find('<') {
         let tag_start = offset + relative_start;
-        let Some(relative_tag_end) = marked[tag_start..].find('>') else {
-            break;
-        };
-        let tag_end = tag_start + relative_tag_end + 1;
-        let tag = &marked[tag_start..tag_end];
-        let Some(marker_id) = extract_marker_id(tag) else {
-            offset = tag_end;
+        let tag = &marked[tag_start..];
+        let Some(open) = parse_paired_marker_open(tag) else {
+            offset = tag_start + 1;
             continue;
         };
-        let Some(relative_close) = marked[tag_end..].find("</m>") else {
+        if !open.id.starts_with('m') {
+            offset = tag_start + open.len;
+            continue;
+        }
+        let tag_end = tag_start + open.len;
+        let close = format!("</{}>", open.tag_name);
+        let Some(relative_close) = marked[tag_end..].find(&close) else {
             break;
         };
         let close_start = tag_end + relative_close;
-        let close_end = close_start + "</m>".len();
-        if italic_ids.contains(marker_id.as_str()) {
+        let close_end = close_start + close.len();
+        if italic_ids.contains(open.id.as_str()) {
             let raw_content = &marked[tag_end..close_start];
             if let Some(phrase) = quoted_italic_phrase(&marked, tag_start, close_end, raw_content) {
                 sources.insert(phrase.to_lowercase());
@@ -684,24 +686,7 @@ fn block_visible_text(block: &Block) -> String {
 }
 
 fn strip_marker_tokens(text: &str) -> String {
-    let mut output = String::new();
-    let mut rest = text;
-
-    while let Some(index) = rest.find('<') {
-        output.push_str(&rest[..index]);
-        let tag = &rest[index..];
-        if (tag.starts_with("<m ") || tag.starts_with("<ref ") || tag.starts_with("</m>"))
-            && let Some(end) = tag.find('>')
-        {
-            rest = &tag[end + 1..];
-            continue;
-        }
-        output.push('<');
-        rest = &tag[1..];
-    }
-
-    output.push_str(rest);
-    output
+    crate::marker::strip_marker_tokens(text)
 }
 
 fn previous_visible_char(text: &str) -> Option<char> {
@@ -909,13 +894,9 @@ mod tests {
     #[test]
     fn extraction_discovers_quoted_italic_invented_phrases() {
         let blocks = vec![marked_block(
-            vec![
-                "He whispered “",
-                "<m id=\"m000000_000\">Lukh</m>",
-                "” once.",
-            ],
+            vec!["He whispered “", "<m1>Lukh</m1>", "” once."],
             vec![InlineMark {
-                id: "m000000_000".to_string(),
+                id: "m1".to_string(),
                 kind: "em".to_string(),
             }],
         )];

--- a/crates/bookforge-core/src/ir.rs
+++ b/crates/bookforge-core/src/ir.rs
@@ -91,6 +91,14 @@ pub enum BlockKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DomPath(pub Vec<usize>);
 
+/// Path component base for addressing text nodes. Element children are
+/// indexed 0, 1, 2, ...; the N-th non-whitespace text node inside an
+/// element is addressed as `TEXT_NODE_PATH_BASE + N` in the final path
+/// component. The offset keeps text-node addresses from ever colliding
+/// with element indices. Reader and writer must count the same set of
+/// text nodes (non-whitespace after entity decoding) for paths to align.
+pub const TEXT_NODE_PATH_BASE: usize = usize::MAX / 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextRun {
     pub id: String,

--- a/crates/bookforge-core/src/marker.rs
+++ b/crates/bookforge-core/src/marker.rs
@@ -1,27 +1,38 @@
 use std::collections::HashSet;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairedMarkerOpen {
+    pub tag_name: String,
+    pub id: String,
+    pub len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmptyMarker {
+    pub id: String,
+    pub len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerClose {
+    pub tag_name: String,
+    pub len: usize,
+}
+
 pub fn marker_ids_in_text(text: &str) -> Vec<String> {
     let mut ids = Vec::new();
     let mut rest = text;
 
     while let Some(index) = rest.find('<') {
         let tag = &rest[index..];
-        if (tag.starts_with("<m ") || tag.starts_with("<keep "))
-            && let Some(end) = tag.find('>')
-        {
-            if let Some(id) = extract_marker_id(&tag[..=end]) {
-                ids.push(id);
-            }
-            rest = &tag[end + 1..];
-        } else if tag.starts_with("<ref ") {
-            if let Some(end) = tag.find("/>") {
-                if let Some(id) = extract_marker_id(&tag[..end + 2]) {
-                    ids.push(id);
-                }
-                rest = &tag[end + 2..];
-            } else {
-                rest = &tag[1..];
-            }
+        if let Some(open) = parse_paired_marker_open(tag) {
+            ids.push(open.id);
+            rest = &tag[open.len..];
+        } else if let Some(empty) = parse_empty_marker(tag) {
+            ids.push(empty.id);
+            rest = &tag[empty.len..];
+        } else if let Some(close) = parse_marker_close(tag) {
+            rest = &tag[close.len..];
         } else {
             rest = &tag[1..];
         }
@@ -31,6 +42,10 @@ pub fn marker_ids_in_text(text: &str) -> Vec<String> {
 }
 
 pub fn extract_marker_id(tag: &str) -> Option<String> {
+    extract_marker_id_attr(tag).or_else(|| short_marker_name(tag).map(ToString::to_string))
+}
+
+fn extract_marker_id_attr(tag: &str) -> Option<String> {
     let id_offset = tag.find("id=")? + 3;
     let quote = tag[id_offset..].chars().next()?;
     if quote != '"' && quote != '\'' {
@@ -41,12 +56,158 @@ pub fn extract_marker_id(tag: &str) -> Option<String> {
     Some(tag[value_start..value_end].to_string())
 }
 
+pub fn parse_paired_marker_open(text: &str) -> Option<PairedMarkerOpen> {
+    if !text.starts_with('<') {
+        return None;
+    }
+    for tag_name in ["m", "keep"] {
+        let prefix = format!("<{tag_name} ");
+        if !text.starts_with(&prefix) {
+            continue;
+        }
+        let open_end = text.find('>')?;
+        if text[..open_end].ends_with('/') {
+            return None;
+        }
+        let id = extract_marker_id_attr(&text[..=open_end])?;
+        return Some(PairedMarkerOpen {
+            tag_name: tag_name.to_string(),
+            id,
+            len: open_end + 1,
+        });
+    }
+
+    let open_end = text.find('>')?;
+    if open_end == 0 {
+        return None;
+    }
+    if text[..open_end].ends_with('/') {
+        return None;
+    }
+    let name = &text[1..open_end];
+    if is_short_paired_marker_name(name) {
+        return Some(PairedMarkerOpen {
+            tag_name: name.to_string(),
+            id: name.to_string(),
+            len: open_end + 1,
+        });
+    }
+
+    None
+}
+
+pub fn parse_empty_marker(text: &str) -> Option<EmptyMarker> {
+    if !text.starts_with('<') {
+        return None;
+    }
+    for tag_name in ["ref", "m", "keep"] {
+        let prefix = format!("<{tag_name} ");
+        if !text.starts_with(&prefix) {
+            continue;
+        }
+        let end = text.find('>')?;
+        let tag = &text[..=end];
+        if !tag.ends_with("/>") {
+            return None;
+        }
+        let id = extract_marker_id_attr(tag)?;
+        return Some(EmptyMarker { id, len: end + 1 });
+    }
+
+    let end = text.find('>')?;
+    if end < 2 {
+        return None;
+    }
+    let tag = &text[..=end];
+    if !tag.ends_with("/>") {
+        return None;
+    }
+    let name = &text[1..end - 1];
+    if is_short_empty_marker_name(name) || is_short_paired_marker_name(name) {
+        return Some(EmptyMarker {
+            id: name.to_string(),
+            len: end + 1,
+        });
+    }
+
+    None
+}
+
+pub fn parse_marker_close(text: &str) -> Option<MarkerClose> {
+    if !text.starts_with("</") {
+        return None;
+    }
+    for tag_name in ["m", "keep"] {
+        let close = format!("</{tag_name}>");
+        if text.starts_with(&close) {
+            return Some(MarkerClose {
+                tag_name: tag_name.to_string(),
+                len: close.len(),
+            });
+        }
+    }
+
+    let end = text.find('>')?;
+    let name = &text[2..end];
+    if is_short_paired_marker_name(name) {
+        return Some(MarkerClose {
+            tag_name: name.to_string(),
+            len: end + 1,
+        });
+    }
+
+    None
+}
+
 pub fn is_marker_token(text: &str) -> bool {
     let text = text.trim();
-    text == "</m>"
-        || text.starts_with("<m ")
-        || text.starts_with("<keep ")
-        || text.starts_with("<ref ")
+    parse_paired_marker_open(text).is_some_and(|marker| marker.len == text.len())
+        || parse_empty_marker(text).is_some_and(|marker| marker.len == text.len())
+        || parse_marker_close(text).is_some_and(|marker| marker.len == text.len())
+}
+
+pub fn strip_marker_tokens(text: &str) -> String {
+    let mut output = String::new();
+    let mut rest = text;
+
+    while let Some(index) = rest.find('<') {
+        output.push_str(&rest[..index]);
+        let tag = &rest[index..];
+
+        if let Some(open) = parse_paired_marker_open(tag) {
+            rest = &tag[open.len..];
+        } else if let Some(empty) = parse_empty_marker(tag) {
+            rest = &tag[empty.len..];
+        } else if let Some(close) = parse_marker_close(tag) {
+            rest = &tag[close.len..];
+        } else {
+            output.push('<');
+            rest = &tag[1..];
+        }
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn short_marker_name(tag: &str) -> Option<&str> {
+    if let Some(open) = tag.strip_prefix("</") {
+        let name = open.strip_suffix('>')?;
+        return is_short_paired_marker_name(name).then_some(name);
+    }
+    let body = tag.strip_prefix('<')?.strip_suffix('>')?;
+    let name = body.strip_suffix('/').unwrap_or(body);
+    (is_short_paired_marker_name(name) || is_short_empty_marker_name(name)).then_some(name)
+}
+
+fn is_short_paired_marker_name(name: &str) -> bool {
+    name.strip_prefix('m')
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn is_short_empty_marker_name(name: &str) -> bool {
+    name.strip_prefix('r')
+        .is_some_and(|suffix| !suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_digit()))
 }
 
 pub fn has_markers_in_expected_set(text: &str, expected: &HashSet<String>) -> bool {
@@ -56,4 +217,42 @@ pub fn has_markers_in_expected_set(text: &str, expected: &HashSet<String>) -> bo
 
 pub fn all_markers_present(text: &str, required: &[String]) -> bool {
     required.iter().all(|marker| text.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_ids_include_short_and_legacy_markers() {
+        let ids =
+            marker_ids_in_text(r#"A <m1>bold <r1/> text</m1> and <m id="m000000_000">old</m>."#);
+
+        assert_eq!(ids, vec!["m1", "r1", "m000000_000"]);
+    }
+
+    #[test]
+    fn parses_short_marker_tokens() {
+        let open = parse_paired_marker_open("<m12>text</m12>").expect("short paired marker");
+        assert_eq!(open.tag_name, "m12");
+        assert_eq!(open.id, "m12");
+        assert_eq!(open.len, "<m12>".len());
+
+        let empty = parse_empty_marker("<r3/>tail").expect("short empty marker");
+        assert_eq!(empty.id, "r3");
+        assert_eq!(empty.len, "<r3/>".len());
+
+        let close = parse_marker_close("</m12>").expect("short close marker");
+        assert_eq!(close.tag_name, "m12");
+        assert_eq!(close.len, "</m12>".len());
+    }
+
+    #[test]
+    fn strips_short_and_legacy_marker_tokens() {
+        let stripped = strip_marker_tokens(
+            r#"Hello <m1>wide <ref id="r000000_000"/> world</m1> and <m id="m000000_000">old</m>."#,
+        );
+
+        assert_eq!(stripped, "Hello wide  world and old.");
+    }
 }

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -12,7 +12,10 @@ pub const CACHE_KEY_SCHEMA_VERSION: u32 = 2;
 /// Bumped when Segment / SegmentBlock layout changes incompatibly.
 pub const SEGMENT_SCHEMA_VERSION: u32 = 1;
 /// Bumped when inline marker extraction (m/keep/ref) changes incompatibly.
-pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 1;
+/// v2: depth-anchored block closing, lazily anchored text blocks for
+/// non-whitelist elements, addressable stray text nodes — block ordinals
+/// and marker assignments differ from v1 on affected books.
+pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 2;
 
 /// Compute a cache namespace that scopes lookups to a single set of
 /// schema and segmentation parameters. Cached rows from a different

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -236,6 +236,13 @@ pub fn build_segments(book: &Book, config: &SegmentationConfig) -> Result<Vec<Se
         let section_segments_start = segments.len();
 
         for block in section_blocks {
+            // pre/code content is layout and syntax, not prose: sending it
+            // to the model both mistranslates it and destroys intentional
+            // whitespace. Excluded blocks are never patched, so the
+            // original markup survives rebuild byte-for-byte.
+            if matches!(block.kind, BlockKind::Code) {
+                continue;
+            }
             let block_tokens = block.token_estimate.max(1);
             let should_flush = !current.is_empty()
                 && current_tokens + block_tokens > config.max_segment_tokens
@@ -467,6 +474,29 @@ mod tests {
         assert_eq!(first[1].section_id.0, "sec_000000");
         assert_eq!(first[2].section_id.0, "sec_000001");
         assert_eq!(first[2].block_ids, vec![BlockId("b_000003".to_string())]);
+    }
+
+    #[test]
+    fn code_blocks_are_excluded_from_segments() {
+        let mut book = book_with_two_sections();
+        book.blocks[1].kind = BlockKind::Code;
+        let config = SegmentationConfig {
+            max_segment_tokens: 100,
+            context_tokens: 0,
+        };
+
+        let segments = build_segments(&book, &config).expect("segments should build");
+        let segmented_blocks: Vec<&str> = segments
+            .iter()
+            .flat_map(|segment| segment.block_ids.iter().map(|id| id.0.as_str()))
+            .collect();
+
+        assert!(
+            !segmented_blocks.contains(&"b_000001"),
+            "code block must not be segmented for translation"
+        );
+        assert!(segmented_blocks.contains(&"b_000000"));
+        assert!(segmented_blocks.contains(&"b_000002"));
     }
 
     #[test]

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -15,7 +15,9 @@ pub const SEGMENT_SCHEMA_VERSION: u32 = 1;
 /// v2: depth-anchored block closing, lazily anchored text blocks for
 /// non-whitelist elements, addressable stray text nodes — block ordinals
 /// and marker assignments differ from v1 on affected books.
-pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 2;
+/// v3: short per-block inline marker tags (`<m1>...</m1>`, `<r1/>`)
+/// replace verbose global ids (`<m id="m000000_000">...</m>`).
+pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 3;
 
 /// Compute a cache namespace that scopes lookups to a single set of
 /// schema and segmentation parameters. Cached rows from a different

--- a/crates/bookforge-epub/src/lib.rs
+++ b/crates/bookforge-epub/src/lib.rs
@@ -2,7 +2,9 @@ pub mod reader;
 pub mod validate;
 pub mod writer;
 
-pub use reader::{EpubInspection, inspect_epub, read_epub};
+pub use reader::{
+    EpubInspection, FileTextCoverage, TextCoverage, inspect_epub, read_epub, text_coverage,
+};
 pub use validate::{
     EpubValidationIssue, EpubValidationReport, ValidationSeverity, validate_block_translations,
     validate_translated_epub,

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -293,7 +293,7 @@ fn visible_body_chars(xhtml: &str) -> Result<usize> {
             },
             Event::Text(text) if in_body && skip_depth == 0 => {
                 let value = text
-                    .decode()
+                    .html_content()
                     .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
                 count += non_whitespace_chars(&value);
             }
@@ -302,6 +302,11 @@ fn visible_body_chars(xhtml: &str) -> Result<usize> {
                     .decode()
                     .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
                 count += non_whitespace_chars(&value);
+            }
+            Event::GeneralRef(reference) if in_body && skip_depth == 0 => {
+                if let Some(value) = resolve_general_ref(&reference)? {
+                    count += non_whitespace_chars(&value);
+                }
             }
             Event::Eof => break,
             _ => {}
@@ -389,7 +394,7 @@ fn parse_package(xml: &str) -> Result<PackageDocument> {
             Event::Text(text) => {
                 if let Some(name) = current_text_element.as_deref() {
                     let value = text
-                        .decode()
+                        .html_content()
                         .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?
                         .trim()
                         .to_string();
@@ -502,13 +507,20 @@ fn attr_value(
 
 #[derive(Debug)]
 struct ElementFrame {
+    name: Vec<u8>,
     path: Vec<usize>,
     child_count: usize,
+    text_count: usize,
 }
 
 #[derive(Debug)]
 struct BlockBuilder {
-    element_name: Vec<u8>,
+    /// Stack depth of the element this block is anchored to. The block
+    /// closes when an End event arrives while the stack is exactly this
+    /// deep — name-independent, so nested same-name elements (li > ul >
+    /// li, nested blockquotes) stay inside the block as inline markers
+    /// instead of ending it early.
+    anchor_depth: usize,
     kind: BlockKind,
     dom_path: DomPath,
     ordinal: usize,
@@ -521,9 +533,9 @@ struct BlockBuilder {
 }
 
 impl BlockBuilder {
-    fn new(element_name: Vec<u8>, kind: BlockKind, dom_path: DomPath, ordinal: usize) -> Self {
+    fn new(anchor_depth: usize, kind: BlockKind, dom_path: DomPath, ordinal: usize) -> Self {
         Self {
-            element_name,
+            anchor_depth,
             kind,
             dom_path,
             ordinal,
@@ -538,6 +550,24 @@ impl BlockBuilder {
 
     fn push_text(&mut self, text: &str) {
         let Some(mut text) = normalize_text_fragment(text) else {
+            // Whitespace-only fragment (e.g. a resolved &nbsp; entity
+            // reference): it still separates words, so keep one space
+            // between non-empty neighbors instead of dropping the
+            // boundary.
+            if !text.is_empty()
+                && !self.visible_text.is_empty()
+                && !self.visible_text.ends_with(' ')
+            {
+                self.visible_text.push(' ');
+                if let Some(run) = self
+                    .text_runs
+                    .iter_mut()
+                    .rev()
+                    .find(|run| !is_marker_token(&run.text))
+                {
+                    run.text.push(' ');
+                }
+            }
             return;
         };
 
@@ -632,18 +662,24 @@ fn extract_blocks(
     let mut element_stack = Vec::<ElementFrame>::new();
     let mut active_block: Option<BlockBuilder> = None;
     let mut blocks = Vec::new();
+    // Depth of never-translate ancestors (script/style/head/svg/...).
+    // While positive, loose text is not captured into lazy blocks.
+    let mut suppress_depth = 0usize;
 
     loop {
         match reader.read_event()? {
             Event::Start(element) => {
                 let name = local_name(element.name().as_ref()).to_vec();
                 let path = enter_element(&mut element_stack, &name);
+                if never_translate_element(&name) {
+                    suppress_depth += 1;
+                }
 
                 if active_block.is_none()
                     && let Some(kind) = block_kind(&name, &element)?
                 {
                     active_block = Some(BlockBuilder::new(
-                        name,
+                        element_stack.len(),
                         kind,
                         DomPath(path),
                         initial_block_count + blocks.len(),
@@ -665,26 +701,59 @@ fn extract_blocks(
                 }
             }
             Event::Text(text) => {
-                if let Some(block) = active_block.as_mut() {
-                    let value = text
-                        .decode()
-                        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
-                    block.push_text(&value);
-                }
+                let value = text
+                    .html_content()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                handle_text(
+                    &value,
+                    &mut active_block,
+                    &mut element_stack,
+                    &mut blocks,
+                    section_id,
+                    initial_block_count,
+                    suppress_depth > 0,
+                    true,
+                );
             }
             Event::CData(text) => {
-                if let Some(block) = active_block.as_mut() {
-                    let value = text
-                        .decode()
-                        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
-                    block.push_text(&value);
+                let value = text
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                handle_text(
+                    &value,
+                    &mut active_block,
+                    &mut element_stack,
+                    &mut blocks,
+                    section_id,
+                    initial_block_count,
+                    suppress_depth > 0,
+                    true,
+                );
+            }
+            // quick-xml surfaces entity references (&nbsp; &mdash; ...) as
+            // separate events rather than resolving them inside Text.
+            // Resolve numeric and HTML5 named references; the resolved
+            // text joins the active block or may anchor a lazy one, but
+            // never consumes a stray text-node index — the writer counts
+            // Text events only, and indices must stay aligned.
+            Event::GeneralRef(reference) => {
+                if let Some(value) = resolve_general_ref(&reference)? {
+                    handle_text(
+                        &value,
+                        &mut active_block,
+                        &mut element_stack,
+                        &mut blocks,
+                        section_id,
+                        initial_block_count,
+                        suppress_depth > 0,
+                        false,
+                    );
                 }
             }
-            Event::End(element) => {
-                let name = local_name(element.name().as_ref()).to_vec();
+            Event::End(_) => {
                 let should_finish = active_block
                     .as_ref()
-                    .is_some_and(|block| block.element_name == name);
+                    .is_some_and(|block| element_stack.len() == block.anchor_depth);
 
                 if should_finish {
                     let block = active_block.take().expect("checked above");
@@ -695,7 +764,12 @@ fn extract_blocks(
                     block.push_inline_end();
                 }
 
-                element_stack.pop();
+                if element_stack
+                    .pop()
+                    .is_some_and(|frame| never_translate_element(&frame.name))
+                {
+                    suppress_depth = suppress_depth.saturating_sub(1);
+                }
             }
             Event::Eof => break,
             _ => {}
@@ -705,11 +779,134 @@ fn extract_blocks(
     Ok(blocks)
 }
 
-fn enter_element(stack: &mut Vec<ElementFrame>, _name: &[u8]) -> Vec<usize> {
+/// Resolve a general entity reference to its replacement text: numeric
+/// character references and the HTML5 named set. Unknown entities are
+/// dropped with a warning rather than failing the whole book.
+fn resolve_general_ref(reference: &quick_xml::events::BytesRef<'_>) -> Result<Option<String>> {
+    if let Some(ch) = reference
+        .resolve_char_ref()
+        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?
+    {
+        return Ok(Some(ch.to_string()));
+    }
+    let name = reference
+        .decode()
+        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+    let resolved = quick_xml::escape::resolve_html5_entity(&name).map(ToString::to_string);
+    if resolved.is_none() {
+        tracing::warn!(entity = %name, "dropping unresolvable entity reference");
+    }
+    Ok(resolved)
+}
+
+/// Route a decoded text fragment: into the active block if there is one,
+/// otherwise — for non-whitespace text the block whitelist missed — start
+/// a block anchored on the enclosing element (text-bearing `<div>`,
+/// `<dt>`, `<dd>`, ...) or, when earlier element children make whole-
+/// element patching unsafe, record a standalone text-node block the
+/// writer can address directly. Without this fallback such text silently
+/// shipped untranslated.
+#[allow(clippy::too_many_arguments)]
+fn handle_text(
+    value: &str,
+    active_block: &mut Option<BlockBuilder>,
+    element_stack: &mut [ElementFrame],
+    blocks: &mut Vec<Block>,
+    section_id: &SectionId,
+    initial_block_count: usize,
+    suppressed: bool,
+    allow_stray: bool,
+) {
+    if let Some(block) = active_block.as_mut() {
+        block.push_text(value);
+        return;
+    }
+    if suppressed || value.trim().is_empty() {
+        return;
+    }
+    let depth = element_stack.len();
+    let Some(frame) = element_stack.last_mut() else {
+        return;
+    };
+    if frame.child_count == 0 && anchors_text_block(&frame.name) {
+        let mut block = BlockBuilder::new(
+            depth,
+            BlockKind::Paragraph,
+            DomPath(frame.path.clone()),
+            initial_block_count + blocks.len(),
+        );
+        block.push_text(value);
+        *active_block = Some(block);
+        return;
+    }
+    if !allow_stray {
+        return;
+    }
+    // Stray text node: prior element siblings (or a wrapper element)
+    // make whole-element patching unsafe, so the text node itself
+    // becomes the patch target. The writer counts non-whitespace text
+    // nodes per frame with the same rule.
+    let mut path = frame.path.clone();
+    path.push(bookforge_core::ir::TEXT_NODE_PATH_BASE + frame.text_count);
+    frame.text_count += 1;
+    let visible = normalize_space(value);
+    if visible.is_empty() {
+        return;
+    }
+    blocks.push(build_block(
+        section_id,
+        initial_block_count + blocks.len(),
+        BlockKind::Paragraph,
+        DomPath(path),
+        Vec::new(),
+        Vec::new(),
+        visible,
+    ));
+}
+
+/// Elements whose text must never be translated.
+fn never_translate_element(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"script" | b"style" | b"head" | b"title" | b"svg" | b"math"
+    )
+}
+
+/// Elements safe to anchor a lazily-started text block on. Structural
+/// wrappers are excluded: anchoring on them would swallow every nested
+/// block element into one giant marker-laden block. Their direct text is
+/// handled as stray text nodes instead.
+fn anchors_text_block(name: &[u8]) -> bool {
+    !matches!(
+        name,
+        b"body"
+            | b"html"
+            | b"section"
+            | b"article"
+            | b"main"
+            | b"nav"
+            | b"header"
+            | b"footer"
+            | b"aside"
+            | b"figure"
+            | b"ul"
+            | b"ol"
+            | b"dl"
+            | b"table"
+            | b"thead"
+            | b"tbody"
+            | b"tfoot"
+            | b"colgroup"
+    )
+}
+
+fn enter_element(stack: &mut Vec<ElementFrame>, name: &[u8]) -> Vec<usize> {
     let path = next_child_path(stack);
     stack.push(ElementFrame {
+        name: name.to_vec(),
         path: path.clone(),
         child_count: 0,
+        text_count: 0,
     });
     path
 }
@@ -1065,6 +1262,119 @@ mod tests {
     }
 
     #[test]
+    fn extracts_text_anchored_block_from_div() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><body><div class=\"x\">Bare div text with <em>emphasis</em>.</div></body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            block_text(&blocks[0]),
+            "Bare div text with <m id=\"m000000_000\">emphasis</m>."
+        );
+        assert_eq!(blocks[0].kind, BlockKind::Paragraph);
+    }
+
+    #[test]
+    fn extracts_dt_and_dd_text() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><body><dl><dt>Term</dt><dd>Definition</dd></dl></body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        let texts: Vec<String> = blocks.iter().map(block_text).collect();
+        assert_eq!(texts, vec!["Term".to_string(), "Definition".to_string()]);
+    }
+
+    #[test]
+    fn stray_text_after_children_becomes_addressable_block() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><body><p>Captured</p>Naked tail text</body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(block_text(&blocks[1]), "Naked tail text");
+        let last = *blocks[1]
+            .dom_path
+            .0
+            .last()
+            .expect("path should not be empty");
+        assert!(
+            last >= bookforge_core::ir::TEXT_NODE_PATH_BASE,
+            "stray text block must use a text-node path component, got {last}"
+        );
+    }
+
+    #[test]
+    fn nested_same_name_blocks_stay_in_one_block() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><body><ul><li>Outer <ul><li>Inner</li></ul> tail</li><li>Sibling</li></ul></body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        assert_eq!(blocks.len(), 2, "outer li (with nested list) + sibling li");
+        let outer = block_text(&blocks[0]);
+        assert!(outer.contains("Outer"), "got: {outer}");
+        assert!(
+            outer.contains("Inner"),
+            "nested li text stays inside the outer block: {outer}"
+        );
+        assert!(
+            outer.contains("tail"),
+            "text after the nested list must not be lost: {outer}"
+        );
+        assert_eq!(block_text(&blocks[1]), "Sibling");
+    }
+
+    #[test]
+    fn named_html_entities_decode_in_text() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><body><p>one&nbsp;two&mdash;three</p></body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("named entities must not fail extraction");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "one two\u{2014}three");
+    }
+
+    #[test]
+    fn script_and_style_text_is_never_extracted() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            "<html><head><title>Meta</title><style>p { color: red; }</style></head><body><script>var x = 1;</script><div>Real</div></body></html>",
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "Real");
+    }
+
+    #[test]
     fn visible_body_chars_counts_text_outside_recognized_blocks() {
         let xhtml = r#"<html><head><title>Ignored</title><style>p { color: red; }</style></head>
 <body><p>captured</p><div>dropped text</div></body></html>"#;
@@ -1074,10 +1384,11 @@ mod tests {
     }
 
     #[test]
-    fn coverage_reports_uncaptured_div_text() {
+    fn coverage_captures_div_text_and_reports_svg_labels_uncaptured() {
         let section_id = SectionId("sec_000000".to_string());
         let xhtml =
-            "<html><body><p>in a block</p><div>only in a div</div></body></html>".to_string();
+            "<html><body><p>in a block</p><div>also in a div</div><svg><text>diagram label</text></svg></body></html>"
+                .to_string();
         let blocks =
             extract_blocks(&xhtml, "chapter.xhtml", &section_id, 0).expect("blocks should parse");
         let captured = blocks
@@ -1086,12 +1397,16 @@ mod tests {
             .sum::<usize>();
         let total = visible_body_chars(&xhtml).expect("count should succeed");
 
-        assert_eq!(captured, non_whitespace_chars("in a block"));
         assert_eq!(
-            total,
-            non_whitespace_chars("in a block") + non_whitespace_chars("only in a div")
+            captured,
+            non_whitespace_chars("in a block") + non_whitespace_chars("also in a div"),
+            "prose in p and div must both be captured"
         );
-        assert!(captured < total, "div text must register as uncaptured");
+        assert_eq!(
+            total - captured,
+            non_whitespace_chars("diagram label"),
+            "svg text stays uncaptured and visible in the coverage gap"
+        );
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -31,6 +31,49 @@ pub struct EpubInspection {
     pub xhtml_spine_count: usize,
 }
 
+/// How much of the document's visible text the reader actually captures
+/// into translatable blocks. Text that lives outside the recognized block
+/// elements (for example directly inside `<div>`) is parsed over but never
+/// extracted, and ships untranslated; this metric makes that visible
+/// before any tokens are spent.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TextCoverage {
+    pub total_chars: usize,
+    pub captured_chars: usize,
+    pub files: Vec<FileTextCoverage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileTextCoverage {
+    pub href: String,
+    pub total_chars: usize,
+    pub captured_chars: usize,
+}
+
+impl TextCoverage {
+    pub fn percent(&self) -> f64 {
+        coverage_percent(self.captured_chars, self.total_chars)
+    }
+}
+
+impl FileTextCoverage {
+    pub fn percent(&self) -> f64 {
+        coverage_percent(self.captured_chars, self.total_chars)
+    }
+
+    pub fn uncaptured_chars(&self) -> usize {
+        self.total_chars.saturating_sub(self.captured_chars)
+    }
+}
+
+fn coverage_percent(captured: usize, total: usize) -> f64 {
+    if total == 0 {
+        100.0
+    } else {
+        (captured.min(total) as f64 / total as f64) * 100.0
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PackageDocument {
     metadata: Metadata,
@@ -175,6 +218,101 @@ pub fn inspect_epub(path: &Path) -> Result<EpubInspection> {
         package_path,
         xhtml_spine_count,
     })
+}
+
+/// Measure how much visible body text each XHTML spine document contributes
+/// versus how much the block extractor captures. Counts non-whitespace
+/// characters so block boundaries and indentation do not skew the ratio.
+pub fn text_coverage(path: &Path) -> Result<TextCoverage> {
+    let mut archive = open_archive(path)?;
+    validate_mimetype(&mut archive)?;
+    let package_path = locate_package(&mut archive)?;
+    let package_xml = read_archive_text(&mut archive, &package_path)?;
+    let package = parse_package(&package_xml)?;
+    let package_dir = package_base_dir(&package_path);
+    let manifest_by_id = package
+        .manifest
+        .iter()
+        .map(|item| (item.id.as_str(), item))
+        .collect::<HashMap<_, _>>();
+
+    let mut coverage = TextCoverage::default();
+    for (spine_index, spine_item) in package.spine.iter().enumerate() {
+        let Some(resource) = manifest_by_id.get(spine_item.idref.as_str()) else {
+            return Err(BookforgeError::InvalidInput(format!(
+                "spine item references missing manifest id '{}'",
+                spine_item.idref
+            )));
+        };
+        if !is_xhtml_media_type(&resource.media_type) {
+            continue;
+        }
+
+        let href = join_epub_path(&package_dir, &resource.href);
+        let xhtml = read_archive_text(&mut archive, &href)?;
+        let section_id = SectionId(format!("sec_{spine_index:06}"));
+        let blocks = extract_blocks(&xhtml, &href, &section_id, 0)?;
+        let captured_chars = blocks
+            .iter()
+            .map(|block| non_whitespace_chars(&block_visible_text(block)))
+            .sum::<usize>();
+        let total_chars = visible_body_chars(&xhtml)?;
+
+        coverage.total_chars += total_chars;
+        coverage.captured_chars += captured_chars;
+        coverage.files.push(FileTextCoverage {
+            href,
+            total_chars,
+            captured_chars,
+        });
+    }
+
+    Ok(coverage)
+}
+
+/// Non-whitespace character count of all text inside `<body>`, excluding
+/// `<script>` and `<style>` content.
+fn visible_body_chars(xhtml: &str) -> Result<usize> {
+    let mut reader = Reader::from_str(xhtml);
+    reader.config_mut().trim_text(false);
+    let mut in_body = false;
+    let mut skip_depth = 0usize;
+    let mut count = 0usize;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) => match local_name(element.name().as_ref()) {
+                b"body" => in_body = true,
+                b"script" | b"style" if in_body => skip_depth += 1,
+                _ => {}
+            },
+            Event::End(element) => match local_name(element.name().as_ref()) {
+                b"body" => in_body = false,
+                b"script" | b"style" if skip_depth > 0 => skip_depth -= 1,
+                _ => {}
+            },
+            Event::Text(text) if in_body && skip_depth == 0 => {
+                let value = text
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                count += non_whitespace_chars(&value);
+            }
+            Event::CData(text) if in_body && skip_depth == 0 => {
+                let value = text
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                count += non_whitespace_chars(&value);
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(count)
+}
+
+fn non_whitespace_chars(text: &str) -> usize {
+    text.chars().filter(|ch| !ch.is_whitespace()).count()
 }
 
 fn open_archive(path: &Path) -> Result<ZipArchive<File>> {
@@ -516,21 +654,14 @@ fn extract_blocks(
             }
             Event::Empty(element) => {
                 let name = local_name(element.name().as_ref()).to_vec();
-                let path = next_child_path(&mut element_stack);
+                // Sibling bookkeeping must advance even though self-closing
+                // block elements (<p/>, <td/>) carry no text and therefore
+                // produce no block — emitting one would send an empty
+                // source to the model and invite hallucinated output.
+                next_child_path(&mut element_stack);
 
                 if let Some(block) = active_block.as_mut() {
                     block.push_inline_empty(&name);
-                } else if let Some(kind) = block_kind(&name, &element)? {
-                    let block = build_block(
-                        section_id,
-                        initial_block_count + blocks.len(),
-                        kind,
-                        DomPath(path),
-                        Vec::new(),
-                        Vec::new(),
-                        String::new(),
-                    );
-                    blocks.push(block);
                 }
             }
             Event::Text(text) => {
@@ -931,6 +1062,36 @@ mod tests {
         assert_eq!(block_text(&blocks[0]), "Line<ref id=\"r000004_000\"/>break");
         assert_eq!(blocks[0].inline_marks[0].id, "r000004_000");
         assert_eq!(blocks[0].inline_marks[0].kind, "br");
+    }
+
+    #[test]
+    fn visible_body_chars_counts_text_outside_recognized_blocks() {
+        let xhtml = r#"<html><head><title>Ignored</title><style>p { color: red; }</style></head>
+<body><p>captured</p><div>dropped text</div></body></html>"#;
+        let total = visible_body_chars(xhtml).expect("count should succeed");
+        // "captured" (8) + "droppedtext" (11); head and style are excluded.
+        assert_eq!(total, 19);
+    }
+
+    #[test]
+    fn coverage_reports_uncaptured_div_text() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml =
+            "<html><body><p>in a block</p><div>only in a div</div></body></html>".to_string();
+        let blocks =
+            extract_blocks(&xhtml, "chapter.xhtml", &section_id, 0).expect("blocks should parse");
+        let captured = blocks
+            .iter()
+            .map(|block| non_whitespace_chars(&block_visible_text(block)))
+            .sum::<usize>();
+        let total = visible_body_chars(&xhtml).expect("count should succeed");
+
+        assert_eq!(captured, non_whitespace_chars("in a block"));
+        assert_eq!(
+            total,
+            non_whitespace_chars("in a block") + non_whitespace_chars("only in a div")
+        );
+        assert!(captured < total, "div text must register as uncaptured");
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -11,6 +11,7 @@ use bookforge_core::{
         Block, BlockId, BlockKind, Book, BookFormat, BookId, DomPath, InlineMark, Metadata,
         ProtectedSpan, ProtectedSpanKind, Resource, Section, SectionId, SpineItem, TextRun,
     },
+    marker::{is_marker_token, strip_marker_tokens},
 };
 use quick_xml::{
     Reader,
@@ -96,6 +97,57 @@ pub fn read_epub(path: &Path) -> Result<Book> {
         .collect::<HashMap<_, _>>();
     let mut sections = Vec::new();
     let mut blocks = Vec::new();
+
+    let package_section_id = SectionId("sec_metadata_opf".to_string());
+    let mut package_blocks =
+        extract_package_title_blocks(&package_xml, &package_section_id, blocks.len())?;
+    if !package_blocks.is_empty() {
+        let block_ids = package_blocks
+            .iter()
+            .map(|block| block.id.clone())
+            .collect::<Vec<_>>();
+        sections.push(Section {
+            id: package_section_id,
+            href: package_path.clone(),
+            spine_index: 0,
+            title: Some("OPF metadata".to_string()),
+            heading_level: None,
+            block_ids,
+            prev: None,
+            next: None,
+        });
+        blocks.append(&mut package_blocks);
+    }
+
+    for (toc_index, resource) in package
+        .manifest
+        .iter()
+        .filter(|item| item.media_type == "application/x-dtbncx+xml")
+        .enumerate()
+    {
+        let href = join_epub_path(&package_dir, &resource.href);
+        let ncx = read_archive_text(&mut archive, &href)?;
+        let section_id = SectionId(format!("sec_toc_{toc_index:06}"));
+        let mut toc_blocks = extract_ncx_text_blocks(&ncx, &section_id, blocks.len())?;
+        if toc_blocks.is_empty() {
+            continue;
+        }
+        let block_ids = toc_blocks
+            .iter()
+            .map(|block| block.id.clone())
+            .collect::<Vec<_>>();
+        sections.push(Section {
+            id: section_id,
+            href,
+            spine_index: 0,
+            title: Some("NCX table of contents".to_string()),
+            heading_level: None,
+            block_ids,
+            prev: None,
+            next: None,
+        });
+        blocks.append(&mut toc_blocks);
+    }
 
     for (spine_index, spine_item) in package.spine.iter_mut().enumerate() {
         let Some(resource) = manifest_by_id.get(spine_item.idref.as_str()) else {
@@ -270,40 +322,47 @@ pub fn text_coverage(path: &Path) -> Result<TextCoverage> {
     Ok(coverage)
 }
 
-/// Non-whitespace character count of all text inside `<body>`, excluding
-/// `<script>` and `<style>` content.
+/// Non-whitespace character count of all reader-visible text: everything
+/// inside `<body>` (minus `<script>`/`<style>` content) plus the document
+/// `<title>`, which the extractor also captures and translates. Keeping
+/// the numerator and denominator in sync stops per-file coverage from
+/// exceeding 100% on title-bearing chapters.
 fn visible_body_chars(xhtml: &str) -> Result<usize> {
     let mut reader = Reader::from_str(xhtml);
     reader.config_mut().trim_text(false);
     let mut in_body = false;
+    let mut in_title = false;
     let mut skip_depth = 0usize;
     let mut count = 0usize;
 
     loop {
+        let counting = (in_body || in_title) && skip_depth == 0;
         match reader.read_event()? {
             Event::Start(element) => match local_name(element.name().as_ref()) {
                 b"body" => in_body = true,
+                b"title" if !in_body => in_title = true,
                 b"script" | b"style" if in_body => skip_depth += 1,
                 _ => {}
             },
             Event::End(element) => match local_name(element.name().as_ref()) {
                 b"body" => in_body = false,
+                b"title" => in_title = false,
                 b"script" | b"style" if skip_depth > 0 => skip_depth -= 1,
                 _ => {}
             },
-            Event::Text(text) if in_body && skip_depth == 0 => {
+            Event::Text(text) if counting => {
                 let value = text
                     .html_content()
                     .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
                 count += non_whitespace_chars(&value);
             }
-            Event::CData(text) if in_body && skip_depth == 0 => {
+            Event::CData(text) if counting => {
                 let value = text
                     .decode()
                     .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
                 count += non_whitespace_chars(&value);
             }
-            Event::GeneralRef(reference) if in_body && skip_depth == 0 => {
+            Event::GeneralRef(reference) if counting => {
                 if let Some(value) = resolve_general_ref(&reference)? {
                     count += non_whitespace_chars(&value);
                 }
@@ -513,6 +572,111 @@ struct ElementFrame {
     text_count: usize,
 }
 
+struct TextCapture {
+    depth: usize,
+    path: Vec<usize>,
+    text: String,
+}
+
+fn extract_package_title_blocks(
+    xml: &str,
+    section_id: &SectionId,
+    initial_block_count: usize,
+) -> Result<Vec<Block>> {
+    extract_xml_text_element_blocks(xml, section_id, initial_block_count, |name| {
+        name == b"title"
+    })
+}
+
+fn extract_ncx_text_blocks(
+    xml: &str,
+    section_id: &SectionId,
+    initial_block_count: usize,
+) -> Result<Vec<Block>> {
+    extract_xml_text_element_blocks(xml, section_id, initial_block_count, |name| name == b"text")
+}
+
+fn extract_xml_text_element_blocks(
+    xml: &str,
+    section_id: &SectionId,
+    initial_block_count: usize,
+    should_capture: impl Fn(&[u8]) -> bool,
+) -> Result<Vec<Block>> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+
+    let mut element_stack = Vec::<ElementFrame>::new();
+    let mut active_capture: Option<TextCapture> = None;
+    let mut blocks = Vec::new();
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) => {
+                let name = local_name(element.name().as_ref()).to_vec();
+                let path = enter_element(&mut element_stack, &name);
+                if active_capture.is_none() && should_capture(&name) {
+                    active_capture = Some(TextCapture {
+                        depth: element_stack.len(),
+                        path,
+                        text: String::new(),
+                    });
+                }
+            }
+            Event::Empty(_) => {
+                next_child_path(&mut element_stack);
+            }
+            Event::Text(text) => {
+                if let Some(capture) = active_capture.as_mut() {
+                    let value = text
+                        .html_content()
+                        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                    capture.text.push_str(&value);
+                }
+            }
+            Event::CData(text) => {
+                if let Some(capture) = active_capture.as_mut() {
+                    let value = text
+                        .decode()
+                        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                    capture.text.push_str(&value);
+                }
+            }
+            Event::GeneralRef(reference) => {
+                if let Some(capture) = active_capture.as_mut()
+                    && let Some(value) = resolve_general_ref(&reference)?
+                {
+                    capture.text.push_str(&value);
+                }
+            }
+            Event::End(_) => {
+                if active_capture
+                    .as_ref()
+                    .is_some_and(|capture| element_stack.len() == capture.depth)
+                {
+                    let capture = active_capture.take().expect("checked above");
+                    let visible = normalize_space(&capture.text);
+                    if !visible.is_empty() {
+                        blocks.push(build_block(
+                            section_id,
+                            initial_block_count + blocks.len(),
+                            BlockKind::Paragraph,
+                            DomPath(capture.path),
+                            Vec::new(),
+                            Vec::new(),
+                            visible,
+                        ));
+                    }
+                }
+                element_stack.pop();
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(blocks)
+}
+
 #[derive(Debug)]
 struct BlockBuilder {
     /// Stack depth of the element this block is anchored to. The block
@@ -584,29 +748,29 @@ impl BlockBuilder {
     }
 
     fn push_inline_start(&mut self, name: &[u8]) {
-        let id = marker_id(b"m", self.ordinal, self.next_marker);
+        let id = marker_id("m", self.next_marker);
         self.next_marker += 1;
         self.inline_marks.push(InlineMark {
             id: id.clone(),
             kind: String::from_utf8_lossy(name).into_owned(),
         });
         self.inline_stack.push(id.clone());
-        self.push_run(format!("<m id=\"{id}\">"));
+        self.push_run(format!("<{id}>"));
     }
 
     fn push_inline_empty(&mut self, name: &[u8]) {
-        let id = marker_id(b"r", self.ordinal, self.next_marker);
+        let id = marker_id("r", self.next_marker);
         self.next_marker += 1;
         self.inline_marks.push(InlineMark {
             id: id.clone(),
             kind: String::from_utf8_lossy(name).into_owned(),
         });
-        self.push_run(format!("<ref id=\"{id}\"/>"));
+        self.push_run(format!("<{id}/>"));
     }
 
     fn push_inline_end(&mut self) {
-        if self.inline_stack.pop().is_some() {
-            self.push_run("</m>".to_string());
+        if let Some(id) = self.inline_stack.pop() {
+            self.push_run(format!("</{id}>"));
         }
     }
 
@@ -866,10 +1030,7 @@ fn handle_text(
 
 /// Elements whose text must never be translated.
 fn never_translate_element(name: &[u8]) -> bool {
-    matches!(
-        name,
-        b"script" | b"style" | b"head" | b"title" | b"svg" | b"math"
-    )
+    matches!(name, b"script" | b"style" | b"svg" | b"math")
 }
 
 /// Elements safe to anchor a lazily-started text block on. Structural
@@ -885,6 +1046,7 @@ fn anchors_text_block(name: &[u8]) -> bool {
             | b"article"
             | b"main"
             | b"nav"
+            | b"head"
             | b"header"
             | b"footer"
             | b"aside"
@@ -1034,41 +1196,11 @@ fn block_visible_text(block: &Block) -> String {
         .map(|run| run.text.as_str())
         .collect::<Vec<_>>()
         .join("");
-    strip_marker_tokens(&marked)
+    normalize_space(&strip_marker_tokens(&marked))
 }
 
-fn strip_marker_tokens(text: &str) -> String {
-    let mut output = String::new();
-    let mut rest = text;
-
-    while let Some(index) = rest.find('<') {
-        output.push_str(&rest[..index]);
-        let tag = &rest[index..];
-
-        if (tag.starts_with("<m id=\"") || tag.starts_with("<ref id=\"") || tag.starts_with("</m>"))
-            && let Some(end) = tag.find('>')
-        {
-            rest = &tag[end + 1..];
-            continue;
-        }
-
-        output.push('<');
-        rest = &tag[1..];
-    }
-
-    output.push_str(rest);
-    normalize_space(&output)
-}
-
-fn is_marker_token(text: &str) -> bool {
-    matches!(text, "</m>") || text.starts_with("<m id=\"") || text.starts_with("<ref id=\"")
-}
-
-fn marker_id(prefix: &[u8], block_ordinal: usize, marker_ordinal: usize) -> String {
-    format!(
-        "{}{block_ordinal:06}_{marker_ordinal:03}",
-        String::from_utf8_lossy(prefix)
-    )
+fn marker_id(prefix: &str, marker_ordinal: usize) -> String {
+    format!("{prefix}{}", marker_ordinal + 1)
 }
 
 fn estimate_tokens(text: &str) -> usize {
@@ -1236,9 +1368,9 @@ mod tests {
 
         assert_eq!(blocks.len(), 1);
         let text = block_text(&blocks[0]);
-        assert_eq!(text, "Hello <m id=\"m000000_000\">world</m>!");
+        assert_eq!(text, "Hello <m1>world</m1>!");
         assert_eq!(blocks[0].inline_marks.len(), 1);
-        assert_eq!(blocks[0].inline_marks[0].id, "m000000_000");
+        assert_eq!(blocks[0].inline_marks[0].id, "m1");
         assert_eq!(blocks[0].inline_marks[0].kind, "em");
         assert_eq!(blocks[0].token_estimate, estimate_tokens("Hello world!"));
     }
@@ -1256,8 +1388,8 @@ mod tests {
 
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].id.0, "b_000004");
-        assert_eq!(block_text(&blocks[0]), "Line<ref id=\"r000004_000\"/>break");
-        assert_eq!(blocks[0].inline_marks[0].id, "r000004_000");
+        assert_eq!(block_text(&blocks[0]), "Line<r1/>break");
+        assert_eq!(blocks[0].inline_marks[0].id, "r1");
         assert_eq!(blocks[0].inline_marks[0].kind, "br");
     }
 
@@ -1275,7 +1407,7 @@ mod tests {
         assert_eq!(blocks.len(), 1);
         assert_eq!(
             block_text(&blocks[0]),
-            "Bare div text with <m id=\"m000000_000\">emphasis</m>."
+            "Bare div text with <m1>emphasis</m1>."
         );
         assert_eq!(blocks[0].kind, BlockKind::Paragraph);
     }
@@ -1370,17 +1502,20 @@ mod tests {
         )
         .expect("block extraction should succeed");
 
-        assert_eq!(blocks.len(), 1);
-        assert_eq!(block_text(&blocks[0]), "Real");
+        let texts = blocks.iter().map(block_text).collect::<Vec<_>>();
+        assert_eq!(texts, vec!["Meta", "Real"]);
+        assert!(!texts.iter().any(|text| text.contains("color")));
+        assert!(!texts.iter().any(|text| text.contains("var x")));
     }
 
     #[test]
-    fn visible_body_chars_counts_text_outside_recognized_blocks() {
-        let xhtml = r#"<html><head><title>Ignored</title><style>p { color: red; }</style></head>
-<body><p>captured</p><div>dropped text</div></body></html>"#;
+    fn visible_body_chars_counts_body_and_title_but_not_style() {
+        let xhtml = r#"<html><head><title>Heading</title><style>p { color: red; }</style></head>
+<body><p>captured</p><div>div text</div></body></html>"#;
         let total = visible_body_chars(xhtml).expect("count should succeed");
-        // "captured" (8) + "droppedtext" (11); head and style are excluded.
-        assert_eq!(total, 19);
+        // "Heading" (7) + "captured" (8) + "divtext" (7); style is excluded.
+        // The head title counts because the extractor translates it too.
+        assert_eq!(total, 22);
     }
 
     #[test]

--- a/crates/bookforge-epub/src/validate.rs
+++ b/crates/bookforge-epub/src/validate.rs
@@ -1,7 +1,10 @@
 use std::io::Read;
 use std::path::Path;
 
-use bookforge_core::segment::{BlockTranslation, Segment};
+use bookforge_core::{
+    marker::marker_ids_in_text,
+    segment::{BlockTranslation, Segment},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EpubValidationReport {
@@ -132,8 +135,9 @@ fn validate_xhtml_content(
                 .copied()
                 .unwrap_or(&block.text);
 
-            for marker in &segment.constraints.preserve_markers {
-                if block.text.contains(marker) && !translated.contains(marker) {
+            let translated_markers = marker_ids_in_text(translated);
+            for marker in marker_ids_in_text(&block.text) {
+                if !translated_markers.contains(&marker) {
                     report.issues.push(EpubValidationIssue {
                         severity: ValidationSeverity::Error,
                         kind: "missing_marker".to_string(),

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use bookforge_core::{
     BookforgeError, Result,
-    ir::{Block, Book, DomPath},
+    ir::{Block, Book, DomPath, TEXT_NODE_PATH_BASE},
     marker::extract_marker_id,
     segment::BlockTranslation,
 };
@@ -155,6 +155,7 @@ struct PatchSpec<'a> {
 struct ElementFrame {
     path: Vec<usize>,
     child_count: usize,
+    text_count: usize,
 }
 
 #[derive(Debug)]
@@ -262,6 +263,36 @@ fn patch_xhtml_with_specs(xhtml: &str, patches: &[PatchSpec<'_>]) -> Result<Patc
             Event::End(element) => {
                 writer.write_event(Event::End(element.borrow()))?;
                 stack.pop();
+            }
+            // Text nodes are addressable patch targets: the reader emits
+            // standalone blocks for non-whitespace text the block
+            // whitelist missed, addressed as parent path plus
+            // TEXT_NODE_PATH_BASE + n. Counting must mirror the reader:
+            // every text node that is non-whitespace after entity
+            // decoding consumes one index in its parent frame.
+            Event::Text(text) => {
+                let non_whitespace = text
+                    .html_content()
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(true);
+                match text_node_patch(&patch_map, &mut stack, non_whitespace) {
+                    Some(translation) => {
+                        writer.write_event(Event::Text(BytesText::new(translation)))?
+                    }
+                    None => writer.write_event(Event::Text(text.borrow()))?,
+                }
+            }
+            Event::CData(text) => {
+                let non_whitespace = text
+                    .decode()
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or(true);
+                match text_node_patch(&patch_map, &mut stack, non_whitespace) {
+                    Some(translation) => {
+                        writer.write_event(Event::Text(BytesText::new(translation)))?
+                    }
+                    None => writer.write_event(Event::CData(text.borrow()))?,
+                }
             }
             Event::Eof => break,
             event => {
@@ -618,11 +649,32 @@ pub(crate) fn validate_xml(xml: &str) -> Result<()> {
     }
 }
 
+/// Consume one text-node index in the enclosing frame and return the
+/// matching patch translation, if any. Whitespace-only nodes consume no
+/// index, mirroring the reader's counting rule.
+fn text_node_patch<'a>(
+    patch_map: &HashMap<&[usize], PatchSpec<'a>>,
+    stack: &mut [ElementFrame],
+    non_whitespace: bool,
+) -> Option<&'a str> {
+    if !non_whitespace {
+        return None;
+    }
+    let frame = stack.last_mut()?;
+    let mut path = frame.path.clone();
+    path.push(TEXT_NODE_PATH_BASE + frame.text_count);
+    frame.text_count += 1;
+    patch_map
+        .get(path.as_slice())
+        .map(|patch| patch.translation)
+}
+
 fn enter_element(stack: &mut Vec<ElementFrame>) -> Vec<usize> {
     let path = next_child_path(stack);
     stack.push(ElementFrame {
         path: path.clone(),
         child_count: 0,
+        text_count: 0,
     });
     path
 }
@@ -729,6 +781,28 @@ mod tests {
         assert!(
             outcome.xhtml.contains("<p>Other</p>"),
             "untargeted block must be untouched"
+        );
+        validate_xml(&outcome.xhtml).expect("output should re-parse");
+    }
+
+    #[test]
+    fn patches_stray_text_node() {
+        let xhtml = "<root><p>Para</p>tail text<p>Other</p></root>";
+        let path = DomPath(vec![0, TEXT_NODE_PATH_BASE]);
+        let outcome =
+            patch_xhtml(xhtml, &[(&path, "coda tradotta")]).expect("patch should succeed");
+
+        assert_eq!(outcome.skipped_blocks, 0);
+        assert!(
+            outcome.xhtml.contains("coda tradotta"),
+            "stray text node should be replaced, got: {}",
+            outcome.xhtml,
+        );
+        assert!(!outcome.xhtml.contains("tail text"));
+        assert!(
+            outcome.xhtml.contains("<p>Para</p>") && outcome.xhtml.contains("<p>Other</p>"),
+            "sibling elements must be untouched, got: {}",
+            outcome.xhtml,
         );
         validate_xml(&outcome.xhtml).expect("output should re-parse");
     }

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -8,7 +8,7 @@ use std::{
 use bookforge_core::{
     BookforgeError, Result,
     ir::{Block, Book, DomPath, TEXT_NODE_PATH_BASE},
-    marker::extract_marker_id,
+    marker::{parse_empty_marker, parse_paired_marker_open},
     segment::BlockTranslation,
 };
 use quick_xml::{
@@ -412,7 +412,6 @@ fn collect_inline_templates(
     block: &Block,
     events: &[Event<'static>],
 ) -> Result<HashMap<String, InlineTemplate>> {
-    let block_ordinal = block_ordinal(block)?;
     let mut marker_ordinal = 0usize;
     let mut templates = HashMap::new();
     let mut stack = Vec::<(String, Event<'static>)>::new();
@@ -420,12 +419,12 @@ fn collect_inline_templates(
     for event in events {
         match event {
             Event::Start(element) => {
-                let id = marker_id("m", block_ordinal, marker_ordinal);
+                let id = marker_id("m", marker_ordinal);
                 marker_ordinal += 1;
                 stack.push((id, Event::Start(element.clone())));
             }
             Event::Empty(element) => {
-                let id = marker_id("r", block_ordinal, marker_ordinal);
+                let id = marker_id("r", marker_ordinal);
                 marker_ordinal += 1;
                 templates.insert(id, InlineTemplate::Empty(Event::Empty(element.clone())));
             }
@@ -467,15 +466,17 @@ fn push_marked_fragment(
         push_text_event(&text[..index], output);
         let tag = &text[index..];
 
-        if let Some((tag_name, id, open_len)) = parse_paired_marker_open(tag) {
+        if let Some(open) = parse_paired_marker_open(tag) {
+            let tag_name = open.tag_name;
+            let id = open.id;
             if used.iter().any(|seen| seen == &id) {
                 return Err(BookforgeError::InvalidInput(format!(
                     "translation contains a duplicate formatting marker '{id}'. The LLM copied the marker twice."
                 )));
             }
 
-            let after_open = &tag[open_len..];
-            let close_start = find_matching_marker_close(after_open, tag_name)?;
+            let after_open = &tag[open.len..];
+            let close_start = find_matching_marker_close(after_open, &tag_name)?;
             let close_len = format!("</{tag_name}>").len();
             let inner = &after_open[..close_start];
             let after_close = &after_open[close_start + close_len..];
@@ -500,7 +501,8 @@ fn push_marked_fragment(
             }
 
             text = after_close;
-        } else if let Some((id, marker_len)) = parse_empty_marker(tag) {
+        } else if let Some(empty) = parse_empty_marker(tag) {
+            let id = empty.id;
             if used.iter().any(|seen| seen == &id) {
                 return Err(BookforgeError::InvalidInput(format!(
                     "translation contains a duplicate formatting marker '{id}'. The LLM copied the marker twice."
@@ -524,7 +526,7 @@ fn push_marked_fragment(
                 }
             }
 
-            text = &tag[marker_len..];
+            text = &tag[empty.len..];
         } else {
             push_text_event("<", output);
             text = &tag[1..];
@@ -541,46 +543,14 @@ fn push_text_event(text: &str, output: &mut Vec<Event<'static>>) {
     }
 }
 
-fn parse_paired_marker_open(text: &str) -> Option<(&'static str, String, usize)> {
-    for tag_name in ["m", "keep"] {
-        let prefix = format!("<{tag_name} ");
-        if !text.starts_with(&prefix) {
-            continue;
-        }
-        let open_end = text.find('>')?;
-        if text[..open_end].ends_with('/') {
-            return None;
-        }
-        let id = extract_marker_id(&text[..=open_end])?;
-        return Some((tag_name, id, open_end + 1));
-    }
-    None
-}
-
-fn parse_empty_marker(text: &str) -> Option<(String, usize)> {
-    for tag_name in ["ref", "m", "keep"] {
-        if !text.starts_with(&format!("<{tag_name} ")) {
-            continue;
-        }
-        if let Some(end) = text.find("/>") {
-            let tag = &text[..end + 2];
-            if let Some(id) = extract_marker_id(tag) {
-                return Some((id, end + 2));
-            }
-        }
-    }
-    None
-}
-
 fn find_matching_marker_close(text: &str, tag_name: &str) -> Result<usize> {
-    let open_prefix = format!("<{tag_name} ");
     let close = format!("</{tag_name}>");
     let mut depth = 0usize;
     let mut offset = 0usize;
 
     loop {
         let remaining = &text[offset..];
-        let next_open = remaining.find(&open_prefix);
+        let next_open = find_marker_open(remaining, tag_name);
         let next_close = remaining.find(&close);
 
         match (next_open, next_close) {
@@ -620,22 +590,16 @@ fn find_matching_marker_close(text: &str, tag_name: &str) -> Result<usize> {
     }
 }
 
-fn block_ordinal(block: &Block) -> Result<usize> {
-    block
-        .id
-        .0
-        .strip_prefix("b_")
-        .and_then(|value| value.parse::<usize>().ok())
-        .ok_or_else(|| {
-            BookforgeError::InvalidInput(format!(
-                "block id '{}' does not use the expected b_000000 shape",
-                block.id.0
-            ))
-        })
+fn find_marker_open(text: &str, tag_name: &str) -> Option<usize> {
+    if matches!(tag_name, "m" | "keep") {
+        text.find(&format!("<{tag_name} "))
+    } else {
+        text.find(&format!("<{tag_name}>"))
+    }
 }
 
-fn marker_id(prefix: &str, block_ordinal: usize, marker_ordinal: usize) -> String {
-    format!("{prefix}{block_ordinal:06}_{marker_ordinal:03}")
+fn marker_id(prefix: &str, marker_ordinal: usize) -> String {
+    format!("{prefix}{}", marker_ordinal + 1)
 }
 
 pub(crate) fn validate_xml(xml: &str) -> Result<()> {
@@ -743,7 +707,7 @@ mod tests {
             "b_000000",
             DomPath(vec![0, 0]),
             vec![InlineMark {
-                id: "m000000_000".to_string(),
+                id: "m1".to_string(),
                 kind: "em".to_string(),
             }],
         );
@@ -751,7 +715,7 @@ mod tests {
             xhtml,
             &[BlockPatch {
                 block: &block,
-                translation: "Ciao <m id=\"m000000_000\">mondo</m>!",
+                translation: "Ciao <m1>mondo</m1>!",
             }],
         )
         .expect("patch should succeed");
@@ -820,7 +784,7 @@ mod tests {
             dom_path,
             text_runs: vec![TextRun {
                 id: "r000000_000".to_string(),
-                text: "Hello <m id=\"m000000_000\">world</m>!".to_string(),
+                text: "Hello <m1>world</m1>!".to_string(),
             }],
             inline_marks,
             protected_spans: Vec::<ProtectedSpan>::new(),

--- a/crates/bookforge-epub/tests/inspect.rs
+++ b/crates/bookforge-epub/tests/inspect.rs
@@ -7,7 +7,7 @@ use std::{
 
 use bookforge_core::{
     config::SegmentationConfig,
-    ir::{BlockId, BlockKind},
+    ir::BlockKind,
     segment::{BlockTranslation, build_segments},
 };
 use bookforge_epub::{inspect_epub, read_epub, rebuild_epub};
@@ -36,10 +36,17 @@ fn builds_basic_ir_from_minimal_epub() {
     let fixture = create_minimal_epub();
     let book = read_epub(&fixture).expect("fixture should parse into IR");
 
-    assert_eq!(book.sections.len(), 1);
-    assert_eq!(book.blocks.len(), 1);
-    assert_eq!(book.blocks[0].kind, BlockKind::Paragraph);
-    assert_eq!(book.blocks[0].text_runs[0].text, "Hello from chapter 1.");
+    assert_eq!(book.sections.len(), 2);
+    assert_eq!(book.blocks.len(), 3);
+    assert!(book.blocks.iter().any(|block| {
+        block.kind == BlockKind::Paragraph && block_text(block) == "Generated Bookforge Fixture"
+    }));
+    assert!(book.blocks.iter().any(
+        |block| block.kind == BlockKind::Paragraph && block_text(block) == "Generated Fixture"
+    ));
+    assert!(book.blocks.iter().any(|block| {
+        block.kind == BlockKind::Paragraph && block_text(block) == "Hello from chapter 1."
+    }));
     assert!(book.blocks.iter().all(|block| block.token_estimate > 0));
 }
 
@@ -55,15 +62,18 @@ fn builds_stable_segments_from_minimal_epub() {
     let first = build_segments(&book, &config).expect("segments should build");
     let second = build_segments(&book, &config).expect("segments should be repeatable");
 
-    assert_eq!(first.len(), 1);
+    assert_eq!(first.len(), 2);
     assert_eq!(first[0].id, second[0].id);
     assert_eq!(first[0].checksum, second[0].checksum);
-    assert_eq!(first[0].section_id.0, "sec_000000");
+    assert_eq!(first[0].section_id.0, "sec_metadata_opf");
     assert_eq!(first[0].block_ids.len(), 1);
-    assert!(first[0].source.text.contains("Hello from chapter 1."));
+    assert!(first[0].source.text.contains("Generated Bookforge Fixture"));
+    assert_eq!(first[1].section_id.0, "sec_000000");
+    assert!(first[1].source.text.contains("Generated Fixture"));
+    assert!(first[1].source.text.contains("Hello from chapter 1."));
     assert!(first[0].source.token_estimate > 0);
     assert!(first[0].context.before.is_none());
-    assert!(first[0].context.after.is_none());
+    assert!(first[0].context.after.is_some());
 }
 
 #[test]
@@ -73,11 +83,16 @@ fn rebuilds_epub_with_patched_xhtml_and_preserved_resources() {
     let output =
         std::env::temp_dir().join(format!("bookforge-rebuilt-{}.epub", std::process::id()));
     let _ = std::fs::remove_file(&output);
+    let body_block = book
+        .blocks
+        .iter()
+        .find(|block| block_text(block) == "Hello from chapter 1.")
+        .expect("body paragraph should be extracted");
 
     rebuild_epub(
         &book,
         &[BlockTranslation {
-            block_id: BlockId("b_000000".to_string()),
+            block_id: body_block.id.clone(),
             text: "Ciao da un EPUB minimo.".to_string(),
         }],
         &output,
@@ -141,8 +156,8 @@ fn parses_complex_generated_fixture_shapes() {
     let paragraph = book
         .blocks
         .iter()
-        .find(|block| block.kind == BlockKind::Paragraph)
-        .expect("fixture should contain a paragraph");
+        .find(|block| block.kind == BlockKind::Paragraph && block_text(block).contains("formatted"))
+        .expect("fixture should contain the body paragraph");
     assert!(paragraph.text_runs.len() > 1);
     assert!(paragraph.inline_marks.iter().any(|mark| mark.kind == "em"));
     assert!(paragraph.inline_marks.iter().any(|mark| mark.kind == "a"));
@@ -150,7 +165,7 @@ fn parses_complex_generated_fixture_shapes() {
         paragraph
             .text_runs
             .iter()
-            .any(|run| run.text.contains("<m id="))
+            .any(|run| run.text.contains("<m"))
     );
 
     let table_row_text = book
@@ -199,7 +214,7 @@ fn parses_huge_paragraph_generated_fixture() {
     let paragraph = book
         .blocks
         .iter()
-        .find(|block| block.kind == BlockKind::Paragraph)
+        .find(|block| block.kind == BlockKind::Paragraph && block_text(block).contains("word1499"))
         .expect("fixture should contain a huge paragraph");
 
     assert_eq!(paragraph.text_runs.len(), 1);
@@ -222,6 +237,14 @@ fn parses_huge_paragraph_generated_fixture() {
 
 fn create_minimal_epub() -> PathBuf {
     create_epub_fixture("minimal", "<p>Hello from chapter 1.</p>")
+}
+
+fn block_text(block: &bookforge_core::ir::Block) -> String {
+    block
+        .text_runs
+        .iter()
+        .map(|run| run.text.as_str())
+        .collect::<String>()
 }
 
 fn create_epub_fixture(name: &str, body: &str) -> PathBuf {

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_marker_safe.v1.md
+﻿# translate_batch_marker_safe.v2.md
 
 ## System
 
@@ -6,12 +6,12 @@ You are a professional EPUB-safe book translator.
 
 Translate from {{source_language}} to {{target_language}}.
 
-CRITICAL REQUIREMENT — MARKER PRESERVATION:
+CRITICAL REQUIREMENT â€” MARKER PRESERVATION:
 
 Every item in the input contains XML-like markers such as:
-  <m id="m000004_000"> ... </m>
-  <ref id="r1"/>
-  <keep id="k2"> ... </keep>
+  <m1> ... </m1>
+  <r1/>
+  <m2> ... </m2>
 
 These markers represent EPUB formatting (links, footnotes, emphasis, anchors).
 They are NOT part of the prose. They are NOT optional. They are NOT decoration.
@@ -24,27 +24,27 @@ will be corrupted and the translation will be REJECTED.
 Rules:
 - Return JSON only. No explanations, notes, or Markdown.
 - Preserve every item ID exactly.
-- PRESERVE EVERY MARKER EXACTLY — same tag, same id, same position.
-- Do not rename markers (e.g. <m id="m1"> must stay <m id="m1">).
+- PRESERVE EVERY MARKER EXACTLY â€” same tag name and same position.
+- Do not rename markers (e.g. <m1> must stay <m1> and close as </m1>).
 - Do not delete markers.
 - Do not duplicate markers.
 - Do not invent new markers.
-- Do not change marker attributes.
+- Do not change marker tag names.
 - Markers may move position only when target-language grammar requires it.
-- Preserve protected spans exactly — copy them character-for-character.
+- Preserve protected spans exactly â€” copy them character-for-character.
 - Preserve meaning, tone, register, and authorial style.
 - Translate the human-readable prose between/around markers naturally.
 
-Markers are the <m>, <ref/>, <keep> tags and their content inside them.
+Markers are the <mN>...</mN> and <rN/> tags and their content inside them.
 For example, given the source:
-  <m id="m1">Hello <ref id="r1"/> world</m>
+  <m1>Hello <r1/> world</m1>
 The translation must keep:
-  <m id="m1">Ciao <ref id="r1"/> mondo</m>
+  <m1>Ciao <r1/> mondo</m1>
 
 BEFORE RETURNING YOUR RESPONSE, verify internally:
 1. Did I include EVERY marker from the input?
-2. Does each marker have exactly the same id attribute?
-3. Are all marker close tags correct (</m> not </ m>)?
+2. Does each marker have exactly the same tag name?
+3. Are all marker close tags correct (</m1> not </ m1>)?
 4. Did I accidentally delete, rename, or duplicate any marker?
 5. Does the output contain ONLY valid JSON with no commentary?
 
@@ -69,7 +69,7 @@ Entity grammatical agreement (use for adjective/article concord across all items
 {{entity_agreement_block}}
 ```
 
-Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}
@@ -84,4 +84,4 @@ Additional instructions:
 Input:
 {{items_json}}
 
-Return JSON only. Markers are CRITICAL — missing markers will corrupt the EPUB.
+Return JSON only. Markers are CRITICAL â€” missing markers will corrupt the EPUB.

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v2.md
@@ -1,10 +1,10 @@
-# translate_batch_marker_safe_compact.v1.md
+﻿# translate_batch_marker_safe_compact.v2.md
 
 ## System
 
 You are an EPUB-safe book translator. Translate from {{source_language}} to {{target_language}}.
 
-CRITICAL: Preserve every XML marker (<m id="...">, </m>, <keep id="...">, <ref id="..."/>) EXACTLY — same tag, id, and position. Markers are EPUB formatting, not prose. Dropped markers corrupt the EPUB.
+CRITICAL: Preserve every XML marker (<m1>, </m1>, <r1/>, etc.) EXACTLY â€” same tag name and position. Markers are EPUB formatting, not prose. Dropped markers corrupt the EPUB.
 
 Rules:
 - Return JSON only.

--- a/crates/bookforge-llm/prompts/translate_batch_plain.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_plain.v1.md
+﻿# translate_batch_plain.v2.md
 
 ## System
 
@@ -35,7 +35,7 @@ Entity grammatical agreement (use for adjective/article concord across all items
 {{entity_agreement_block}}
 ```
 
-Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}

--- a/crates/bookforge-llm/prompts/translate_batch_plain_compact.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain_compact.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_plain_compact.v1.md
+﻿# translate_batch_plain_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_repair.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_repair.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_repair.v1.md
+﻿# translate_batch_repair.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_repair_compact.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_repair_compact.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_repair_compact.v1.md
+﻿# translate_batch_repair_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_run_preserving.v1.md
+﻿# translate_batch_run_preserving.v2.md
 
 ## System
 
@@ -36,7 +36,7 @@ Entity grammatical agreement (use for adjective/article concord across all items
 {{entity_agreement_block}}
 ```
 
-Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments from the same chapter (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v2.md
@@ -1,4 +1,4 @@
-# translate_batch_run_preserving_compact.v1.md
+﻿# translate_batch_run_preserving_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_marker_safe.v2.md
+++ b/crates/bookforge-llm/prompts/translate_marker_safe.v2.md
@@ -1,4 +1,4 @@
-# translate_marker_safe.v1.md
+﻿# translate_marker_safe.v2.md
 
 ## System
 
@@ -6,16 +6,16 @@ You are a professional book translator working inside a structured EPUB translat
 
 Translate the human-readable prose from {{source_language}} to {{target_language}} while preserving all structural markers exactly.
 
-CRITICAL REQUIREMENT — MARKER PRESERVATION:
+CRITICAL REQUIREMENT â€” MARKER PRESERVATION:
 
 Structural markers represent formatting, links, footnotes, emphasis, anchors, spans, or other EPUB inline structure. They are NOT part of the prose. They are NOT optional. They are NOT decoration. THEY MUST APPEAR UNCHANGED IN YOUR OUTPUT.
 
 If a marker is present in the source text, it MUST be present in exactly the same form in the translation. If you drop a single marker, the entire EPUB will be corrupted and the translation will be REJECTED.
 
 For example, given the source:
-  <m id="m1">Hello <ref id="r1"/> world</m>
+  <m1>Hello <r1/> world</m1>
 The translation must keep:
-  <m id="m1">Ciao <ref id="r1"/> mondo</m>
+  <m1>Ciao <r1/> mondo</m1>
 
 Hard rules:
 
@@ -29,7 +29,7 @@ Hard rules:
 8. Do not invent new markers.
 9. Preserve valid marker nesting.
 10. Markers may move only when required by target-language grammar.
-11. Do not translate marker IDs, block IDs, or segment IDs.
+11. Do not translate marker names, block IDs, or segment IDs.
 12. Do not change URLs, email addresses, filenames, code-like spans, citation keys, or exact numeric references unless explicitly required.
 13. Translate naturally and preserve the author's tone.
 14. Do not leave source-language prose untranslated unless it is a name, quote, technical token, or intentionally untranslated expression.
@@ -37,12 +37,12 @@ Hard rules:
 Markers look like this:
 
 ```xml
-<m id="m0"> ... </m>
-<ref id="r1"/>
-<keep id="k2"> ... </keep>
+<m1> ... </m1>
+<r1/>
+<m2> ... </m2>
 ```
 
-Close tags are exactly `</m>` or `</keep>` — no spaces inside the tag. `<m id="m0">text</m>` is correct. `<m id="m0">text</ m>` is incorrect.
+Close tags must match the marker name exactly, with no spaces inside the tag. `<m1>text</m1>` is correct. `<m1>text</ m1>` is incorrect.
 
 The output must match this JSON shape exactly:
 
@@ -89,7 +89,7 @@ Context after this segment:
 {{context_after}}
 ```
 
-Already-translated prior segments (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}
@@ -161,11 +161,11 @@ Before returning, verify internally that:
 
 1. Every input block ID appears once.
 2. Every required marker appears exactly once unless the input explicitly contains it multiple times.
-3. Each marker has exactly the same id attribute as in the source.
-4. All marker close tags are correct (`</m>` not `</ m>`).
+3. Each marker has exactly the same tag name as in the source.
+4. All marker close tags are correct (`</m1>` not `</ m1>`).
 5. No marker has been deleted, renamed, or duplicated.
 6. No unknown marker has been invented.
 7. No prose has been skipped.
-8. The output contains ONLY valid JSON — no commentary or Markdown.
+8. The output contains ONLY valid JSON â€” no commentary or Markdown.
 
-Markers are CRITICAL — missing markers will corrupt the EPUB.
+Markers are CRITICAL â€” missing markers will corrupt the EPUB.

--- a/crates/bookforge-llm/prompts/translate_run_preserving.v2.md
+++ b/crates/bookforge-llm/prompts/translate_run_preserving.v2.md
@@ -1,4 +1,4 @@
-# translate_run_preserving.v1.md
+﻿# translate_run_preserving.v2.md
 
 ## System
 
@@ -69,7 +69,7 @@ Context after this segment:
 {{context_after}}
 ```
 
-Already-translated prior segments (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}

--- a/crates/bookforge-llm/prompts/translate_segment.v2.md
+++ b/crates/bookforge-llm/prompts/translate_segment.v2.md
@@ -1,4 +1,4 @@
-# translate_segment.v1.md
+﻿# translate_segment.v2.md
 
 ## System
 
@@ -61,7 +61,7 @@ Context after this segment:
 {{context_after}}
 ```
 
-Already-translated prior segments (use for pronoun, gender, and voice consistency only — do not retranslate):
+Already-translated prior segments (use for pronoun, gender, and voice consistency only â€” do not retranslate):
 
 ```txt
 {{context_translation_pairs}}

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -765,16 +765,35 @@ fn batch_token_estimate(
             .sum::<usize>()
 }
 
-fn restore_missing_tokens(mut translation: String, required: &[String]) -> String {
-    for token in required {
-        if !translation.contains(token) {
-            if !translation.is_empty() && !translation.ends_with(char::is_whitespace) {
-                translation.push(' ');
-            }
-            translation.push_str(token);
+/// Deterministic per-item validation for text-mode batch responses. The
+/// markers that must survive are the ones present in THIS block's source
+/// (`item.required_markers` is segment-wide and would wrongly demand
+/// sibling blocks' markers); protected spans are already block-scoped.
+/// Failures flow into the normal repair/failure pipeline instead of the
+/// translation being silently patched up.
+fn batch_item_validation_error(item: &TranslationBatchItem, translation: &str) -> Option<String> {
+    let expected = bookforge_core::marker::marker_ids_in_text(&item.source_text);
+    let actual = bookforge_core::marker::marker_ids_in_text(translation);
+    for marker in &expected {
+        let count = actual.iter().filter(|found| *found == marker).count();
+        if count == 0 {
+            return Some(format!("inline marker missing: {marker}"));
+        }
+        if count > 1 {
+            return Some(format!("inline marker duplicated: {marker}"));
         }
     }
-    translation
+    for marker in &actual {
+        if !expected.contains(marker) {
+            return Some(format!("unknown inline marker: {marker}"));
+        }
+    }
+    for span in &item.protected_spans {
+        if !span.trim().is_empty() && !translation.contains(span) {
+            return Some(format!("protected span missing: {span}"));
+        }
+    }
+    None
 }
 
 impl TranslationBatchItem {
@@ -881,10 +900,18 @@ fn parse_text_batch_response(
             continue;
         }
 
-        let mut translation = item.translation.clone();
-        if !turbo {
-            translation = restore_missing_tokens(translation, &request_item.required_markers);
-            translation = restore_missing_tokens(translation, &request_item.protected_spans);
+        let translation = item.translation.clone();
+        if !turbo && let Some(error) = batch_item_validation_error(request_item, &translation) {
+            failures.push(BatchItemFailure {
+                item_id: item.id.clone(),
+                segment_id: request_item.segment_id.clone(),
+                error,
+                input_tokens: None,
+                input_cached_tokens: None,
+                output_tokens: None,
+                tokens_estimated: false,
+            });
+            continue;
         }
 
         translations.push(BatchItemTranslation {
@@ -1297,7 +1324,15 @@ where
                 let request_semaphore = request_semaphore.clone();
 
                 tasks.spawn(async move {
-                    let context_pairs = context_pairs_for_batch(&batch, &config).await;
+                    // Strict context must be awaited before any permit is
+                    // held (waiters would starve prerequisite batches);
+                    // best-effort context is snapshotted after permits so
+                    // earlier batches have had time to publish.
+                    let strict_context_pairs = if config.context.strict {
+                        Some(context_pairs_for_batch(&batch, &config).await)
+                    } else {
+                        None
+                    };
                     let request_permit = match request_semaphore.acquire_owned().await {
                         Ok(permit) => permit,
                         Err(_) => {
@@ -1329,6 +1364,11 @@ where
                             }
                         },
                         None => None,
+                    };
+
+                    let context_pairs = match strict_context_pairs {
+                        Some(pairs) => pairs,
+                        None => context_pairs_for_batch(&batch, &config).await,
                     };
 
                     let started = std::time::Instant::now();
@@ -2238,9 +2278,11 @@ async fn context_pairs_for_batch(
     // section boundary, so awaiting the batch's earliest segment is safe:
     // its prior-N dependencies are necessarily in *earlier* batches of
     // the same section (or earlier sections, depending on scope) and
-    // can't deadlock on a sibling item in this same batch. The scheduler
-    // calls this before acquiring request concurrency so context waiters
-    // cannot starve prerequisite split batches.
+    // can't deadlock on a sibling item in this same batch. In strict mode
+    // the scheduler calls this before acquiring request concurrency so
+    // context waiters cannot starve prerequisite split batches; in
+    // best-effort mode it is called after permits are held and returns
+    // without waiting.
     match (config.context_registry.as_deref(), batch.kind) {
         (Some(registry), BatchKind::Translation) if config.context.enabled() => {
             let earliest = batch
@@ -2838,7 +2880,7 @@ mod tests {
     }
 
     #[test]
-    fn restores_missing_protected_tokens_in_batch_response() {
+    fn missing_protected_span_fails_batch_item_instead_of_appending() {
         let seg = make_segment(
             "seg1",
             vec![protected_block("Chapter 4th", vec!["4th".to_string()])],
@@ -2863,11 +2905,56 @@ mod tests {
         })
         .to_string();
 
+        // The dropped span must surface as an item failure feeding the
+        // repair pipeline — never be glued onto the translated text.
+        let result = parse_batch_response(batch, &response).expect("parse");
+        assert_eq!(result.translations.len(), 0);
+        assert_eq!(result.failures.len(), 1);
+        assert!(
+            result.failures[0]
+                .error
+                .contains("protected span missing: 4th"),
+            "got: {}",
+            result.failures[0].error
+        );
+    }
+
+    #[test]
+    fn intact_protected_span_passes_batch_validation_unmodified() {
+        let seg = make_segment(
+            "seg1",
+            vec![protected_block("Chapter 4th", vec!["4th".to_string()])],
+            // Segment-wide marker list intentionally names a marker that is
+            // NOT in this block's source; per-block validation must not
+            // demand it (and must never append it).
+            vec!["<bf:keep/>".to_string()],
+        );
+        let config = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 64,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&[seg], &config, TranslationProfile::Balanced);
+        let batch = &batches[0];
+        let id = &batch.items[0].item_id;
+
+        let response = serde_json::json!({
+            "items": [
+                {"id": id, "translation": "Capitolo 4th"},
+            ]
+        })
+        .to_string();
+
         let result = parse_batch_response(batch, &response).expect("parse");
         assert_eq!(result.failures.len(), 0);
         assert_eq!(result.translations.len(), 1);
-        assert!(result.translations[0].text.contains("4th"));
-        assert!(result.translations[0].text.contains("<bf:keep/>"));
+        assert_eq!(
+            result.translations[0].text, "Capitolo 4th",
+            "translation must pass through without appended tokens"
+        );
     }
 
     #[test]
@@ -3472,6 +3559,7 @@ mod tests {
             window: 1,
             budget_tokens: 1000,
             scope: bookforge_core::config::ContextScope::Book,
+            strict: true,
         };
         config.context_registry = Some(Arc::new(crate::ContextRegistry::new(&segments)));
 

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -27,8 +27,13 @@ pub struct PromptTemplate {
 
 impl PromptTemplate {
     pub fn parse(name: &str, version: &str, source: &str) -> Result<Self> {
-        let system = extract_section(name, source, "System")?;
-        let user = extract_section(name, source, "User")?;
+        // include_str! embeds whatever line endings the checkout produced;
+        // on Windows with git autocrlf that is CRLF. Normalize so rendered
+        // prompts (and everything parsed back out of them) are LF-only on
+        // every platform.
+        let source = source.replace("\r\n", "\n");
+        let system = extract_section(name, &source, "System")?;
+        let user = extract_section(name, &source, "User")?;
         Ok(Self {
             name: name.to_string(),
             version: version.to_string(),

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+﻿use std::collections::HashMap;
 
 use serde::Serialize;
 use serde_json::Value;
@@ -174,26 +174,26 @@ fn json_escape_inner(value: &str) -> String {
     serialized[1..serialized.len() - 1].to_string()
 }
 
-const PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_segment.v1.md");
-const MARKER_SAFE_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_marker_safe.v1.md");
+const PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_segment.v2.md");
+const MARKER_SAFE_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_marker_safe.v2.md");
 const RUN_PRESERVING_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_run_preserving.v1.md");
+    include_str!("../prompts/translate_run_preserving.v2.md");
 const QA_TEMPLATE_SOURCE: &str = include_str!("../prompts/qa_segment.v1.md");
 
-const BATCH_PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_plain.v1.md");
+const BATCH_PLAIN_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_plain.v2.md");
 const BATCH_MARKER_SAFE_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_marker_safe.v1.md");
+    include_str!("../prompts/translate_batch_marker_safe.v2.md");
 const BATCH_RUN_PRESERVING_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_run_preserving.v1.md");
-const BATCH_REPAIR_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_repair.v1.md");
+    include_str!("../prompts/translate_batch_run_preserving.v2.md");
+const BATCH_REPAIR_TEMPLATE_SOURCE: &str = include_str!("../prompts/translate_batch_repair.v2.md");
 const BATCH_PLAIN_COMPACT_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_plain_compact.v1.md");
+    include_str!("../prompts/translate_batch_plain_compact.v2.md");
 const BATCH_MARKER_SAFE_COMPACT_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_marker_safe_compact.v1.md");
+    include_str!("../prompts/translate_batch_marker_safe_compact.v2.md");
 const BATCH_RUN_PRESERVING_COMPACT_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_run_preserving_compact.v1.md");
+    include_str!("../prompts/translate_batch_run_preserving_compact.v2.md");
 const BATCH_REPAIR_COMPACT_TEMPLATE_SOURCE: &str =
-    include_str!("../prompts/translate_batch_repair_compact.v1.md");
+    include_str!("../prompts/translate_batch_repair_compact.v2.md");
 const QA_BATCH_TEMPLATE_SOURCE: &str = include_str!("../prompts/qa_batch.v1.md");
 const DOUBLE_CHECK_BATCH_TEMPLATE_SOURCE: &str =
     include_str!("../prompts/double_check_batch.v1.md");
@@ -226,14 +226,14 @@ impl PromptLibrary {
     }
 
     pub fn embedded() -> Self {
-        let plain = PromptTemplate::parse("translate_segment", "v1", PLAIN_TEMPLATE_SOURCE)
+        let plain = PromptTemplate::parse("translate_segment", "v2", PLAIN_TEMPLATE_SOURCE)
             .expect("embedded plain template must parse");
         let marker_safe =
-            PromptTemplate::parse("translate_marker_safe", "v1", MARKER_SAFE_TEMPLATE_SOURCE)
+            PromptTemplate::parse("translate_marker_safe", "v2", MARKER_SAFE_TEMPLATE_SOURCE)
                 .expect("embedded marker-safe template must parse");
         let run_preserving = PromptTemplate::parse(
             "translate_run_preserving",
-            "v1",
+            "v2",
             RUN_PRESERVING_TEMPLATE_SOURCE,
         )
         .expect("embedded run-preserving template must parse");
@@ -241,44 +241,44 @@ impl PromptLibrary {
             .expect("embedded QA template must parse");
 
         let batch_plain =
-            PromptTemplate::parse("translate_batch_plain", "v1", BATCH_PLAIN_TEMPLATE_SOURCE)
+            PromptTemplate::parse("translate_batch_plain", "v2", BATCH_PLAIN_TEMPLATE_SOURCE)
                 .expect("embedded batch plain template must parse");
         let batch_marker_safe = PromptTemplate::parse(
             "translate_batch_marker_safe",
-            "v1",
+            "v2",
             BATCH_MARKER_SAFE_TEMPLATE_SOURCE,
         )
         .expect("embedded batch marker-safe template must parse");
         let batch_run_preserving = PromptTemplate::parse(
             "translate_batch_run_preserving",
-            "v1",
+            "v2",
             BATCH_RUN_PRESERVING_TEMPLATE_SOURCE,
         )
         .expect("embedded batch run-preserving template must parse");
         let batch_repair =
-            PromptTemplate::parse("translate_batch_repair", "v1", BATCH_REPAIR_TEMPLATE_SOURCE)
+            PromptTemplate::parse("translate_batch_repair", "v2", BATCH_REPAIR_TEMPLATE_SOURCE)
                 .expect("embedded batch repair template must parse");
         let batch_plain_compact = PromptTemplate::parse(
             "translate_batch_plain_compact",
-            "v1",
+            "v2",
             BATCH_PLAIN_COMPACT_TEMPLATE_SOURCE,
         )
         .expect("embedded batch plain compact template must parse");
         let batch_marker_safe_compact = PromptTemplate::parse(
             "translate_batch_marker_safe_compact",
-            "v1",
+            "v2",
             BATCH_MARKER_SAFE_COMPACT_TEMPLATE_SOURCE,
         )
         .expect("embedded batch marker-safe compact template must parse");
         let batch_run_preserving_compact = PromptTemplate::parse(
             "translate_batch_run_preserving_compact",
-            "v1",
+            "v2",
             BATCH_RUN_PRESERVING_COMPACT_TEMPLATE_SOURCE,
         )
         .expect("embedded batch run-preserving compact template must parse");
         let batch_repair_compact = PromptTemplate::parse(
             "translate_batch_repair_compact",
-            "v1",
+            "v2",
             BATCH_REPAIR_COMPACT_TEMPLATE_SOURCE,
         )
         .expect("embedded batch repair compact template must parse");
@@ -393,7 +393,7 @@ mod tests {
     fn embedded_library_loads_all_templates() {
         let library = PromptLibrary::embedded();
         assert_eq!(library.plain.name, "translate_segment");
-        assert_eq!(library.plain.version, "v1");
+        assert_eq!(library.plain.version, "v2");
         assert!(library.plain.system.contains("Translate"));
         assert!(library.plain.user.contains("{{segment_id}}"));
         assert_eq!(library.marker_safe.name, "translate_marker_safe");

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -72,11 +72,19 @@ pub struct EntityRunConfig {
 /// entirely; existing cache entries stay valid because the context block
 /// is rendered as an empty string and the rendered prompt itself is not
 /// part of the cache key.
+///
+/// `strict` controls the completion fence. When `true`, a segment waits
+/// until all `window` predecessors have finished, which guarantees a full
+/// context block but serializes segments within the scope (a one-file
+/// EPUB translates strictly one segment at a time). When `false` (the
+/// default), the segment takes whatever predecessors have already
+/// completed at the moment it starts and never waits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContextRunConfig {
     pub window: usize,
     pub budget_tokens: usize,
     pub scope: ContextScope,
+    pub strict: bool,
 }
 
 impl Default for ContextRunConfig {
@@ -85,6 +93,7 @@ impl Default for ContextRunConfig {
             window: 0,
             budget_tokens: 1200,
             scope: ContextScope::Chapter,
+            strict: false,
         }
     }
 }
@@ -230,10 +239,14 @@ impl ContextRegistry {
         });
     }
 
-    /// Wait for the prior `config.window` segments (scoped per `config.scope`)
-    /// to complete, then return their `CompletedContext` entries in
-    /// closest-first order, filtered to successful translations and
-    /// truncated to fit `config.budget_tokens`.
+    /// Return the prior `config.window` segments' `CompletedContext`
+    /// entries (scoped per `config.scope`) in closest-first order, filtered
+    /// to successful translations and truncated to fit
+    /// `config.budget_tokens`.
+    ///
+    /// In strict mode this waits until every prior segment has completed.
+    /// In best-effort mode (the default) it returns immediately with
+    /// whatever predecessors happen to be done.
     pub async fn await_context_for(
         &self,
         segment_id: &SegmentId,
@@ -258,6 +271,24 @@ impl ContextRegistry {
         };
         if prior.is_empty() {
             return Vec::new();
+        }
+        if !config.strict {
+            let map = self
+                .inner
+                .completed
+                .lock()
+                .expect("context registry mutex poisoned");
+            let succeeded: Vec<CompletedContext> = prior
+                .iter()
+                .filter_map(|id| map.get(id).cloned())
+                .filter(|ctx| {
+                    matches!(
+                        ctx.status,
+                        SegmentStatus::Succeeded | SegmentStatus::SkippedCached
+                    )
+                })
+                .collect();
+            return apply_context_budget(succeeded, config.budget_tokens);
         }
         loop {
             let notified = self.inner.notify.notified();
@@ -494,7 +525,15 @@ where
 
         tasks.spawn(async move {
             let mode = select_mode(&segment);
-            let context_pairs = context_pairs_for_segment(&segment, &config).await;
+            // Strict mode must wait for predecessors BEFORE taking a permit,
+            // otherwise waiters occupy the whole pool and deadlock. Best-
+            // effort mode snapshots AFTER taking a permit so predecessors
+            // have had as long as possible to finish.
+            let strict_context_pairs = if config.context.strict {
+                Some(context_pairs_for_segment(&segment, &config).await)
+            } else {
+                None
+            };
             let Ok(_permit) = semaphore.acquire_owned().await else {
                 let failed = failed_translation_with_tokens(
                     &segment,
@@ -508,6 +547,10 @@ where
                     registry.pre_populate(&segment, &failed);
                 }
                 return failed;
+            };
+            let context_pairs = match strict_context_pairs {
+                Some(pairs) => pairs,
+                None => context_pairs_for_segment(&segment, &config).await,
             };
             let translation =
                 translate_one(provider, library, segment.clone(), &config, context_pairs).await;
@@ -1167,15 +1210,7 @@ fn parse_and_validate(
                 .first()
                 .map(|block| block.protected_spans.as_slice())
                 .unwrap_or(&[]);
-            let (translation, repaired) =
-                repair_missing_protected_spans(expected_spans, parsed.translation);
-            if !repaired.is_empty() {
-                tracing::warn!(
-                    segment_id = %segment.id.0,
-                    "re-inserted missing protected spans: {:?}",
-                    repaired
-                );
-            }
+            let translation = parsed.translation;
             validate_protected_spans(segment, expected_spans, &translation)?;
             let block_id = segment
                 .block_ids
@@ -1231,16 +1266,6 @@ fn parse_and_validate(
                                 segment.id.0, source_block.block_id.0
                             ))
                         })?;
-                let (translation, repaired) =
-                    repair_missing_protected_spans(&source_block.protected_spans, translation);
-                if !repaired.is_empty() {
-                    tracing::warn!(
-                        segment_id = %segment.id.0,
-                        block_id = %source_block.block_id.0,
-                        "re-inserted missing protected spans: {:?}",
-                        repaired
-                    );
-                }
                 let expected_markers = marker_ids_in_text(&source_block.text);
                 validate_markers(segment, &expected_markers, &translation)?;
                 validate_protected_spans(segment, &source_block.protected_spans, &translation)?;
@@ -1292,16 +1317,6 @@ fn parse_and_validate(
                         ))
                     })?;
                 let text = validate_and_join_runs(segment, source_block, block.translated_runs)?;
-                let (text, repaired) =
-                    repair_missing_protected_spans(&source_block.protected_spans, text);
-                if !repaired.is_empty() {
-                    tracing::warn!(
-                        segment_id = %segment.id.0,
-                        block_id = %source_block.block_id.0,
-                        "re-inserted missing protected spans in run-preserving: {:?}",
-                        repaired
-                    );
-                }
                 let expected_markers = marker_ids_in_text(&source_block.text);
                 validate_markers(segment, &expected_markers, &text)?;
                 validate_protected_spans(segment, &source_block.protected_spans, &text)?;
@@ -1419,24 +1434,6 @@ fn validation_retry_appendix(segment: &Segment, mode: TranslationMode, error: &s
          Required markers:\n{markers}\n",
         mode.template_name()
     )
-}
-
-fn repair_missing_protected_spans(
-    spans: &[String],
-    mut translation: String,
-) -> (String, Vec<String>) {
-    let mut reinserted = Vec::new();
-    for span in spans {
-        if span.trim().is_empty() || translation.contains(span) {
-            continue;
-        }
-        if !translation.is_empty() && !translation.ends_with(char::is_whitespace) {
-            translation.push(' ');
-        }
-        translation.push_str(span);
-        reinserted.push(span.clone());
-    }
-    (translation, reinserted)
 }
 
 fn validate_protected_spans(segment: &Segment, spans: &[String], translation: &str) -> Result<()> {
@@ -1648,6 +1645,7 @@ mod tests {
             window: 1,
             budget_tokens: 1000,
             scope: ContextScope::Book,
+            strict: true,
         };
         cfg.context_registry = Some(Arc::new(ContextRegistry::new(&segments)));
 
@@ -1698,7 +1696,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn protected_span_failure_is_repaired() {
+    async fn protected_span_failure_surfaces_as_needs_review() {
+        // The uppercase mock destroys the URL's casing on every attempt;
+        // that is a genuine translation defect and must be flagged for
+        // review with the source preserved, not papered over by appending
+        // the original URL after the mangled one.
         let mut segment = segment("seg_a", 0, vec![("b0", "Visit https://example.com")]);
         segment.source.blocks[0]
             .protected_spans
@@ -1716,16 +1718,23 @@ mod tests {
         .await
         .expect("validation failure should not propagate");
 
-        assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+        assert_eq!(translations[0].status, SegmentStatus::NeedsReview);
         assert!(
-            translations[0].blocks[0]
-                .text
-                .contains("https://example.com")
+            translations[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("protected span missing")),
+            "error should name the missing span, got: {:?}",
+            translations[0].error
+        );
+        assert_eq!(
+            translations[0].blocks[0].text, "Visit https://example.com",
+            "needs-review fallback must preserve the source text"
         );
     }
 
     #[tokio::test]
-    async fn missing_protected_span_is_reinserted_before_validation() {
+    async fn missing_protected_span_fails_validation_instead_of_appending() {
         let mut segment = segment("seg_a", 0, vec![("b0", "The 4th day")]);
         segment.source.blocks[0]
             .protected_spans
@@ -1734,10 +1743,24 @@ mod tests {
 
         let translations = translate_segments(MissingProtectedSpanProvider, &[segment], &config())
             .await
-            .expect("protected span repair should keep segment successful");
+            .expect("validation failure should not propagate");
 
-        assert_eq!(translations[0].status, SegmentStatus::Succeeded);
-        assert!(translations[0].blocks[0].text.contains("4th"));
+        // A dropped protected span must surface as needs-review with the
+        // source text preserved — never be silently glued onto the end of
+        // the translated paragraph.
+        assert_eq!(translations[0].status, SegmentStatus::NeedsReview);
+        assert!(
+            translations[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("protected span missing")),
+            "error should name the missing span, got: {:?}",
+            translations[0].error
+        );
+        assert_eq!(
+            translations[0].blocks[0].text, "The 4th day",
+            "needs-review fallback must preserve the source text"
+        );
     }
 
     #[tokio::test]
@@ -2123,6 +2146,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Chapter,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[3].id, cfg).await;
         let ids: Vec<&str> = pairs.iter().map(|p| p.segment_id.0.as_str()).collect();
@@ -2149,6 +2173,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Chapter,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[2].id, cfg).await;
         let ids: Vec<&str> = pairs.iter().map(|p| p.segment_id.0.as_str()).collect();
@@ -2181,6 +2206,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Chapter,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[2].id, cfg).await;
         let ids: Vec<&str> = pairs.iter().map(|p| p.segment_id.0.as_str()).collect();
@@ -2213,6 +2239,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Book,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[2].id, cfg).await;
         let ids: Vec<&str> = pairs.iter().map(|p| p.segment_id.0.as_str()).collect();
@@ -2246,6 +2273,7 @@ mod tests {
             window: 3,
             budget_tokens: 30, // intentionally tight
             scope: ContextScope::Chapter,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[3].id, cfg).await;
         assert!(
@@ -2274,6 +2302,7 @@ mod tests {
             window: 0,
             budget_tokens: 1200,
             scope: ContextScope::Chapter,
+            strict: false,
         };
         let pairs = registry.await_context_for(&segs[1].id, cfg).await;
         assert!(pairs.is_empty());
@@ -2299,6 +2328,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Chapter,
+            strict: true,
         };
         let pairs = tokio::time::timeout(
             std::time::Duration::from_millis(500),
@@ -2308,6 +2338,37 @@ mod tests {
         .expect("fence must unblock once segment a publishes");
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].translated_text, "[T]Alpha-late");
+    }
+
+    #[tokio::test]
+    async fn best_effort_context_returns_partial_pairs_without_waiting() {
+        let segs = vec![
+            segment_in_section("a", "s1", 0, "Alpha"),
+            segment_in_section("b", "s1", 1, "Bravo"),
+            segment_in_section("c", "s1", 2, "Charlie"),
+            segment_in_section("d", "s1", 3, "Delta"),
+        ];
+        let registry = ContextRegistry::new(&segs);
+        // Only the closest predecessor has completed; a and b are still
+        // in flight.
+        registry.pre_populate(
+            &segs[2],
+            &translation_for(&segs[2], "[T]Charlie", SegmentStatus::Succeeded),
+        );
+        let cfg = ContextRunConfig {
+            window: 3,
+            budget_tokens: 10_000,
+            scope: ContextScope::Chapter,
+            strict: false,
+        };
+        let pairs = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            registry.await_context_for(&segs[3].id, cfg),
+        )
+        .await
+        .expect("best-effort context must not block on missing predecessors");
+        let ids: Vec<&str> = pairs.iter().map(|p| p.segment_id.0.as_str()).collect();
+        assert_eq!(ids, vec!["c"], "only completed predecessors are returned");
     }
 
     #[test]
@@ -2409,6 +2470,7 @@ mod tests {
             window: 3,
             budget_tokens: 10_000,
             scope: ContextScope::Chapter,
+            strict: true,
         };
         cfg.context_registry = Some(registry.clone());
 

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -1834,15 +1834,8 @@ mod tests {
 
     #[tokio::test]
     async fn inline_marker_failure_is_marked_needs_review() {
-        let mut segment = segment(
-            "seg_a",
-            0,
-            vec![("b0", "Hello <m id=\"m000000_000\">world</m>!")],
-        );
-        segment
-            .constraints
-            .preserve_markers
-            .push("m000000_000".to_string());
+        let mut segment = segment("seg_a", 0, vec![("b0", "Hello <m1>world</m1>!")]);
+        segment.constraints.preserve_markers.push("m1".to_string());
 
         let translations = translate_segments(
             MockProvider::new(MockMode::Uppercase, "Italian"),
@@ -1853,10 +1846,7 @@ mod tests {
         .expect("marker validation failure should not propagate");
 
         assert_eq!(translations[0].status, SegmentStatus::NeedsReview);
-        assert_eq!(
-            translations[0].blocks[0].text,
-            "Hello <m id=\"m000000_000\">world</m>!"
-        );
+        assert_eq!(translations[0].blocks[0].text, "Hello <m1>world</m1>!");
         assert!(
             translations[0]
                 .error
@@ -1867,11 +1857,7 @@ mod tests {
 
     #[tokio::test]
     async fn marker_failure_falls_back_to_run_preserving_mode() {
-        let mut segment = segment(
-            "seg_a",
-            0,
-            vec![("b0", "Hello <m id=\"m000000_000\">world</m>!")],
-        );
+        let mut segment = segment("seg_a", 0, vec![("b0", "Hello <m1>world</m1>!")]);
         segment.source.blocks[0].text_runs = vec![
             SegmentTextRun {
                 id: "r0".to_string(),
@@ -1879,7 +1865,7 @@ mod tests {
             },
             SegmentTextRun {
                 id: "r1".to_string(),
-                text: "<m id=\"m000000_000\">".to_string(),
+                text: "<m1>".to_string(),
             },
             SegmentTextRun {
                 id: "r2".to_string(),
@@ -1887,17 +1873,14 @@ mod tests {
             },
             SegmentTextRun {
                 id: "r3".to_string(),
-                text: "</m>".to_string(),
+                text: "</m1>".to_string(),
             },
             SegmentTextRun {
                 id: "r4".to_string(),
                 text: "!".to_string(),
             },
         ];
-        segment
-            .constraints
-            .preserve_markers
-            .push("m000000_000".to_string());
+        segment.constraints.preserve_markers.push("m1".to_string());
 
         let mut config = config();
         config.scheduler.max_attempts = 1;
@@ -1911,10 +1894,7 @@ mod tests {
 
         assert_eq!(translations[0].status, SegmentStatus::Succeeded);
         assert_eq!(translations[0].template, "translate_run_preserving");
-        assert_eq!(
-            translations[0].blocks[0].text,
-            "HELLO <m id=\"m000000_000\">WORLD</m>!"
-        );
+        assert_eq!(translations[0].blocks[0].text, "HELLO <m1>WORLD</m1>!");
     }
 
     #[tokio::test]

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bookforge-pdf"
+version = "1.4.0"
+description = "PDF ingestion for BookForge: poppler-based layout extraction and deterministic reconstruction into a translatable EPUB."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+quick-xml.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+zip.workspace = true
+
+[dev-dependencies]
+bookforge-core = { version = "1.4.0", path = "../bookforge-core" }
+bookforge-epub = { version = "1.4.0", path = "../bookforge-epub" }
+tempfile = "3"

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -1,0 +1,78 @@
+//! End-to-end conversion orchestration: poppler → parse → reconstruct →
+//! EPUB + report.
+
+use std::path::{Path, PathBuf};
+
+use crate::{
+    Result,
+    epub::write_epub,
+    model::{ColumnMode, DocBlock},
+    parse::parse_pdf2xml,
+    reconstruct::reconstruct,
+    report::ConversionReport,
+    tools::PopplerTools,
+};
+
+#[derive(Debug, Clone)]
+pub struct ConvertOptions {
+    pub columns: ColumnMode,
+    /// dc:language for the produced EPUB (source language of the PDF).
+    pub language: String,
+    /// dc:title; defaults to the input file stem when empty.
+    pub title: String,
+}
+
+impl Default for ConvertOptions {
+    fn default() -> Self {
+        Self {
+            columns: ColumnMode::Auto,
+            language: "en".to_string(),
+            title: String::new(),
+        }
+    }
+}
+
+pub struct ConvertOutcome {
+    pub output: PathBuf,
+    pub report: ConversionReport,
+}
+
+pub fn convert_pdf(
+    input: &Path,
+    output: &Path,
+    options: &ConvertOptions,
+) -> Result<ConvertOutcome> {
+    let tools = PopplerTools::discover()?;
+
+    let xml = tools.pdf_to_xml(input)?;
+    let pages = parse_pdf2xml(&xml)?;
+    let reconstruction = reconstruct(&pages, options.columns);
+
+    let title = if options.title.is_empty() {
+        input
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "Converted PDF".to_string())
+    } else {
+        options.title.clone()
+    };
+    write_epub(&reconstruction.blocks, &title, &options.language, output)?;
+
+    let baseline = tools.pdf_to_text(input)?;
+    let baseline_chars = baseline.chars().filter(|ch| !ch.is_whitespace()).count();
+    let reconstructed_chars: usize = reconstruction.blocks.iter().map(DocBlock::char_count).sum();
+
+    let report = ConversionReport::build(
+        &input.to_string_lossy(),
+        &output.to_string_lossy(),
+        reconstruction.pages,
+        reconstruction.blocks.len(),
+        reconstructed_chars,
+        baseline_chars,
+    );
+
+    Ok(ConvertOutcome {
+        output: output.to_path_buf(),
+        report,
+    })
+}

--- a/crates/bookforge-pdf/src/epub.rs
+++ b/crates/bookforge-pdf/src/epub.rs
@@ -1,0 +1,158 @@
+//! Synthetic EPUB assembly from reconstructed blocks. The output is a
+//! minimal, valid, reflowable EPUB 3 that the ordinary BookForge
+//! pipeline (inspect, translate, validate, review) consumes unchanged.
+
+use std::{fs::File, io::Write, path::Path};
+
+use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+
+use crate::{
+    Result,
+    model::{DocBlock, Span},
+};
+
+const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+pub fn write_epub(blocks: &[DocBlock], title: &str, language: &str, output: &Path) -> Result<()> {
+    let file = File::create(output)?;
+    let mut zip = ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored)?;
+    zip.write_all(b"application/epub+zip")?;
+    zip.start_file("META-INF/container.xml", deflated)?;
+    zip.write_all(CONTAINER_XML.as_bytes())?;
+    zip.start_file("content.opf", deflated)?;
+    zip.write_all(opf(title, language).as_bytes())?;
+    zip.start_file("content.xhtml", deflated)?;
+    zip.write_all(chapter_xhtml(blocks, title).as_bytes())?;
+    zip.finish()?;
+    Ok(())
+}
+
+fn opf(title: &str, language: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">bookforge-pdf-conversion</dc:identifier>
+    <dc:title>{}</dc:title>
+    <dc:language>{}</dc:language>
+  </metadata>
+  <manifest>
+    <item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="content"/>
+  </spine>
+</package>"#,
+        escape_text(title),
+        escape_text(language)
+    )
+}
+
+fn chapter_xhtml(blocks: &[DocBlock], title: &str) -> String {
+    let mut body = String::new();
+    for block in blocks {
+        match block {
+            DocBlock::Heading { level, spans } => {
+                let level = (*level).clamp(1, 6);
+                body.push_str(&format!("<h{level}>{}</h{level}>\n", render_spans(spans)));
+            }
+            DocBlock::Paragraph { spans } => {
+                body.push_str(&format!("<p>{}</p>\n", render_spans(spans)));
+            }
+        }
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>{}</title></head>
+<body>
+{body}</body>
+</html>"#,
+        escape_text(title)
+    )
+}
+
+fn render_spans(spans: &[Span]) -> String {
+    let mut out = String::new();
+    for span in spans {
+        let text = escape_text(span.text.trim_matches('\u{0}'));
+        match (span.bold, span.italic) {
+            (true, true) => out.push_str(&format!("<b><i>{text}</i></b>")),
+            (true, false) => out.push_str(&format!("<b>{text}</b>")),
+            (false, true) => out.push_str(&format!("<i>{text}</i>")),
+            (false, false) => out.push_str(&text),
+        }
+    }
+    out.trim().to_string()
+}
+
+fn escape_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Span;
+
+    fn span(text: &str) -> Span {
+        Span {
+            text: text.to_string(),
+            bold: false,
+            italic: false,
+        }
+    }
+
+    #[test]
+    fn produced_epub_is_readable_by_the_bookforge_reader() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("converted.epub");
+        let blocks = vec![
+            DocBlock::Heading {
+                level: 1,
+                spans: vec![span("Paper Title")],
+            },
+            DocBlock::Paragraph {
+                spans: vec![
+                    span("Body with "),
+                    Span {
+                        text: "emphasis".into(),
+                        bold: false,
+                        italic: true,
+                    },
+                    span(" & escapes <ok>."),
+                ],
+            },
+        ];
+
+        write_epub(&blocks, "Paper Title", "en", &path).expect("epub writes");
+
+        let book = bookforge_epub::read_epub(&path).expect("bookforge must read its own output");
+        assert!(
+            book.blocks
+                .iter()
+                .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Heading(1))),
+            "heading must survive"
+        );
+        let coverage = bookforge_epub::text_coverage(&path).expect("coverage");
+        assert_eq!(coverage.percent(), 100.0, "all text must be translatable");
+    }
+}

--- a/crates/bookforge-pdf/src/lib.rs
+++ b/crates/bookforge-pdf/src/lib.rs
@@ -1,0 +1,43 @@
+//! PDF ingestion for BookForge (ROADMAP §9b).
+//!
+//! Layout extraction is delegated to poppler's command-line tools;
+//! everything after the `pdftohtml -xml` output is deterministic Rust:
+//! line merging, column detection, reading order, paragraph clustering,
+//! heading detection, and synthetic-EPUB assembly. The produced EPUB
+//! flows through the ordinary BookForge pipeline — this crate is an
+//! ingestion front-end, not a parallel translation path.
+
+pub mod convert;
+pub mod epub;
+pub mod model;
+pub mod parse;
+pub mod reconstruct;
+pub mod report;
+pub mod tools;
+
+pub use convert::{ConvertOptions, ConvertOutcome, convert_pdf};
+pub use model::{ColumnMode, DocBlock, Line, Page, Span};
+pub use parse::parse_pdf2xml;
+pub use reconstruct::reconstruct;
+pub use report::ConversionReport;
+pub use tools::{PopplerTools, ToolError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PdfError {
+    #[error("poppler tooling: {0}")]
+    Tool(#[from] tools::ToolError),
+
+    #[error("pdftohtml XML parse: {0}")]
+    Xml(#[from] quick_xml::Error),
+
+    #[error("invalid pdftohtml output: {0}")]
+    InvalidInput(String),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("zip: {0}")]
+    Zip(#[from] zip::result::ZipError),
+}
+
+pub type Result<T> = std::result::Result<T, PdfError>;

--- a/crates/bookforge-pdf/src/model.rs
+++ b/crates/bookforge-pdf/src/model.rs
@@ -1,0 +1,117 @@
+//! Page/line intermediate representation produced by the poppler XML
+//! parser and consumed by reconstruction. Coordinates are pdftohtml's
+//! integer pixel units, top-left origin.
+
+/// A styled run of text within a line fragment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Span {
+    pub text: String,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+/// One `<text>` fragment from pdftohtml, already a visual line or part
+/// of one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Fragment {
+    pub top: i32,
+    pub left: i32,
+    pub width: i32,
+    pub height: i32,
+    pub font: u32,
+    pub spans: Vec<Span>,
+}
+
+impl Fragment {
+    pub fn right(&self) -> i32 {
+        self.left + self.width
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.spans
+            .iter()
+            .map(|span| span.text.chars().filter(|ch| !ch.is_whitespace()).count())
+            .sum()
+    }
+}
+
+/// A merged visual line (one or more fragments at the same height).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Line {
+    pub top: i32,
+    pub left: i32,
+    pub right: i32,
+    pub height: i32,
+    pub font_size: u32,
+    pub spans: Vec<Span>,
+}
+
+impl Line {
+    pub fn width(&self) -> i32 {
+        self.right - self.left
+    }
+
+    pub fn text(&self) -> String {
+        self.spans
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<String>()
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.spans
+            .iter()
+            .map(|span| span.text.chars().filter(|ch| !ch.is_whitespace()).count())
+            .sum()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Page {
+    pub number: u32,
+    pub width: i32,
+    pub height: i32,
+    pub fragments: Vec<Fragment>,
+    /// font id -> point size, from `<fontspec>` declarations.
+    pub font_sizes: std::collections::HashMap<u32, u32>,
+}
+
+/// Column handling requested on the CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColumnMode {
+    #[default]
+    Auto,
+    Single,
+    Two,
+}
+
+/// A reconstructed, reading-ordered document block ready for XHTML
+/// emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DocBlock {
+    Heading { level: u8, spans: Vec<Span> },
+    Paragraph { spans: Vec<Span> },
+}
+
+impl DocBlock {
+    pub fn spans(&self) -> &[Span] {
+        match self {
+            DocBlock::Heading { spans, .. } => spans,
+            DocBlock::Paragraph { spans } => spans,
+        }
+    }
+
+    pub fn text(&self) -> String {
+        self.spans()
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<String>()
+    }
+
+    pub fn char_count(&self) -> usize {
+        self.spans()
+            .iter()
+            .map(|span| span.text.chars().filter(|ch| !ch.is_whitespace()).count())
+            .sum()
+    }
+}

--- a/crates/bookforge-pdf/src/parse.rs
+++ b/crates/bookforge-pdf/src/parse.rs
@@ -1,0 +1,259 @@
+//! Parser for `pdftohtml -xml` output into the page/fragment IR.
+//!
+//! The format, per page:
+//!
+//! ```xml
+//! <page number="1" width="918" height="1188" ...>
+//!   <fontspec id="0" size="17" family="Times" color="#000000"/>
+//!   <text top="246" left="261" width="394" height="18" font="0">Line with <b>bold</b></text>
+//! </page>
+//! ```
+//!
+//! `<text>` content may nest `<b>`, `<i>` (and occasionally `<a>`);
+//! styling is flattened into spans, anchors into plain text.
+
+use std::collections::HashMap;
+
+use quick_xml::{Reader, events::Event};
+
+use crate::{
+    PdfError, Result,
+    model::{Fragment, Page, Span},
+};
+
+pub fn parse_pdf2xml(xml: &str) -> Result<Vec<Page>> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+
+    let mut pages = Vec::new();
+    let mut current_page: Option<Page> = None;
+    let mut current_fragment: Option<Fragment> = None;
+    let mut bold_depth = 0usize;
+    let mut italic_depth = 0usize;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) | Event::Empty(element)
+                if local(element.name().as_ref()) == b"page" =>
+            {
+                if let Some(page) = current_page.take() {
+                    pages.push(page);
+                }
+                let mut number = 0u32;
+                let mut width = 0i32;
+                let mut height = 0i32;
+                for attr in element.attributes() {
+                    let attr = attr.map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    let value = attr
+                        .decode_and_unescape_value(reader.decoder())
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    match local(attr.key.as_ref()) {
+                        b"number" => number = value.parse().unwrap_or(0),
+                        b"width" => width = parse_coord(&value),
+                        b"height" => height = parse_coord(&value),
+                        _ => {}
+                    }
+                }
+                current_page = Some(Page {
+                    number,
+                    width,
+                    height,
+                    fragments: Vec::new(),
+                    font_sizes: HashMap::new(),
+                });
+            }
+            Event::Empty(element) if local(element.name().as_ref()) == b"fontspec" => {
+                let Some(page) = current_page.as_mut() else {
+                    continue;
+                };
+                let mut id = None;
+                let mut size = None;
+                for attr in element.attributes() {
+                    let attr = attr.map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    let value = attr
+                        .decode_and_unescape_value(reader.decoder())
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    match local(attr.key.as_ref()) {
+                        b"id" => id = value.parse::<u32>().ok(),
+                        b"size" => size = Some(parse_coord(&value).unsigned_abs()),
+                        _ => {}
+                    }
+                }
+                if let (Some(id), Some(size)) = (id, size) {
+                    page.font_sizes.insert(id, size);
+                }
+            }
+            Event::Start(element) if local(element.name().as_ref()) == b"text" => {
+                let mut fragment = Fragment {
+                    top: 0,
+                    left: 0,
+                    width: 0,
+                    height: 0,
+                    font: 0,
+                    spans: Vec::new(),
+                };
+                for attr in element.attributes() {
+                    let attr = attr.map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    let value = attr
+                        .decode_and_unescape_value(reader.decoder())
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    match local(attr.key.as_ref()) {
+                        b"top" => fragment.top = parse_coord(&value),
+                        b"left" => fragment.left = parse_coord(&value),
+                        b"width" => fragment.width = parse_coord(&value),
+                        b"height" => fragment.height = parse_coord(&value),
+                        b"font" => fragment.font = value.parse().unwrap_or(0),
+                        _ => {}
+                    }
+                }
+                current_fragment = Some(fragment);
+                bold_depth = 0;
+                italic_depth = 0;
+            }
+            Event::Start(element) if current_fragment.is_some() => {
+                match local(element.name().as_ref()) {
+                    b"b" => bold_depth += 1,
+                    b"i" => italic_depth += 1,
+                    _ => {}
+                }
+            }
+            Event::End(element) if current_fragment.is_some() => {
+                match local(element.name().as_ref()) {
+                    b"text" => {
+                        let fragment = current_fragment.take().expect("checked above");
+                        if let Some(page) = current_page.as_mut()
+                            && fragment.spans.iter().any(|span| !span.text.is_empty())
+                        {
+                            page.fragments.push(fragment);
+                        }
+                    }
+                    b"b" => bold_depth = bold_depth.saturating_sub(1),
+                    b"i" => italic_depth = italic_depth.saturating_sub(1),
+                    _ => {}
+                }
+            }
+            Event::Text(text) => {
+                if let Some(fragment) = current_fragment.as_mut() {
+                    let value = text
+                        .html_content()
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    push_span(fragment, &value, bold_depth > 0, italic_depth > 0);
+                }
+            }
+            Event::GeneralRef(reference) => {
+                if let Some(fragment) = current_fragment.as_mut() {
+                    if let Some(ch) = reference
+                        .resolve_char_ref()
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?
+                    {
+                        push_span(fragment, &ch.to_string(), bold_depth > 0, italic_depth > 0);
+                    } else {
+                        let name = reference
+                            .decode()
+                            .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                        if let Some(value) = quick_xml::escape::resolve_html5_entity(&name) {
+                            push_span(fragment, value, bold_depth > 0, italic_depth > 0);
+                        }
+                    }
+                }
+            }
+            Event::End(element) if local(element.name().as_ref()) == b"page" => {
+                if let Some(page) = current_page.take() {
+                    pages.push(page);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    if let Some(page) = current_page.take() {
+        pages.push(page);
+    }
+
+    Ok(pages)
+}
+
+fn push_span(fragment: &mut Fragment, text: &str, bold: bool, italic: bool) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = fragment.spans.last_mut()
+        && last.bold == bold
+        && last.italic == italic
+    {
+        last.text.push_str(text);
+        return;
+    }
+    fragment.spans.push(Span {
+        text: text.to_string(),
+        bold,
+        italic,
+    });
+}
+
+/// pdftohtml emits integer coordinates, but some builds produce
+/// fractional values; accept both.
+fn parse_coord(value: &str) -> i32 {
+    value
+        .parse::<i32>()
+        .or_else(|_| value.parse::<f64>().map(|f| f.round() as i32))
+        .unwrap_or(0)
+}
+
+fn local(name: &[u8]) -> &[u8] {
+    name.rsplit(|byte| *byte == b':').next().unwrap_or(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r##"<?xml version="1.0" encoding="UTF-8"?>
+<pdf2xml producer="poppler" version="24.02.0">
+<page number="1" position="absolute" top="0" left="0" height="1188" width="918">
+  <fontspec id="0" size="22" family="Times" color="#000000"/>
+  <fontspec id="1" size="11" family="Times" color="#000000"/>
+  <text top="100" left="200" width="500" height="24" font="0">A <b>Bold</b> Title</text>
+  <text top="200" left="100" width="350" height="12" font="1">Left column line with <i>italics</i>.</text>
+  <text top="200" left="480" width="350" height="12" font="1">Right column &amp; more.</text>
+</page>
+</pdf2xml>"##;
+
+    #[test]
+    fn parses_pages_fonts_and_styled_fragments() {
+        let pages = parse_pdf2xml(SAMPLE).expect("sample should parse");
+        assert_eq!(pages.len(), 1);
+        let page = &pages[0];
+        assert_eq!(page.number, 1);
+        assert_eq!(page.width, 918);
+        assert_eq!(page.font_sizes.get(&0), Some(&22));
+        assert_eq!(page.fragments.len(), 3);
+
+        let title = &page.fragments[0];
+        assert_eq!(title.font, 0);
+        assert_eq!(
+            title.spans,
+            vec![
+                Span {
+                    text: "A ".into(),
+                    bold: false,
+                    italic: false
+                },
+                Span {
+                    text: "Bold".into(),
+                    bold: true,
+                    italic: false
+                },
+                Span {
+                    text: " Title".into(),
+                    bold: false,
+                    italic: false
+                },
+            ]
+        );
+
+        let right = &page.fragments[2];
+        assert_eq!(right.spans[0].text, "Right column & more.");
+    }
+}

--- a/crates/bookforge-pdf/src/reconstruct.rs
+++ b/crates/bookforge-pdf/src/reconstruct.rs
@@ -1,0 +1,569 @@
+//! Deterministic layout reconstruction: fragments → lines → columns →
+//! reading order → paragraphs/headings.
+//!
+//! The heuristics here are deliberately simple and inspectable. They are
+//! tuned for the two layouts that matter first (ROADMAP §9b.1):
+//! single-column books and two-column scientific papers. Anything the
+//! heuristics get wrong shows up in the conversion report as a per-page
+//! coverage gap, never as silently dropped text.
+
+use std::collections::HashMap;
+
+use crate::model::{ColumnMode, DocBlock, Fragment, Line, Page, Span};
+
+/// Per-page reconstruction diagnostics for the conversion report.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PageStats {
+    pub page: u32,
+    pub lines: usize,
+    pub chars: usize,
+    pub two_column: bool,
+}
+
+pub struct Reconstruction {
+    pub blocks: Vec<DocBlock>,
+    pub pages: Vec<PageStats>,
+}
+
+pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
+    let body_size = body_font_size(pages);
+    let heading_levels = heading_levels(pages, body_size);
+
+    let mut blocks: Vec<DocBlock> = Vec::new();
+    let mut stats = Vec::new();
+
+    for page in pages {
+        let lines = merge_fragments_into_lines(page);
+        let two_column = match columns {
+            ColumnMode::Single => false,
+            ColumnMode::Two => true,
+            ColumnMode::Auto => detect_two_columns(page, &lines),
+        };
+        let ordered = if two_column {
+            order_two_column(page, &lines)
+        } else {
+            let mut ordered = lines.clone();
+            ordered.sort_by_key(|line| (line.top, line.left));
+            ordered
+        };
+
+        stats.push(PageStats {
+            page: page.number,
+            lines: ordered.len(),
+            chars: ordered.iter().map(Line::char_count).sum(),
+            two_column,
+        });
+
+        let page_blocks = cluster_paragraphs(&ordered, body_size, &heading_levels);
+        append_with_continuation(&mut blocks, page_blocks);
+    }
+
+    Reconstruction {
+        blocks,
+        pages: stats,
+    }
+}
+
+/// Group fragments that share a baseline into one visual line, joining
+/// fragment gaps with a space when they are visually separated.
+fn merge_fragments_into_lines(page: &Page) -> Vec<Line> {
+    // poppler reports rotated text (arXiv margin watermarks, sidebar
+    // decorations) with zero width. It is not part of the reading flow
+    // and, left in, it skews the column-midline estimate.
+    let mut fragments: Vec<&Fragment> = page
+        .fragments
+        .iter()
+        .filter(|fragment| fragment.width > 0)
+        .collect();
+    fragments.sort_by_key(|fragment| (fragment.top, fragment.left));
+
+    let mut lines: Vec<Line> = Vec::new();
+    for fragment in fragments {
+        let size = page
+            .font_sizes
+            .get(&fragment.font)
+            .copied()
+            .unwrap_or(fragment.height.unsigned_abs());
+        let same_line = lines.last().is_some_and(|line| {
+            let tolerance = (line.height.max(fragment.height) as f32 * 0.5) as i32;
+            // The gap cap keeps same-baseline lines in *different columns*
+            // from merging. Style-split fragments sit flush and justified
+            // word gaps stay under ~1em, while column gutters run wider
+            // than the line height — observed as low as ~1.7× height on
+            // two-column papers, so the cap must stay below that.
+            let max_join_gap = line.height.max(fragment.height) * 5 / 4;
+            (fragment.top - line.top).abs() <= tolerance
+                && fragment.left >= line.right - 2
+                && fragment.left - line.right <= max_join_gap
+        });
+
+        if same_line {
+            let line = lines.last_mut().expect("checked above");
+            let gap = fragment.left - line.right;
+            if gap > 1 && !line.spans.last().is_some_and(|s| s.text.ends_with(' ')) {
+                push_joined(&mut line.spans, " ", false, false);
+            }
+            for span in &fragment.spans {
+                push_joined(&mut line.spans, &span.text, span.bold, span.italic);
+            }
+            line.right = line.right.max(fragment.right());
+            line.height = line.height.max(fragment.height);
+            line.font_size = line.font_size.max(size);
+        } else {
+            lines.push(Line {
+                top: fragment.top,
+                left: fragment.left,
+                right: fragment.right(),
+                height: fragment.height,
+                font_size: size,
+                spans: fragment.spans.clone(),
+            });
+        }
+    }
+
+    lines.retain(|line| !line.text().trim().is_empty());
+    lines
+}
+
+fn push_joined(spans: &mut Vec<Span>, text: &str, bold: bool, italic: bool) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = spans.last_mut()
+        && last.bold == bold
+        && last.italic == italic
+    {
+        last.text.push_str(text);
+        return;
+    }
+    spans.push(Span {
+        text: text.to_string(),
+        bold,
+        italic,
+    });
+}
+
+/// A page is two-column when most non-full-width lines sit entirely in
+/// the left or right half with a clear gutter and few lines crossing it.
+fn detect_two_columns(page: &Page, lines: &[Line]) -> bool {
+    if lines.len() < 8 {
+        return false;
+    }
+    let content_left = lines.iter().map(|line| line.left).min().unwrap_or(0);
+    let content_right = lines
+        .iter()
+        .map(|line| line.right)
+        .max()
+        .unwrap_or(page.width);
+    let content_width = (content_right - content_left).max(1);
+    let mid = content_left + content_width / 2;
+    let slack = content_width / 20;
+
+    let column_lines: Vec<&Line> = lines
+        .iter()
+        .filter(|line| line.width() < (content_width as f32 * 0.62) as i32)
+        .collect();
+    if column_lines.len() < 6 {
+        return false;
+    }
+
+    let left = column_lines
+        .iter()
+        .filter(|line| line.right <= mid + slack)
+        .count();
+    let right = column_lines
+        .iter()
+        .filter(|line| line.left >= mid - slack)
+        .count();
+    let crossing = column_lines.len().saturating_sub(left + right);
+
+    left >= 3 && right >= 3 && crossing * 10 <= column_lines.len()
+}
+
+/// Reading order for a two-column page: full-width lines act as band
+/// separators (title, abstract, figure rows); within each band the left
+/// column is read before the right.
+fn order_two_column(page: &Page, lines: &[Line]) -> Vec<Line> {
+    let content_left = lines.iter().map(|line| line.left).min().unwrap_or(0);
+    let content_right = lines
+        .iter()
+        .map(|line| line.right)
+        .max()
+        .unwrap_or(page.width);
+    let content_width = (content_right - content_left).max(1);
+    let mid = content_left + content_width / 2;
+
+    let mut sorted: Vec<&Line> = lines.iter().collect();
+    sorted.sort_by_key(|line| (line.top, line.left));
+
+    let mut ordered = Vec::with_capacity(lines.len());
+    let mut band_left: Vec<&Line> = Vec::new();
+    let mut band_right: Vec<&Line> = Vec::new();
+
+    let flush =
+        |ordered: &mut Vec<Line>, band_left: &mut Vec<&Line>, band_right: &mut Vec<&Line>| {
+            for line in band_left.drain(..) {
+                ordered.push(line.clone());
+            }
+            for line in band_right.drain(..) {
+                ordered.push(line.clone());
+            }
+        };
+
+    for line in sorted {
+        if line.width() >= (content_width as f32 * 0.62) as i32 {
+            flush(&mut ordered, &mut band_left, &mut band_right);
+            ordered.push(line.clone());
+        } else if line.left + line.width() / 2 <= mid {
+            band_left.push(line);
+        } else {
+            band_right.push(line);
+        }
+    }
+    flush(&mut ordered, &mut band_left, &mut band_right);
+
+    ordered
+}
+
+/// The dominant body font size, weighted by character volume.
+fn body_font_size(pages: &[Page]) -> u32 {
+    let mut weights: HashMap<u32, usize> = HashMap::new();
+    for page in pages {
+        for fragment in &page.fragments {
+            let size = page
+                .font_sizes
+                .get(&fragment.font)
+                .copied()
+                .unwrap_or(fragment.height.unsigned_abs());
+            *weights.entry(size).or_default() += fragment.char_count();
+        }
+    }
+    weights
+        .into_iter()
+        .max_by_key(|(_, chars)| *chars)
+        .map(|(size, _)| size)
+        .unwrap_or(12)
+}
+
+/// Distinct font sizes clearly larger than body text, ranked largest
+/// first, mapped to heading levels h1..h3.
+fn heading_levels(pages: &[Page], body_size: u32) -> HashMap<u32, u8> {
+    let mut sizes: Vec<u32> = pages
+        .iter()
+        .flat_map(|page| page.font_sizes.values().copied())
+        .filter(|size| *size as f32 >= body_size as f32 * 1.15 && *size >= body_size + 2)
+        .collect();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+    sizes.dedup();
+    sizes
+        .into_iter()
+        .take(3)
+        .enumerate()
+        .map(|(rank, size)| (size, rank as u8 + 1))
+        .collect()
+}
+
+/// Cluster ordered lines into paragraphs and headings.
+fn cluster_paragraphs(
+    lines: &[Line],
+    body_size: u32,
+    heading_levels: &HashMap<u32, u8>,
+) -> Vec<DocBlock> {
+    let median_gap = median_line_gap(lines);
+    let mut blocks = Vec::new();
+    let mut current: Vec<Span> = Vec::new();
+    let mut current_heading: Option<u8> = None;
+    let mut previous: Option<&Line> = None;
+
+    let flush = |spans: &mut Vec<Span>, heading: &mut Option<u8>, blocks: &mut Vec<DocBlock>| {
+        if spans.is_empty() {
+            return;
+        }
+        let spans = std::mem::take(spans);
+        match heading.take() {
+            Some(level) => blocks.push(DocBlock::Heading { level, spans }),
+            None => blocks.push(DocBlock::Paragraph { spans }),
+        }
+    };
+
+    for line in lines {
+        let heading = heading_levels.get(&line.font_size).copied();
+        let new_block = match previous {
+            None => true,
+            Some(prev) => {
+                let gap = line.top - prev.top;
+                let size_changed = line.font_size != prev.font_size
+                    && (heading.is_some()
+                        || heading_levels.contains_key(&prev.font_size)
+                        || line.font_size.abs_diff(prev.font_size) >= 2);
+                let large_gap = gap > (median_gap as f32 * 1.8) as i32 || gap < 0;
+                let indented =
+                    line.left > prev.left + (body_size as i32) / 2 && prev.left <= line.left; // fresh indent, not a continuation of one
+                size_changed || large_gap || indented
+            }
+        };
+
+        if new_block {
+            flush(&mut current, &mut current_heading, &mut blocks);
+            current_heading = heading;
+        }
+        join_line_into(&mut current, line);
+        previous = Some(line);
+    }
+    flush(&mut current, &mut current_heading, &mut blocks);
+
+    blocks
+}
+
+/// Append a line's spans to a paragraph buffer, repairing soft hyphens
+/// at the join.
+fn join_line_into(buffer: &mut Vec<Span>, line: &Line) {
+    if buffer.is_empty() {
+        buffer.extend(line.spans.iter().cloned());
+        return;
+    }
+
+    let next_starts_lower = line
+        .text()
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_lowercase());
+    let hyphenated = buffer
+        .last()
+        .is_some_and(|span| span.text.trim_end().ends_with('-'));
+
+    if hyphenated && next_starts_lower {
+        if let Some(last) = buffer.last_mut() {
+            let trimmed = last.text.trim_end();
+            let without = trimmed[..trimmed.len() - 1].to_string();
+            last.text = without;
+        }
+    } else if !buffer.last().is_some_and(|span| span.text.ends_with(' ')) {
+        push_joined(buffer, " ", false, false);
+    }
+    for span in &line.spans {
+        push_joined(buffer, &span.text, span.bold, span.italic);
+    }
+}
+
+fn median_line_gap(lines: &[Line]) -> i32 {
+    let mut gaps: Vec<i32> = lines
+        .windows(2)
+        .filter_map(|pair| {
+            let gap = pair[1].top - pair[0].top;
+            let height = pair[0].height.max(1);
+            // Only genuine line advances vote: superscript and subscript
+            // fragments produce micro-gaps that would drag the median
+            // down until ordinary leading looks like a paragraph break,
+            // and figure whitespace would drag it up.
+            (gap >= height / 2 && gap <= height * 4).then_some(gap)
+        })
+        .collect();
+    if gaps.is_empty() {
+        return 16;
+    }
+    gaps.sort_unstable();
+    // Lower median: on short pages the gap list is tiny and the upper
+    // median can land on the paragraph gap itself, hiding the break.
+    gaps[(gaps.len() - 1) / 2]
+}
+
+/// Cross-page paragraph continuation: a page's first paragraph continues
+/// the previous page's last one when the earlier text does not end a
+/// sentence and the new text starts lowercase.
+fn append_with_continuation(blocks: &mut Vec<DocBlock>, mut incoming: Vec<DocBlock>) {
+    if let (Some(DocBlock::Paragraph { spans: tail }), Some(DocBlock::Paragraph { spans: head })) =
+        (blocks.last_mut(), incoming.first_mut())
+    {
+        let tail_text: String = tail.iter().map(|span| span.text.as_str()).collect();
+        let head_text: String = head.iter().map(|span| span.text.as_str()).collect();
+        let continues = !tail_text
+            .trim_end()
+            .ends_with(['.', '!', '?', ':', ';', '"', '\u{201d}', '\u{2019}'])
+            && head_text.chars().next().is_some_and(|ch| ch.is_lowercase());
+        if continues {
+            let hyphenated = tail_text.trim_end().ends_with('-');
+            if hyphenated {
+                if let Some(last) = tail.last_mut() {
+                    let trimmed = last.text.trim_end();
+                    last.text = trimmed[..trimmed.len() - 1].to_string();
+                }
+            } else if !tail.last().is_some_and(|span| span.text.ends_with(' ')) {
+                push_joined(tail, " ", false, false);
+            }
+            for span in head.drain(..) {
+                push_joined(tail, &span.text, span.bold, span.italic);
+            }
+            incoming.remove(0);
+        }
+    }
+    blocks.append(&mut incoming);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_pdf2xml;
+
+    fn fixture_two_column() -> String {
+        // A miniature two-column paper page: full-width title, abstract,
+        // then two columns whose reading order must be left-then-right,
+        // with a hyphenated join inside the left column.
+        let mut texts = String::new();
+        texts.push_str(
+            r#"<text top="80" left="150" width="620" height="26" font="0">A Study of <i>Synthetic</i> Layouts</text>"#,
+        );
+        texts.push_str(
+            r#"<text top="140" left="120" width="680" height="13" font="1">Abstract spanning the full width of the page for testing purposes.</text>"#,
+        );
+        for (i, words) in [
+            "Left column opening line about num-",
+            "bers and continuation of thought.",
+            "Another left line here.",
+        ]
+        .iter()
+        .enumerate()
+        {
+            texts.push_str(&format!(
+                r#"<text top="{}" left="100" width="330" height="12" font="1">{}</text>"#,
+                220 + i * 16,
+                words
+            ));
+        }
+        for (i, words) in [
+            "Right column first line.",
+            "Right column second line.",
+            "Right column third line.",
+        ]
+        .iter()
+        .enumerate()
+        {
+            texts.push_str(&format!(
+                r#"<text top="{}" left="480" width="330" height="12" font="1">{}</text>"#,
+                220 + i * 16,
+                words
+            ));
+        }
+        format!(
+            r#"<?xml version="1.0"?>
+<pdf2xml producer="poppler">
+<page number="1" width="918" height="1188">
+<fontspec id="0" size="22" family="T"/>
+<fontspec id="1" size="11" family="T"/>
+{texts}
+</page>
+</pdf2xml>"#
+        )
+    }
+
+    #[test]
+    fn two_column_page_reads_title_left_then_right() {
+        let pages = parse_pdf2xml(&fixture_two_column()).expect("fixture parses");
+        let result = reconstruct(&pages, ColumnMode::Auto);
+
+        assert!(result.pages[0].two_column, "page must detect two columns");
+        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+
+        assert!(
+            matches!(&result.blocks[0], DocBlock::Heading { level: 1, .. }),
+            "title should be an h1, got {:?}",
+            result.blocks[0]
+        );
+        assert_eq!(texts[0], "A Study of Synthetic Layouts");
+        assert!(texts[1].starts_with("Abstract spanning"));
+        assert!(
+            texts[2].contains("numbers and continuation"),
+            "hyphenated line join must repair the soft hyphen, got: {}",
+            texts[2]
+        );
+        assert!(
+            texts[2].contains("Another left line"),
+            "left column must precede right, got: {texts:?}"
+        );
+        assert!(texts[3].starts_with("Right column first"));
+    }
+
+    #[test]
+    fn single_column_page_clusters_paragraphs_by_gap() {
+        let xml = r#"<?xml version="1.0"?>
+<pdf2xml><page number="1" width="600" height="800">
+<fontspec id="0" size="11" family="T"/>
+<text top="100" left="80" width="440" height="12" font="0">First paragraph line one.</text>
+<text top="116" left="80" width="440" height="12" font="0">First paragraph line two.</text>
+<text top="170" left="80" width="440" height="12" font="0">Second paragraph after a large gap.</text>
+</page></pdf2xml>"#;
+        let pages = parse_pdf2xml(xml).expect("fixture parses");
+        let result = reconstruct(&pages, ColumnMode::Auto);
+
+        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        assert_eq!(
+            texts,
+            vec![
+                "First paragraph line one. First paragraph line two.".to_string(),
+                "Second paragraph after a large gap.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn narrow_gutter_does_not_merge_columns_on_aligned_baselines() {
+        // Regression for the BERT page-1 defect: left and right column
+        // lines sharing the exact same `top`, separated by a gutter of
+        // only ~1.7x line height (461 - 435 = 26 at height 15). Merging
+        // them creates a fake full-width line that scrambles band order.
+        let xml = r#"<?xml version="1.0"?>
+<pdf2xml><page number="1" width="892" height="1262">
+<fontspec id="0" size="15" family="T"/>
+<text top="100" left="108" width="327" height="15" font="0">left one alpha beta gamma delta.</text>
+<text top="120" left="108" width="327" height="15" font="0">left two epsilon zeta eta theta.</text>
+<text top="100" left="461" width="327" height="15" font="0">right one iota kappa lambda mu.</text>
+<text top="120" left="461" width="327" height="15" font="0">right two nu xi omicron pi rho.</text>
+<text top="140" left="108" width="327" height="15" font="0">left three sigma tau upsilon phi.</text>
+<text top="140" left="461" width="327" height="15" font="0">right three chi psi omega end.</text>
+<text top="160" left="108" width="327" height="15" font="0">left four extra line for detection.</text>
+<text top="160" left="461" width="327" height="15" font="0">right four extra line as well.</text>
+</page></pdf2xml>"#;
+        let pages = parse_pdf2xml(xml).expect("fixture parses");
+        let result = reconstruct(&pages, ColumnMode::Two);
+
+        let all_text: String = result
+            .blocks
+            .iter()
+            .map(|block| block.text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let left_pos = all_text.find("left four").expect("left text present");
+        let right_pos = all_text.find("right one").expect("right text present");
+        assert!(
+            left_pos < right_pos,
+            "every left-column line must precede the right column, got:\n{all_text}"
+        );
+        assert!(
+            !all_text.contains("alpha beta gamma delta. right one"),
+            "aligned baselines must not merge across the gutter:\n{all_text}"
+        );
+    }
+
+    #[test]
+    fn paragraph_continues_across_pages() {
+        let xml = r#"<?xml version="1.0"?>
+<pdf2xml>
+<page number="1" width="600" height="800">
+<fontspec id="0" size="11" family="T"/>
+<text top="700" left="80" width="440" height="12" font="0">This sentence does not end</text>
+</page>
+<page number="2" width="600" height="800">
+<fontspec id="0" size="11" family="T"/>
+<text top="80" left="80" width="440" height="12" font="0">until the following page.</text>
+</page>
+</pdf2xml>"#;
+        let pages = parse_pdf2xml(xml).expect("fixture parses");
+        let result = reconstruct(&pages, ColumnMode::Auto);
+
+        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        assert_eq!(
+            texts,
+            vec!["This sentence does not end until the following page.".to_string()]
+        );
+    }
+}

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -1,0 +1,91 @@
+//! Conversion fidelity report. The contract from ROADMAP §9b: pages
+//! that reconstruct badly are flagged, never hidden.
+
+use serde::Serialize;
+
+use crate::reconstruct::PageStats;
+
+#[derive(Debug, Serialize)]
+pub struct ConversionReport {
+    pub input: String,
+    pub output: String,
+    pub pages: usize,
+    pub blocks: usize,
+    /// Non-whitespace characters in reconstructed blocks.
+    pub reconstructed_chars: usize,
+    /// Non-whitespace characters in the raw `pdftotext` baseline.
+    pub baseline_chars: usize,
+    /// reconstructed/baseline, capped at 100. Above ~100 means the
+    /// baseline missed text (rare); far below means reconstruction
+    /// dropped content and the page list below says where.
+    pub coverage_percent: f64,
+    pub two_column_pages: usize,
+    pub page_stats: Vec<PageStats>,
+    pub warnings: Vec<String>,
+}
+
+impl ConversionReport {
+    pub fn build(
+        input: &str,
+        output: &str,
+        page_stats: Vec<PageStats>,
+        blocks: usize,
+        reconstructed_chars: usize,
+        baseline_chars: usize,
+    ) -> Self {
+        let coverage_percent = if baseline_chars == 0 {
+            100.0
+        } else {
+            (reconstructed_chars as f64 / baseline_chars as f64 * 100.0).min(100.0)
+        };
+
+        let mut warnings = Vec::new();
+        if coverage_percent < 95.0 {
+            warnings.push(format!(
+                "reconstructed text covers only {coverage_percent:.1}% of the pdftotext baseline; some content was not captured"
+            ));
+        }
+        for page in &page_stats {
+            if page.chars == 0 {
+                warnings.push(format!(
+                    "page {}: no text reconstructed (image-only page, or extraction failure)",
+                    page.page
+                ));
+            }
+        }
+
+        Self {
+            input: input.to_string(),
+            output: output.to_string(),
+            pages: page_stats.len(),
+            blocks,
+            reconstructed_chars,
+            baseline_chars,
+            coverage_percent,
+            two_column_pages: page_stats.iter().filter(|page| page.two_column).count(),
+            page_stats,
+            warnings,
+        }
+    }
+
+    pub fn summary(&self) -> String {
+        let mut out = format!(
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nText coverage vs pdftotext: {:.1}% ({} of {} characters)\n",
+            self.pages,
+            self.blocks,
+            self.two_column_pages,
+            self.coverage_percent,
+            self.reconstructed_chars,
+            self.baseline_chars,
+        );
+        if self.warnings.is_empty() {
+            out.push_str("Warnings: none\n");
+        } else {
+            out.push_str("Warnings:\n");
+            for warning in &self.warnings {
+                out.push_str(&format!("  - {warning}\n"));
+            }
+        }
+        out
+    }
+}

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -1,0 +1,113 @@
+//! Discovery and invocation of poppler command-line tools.
+//!
+//! Resolution order: `POPPLER_PATH` environment variable (a directory
+//! containing the binaries), then the system `PATH`. External binaries
+//! follow the EPUBCheck precedent (ROADMAP §1.6, §8.4): subprocesses
+//! are acceptable, embedded runtimes are not.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ToolError {
+    #[error(
+        "poppler tool '{0}' not found. Install poppler and either add it to PATH or set POPPLER_PATH to its bin directory."
+    )]
+    NotFound(&'static str),
+
+    #[error("'{tool}' failed (exit {code:?}): {stderr}")]
+    Failed {
+        tool: &'static str,
+        code: Option<i32>,
+        stderr: String,
+    },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct PopplerTools {
+    pub pdftohtml: PathBuf,
+    pub pdftotext: PathBuf,
+}
+
+impl PopplerTools {
+    /// Locate the required poppler binaries or explain what is missing.
+    pub fn discover() -> Result<Self, ToolError> {
+        Ok(Self {
+            pdftohtml: find_tool("pdftohtml")?,
+            pdftotext: find_tool("pdftotext")?,
+        })
+    }
+
+    /// `pdftohtml -v` prints its version banner on stderr.
+    pub fn version(&self) -> Option<String> {
+        let output = Command::new(&self.pdftohtml).arg("-v").output().ok()?;
+        let banner = String::from_utf8_lossy(&output.stderr);
+        banner.lines().next().map(|line| line.trim().to_string())
+    }
+
+    /// Run `pdftohtml -xml` and return the XML document.
+    pub fn pdf_to_xml(&self, pdf: &Path) -> Result<String, ToolError> {
+        let output = Command::new(&self.pdftohtml)
+            .args(["-xml", "-i", "-stdout", "-q", "-enc", "UTF-8"])
+            .arg(pdf)
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdftohtml",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    /// Raw text via `pdftotext`, used as the coverage baseline: it makes
+    /// no layout decisions, so its character count approximates "all the
+    /// text poppler can see".
+    pub fn pdf_to_text(&self, pdf: &Path) -> Result<String, ToolError> {
+        let output = Command::new(&self.pdftotext)
+            .args(["-enc", "UTF-8", "-q"])
+            .arg(pdf)
+            .arg("-")
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdftotext",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+fn find_tool(name: &'static str) -> Result<PathBuf, ToolError> {
+    let exe = if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+
+    if let Ok(dir) = std::env::var("POPPLER_PATH") {
+        let candidate = Path::new(&dir).join(&exe);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    if let Some(paths) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&paths) {
+            let candidate = dir.join(&exe);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(ToolError::NotFound(name))
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,3 +2,23 @@
 
 Bookforge is an EPUB-first translation engine. The program owns document structure; language models translate prose segments only.
 
+## Crates
+
+- `bookforge-core` defines the IR, segmentation, run settings, progress events, cache namespace rules, glossary/style/entity helpers, and marker parsing.
+- `bookforge-epub` reads EPUB containers into the IR and rebuilds EPUBs by patching original XML resources in place.
+- `bookforge-llm` owns prompt rendering, provider calls, batching, validation, repair, QA, context registries, and telemetry.
+- `bookforge-store` owns the SQLite job store, segment records, block translations, cache lookup, retry state, and run snapshots.
+- `bookforge-cli` wires those pieces into commands such as `translate`, `resume`, `retry`, `review`, `inspect`, `validate`, and `status`.
+
+## Translation Flow
+
+1. `translate` resolves the profile and provider settings. The default profile is the fast v1 profile, which enables batching and adaptive sizing.
+2. The EPUB reader parses the package document, NCX files, spine XHTML, XHTML head titles, and visible body text into stable sections and blocks.
+3. Segmentation groups blocks into bounded translation units. Code blocks are retained in the IR but skipped for translation.
+4. The CLI creates a job, snapshots the input EPUB and resolved run settings, inserts segment records, and scans the cache.
+5. `commands/translate/engine.rs` runs the shared checkpointed execution path used by both fresh translation and resume. It selects batch or single-segment execution, starts the checkpoint writer, and persists each validated segment as it completes.
+6. Post-processing can run QA, fallback, and double-check passes depending on settings.
+7. The EPUB writer patches translated blocks back into the original resources and writes a report next to the output.
+
+The key invariant is that models never produce EPUB structure. They produce JSON translations of prose strings. Rust validates the response, maps marker-protected prose back to known blocks, and patches the original package resources.
+

--- a/docs/CHECKPOINTING.md
+++ b/docs/CHECKPOINTING.md
@@ -2,3 +2,34 @@
 
 Checkpointing is segment-level and content-addressed by source hash, prompt version, provider, and model.
 
+## Store
+
+Jobs live in `.bookforge/jobs.sqlite`. The store tracks job metadata, segment records, translated segment text, translated block text, report paths, retry state, glossary/style/entity data, and a JSON run snapshot.
+
+When a job is created, `translate` snapshots the input EPUB into the job directory and stores a resolved run configuration. `resume` reads that snapshot instead of trusting current CLI defaults, then rebuilds the source IR and verifies that pending segment IDs still exist.
+
+## Segment States
+
+Segments move through pending, running, succeeded, skipped-cached, failed, needs-review, and retry-pending states. A segment translation is saved as soon as it validates, before the whole job finishes. If the process is interrupted, terminal segments remain usable.
+
+`retry` marks selected failed or needs-review segments retry-pending. `resume` translates only resumable segments. Retry-pending segments bypass cache so the user gets a fresh provider call instead of reusing a known-bad result.
+
+## Cache Keys
+
+Cache lookup requires matching:
+
+- source hash;
+- cache namespace;
+- prompt version;
+- provider and model;
+- source and target language;
+- terminal segment status.
+
+The cache namespace is derived from segmentation settings, profile namespace, batch mode, prompt version, glossary fingerprint, style fingerprint, entity fingerprint, and the inline marker schema version.
+
+## Shared Execution Engine
+
+Fresh translation and resume share `commands/translate/engine.rs` for the checkpointed provider run. That engine starts the SQLite checkpoint writer, chooses batch or single-segment execution from the resolved settings, sends save commands as segments complete, shuts the writer down, and returns fresh translations to the caller.
+
+The callers still own their surrounding policy: fresh `translate` creates jobs and snapshots settings; `resume` resolves stored settings, checks cache namespace compatibility, and rebuilds output from stored plus fresh translations.
+

--- a/docs/EPUB_PIPELINE.md
+++ b/docs/EPUB_PIPELINE.md
@@ -1,4 +1,27 @@
 # EPUB Pipeline
 
-The EPUB pipeline will parse package metadata, preserve resources, translate XHTML text through the document IR, and rebuild a valid EPUB deterministically.
+The EPUB pipeline parses package metadata, preserves resources, translates XML text through the document IR, and rebuilds a valid EPUB deterministically.
+
+## Read
+
+`bookforge-epub::read_epub` opens the container, finds the package document, parses the OPF manifest/spine, and stores the original bytes for every resource. It extracts translatable blocks from:
+
+- OPF metadata titles such as `dc:title`;
+- NCX `text` labels, including `docTitle` and navigation labels;
+- XHTML `head/title`;
+- XHTML body content from known block elements and from visible direct text inside non-structural wrappers.
+
+The reader suppresses `script`, `style`, `svg`, and `math`. It preserves package resources, stylesheets, images, fonts, and non-translated XML entries. Named and numeric entities are decoded for segmentation, while path accounting ignores entity events so reader and writer stay aligned.
+
+## Inline Structure
+
+Inline formatting, links, anchors, and empty inline elements are represented as marker tokens inside a block's prose. New extraction emits short per-block markers such as `<m1>...</m1>` and `<r1/>`. The marker parser also accepts the older verbose marker forms so stored jobs and tests can read legacy text.
+
+## Rebuild
+
+`bookforge-epub::rebuild_epub` does not serialize a new EPUB tree from scratch. It copies the original archive entries and patches only resources that have translated block IDs. The same patcher handles XHTML, OPF, and NCX XML resources.
+
+Patch routing is by section href and DOM path. For ordinary element blocks, the writer replaces the captured element text while preserving attributes and child elements represented by markers. For addressable stray text nodes, the writer uses the same non-whitespace text-node counting rule as the reader.
+
+After patching, XML is parsed again as a basic validity check. Missing translations leave source text in place; failed or needs-review segments are visible in the report and review flow.
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -2,3 +2,26 @@
 
 The initial provider target is OpenAI-compatible chat completions, with DeepSeek as a preset.
 
+## Supported Providers
+
+- `mock` is used by tests and local roundtrip checks. It can echo, prefix, uppercase, or deliberately return malformed output.
+- `deepseek` defaults to `https://api.deepseek.com/v1`, `DEEPSEEK_API_KEY`, and `deepseek-v4-flash`.
+- `openrouter` defaults to `https://openrouter.ai/api/v1`, `OPENROUTER_API_KEY`, and `openrouter/auto`.
+- `openai-compatible` requires an explicit `--base-url` unless a preset resolves one.
+
+All non-mock providers go through `OpenAiCompatibleProvider`. Provider settings include timeout, provider-level attempts, retry-after handling, max backoff, idle connection pool size, JSON mode, model context tokens, and output-token limits.
+
+## Presets And Profiles
+
+Provider presets can change both endpoint/model defaults and runtime knobs such as concurrency, provider attempts, batch target size, adaptive batch sizing, and retry policy. Explicit CLI flags win over preset values.
+
+Translation profiles control segmentation, scheduler, batching, compact prompts, and provider defaults. The CLI default is `v1-fast`, which enables batching by default. Batch translation uses the batch prompt version and apportions request-level token usage back to segments for reporting.
+
+## JSON Mode
+
+`JsonMode::Auto` tries provider-native JSON response format where supported and falls back when the provider rejects it. `PromptOnly` relies on prompt instructions only. `Strict` requires native JSON support to work.
+
+## Retry Boundaries
+
+Provider attempts handle network and provider errors. Scheduler attempts handle translation validation failures. Batch repair can retry invalid batch items, and resume/retry commands use the SQLite checkpoint store to avoid paying again for already terminal segments.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,10 +98,17 @@ via `java`, but the BookForge binary itself does not need Java to run.
 | v1.2 | Glossary, manual | 8–12 days | none (development quiet) | shipped |
 | v1.2.x | Glossary, auto-extraction | 4–6 days | none | shipped |
 | v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) | shipped |
-| v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here | planned |
-| v1.5 | Structural credibility | 10–14 days | README final rewrite citing corpus | planned |
+| v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here | shipped |
+| v1.5 | Extraction + scheduling overhaul (shipped scope; see §8 post-ship note) | — | none | shipped 2026-06-12 |
 | v1.6 | Bilingual output | 5–8 days | passive (release notes only) | planned |
-| v2 | Open-ended | not committed | recompute from v1.4/v1.5 feedback | planned |
+| v1.7 | PDF ingestion (§9b) | 8–14 days | release notes; maybe a short writeup if the layout-reconstruction part turns out interesting | **next — pulled ahead of v1.6 per owner priority, 2026-06** |
+| v1.8 | Structural credibility (EPUBCheck + corpus; was the planned v1.5 scope, §8) | 10–14 days | README final rewrite citing corpus | planned |
+| v2 | Open-ended | not committed | recompute from v1.4/v1.7 feedback | planned |
+
+Priority note (2026-06): the owner needs PDF translation more than
+bilingual output — scientific papers (figures/tables must survive) and
+unorthodox-layout books (CCRU-style scans/conversions). v1.7 therefore
+executes before v1.6 and v1.8 despite the numbering.
 
 Total v1.x roadmap is roughly 45–70 person-days of focused work; in calendar
 terms, with a maintainer who has limited evenings and weekends and a
@@ -1770,6 +1777,20 @@ including the manifest curation, fetch script, and CI plumbing.
 
 v1.4 (distribution). The CI changes need a working release pipeline.
 
+### 8.13 Implementation notes (post-ship, 2026-06-12)
+
+What actually shipped under the v1.5 tag diverged from this spec. Real-book
+testing surfaced extraction and scheduling defects that outranked external
+validation, so v1.5 became an extraction/scheduling overhaul instead:
+depth-anchored block extraction (div/dt/dd/stray text, nested same-name
+blocks), HTML entity resolution, code-block passthrough, best-effort sliding
+context (strict fence behind `--context-strict`), short per-block markers
+(`<m1>`, prompt contract v2, marker schema v3), NCX/OPF/head-title
+translation, a shared translate/resume run engine, v1-fast as the default
+profile, an identity-roundtrip harness, a text-coverage metric in `inspect`,
+and synthetic CI fixtures. The EPUBCheck + Standard Ebooks corpus scope in
+§8.4–§8.8 is still wanted and moves to v1.8, after PDF ingestion (§9b).
+
 ---
 
 ## 9. v1.6 — Bilingual output
@@ -2033,6 +2054,140 @@ v1.5 (EPUBCheck integration is required to verify correctness).
 
 ---
 
+## 9b. v1.7 — PDF ingestion
+
+Executes before v1.6 and v1.8 (owner priority, 2026-06).
+
+### 9b.1 Goal
+
+Translate the PDFs the owner actually has and cannot translate today:
+
+1. **Scientific papers** — usually two-column, dense with figures,
+   tables, equations, and references. Figures and tables must survive
+   visually; prose must translate; nothing may silently disappear.
+2. **Unorthodox-layout books** — CCRU-style material: scanned or
+   converted PDFs with non-standard typography, mixed layouts, decorative
+   text. These must degrade *visibly and gracefully*, never silently.
+
+Output is a **translated reflowable EPUB** (readable on the same devices
+all other BookForge output targets). Re-laying-out translated text into
+the original PDF geometry is explicitly out of scope: it is a research
+problem, it cannot be done deterministically, and it violates §1.2.
+
+### 9b.2 Architectural rationale
+
+PDF has no DOM. There are no blocks to own — only positioned glyphs. The
+invariants survive by splitting the problem in two:
+
+- **Layout extraction** is delegated to proven external tooling
+  (poppler's `pdftohtml -xml`, `pdfimages`, `pdftoppm`, `pdftotext`),
+  exactly the precedent §8.4 set for EPUBCheck-via-java: external
+  binaries are acceptable; embedded runtimes are not. `doctor` learns to
+  report their presence and version.
+- **Document reconstruction** is deterministic Rust: poppler's XML gives
+  per-line text with x/y/width/height/font; BookForge clusters lines
+  into columns, columns into reading order, lines into paragraphs,
+  font-size outliers into headings — and emits a synthetic EPUB through
+  the existing writer machinery.
+
+From that point on, **nothing is new**: the produced EPUB flows through
+the same segmentation, markers, cache, checkpoints, validation, QA,
+review, and rebuild as any other book. The PDF milestone is an ingestion
+front-end, not a parallel pipeline.
+
+The quality gate is the same one that already exists: the `inspect`
+text-coverage metric, plus a conversion report comparing reconstructed
+text volume against a raw `pdftotext` baseline, per page. Pages that
+reconstruct badly are *flagged*, not hidden.
+
+### 9b.3 Deliverables
+
+- `bookforge-pdf` crate: poppler XML parsing + layout reconstruction +
+  synthetic EPUB assembly. No C dependencies; talks to poppler binaries
+  via subprocess only.
+- `bookforge convert input.pdf --out book.epub` CLI command with a
+  conversion report (text coverage vs `pdftotext` baseline, per-page
+  anomalies, image/figure count).
+- `doctor` reports poppler tool availability and versions.
+- Committed poppler-XML fixtures so all reconstruction logic is
+  unit-testable in CI without poppler installed; end-to-end tests gated
+  on tool presence (skip with a printed reason, mirroring the EPUBCheck
+  pattern).
+
+### 9b.4 Phases
+
+- **P0 — plumbing.** Tool discovery (`POPPLER_PATH` env override, PATH
+  fallback), `convert` command skeleton, `pdftohtml -xml` invocation and
+  XML parse into a page/line IR. Unit-testable from fixtures.
+- **P1 — reconstruction.** Line merge → per-page column detection
+  (x-gutter clustering) → reading order → paragraph clustering (leading,
+  indent, font continuity) → heading heuristic (font-size percentile) →
+  block emission → EPUB assembly → conversion report.
+- **P2 — figures.** `pdfimages` extraction, placement by page anchor,
+  caption detection ("Figure N", "Fig.", "Table N" prefixes near the
+  image) feeding `Caption` blocks.
+- **P3 — tables and equations.** v1 policy: detected table/equation
+  regions are preserved as page-crop raster images (`pdftoppm` crops) —
+  reliable and honest for scientific papers; inline math glyph runs
+  become protected spans. HTML table reconstruction is a later, separate
+  decision.
+- **P4 — degraded-layout fallback.** Pages whose reconstruction
+  confidence is low (coverage gap vs `pdftotext`, column chaos) are
+  handled per `--low-confidence preserve|linearize`: `preserve` embeds
+  the page as a full-page image (CCRU scan posture: keep the artifact,
+  skip translation); `linearize` emits best-effort text order and lets
+  translation proceed. Either way the report names every affected page.
+- **P5 (optional, post-MVP) — pluggable ML backend.** `--pdf-backend
+  marker` for layout models (marker/nougat) when installed, emitting
+  into the same page/line IR. Never a hard dependency.
+
+### 9b.5 CLI surface
+
+```bash
+bookforge doctor --pdf
+bookforge convert paper.pdf --out paper.epub \
+  [--columns auto|1|2] [--low-confidence preserve|linearize] \
+  [--report paper.convert.json]
+# then the standard flow:
+bookforge translate paper.epub --target Italian ...
+```
+
+`translate input.pdf` (implicit convert) is deliberately deferred until
+the convert step has earned trust on real papers.
+
+### 9b.6 Out of scope (within milestone)
+
+- PDF output / translated-PDF re-layout (see §12).
+- OCR for image-only scans (`preserve` posture handles them; OCR is a
+  separate decision with separate tooling).
+- HTML table reconstruction (raster crops first; reassess after real use).
+- DRM'd PDFs.
+
+### 9b.7 Acceptance criteria
+
+- A real two-column arXiv paper converts to an EPUB with ≥95% text
+  coverage against the `pdftotext` baseline, correct reading order on
+  manual inspection, and every embedded figure present.
+- A CCRU-style PDF converts with every low-confidence page either
+  preserved as an image or linearized — and each one named in the report.
+- The converted EPUB passes the identity-roundtrip harness (mock
+  translate → visible text unchanged).
+- All reconstruction logic runs in CI from committed XML fixtures with
+  poppler absent.
+- `cargo test`, `cargo fmt`, `cargo clippy` clean.
+
+### 9b.8 Effort
+
+8–14 days total. P0+P1 are the load-bearing 3–5 days; P2–P4 are
+incremental; P5 only if real books demand it.
+
+### 9b.9 Dependencies
+
+None on other milestones. Requires poppler binaries on the user's
+machine (documented per-OS install one-liners in README).
+
+---
+
 ## 10. v2 — open-ended (sketched, not committed)
 
 The v2 list is what's interesting *as of writing*. The real v2
@@ -2059,9 +2214,9 @@ So this section is a **sketch**, not a commitment. Re-evaluate after v1.6 ships.
 - **Native Anthropic and Gemini providers.** Only if quality measurements
   prove the OpenRouter detour is hurting.
 - **Streaming translation output** for live token meters during long jobs.
-- **Format-adjacent sibling tools**: `bookforge-pdf2epub`, `bookforge-docx2epub`.
-  Strictly siblings, not engine surface. PDF is the most-requested adjacent
-  format and has good prior art (PDF Craft from oomol-lab).
+- **Format-adjacent sibling tools**: `bookforge-docx2epub` and similar.
+  Strictly siblings, not engine surface. PDF graduated out of this bullet:
+  it is now mainline ingestion, spec'd as v1.7 in §9b (decision 2026-06).
 - **Glossary auto-extraction (v1.2.x)** — already mentioned, file here as
   a reminder if it didn't ship as a point release.
 
@@ -2221,7 +2376,7 @@ considered and rejected.
 | Multi-agent debate QA | Poor cost/quality profile for translation |
 | Hosted demo / SaaS | Wrong scope for one-maintainer project |
 | Native Anthropic/Gemini providers (pre-v2) | OpenRouter routes to both; prove necessity first |
-| PDF/DOCX/MOBI/AZW3 input | Sibling tools, not engine surface |
+| DOCX/MOBI/AZW3 input | Sibling tools, not engine surface. (PDF input was on this list until 2026-06; owner priority moved it mainline as v1.7, §9b. PDF *output* — re-laying-out translated text into the original PDF geometry — remains out of scope.) |
 | Manga / comic translation | Different engine entirely |
 | Trilingual+ output | YAGNI |
 | Comparison matrices in README | Hard to keep current, not honest |

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -2,3 +2,28 @@
 
 Segments are stable, bounded translation units derived from the document IR. A segment must not cross a spine resource boundary.
 
+## Blocks
+
+The EPUB reader emits blocks for headings, paragraphs, list items, quotes, table cells/rows, captions, footnotes, and addressable stray text nodes. `pre` and `code` content becomes `BlockKind::Code`; those blocks remain in the rebuilt EPUB but are not sent to the model.
+
+Each block has a stable section id, block id, DOM path, ordinal, text runs, inline markers, protected spans, and token estimate. Inline EPUB structure is represented in the source prose with short per-block markers:
+
+```text
+Hello <m1>formatted</m1> text <r1/> here.
+```
+
+Paired inline elements use `<mN>...</mN>`. Empty inline elements use `<rN/>`. Legacy markers such as `<m id="...">` and `<ref id="..."/>` are still parsed for compatibility, but newly generated segments use the short syntax.
+
+## Segment Construction
+
+`bookforge-core::segment::build_segments` walks blocks in book order and groups them under the configured token budget. Segments do not cross section/resource boundaries. Short headings can be grouped with the following block when they fit.
+
+Each segment records:
+
+- source text and block payloads;
+- context before/after summaries;
+- required markers and protected spans;
+- a checksum/source hash used by checkpointing and cache lookup.
+
+The cache namespace includes segmentation settings, profile namespace, batch mode, prompt version, glossary/style/entity fingerprints, and the inline marker schema version. Marker schema version `3` corresponds to the short per-block marker syntax.
+

--- a/docs/writeup-v1.4.md
+++ b/docs/writeup-v1.4.md
@@ -1,290 +1,135 @@
 # BookForge: Translating EPUBs Without Letting the LLM Near the Structure
 
-*Draft — v1.4 launch writeup. Edit to taste before posting. Target
-venues per ROADMAP §7.8: r/rust, Lobsters, optionally HN.*
+Draft note refreshed after the v1.5 extraction and scheduling work. The file
+name is historical; the details below describe the current implementation.
 
----
+## The Problem
 
-I built BookForge because the obvious way to translate an EPUB with an
-LLM is wrong, and the second-most-obvious way is wrong in a more
-interesting way. This post is about the third way.
+The naive way to translate an EPUB with an LLM is to unzip the book, send each
+XHTML file to a model, ask for XHTML back, then zip it again. That works until
+the model drops a footnote anchor, rewrites an `href`, normalizes a structural
+attribute, truncates a long chapter, or translates the chapter title in the
+body but leaves the table of contents behind.
 
-## The naive approach, and what it breaks
+Those failures all come from the same mistake: the model is being asked to
+translate prose and preserve arbitrary document structure at the same time.
+BookForge keeps those responsibilities separate.
 
-The naive approach to LLM EPUB translation is: unzip the book, hand each
-XHTML file to a model, ask for the same XHTML back in the target
-language, zip it up. People build this every weekend. It seems to work.
+## The Invariant
 
-What actually happens on a real book:
+BookForge's central invariant is:
 
-- The model occasionally drops a `<sup>` footnote reference or moves it
-  to the wrong sentence. The footnote anchor in the back matter now
-  points at nothing. A reader hits the back of the chapter and the link
-  goes nowhere.
-- The model "helpfully" normalizes a Unicode em-dash to two hyphens
-  somewhere in chapter four. The book's typography quietly drifts.
-- The model translates a chapter title in the spine but not the
-  identical title in the TOC, because the two requests happened to fall
-  on different model invocations and the temperature wasn't quite zero.
-  EPUBCheck flags the inconsistency. The book opens in iBooks with a
-  blank chapter title.
-- Twelve thousand tokens into a long chapter, the model hits its output
-  budget mid-paragraph and emits truncated XHTML. The XML parser at the
-  other end refuses to reassemble the file. The user is told the book
-  failed to translate, but doesn't know which chapter or why.
-- The cost is one ill-advised refactor away from being three times what
-  the user expected, because nothing caches per-segment and an
-  interrupted job restarts from scratch.
+> Rust owns EPUB structure. The model translates prose payloads only.
 
-You can patch any one of these. You can't patch all of them, because
-the failure surface compounds. The root cause is that the model is
-being asked to do two jobs at once: translate prose, *and* preserve
-arbitrary structured XML. It's bad at the second one in proportion to
-how good it has to be at it.
+In practice:
 
-## The structure-sacred invariant
+- The EPUB reader parses package metadata, NCX labels, XHTML head titles, and
+  visible body text into stable IR blocks.
+- Inline formatting, links, footnote references, anchors, and empty inline
+  elements become marker tokens inside the prose.
+- The model receives JSON translation payloads and returns JSON translations.
+- Validators check JSON shape, marker preservation, protected spans, and other
+  deterministic constraints.
+- The writer patches translated strings back into the original OPF, NCX, and
+  XHTML resources instead of serializing a brand-new document tree.
 
-BookForge's central design decision is:
+The model never creates an EPUB id, `href`, spine item, package entry, or XML
+attribute. It only moves words between languages.
 
-> The program owns EPUB structure. The model only ever sees validated
-> JSON prose payloads.
+## Markers
 
-Everything else in the codebase is downstream of that one sentence.
+Inline structure is represented with short per-block markers:
 
-In practice this means:
+```text
+Hello <m1>formatted</m1> text <r1/> here.
+```
 
-- An EPUB comes in. The Rust side parses it into an internal IR — a
-  tree of blocks, runs, footnote references, links, images, with stable
-  IDs assigned to every piece of text the model will ever need to
-  translate.
-- The IR is segmented into translation units. A segment is a JSON
-  payload of prose fragments, each tagged with its stable ID. Inline
-  formatting (italics, links, footnote anchors) is represented as
-  markers inside the prose strings, with documented escape rules.
-- That JSON goes to the model. The model emits JSON of the same shape,
-  with the prose translated. The response is validated as JSON,
-  parsed, and reassembled back into the IR.
-- The reassembled IR is serialized back to XHTML by deterministic code.
-  Every footnote anchor, every internal link, every image reference,
-  every `xml:lang` attribute is preserved because the program never lost
-  track of them.
+Paired inline elements use `<mN>...</mN>`. Empty inline elements use `<rN/>`.
+The marker ids are local to a block, which keeps prompts shorter than the old
+`<m id="...">` form. The parser still accepts legacy markers for stored jobs
+and compatibility tests, but new extraction emits the short form.
 
-The model never sees XHTML, never produces XHTML, never produces an
-ID, never produces an `href`, never normalizes Unicode, never decides
-where a chapter break is. It does one thing — translate prose — and the
-program checks that it stayed within those lines.
+The contract is strict: if the source text has a marker, the translated text
+must preserve that marker with the same tag name and valid nesting. If the
+model drops, renames, duplicates, or invents markers, the response fails
+validation.
 
-When the response fails validation, the segment is retried. It is
-*not* sent to a "repair" model. The roadmap is explicit about this:
+## Translation Contracts
 
-> If the model produces malformed output, the response is rejected and
-> the segment is retried — never sent to a "repair" model. If repair is
-> genuinely required, that is a bug in `bookforge-core` segmentation or
-> `bookforge-epub` rebuild logic, and that is where it must be fixed.
+There are plain, marker-safe, and run-preserving contracts, each with batch and
+compact variants. The runtime prompt contract version is `v2` for single
+translation and `batch_v2` for batch translation, and the translation template
+files carry matching `.v2.md` names.
 
-This is a deliberate constraint, not a missing feature. Every "repair
-LLM" pass I've seen in this space exists because the primary contract
-is too loose. Tightening the primary contract is the right fix; bolting
-on a cleanup layer is the wrong one.
+The default CLI profile is the fast v1 profile. It enables batching, compact
+prompting where appropriate, adaptive batch sizing, and the provider/runtime
+knobs needed for high-throughput translation. The older balanced profile is
+still available explicitly.
 
-## Three translation contracts
+## Metadata And TOC
 
-There are three contracts in `crates/bookforge-llm/prompts/`, picked per
-segment based on what's actually inside:
+BookForge now treats several non-body strings as normal translatable blocks:
 
-**Plain** — for segments with no inline formatting beyond paragraph
-breaks. The payload is the prose, the response is the translation. The
-prompt asks for nothing else.
+- OPF metadata titles such as `dc:title`;
+- NCX `docTitle` and navigation `text` labels;
+- XHTML `head/title`;
+- visible body text in spine XHTML.
 
-**Marker-safe** — for segments with inline emphasis, links, footnote
-references. The prose carries markers like `<b1>...</b1>` that
-correspond to specific IR nodes. The contract demands the same set of
-markers in the same order in the output; if any marker is added,
-removed, or relocated, the response is rejected. The reassembler then
-rebinds the markers to their IR nodes and rebuilds the XHTML.
+Those blocks enter the same segmentation, cache, checkpoint, validation, and
+writer paths as body prose. If the same source string appears in both a chapter
+heading and a TOC label, normal cache behavior makes the second translation
+cheap and consistent.
 
-**Run-preserving** — for segments where multiple inline runs of mixed
-formatting interleave (the most pathological case, common in
-19th-century novels with frequent emphasis shifts). The contract is
-stricter: the model is given an ordered list of runs and asked to
-return the translated text aligned to the same run boundaries. The
-validator confirms count, order, and presence; the reassembler does
-the rest.
+## Rebuild
 
-Each contract has a single-segment and a batch variant, plus a compact
-form for high-throughput runs. The versioning is in the filename:
-`translate_marker_safe.v1.md`. When the JSON contract has to change
-incompatibly, the file bumps to `v2` and the cache namespace bumps with
-it. Prose-level edits to a prompt (the model's instructions, the
-examples) bump a minor version that does not invalidate cache.
+The writer does not ask a second model to fill XML around the translation. It
+copies the original EPUB entries and patches only the resources that contain
+translated block IDs. Patch routing uses section hrefs and DOM paths captured
+by the reader.
 
-None of these contracts ask the model to think about EPUB. The model
-sees prose and markers; the program does everything else.
+This is why the reader/writer counting rules are strict. Element child indices,
+addressable text-node indices, and entity-reference handling must match on both
+sides or a translation could land in the wrong place. The roundtrip tests are
+designed to catch those mistakes.
 
-## Why there is no fill-LLM
+## Checkpointing And Resume
 
-Some tools in this space use a second, low-temperature LLM to "fill in
-the XML structure" around the translated prose. The pattern is: model
-A translates, model B reassembles, and the user gets a working EPUB.
+Every job is stored in `.bookforge/jobs.sqlite`. A fresh translation snapshots
+the input EPUB and resolved run settings, inserts segment records, scans the
+cache, then runs the shared checkpointed execution engine.
 
-This works often enough to be tempting and fails often enough to be a
-problem. The failure mode that matters most is the one where model B
-"helpfully" merges two paragraphs because the prose flowed nicely, or
-silently drops a stray `<i>` it thought was a noise tag, or invents an
-`id` that doesn't exist anywhere in the book. By the time the user
-notices, they're hundreds of segments in and the cache is full of
-output they can't trust.
+`bookforge resume <job-id>` reads the stored snapshot instead of current CLI
+defaults. It rebuilds the source IR, verifies pending segment IDs, rehydrates
+sliding context from stored terminal translations, and translates only
+resumable segments. Retry-pending segments bypass cache so a known-bad result
+does not get reused.
 
-The deeper objection is that the fill-LLM is solving a problem that
-doesn't need a model. Reassembling JSON-tagged prose into the original
-XHTML tree is pure code — given the IR, you walk the tree, you bind
-each translated string to its block, you serialize. There's no
-ambiguity. The only reason a model gets involved is that the primary
-contract leaked structure into the response, and now somebody has to
-guess what the model meant.
+Fresh translation and resume now share `commands/translate/engine.rs` for the
+provider execution core. That engine owns the checkpoint writer lifecycle and
+selects batch or single-segment execution from the resolved settings.
 
-BookForge avoids the situation by not letting the primary contract leak
-in the first place. Reassembly is deterministic Rust over an IR. No
-second model. No "structure-aware" pass. If reassembly produces a
-broken EPUB, that's a bug in the deterministic code, and bugs in
-deterministic code can be reproduced and fixed.
+## Recovery And Review
 
-## The boring reliability layer
+Validation failures are not silently repaired into the EPUB. The scheduler
+retries within the configured attempt budget. Batch mode can split or repair
+invalid items. Optional fallback and double-check passes can be enabled. If a
+segment still cannot be trusted, it is marked failed or needs-review and source
+text is preserved.
 
-The least glamorous part of BookForge is the part the maintainer is
-proudest of: it doesn't lose work.
+Reports and review artifacts make those decisions visible. The review command
+builds a local static page from the stored job, source snapshot, translations,
+QA findings, and deterministic warnings. The review data lives under
+`.bookforge/runs/<job-id>/review/` and should be treated as private book data.
 
-Every job has a SQLite checkpoint store at `.bookforge/jobs.sqlite`.
-Every segment translation is persisted as soon as it's validated. If
-the process dies, the network drops, the laptop sleeps, or the user
-hits Ctrl-C, `bookforge resume <job-id>` picks up where the previous
-run left off. The original input EPUB is snapshotted into the job
-directory at submit time, so resume works even if the source file has
-been moved or deleted between submission and resume.
+## What The Design Buys
 
-The segment cache is content-addressable. A cached translation is
-reused if and only if all of these match:
+The system pays for translation work, not structure recovery. It can resume
+after interruption, cache terminal segments, preserve unusual EPUB formatting,
+translate metadata and TOC labels through the same path as body prose, and
+report exactly which segments failed instead of producing a silently damaged
+book.
 
-- the source segment's SHA-256
-- the prompt contract major version
-- the provider
-- the model
-- the source language
-- the target language
-- the glossary content fingerprint (in v1.2+)
-- the glossary render format (json vs prose, in v1.2+)
-- the context-window settings (in v1.3+)
-
-If any of these change, the segment re-translates. If none of them
-change, an interrupted job resumes from cache and only pays for the
-remainder. A run that completes on the second attempt with all the
-same settings costs no more than a run that completes on the first
-attempt minus the network calls for cached segments.
-
-This is invisible when it works and invaluable when it doesn't. The
-maintainer's girlfriend reads books on a phone with intermittent wifi;
-the maintainer translates books at a desk with reasonable wifi; the
-process between them has to survive a dropped connection and a closed
-laptop lid mid-chapter. It does, because the SQLite store doesn't
-care about transient failures.
-
-JSONL progress events are emitted for every state transition. The
-event schema is frozen for v1; new fields are additive, breaking
-changes go in v2. You can pipe them to a file, watch them with `tail`,
-or wire them into whatever progress UI you want.
-
-## The quality layer
-
-On top of the reliability layer is the part that decides whether the
-translation is *good*.
-
-**Glossary** (v1.2). A TOML file maps source terms to target terms,
-scoped to a book, a series, or globally. When a segment contains a
-glossed term, the term is injected into the prompt as an active
-constraint, ranked by relevance and capped at a configurable token
-budget. The review HTML highlights segments where the model emitted a
-target term inconsistent with the glossary. The series scope is the
-load-bearing feature here: translating book three of a series with the
-same glossary as books one and two means character names, place names,
-and invented terminology stay consistent across the whole arc.
-
-**Sliding context** (v1.3). The previous N segments' source-and-target
-pairs are included as context in the next segment's prompt, capped at
-a token budget, scoped to the same chapter. This catches the failure
-modes that glossary alone can't: pronoun resolution across paragraphs,
-narrative voice consistency, register drift across long chapters.
-Failed segments are never injected as context — contaminating the next
-prompt with a known-bad translation regresses the next one toward it.
-
-**Style sheets** (v1.3). Per-book or per-series TOML files that encode
-register, narration tense, dialogue formality default, loanword policy,
-and free-form custom instructions. Merged at translate time with the
-same precedence as glossaries (book > series > global) and rendered as
-a prompt block.
-
-**Entity sheets** (v1.3). A structured list of named entities with
-their grammatical gender in the target language. Italian, French,
-Spanish, and German all need this; English doesn't. The model gets a
-grammatical-agreement table along with each segment, so "she said,
-looking at the Ring" doesn't translate with feminine agreement on the
-wrong noun.
-
-These layers compose. A job with a series glossary, a book style
-sheet, sliding context, and an entity sheet still goes through the
-same JSON contract; the prompt block just has more constraints
-injected into it. None of them changes the structure invariant.
-
-## What BookForge deliberately doesn't do
-
-The roadmap doubles as a "no" list. A few of the louder ones:
-
-- **No RocksDB, no embedded V8, no JVM components.** SQLite via
-  `rusqlite` (bundled) is the entire storage substrate. The binary is
-  single-file. EPUBCheck is allowed as an *external* tool invoked via
-  `java`, but BookForge itself runs on a machine with nothing but
-  itself installed.
-- **No multi-agent QA orchestrator.** There is one optional LLM QA pass
-  (`--qa suspicious|all`) that runs *after* deterministic validators
-  and explicitly does not replace them. It's not a planning loop, not
-  a critique-and-revise loop, not a debate framework. It's one model
-  call per segment that says "is this translation suspicious?"
-- **No fill-LLM, no structure model, no repair model.** Covered above.
-- **No "translate the whole chapter in one shot."** Chapters are
-  segmented; segments are bounded; the model never gets a payload large
-  enough to truncate mid-output. If truncation does happen on a
-  pathological segment, that's a bug in segmentation, not in the LLM
-  contract.
-- **No web server, no daemon, no cloud component.** Review HTML is a
-  static file. Flagged segments are exported as a downloaded JSON file
-  and ingested back via a CLI command. Nothing phones home.
-- **No ratatui TUI.** Progress is an `indicatif` bar, a JSON stream, or
-  silence. A full TUI is a feature for someone who is not me.
-
-Each of these is a thing other tools in this space do, and each was
-considered explicitly and declined. Most of them violate the single-
-binary distribution goal, the structure-sacred invariant, or both.
-
-## Closing
-
-I built BookForge to translate books for my partner. She reads in
-Italian; the books I want to share with her aren't in Italian. Every
-existing tool I tried produced something that opened in her e-reader
-and then made her stop reading three chapters in because the
-typography or the consistency was off enough to be distracting.
-
-The architectural decisions in this post are the ones that fix the
-specific failure modes I watched her hit. They are not the only
-reasonable choices for an EPUB translator — they are the choices that
-make the tool work for one specific reader. The fact that they
-generalize is a bonus.
-
-It's MIT-licensed in case any of this is useful to you. The roadmap
-through v1.6 is public. Issues and PRs are welcome but the maintainer's
-response time is "weeks, not days."
-
-If you read all the way through, thank you. Now go translate a book.
-
----
-
-*BookForge source: <https://github.com/JunjoSick/bookforge>*
-*Roadmap: <https://github.com/JunjoSick/bookforge/blob/main/docs/ROADMAP.md>*
+The main tradeoff is that deterministic extraction and patching are harder
+than handing a whole XHTML file to a model. That cost is intentional. Bugs in
+Rust path accounting can be reproduced, tested, and fixed. Silent structural
+changes from a model cannot be trusted at book scale.


### PR DESCRIPTION
## Summary

Two sessions of work on top of `main` (`5f6debb`), addressing the two standing pain points -- slow translations and broken formatting on unorthodox books -- then adding PDF ingestion. 16 commits; squash-merge intended.

Validated: `cargo test --workspace` green (298 tests), `cargo fmt --check` clean, `cargo clippy --all-targets` clean apart from 4 pre-existing "too many arguments" warnings. A real DeepSeek run on a full book completed at 24.5 min, 0 needs-review, 0 failed, output structurally intact (51/51 footnote links, classes preserved, no leaked markers).

## Extraction and formatting fixes (the "broken formatting" complaint)

- Capture text outside the block whitelist -- text directly inside div/dt/dd and stray body text was silently shipping untranslated; now lazily anchored or addressed as text nodes (reader/writer counting kept in lockstep).
- Nested same-name blocks (li>ul>li, nested blockquotes) closed early and dropped inner translations -- now depth-anchored.
- Named HTML entities (nbsp, mdash) silently vanished -- now resolved (numeric + HTML5 named).
- pre/code blocks are no longer mistranslated or whitespace-mangled; passed through byte-for-byte.
- Span-append "repair" deleted -- reformatted protected spans no longer get glued onto paragraph ends; they fail validation, then needs-review with source preserved.
- Short per-block markers (m1 / r1 replacing the verbose global id form): fewer tokens, far less LLM mangling. Schema/prompt versions bumped (marker v3, prompt v2) so stale cache is never reused.
- NCX TOC, OPF dc:title, and XHTML head titles are now translated through the normal pipeline.

## Speed (the "takes a long time" complaint)

- Best-effort sliding context -- segments no longer block on predecessors (the old fence serialized whole single-file books). Strict behavior available via --context-strict.
- v1-fast is the default profile -- batched/adaptive out of the box instead of the slowest path.

## Reliability / quality infrastructure

- CRLF normalization in embedded prompt templates (4 tests failed on any Windows clone before this).
- Identity-roundtrip harness + text-coverage metric in inspect -- silently-dropped text becomes a visible number before tokens are spent.
- Lifecycle tests build synthetic fixtures -- CI now exercises the real EPUB path instead of skipping.
- Shared translate/resume run engine -- removes the duplicated execution core whose parity bugs litter the history.
- Empty self-closing block elements no longer generate wasted LLM calls.

## PDF ingestion (v1.7, new `bookforge convert`)

New bookforge-pdf crate per ROADMAP section 9b: poppler-based layout extraction + deterministic reconstruction (two-column detection, band reading order, hyphen repair, cross-page paragraph joins, font-size heading mapping) into a synthetic EPUB the existing pipeline consumes unchanged, with a coverage report vs the pdftotext baseline. Validated on a real two-column paper (arXiv 1810.04805): 100% coverage, correct reading order. Figures/tables/scan-fallback are the next phases (P2-P4).

## Docs

Roadmap updated (PDF to v1.7, pulled ahead of bilingual; v1.5 post-ship divergence recorded). Five doc stubs filled; v1.4 writeup rewritten to match the implementation.

Generated with Claude Code
