### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.claude/
 /test/
 /tests/
+/tmp/
 *.tmp
 *.log
 *.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## v1.5.0 - 2026-06-13
+
+BookForge v1.5 is the extraction and scheduling hardening release. It
+focuses on making EPUB translation safer before spending real provider
+tokens. The GitHub `main` release base also includes the first committed
+PDF ingestion slice: poppler-based PDF-to-EPUB conversion P0/P1.
+
+### Highlights
+
+- Added text-coverage reporting to `inspect`, including per-file
+  low-coverage diagnostics for visible text that would not be translated.
+- Captured more real EPUB text shapes: bare text in common containers,
+  OPF titles, NCX TOC labels, XHTML head titles, named HTML entities,
+  nested same-name blocks, and text outside the original block whitelist.
+- Kept `pre` and `code` blocks out of translation so source whitespace is
+  preserved byte-for-byte.
+- Replaced long inline marker tags with short per-block markers and moved
+  translation prompts to the v2 prompt contract.
+- Changed missing protected spans from silent append-repair into explicit
+  validation failures that fall back to source text and `needs_review`.
+- Made sliding context best-effort by default to avoid serializing or
+  deadlocking long runs; `--context-strict` restores the old completion
+  fence when needed.
+- Shared the checkpointed run engine between `translate` and `resume`,
+  with expanded lifecycle tests using synthetic EPUB fixtures.
+- Made `v1-fast` the default translation profile.
+- Added `bookforge convert` for initial poppler-based PDF text
+  extraction and synthetic EPUB assembly.
+
+### Validation
+
+- `cargo fmt --all --check`
+- `RUSTFLAGS="-D warnings" cargo test --workspace --locked`
+- `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings`
+- `RUSTFLAGS="-D warnings" cargo build --release --locked`
+
+The local Rust 1.88.0 MSRV check and crates.io packaging verification
+were not run in this environment because external download approval was
+blocked earlier.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "quick-xml",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-epub"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "bookforge-core",
  "quick-xml",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-llm"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "bookforge-core",
  "reqwest",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-pdf"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "bookforge-core",
  "bookforge-epub",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-store"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "bookforge-core",
  "rusqlite",

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-cli"
-version = "1.4.0"
+version = "1.5.0"
 description = "CLI-first EPUB translation engine with deterministic structure rebuild and review loop."
 readme = "../../README.md"
 edition.workspace = true
@@ -14,11 +14,11 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-bookforge-core = { version = "1.4.0", path = "../bookforge-core", features = ["cli"] }
-bookforge-epub = { version = "1.4.0", path = "../bookforge-epub" }
-bookforge-llm = { version = "1.4.0", path = "../bookforge-llm" }
-bookforge-pdf = { version = "1.4.0", path = "../bookforge-pdf" }
-bookforge-store = { version = "1.4.0", path = "../bookforge-store" }
+bookforge-core = { version = "1.5.0", path = "../bookforge-core", features = ["cli"] }
+bookforge-epub = { version = "1.5.0", path = "../bookforge-epub" }
+bookforge-llm = { version = "1.5.0", path = "../bookforge-llm" }
+bookforge-pdf = { version = "1.5.0", path = "../bookforge-pdf" }
+bookforge-store = { version = "1.5.0", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true
 indicatif.workspace = true

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-core"
-version = "1.4.0"
+version = "1.5.0"
 description = "Core IR, segmentation, configuration, and progress types for BookForge."
 edition.workspace = true
 license.workspace = true

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-epub"
-version = "1.4.0"
+version = "1.5.0"
 description = "EPUB reading, validation, and deterministic rebuild support for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.5.0", path = "../bookforge-core" }
 quick-xml.workspace = true
 tracing.workspace = true
 zip.workspace = true

--- a/crates/bookforge-llm/Cargo.toml
+++ b/crates/bookforge-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-llm"
-version = "1.4.0"
+version = "1.5.0"
 description = "Prompting, providers, batching, and validation for BookForge translation runs."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.5.0", path = "../bookforge-core" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -1,4 +1,4 @@
-﻿use std::collections::HashMap;
+use std::collections::HashMap;
 
 use serde::Serialize;
 use serde_json::Value;

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-pdf"
-version = "1.4.0"
+version = "1.5.0"
 description = "PDF ingestion for BookForge: poppler-based layout extraction and deterministic reconstruction into a translatable EPUB."
 edition.workspace = true
 license.workspace = true
@@ -16,6 +16,6 @@ tracing.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-bookforge-core = { version = "1.4.0", path = "../bookforge-core" }
-bookforge-epub = { version = "1.4.0", path = "../bookforge-epub" }
+bookforge-core = { version = "1.5.0", path = "../bookforge-core" }
+bookforge-epub = { version = "1.5.0", path = "../bookforge-epub" }
 tempfile = "3"

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-store"
-version = "1.4.0"
+version = "1.5.0"
 description = "SQLite checkpoint and job store for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "1.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "1.5.0", path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2131,6 +2131,30 @@ reconstruct badly are *flagged*, not hidden.
   reliable and honest for scientific papers; inline math glyph runs
   become protected spans. HTML table reconstruction is a later, separate
   decision.
+- **P3.5 — figure/table layout hardening.** Real BERT read-through after
+  P2/P3 exposed remaining defects to fix before calling scientific-paper
+  PDF ingestion polished:
+  1. **Caption-safe figure crops.** A figure raster must not include the
+     source caption text when the EPUB also emits a translatable
+     `<figcaption>`. Crop boundaries should snap above the detected
+     caption baseline, and the report should warn when text overlap
+     suggests a duplicated caption inside the image.
+  2. **Media-aware paragraph continuation.** Figures/tables/equations
+     should act as layout separators without breaking prose continuity.
+     Lowercase or suffix continuations after a media block should be
+     joined to the preceding paragraph or flagged as orphan continuations.
+  3. **Tighter equation/table crop detection.** Do not rasterize ordinary
+     prose fragments, model-parameter snippets, or table-adjacent labels
+     merely because they contain numbers, parentheses, or `=`.
+     Display-equation detection needs stronger math-density and geometry
+     tests; inline math should remain protected text where possible.
+  4. **Visual regression fixtures.** Add committed BERT-derived
+     `pdftohtml` XML/page fixtures for the known hard pages: Figure 1
+     caption boundary, Figure 4 multi-panel crop, Figure 5 vector chart,
+     and nearby model-parameter/equation false positives. CI should prove
+     the generated EPUB has one logical figure per caption, no duplicated
+     caption inside crops, no orphan lowercase paragraph starts, and no
+     over-broad equation crop count.
 - **P4 — degraded-layout fallback.** Pages whose reconstruction
   confidence is low (coverage gap vs `pdftotext`, column chaos) are
   handled per `--low-confidence preserve|linearize`: `preserve` embeds


### PR DESCRIPTION
## Summary

- Bump all BookForge workspace crates, including `bookforge-pdf`, to `1.5.0`.
- Add v1.5.0 changelog notes for the extraction/scheduling hardening release and initial PDF P0/P1 conversion support.
- Restore the PDF figures/tables roadmap note, ignore local `tmp/`, and remove a UTF-8 BOM from `crates/bookforge-llm/src/prompt.rs`.

## Validation

- `cargo fmt --all --check`
- `RUSTFLAGS="-D warnings" cargo test --workspace --locked`
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings`
- `RUSTFLAGS="-D warnings" cargo build --release --locked`

## Release Notes

This branch is based directly on GitHub `origin/main` at `0a3f1f2`, not on the stale local v1.5 worktree. After merge, tag the resulting `main` commit as `v1.5.0` to trigger the cargo-dist release workflow.