### PR TITLE
feat(pdf): preserve extracted figures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,8 @@ version = "2.0.3"
 dependencies = [
  "bookforge-core",
  "bookforge-epub",
+ "crc32fast",
+ "flate2",
  "quick-xml",
  "serde",
  "serde_json",

--- a/crates/bookforge-cli/src/commands/convert.rs
+++ b/crates/bookforge-cli/src/commands/convert.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use bookforge_pdf::{ColumnMode, ConvertOptions, convert_pdf};
+use bookforge_pdf::{ColumnMode, ConvertOptions, LowConfidenceMode, convert_pdf};
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -25,6 +25,10 @@ pub struct ConvertArgs {
     #[arg(long)]
     pub title: Option<String>,
 
+    /// Low-confidence page handling: preserve as page image or keep best-effort text.
+    #[arg(long, value_enum, default_value_t = LowConfidenceArg::Linearize)]
+    pub low_confidence: LowConfidenceArg,
+
     /// Where to write the JSON conversion report. Defaults to
     /// `<out>.convert.json`.
     #[arg(long)]
@@ -40,12 +44,27 @@ pub enum ColumnsArg {
     Two,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum LowConfidenceArg {
+    Preserve,
+    Linearize,
+}
+
 impl From<ColumnsArg> for ColumnMode {
     fn from(value: ColumnsArg) -> Self {
         match value {
             ColumnsArg::Auto => ColumnMode::Auto,
             ColumnsArg::Single => ColumnMode::Single,
             ColumnsArg::Two => ColumnMode::Two,
+        }
+    }
+}
+
+impl From<LowConfidenceArg> for LowConfidenceMode {
+    fn from(value: LowConfidenceArg) -> Self {
+        match value {
+            LowConfidenceArg::Preserve => LowConfidenceMode::Preserve,
+            LowConfidenceArg::Linearize => LowConfidenceMode::Linearize,
         }
     }
 }
@@ -65,6 +84,7 @@ pub async fn run(args: ConvertArgs) -> Result<()> {
 
     let options = ConvertOptions {
         columns: args.columns.into(),
+        low_confidence: args.low_confidence.into(),
         language: args.language.clone(),
         title: args.title.clone().unwrap_or_default(),
     };

--- a/crates/bookforge-cli/src/commands/doctor.rs
+++ b/crates/bookforge-cli/src/commands/doctor.rs
@@ -5,6 +5,7 @@ use bookforge_llm::{
     CompletionRequest, LlmProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
     RequestMetadata, ResponseFormat,
 };
+use bookforge_pdf::PopplerTools;
 use bookforge_store::run_doctor;
 
 #[derive(Debug, Args)]
@@ -12,6 +13,10 @@ pub struct DoctorArgs {
     /// Check storage health
     #[arg(long)]
     pub storage: bool,
+
+    /// Check PDF conversion tooling
+    #[arg(long)]
+    pub pdf: bool,
 
     /// Check provider health
     #[arg(long)]
@@ -42,6 +47,11 @@ pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
         run_storage_doctor().await?;
     }
 
+    if args.pdf {
+        ran = true;
+        run_pdf_doctor()?;
+    }
+
     if let Some(provider) = &args.provider {
         ran = true;
         run_provider_doctor(
@@ -58,6 +68,26 @@ pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
         run_storage_doctor().await?;
     }
 
+    Ok(())
+}
+
+fn run_pdf_doctor() -> anyhow::Result<()> {
+    println!("PDF conversion tooling:");
+    match PopplerTools::discover() {
+        Ok(tools) => {
+            println!("  pdftohtml: {}", tools.pdftohtml.display());
+            println!("  pdftotext: {}", tools.pdftotext.display());
+            println!("  pdfimages: {}", tools.pdfimages.display());
+            if let Some(version) = tools.version() {
+                println!("  version: {version}");
+            }
+        }
+        Err(err) => {
+            println!("  MISSING: {err}");
+            println!();
+            println!("  Install poppler and add pdftohtml, pdftotext, and pdfimages to PATH.");
+        }
+    }
     Ok(())
 }
 

--- a/crates/bookforge-cli/src/commands/doctor.rs
+++ b/crates/bookforge-cli/src/commands/doctor.rs
@@ -75,10 +75,22 @@ fn run_pdf_doctor() -> anyhow::Result<()> {
     println!("PDF conversion tooling:");
     match PopplerTools::discover() {
         Ok(tools) => {
-            println!("  pdftohtml: {}", tools.pdftohtml.display());
-            println!("  pdftotext: {}", tools.pdftotext.display());
-            println!("  pdfimages: {}", tools.pdfimages.display());
-            println!("  pdftoppm: {}", tools.pdftoppm.display());
+            println!("  pdftohtml (required): {}", tools.pdftohtml.display());
+            println!("  pdftotext (required): {}", tools.pdftotext.display());
+            match &tools.pdfimages {
+                Some(path) => println!(
+                    "  pdfimages (recommended, figure preservation): {}",
+                    path.display()
+                ),
+                None => println!("  pdfimages (recommended, figure preservation): missing"),
+            }
+            match &tools.pdftoppm {
+                Some(path) => println!(
+                    "  pdftoppm (recommended, figure/table/equation crops): {}",
+                    path.display()
+                ),
+                None => println!("  pdftoppm (recommended, figure/table/equation crops): missing"),
+            }
             if let Some(version) = tools.version() {
                 println!("  version: {version}");
             }
@@ -87,7 +99,7 @@ fn run_pdf_doctor() -> anyhow::Result<()> {
             println!("  MISSING: {err}");
             println!();
             println!(
-                "  Install poppler and add pdftohtml, pdftotext, pdfimages, and pdftoppm to PATH."
+                "  Install poppler and add at least pdftohtml and pdftotext to PATH. pdfimages and pdftoppm are recommended for figure preservation."
             );
         }
     }

--- a/crates/bookforge-cli/src/commands/doctor.rs
+++ b/crates/bookforge-cli/src/commands/doctor.rs
@@ -78,6 +78,7 @@ fn run_pdf_doctor() -> anyhow::Result<()> {
             println!("  pdftohtml: {}", tools.pdftohtml.display());
             println!("  pdftotext: {}", tools.pdftotext.display());
             println!("  pdfimages: {}", tools.pdfimages.display());
+            println!("  pdftoppm: {}", tools.pdftoppm.display());
             if let Some(version) = tools.version() {
                 println!("  version: {version}");
             }
@@ -85,7 +86,9 @@ fn run_pdf_doctor() -> anyhow::Result<()> {
         Err(err) => {
             println!("  MISSING: {err}");
             println!();
-            println!("  Install poppler and add pdftohtml, pdftotext, and pdfimages to PATH.");
+            println!(
+                "  Install poppler and add pdftohtml, pdftotext, pdfimages, and pdftoppm to PATH."
+            );
         }
     }
     Ok(())

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod glossary;
 pub mod ir;
 pub mod marker;
+pub mod math;
 pub mod progress;
 pub mod run_snapshot;
 pub mod scheduler;

--- a/crates/bookforge-core/src/math.rs
+++ b/crates/bookforge-core/src/math.rs
@@ -1,0 +1,41 @@
+//! Shared math-token classification used by EPUB and PDF ingestion.
+
+pub fn is_inline_math_operator(ch: char) -> bool {
+    matches!(
+        ch,
+        '=' | '+'
+            | '-'
+            | '*'
+            | '/'
+            | '^'
+            | '_'
+            | '('
+            | ')'
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '|'
+            | '<'
+            | '>'
+            | '\u{2211}'
+            | '\u{222b}'
+            | '\u{221a}'
+            | '\u{2264}'
+            | '\u{2265}'
+            | '\u{2248}'
+            | '\u{2260}'
+            | '\u{00b1}'
+            | '\u{00d7}'
+            | '\u{00f7}'
+            | '\u{2202}'
+            | '\u{2207}'
+            | '\u{221e}'
+            | '\u{2208}'
+    )
+}
+
+pub fn is_strong_inline_math_operator(ch: char) -> bool {
+    is_inline_math_operator(ch)
+        && !matches!(ch, '_' | '-' | '(' | ')' | '[' | ']' | '{' | '}' | '|')
+}

--- a/crates/bookforge-core/src/math.rs
+++ b/crates/bookforge-core/src/math.rs
@@ -37,5 +37,8 @@ pub fn is_inline_math_operator(ch: char) -> bool {
 
 pub fn is_strong_inline_math_operator(ch: char) -> bool {
     is_inline_math_operator(ch)
-        && !matches!(ch, '_' | '-' | '(' | ')' | '[' | ']' | '{' | '}' | '|')
+        && !matches!(
+            ch,
+            '_' | '-' | '/' | '(' | ')' | '[' | ']' | '{' | '}' | '|'
+        )
 }

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1359,23 +1359,7 @@ fn is_math_operator_token(value: &str) -> bool {
 }
 
 fn is_inline_math_operator(ch: char) -> bool {
-    matches!(
-        ch,
-        '=' | '+'
-            | '*'
-            | '/'
-            | '^'
-            | '_'
-            | '<'
-            | '>'
-            | '\u{2264}'
-            | '\u{2265}'
-            | '\u{2248}'
-            | '\u{2260}'
-            | '\u{00b1}'
-            | '\u{00d7}'
-            | '\u{00f7}'
-    )
+    bookforge_core::math::is_inline_math_operator(ch)
 }
 
 fn is_math_token_char(ch: char) -> bool {
@@ -1383,7 +1367,7 @@ fn is_math_token_char(ch: char) -> bool {
 }
 
 fn is_strong_inline_math_operator(ch: char) -> bool {
-    is_inline_math_operator(ch) && ch != '_'
+    bookforge_core::math::is_strong_inline_math_operator(ch)
 }
 
 fn trim_token(raw: &str) -> &str {

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1261,6 +1261,14 @@ fn detect_protected_spans(text: &str) -> Vec<ProtectedSpan> {
             })
         })
         .collect::<Vec<_>>();
+    spans.extend(
+        detect_math_spans(text)
+            .into_iter()
+            .map(|text| ProtectedSpan {
+                kind: ProtectedSpanKind::Math,
+                text,
+            }),
+    );
     spans.sort_by(|left, right| left.text.cmp(&right.text));
     spans.dedup_by(|left, right| left.kind == right.kind && left.text == right.text);
     spans
@@ -1279,11 +1287,103 @@ fn protected_span_kind(value: &str) -> Option<ProtectedSpanKind> {
         Some(ProtectedSpanKind::Citation)
     } else if looks_like_protected_number(value) {
         Some(ProtectedSpanKind::Number)
+    } else if looks_like_inline_math_token(value) {
+        Some(ProtectedSpanKind::Math)
     } else if looks_like_filename(value) {
         Some(ProtectedSpanKind::Filename)
     } else {
         None
     }
+}
+
+fn detect_math_spans(text: &str) -> Vec<String> {
+    let tokens = text
+        .split_whitespace()
+        .map(trim_token)
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let mut spans = Vec::new();
+
+    for window in tokens.windows(3) {
+        let [left, op, right] = window else {
+            continue;
+        };
+        if is_math_operator_token(op)
+            && looks_like_math_operand(left)
+            && looks_like_math_operand(right)
+            && (looks_like_inline_math_token(left)
+                || looks_like_inline_math_token(right)
+                || is_symbolic_operand(left)
+                || is_symbolic_operand(right))
+        {
+            spans.push(format!("{left} {op} {right}"));
+        }
+    }
+
+    spans.sort();
+    spans.dedup();
+    spans
+}
+
+fn looks_like_inline_math_token(value: &str) -> bool {
+    let chars = value.chars().collect::<Vec<_>>();
+    if chars.len() < 3 {
+        return false;
+    }
+    let has_operand = chars.iter().any(|ch| ch.is_ascii_alphanumeric());
+    let has_strong_operator = chars.iter().any(|ch| is_strong_inline_math_operator(*ch));
+    let has_numeric_subscript = chars.contains(&'_') && chars.iter().any(|ch| ch.is_ascii_digit());
+    has_operand
+        && (has_strong_operator || has_numeric_subscript)
+        && chars.iter().all(|ch| is_math_token_char(*ch))
+}
+
+fn looks_like_math_operand(value: &str) -> bool {
+    let chars = value.chars().collect::<Vec<_>>();
+    !chars.is_empty()
+        && chars.len() <= 24
+        && chars.iter().any(|ch| ch.is_ascii_alphanumeric())
+        && chars.iter().all(|ch| is_math_token_char(*ch))
+}
+
+fn is_symbolic_operand(value: &str) -> bool {
+    let mut chars = value.chars();
+    matches!(chars.next(), Some(ch) if ch.is_ascii_alphabetic()) && chars.next().is_none()
+}
+
+fn is_math_operator_token(value: &str) -> bool {
+    matches!(
+        value,
+        "=" | "<" | ">" | "<=" | ">=" | "==" | "\u{2264}" | "\u{2265}" | "\u{2248}" | "\u{2260}"
+    )
+}
+
+fn is_inline_math_operator(ch: char) -> bool {
+    matches!(
+        ch,
+        '=' | '+'
+            | '*'
+            | '/'
+            | '^'
+            | '_'
+            | '<'
+            | '>'
+            | '\u{2264}'
+            | '\u{2265}'
+            | '\u{2248}'
+            | '\u{2260}'
+            | '\u{00b1}'
+            | '\u{00d7}'
+            | '\u{00f7}'
+    )
+}
+
+fn is_math_token_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || is_inline_math_operator(ch) || matches!(ch, '.' | ',')
+}
+
+fn is_strong_inline_math_operator(ch: char) -> bool {
+    is_inline_math_operator(ch) && ch != '_'
 }
 
 fn trim_token(raw: &str) -> &str {
@@ -1760,6 +1860,34 @@ mod tests {
         assert!(texts.contains(&"chapter.xhtml"));
         assert!(texts.contains(&"[@tolstoy1886]"));
         assert!(texts.contains(&"@note1"));
+    }
+
+    #[test]
+    fn protected_spans_include_inline_math_without_overflagging_prose() {
+        let spans = detect_protected_spans("Einstein wrote E = mc^2, with p<0.05 elsewhere.");
+        let math = spans
+            .iter()
+            .filter(|span| span.kind == ProtectedSpanKind::Math)
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(math.contains(&"E = mc^2"));
+        assert!(math.contains(&"p<0.05"));
+
+        let prose = detect_protected_spans("The model = stable result was described in prose.");
+        assert!(
+            !prose
+                .iter()
+                .any(|span| span.kind == ProtectedSpanKind::Math && span.text == "model = stable")
+        );
+
+        let sentinel =
+            detect_protected_spans("OUTER_SENTINEL should remain ordinary fixture text.");
+        assert!(
+            !sentinel
+                .iter()
+                .any(|span| span.kind == ProtectedSpanKind::Math)
+        );
     }
 
     fn block_text(block: &Block) -> String {

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -8,7 +8,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+bookforge-core = { version = "2.0.3", path = "../bookforge-core" }
 quick-xml.workspace = true
+crc32fast = "1.5.0"
+flate2 = "1.1.9"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -16,6 +19,5 @@ tracing.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-bookforge-core = { version = "2.0.3", path = "../bookforge-core" }
 bookforge-epub = { version = "2.0.3", path = "../bookforge-epub" }
 tempfile = "3"

--- a/crates/bookforge-pdf/fixtures/bert_figure1_caption_boundary.xml
+++ b/crates/bookforge-pdf/fixtures/bert_figure1_caption_boundary.xml
@@ -1,0 +1,11 @@
+<pdf2xml producer="poppler">
+  <page number="1" width="612" height="792">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <fontspec id="1" size="10" family="Times" color="#000000"/>
+    <text top="72" left="72" width="280" height="12" font="0">Results introduce a boundary-sensitive figure.</text>
+    <image top="110" left="96" width="180" height="90" src="figure1-a.png"/>
+    <image top="110" left="302" width="180" height="90" src="figure1-b.png"/>
+    <text top="204" left="96" width="360" height="12" font="1">Figure 1. Boundary-sensitive raster caption.</text>
+    <text top="245" left="72" width="340" height="12" font="0">The caption should be translated once.</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/fixtures/bert_figure1_token_strip.xml
+++ b/crates/bookforge-pdf/fixtures/bert_figure1_token_strip.xml
@@ -1,0 +1,19 @@
+<pdf2xml producer="poppler">
+  <page number="1" width="612" height="792">
+    <fontspec id="0" size="9" family="Times" color="#000000"/>
+    <image top="116" left="72" width="468" height="180" src="figure1-diagram.png"/>
+    <text top="148" left="92" width="42" height="9" font="0">E_[CLS]</text>
+    <text top="148" left="198" width="24" height="9" font="0">E_1</text>
+    <text top="148" left="304" width="24" height="9" font="0">E_2</text>
+    <text top="148" left="410" width="26" height="9" font="0">E_N</text>
+    <text top="170" left="92" width="42" height="9" font="0">T_[CLS]</text>
+    <text top="170" left="198" width="24" height="9" font="0">T_1</text>
+    <text top="170" left="304" width="24" height="9" font="0">T_2</text>
+    <text top="170" left="410" width="26" height="9" font="0">T_N</text>
+    <text top="192" left="92" width="42" height="9" font="0">C_[CLS]</text>
+    <text top="192" left="198" width="24" height="9" font="0">C_1</text>
+    <text top="192" left="304" width="24" height="9" font="0">C_2</text>
+    <text top="192" left="410" width="26" height="9" font="0">C_N</text>
+    <text top="318" left="72" width="420" height="10" font="0">Figure 1. Overall pre-training and fine-tuning procedures for BERT.</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/fixtures/bert_figure4_multipanel.xml
+++ b/crates/bookforge-pdf/fixtures/bert_figure4_multipanel.xml
@@ -1,0 +1,11 @@
+<pdf2xml producer="poppler">
+  <page number="1" width="612" height="792">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <fontspec id="1" size="10" family="Times" color="#000000"/>
+    <text top="72" left="72" width="300" height="12" font="0">A multi-panel result follows.</text>
+    <image top="120" left="84" width="210" height="100" src="figure4-left.png"/>
+    <image top="120" left="318" width="210" height="100" src="figure4-right.png"/>
+    <text top="245" left="84" width="390" height="12" font="1">Figure 4. Multi-panel activation maps.</text>
+    <text top="290" left="72" width="340" height="12" font="0">Discussion resumes after the figure.</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/fixtures/bert_figure5_vector_chart.xml
+++ b/crates/bookforge-pdf/fixtures/bert_figure5_vector_chart.xml
@@ -1,0 +1,16 @@
+<pdf2xml producer="poppler">
+  <page number="1" width="612" height="792">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <fontspec id="1" size="10" family="Times" color="#000000"/>
+    <text top="30" left="72" width="300" height="12" font="0">Vector-chart results are below.</text>
+    <text top="126" left="112" width="24" height="10" font="1">1.0</text>
+    <text top="196" left="112" width="24" height="10" font="1">0.5</text>
+    <text top="266" left="112" width="24" height="10" font="1">0.0</text>
+    <text top="286" left="180" width="12" height="10" font="1">0</text>
+    <text top="286" left="300" width="18" height="10" font="1">10</text>
+    <text top="286" left="420" width="18" height="10" font="1">20</text>
+    <text top="320" left="265" width="48" height="10" font="1">Epoch</text>
+    <text top="356" left="96" width="390" height="12" font="1">Figure 5. Vector chart of held-out accuracy.</text>
+    <text top="400" left="72" width="330" height="12" font="0">The next paragraph should stay prose.</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/fixtures/bert_model_parameter_false_positive.xml
+++ b/crates/bookforge-pdf/fixtures/bert_model_parameter_false_positive.xml
@@ -1,0 +1,6 @@
+<pdf2xml producer="poppler">
+  <page number="1" width="612" height="792">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="80" width="440" height="12" font="0">The model = stable result used k = 3 in parentheses (n = 12).</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/fixtures/bert_page16_vector_chart_twocol.xml
+++ b/crates/bookforge-pdf/fixtures/bert_page16_vector_chart_twocol.xml
@@ -1,0 +1,26 @@
+<pdf2xml producer="poppler">
+  <page number="16" width="612" height="792">
+    <fontspec id="0" size="10" family="Times" color="#000000"/>
+    <fontspec id="1" size="8" family="Times" color="#000000"/>
+    <fontspec id="2" size="12" family="Times" color="#000000"/>
+    <text top="72" left="72" width="220" height="10" font="0">Left column prose starts this appendix page.</text>
+    <text top="88" left="72" width="220" height="10" font="0">It has enough sentence text to remain translatable.</text>
+    <text top="104" left="72" width="220" height="10" font="0">The detector must not preserve this line as pixels.</text>
+    <text top="72" left="324" width="220" height="10" font="0">Right column prose starts beside the chart.</text>
+    <text top="88" left="324" width="220" height="10" font="0">It also has enough sentence text to remain translatable.</text>
+    <text top="104" left="324" width="220" height="10" font="0">The chart crop must not cross into this column.</text>
+    <text top="342" left="72" width="230" height="12" font="2">C.2 Ablation for Different Masking Procedures</text>
+    <text top="366" left="72" width="230" height="10" font="0">This paragraph describes the ablation and must stay as text.</text>
+    <text top="382" left="72" width="230" height="10" font="0">Wrongly imaging prose here would make translation worse.</text>
+    <text top="366" left="324" width="220" height="10" font="0">The opposite column continues with ordinary prose.</text>
+    <text top="382" left="324" width="220" height="10" font="0">It should be outside the vector figure region.</text>
+    <text top="508" left="86" width="20" height="8" font="1">1.0</text>
+    <text top="568" left="86" width="20" height="8" font="1">0.9</text>
+    <text top="628" left="86" width="20" height="8" font="1">0.8</text>
+    <text top="646" left="130" width="8" height="8" font="1">0</text>
+    <text top="646" left="198" width="14" height="8" font="1">10</text>
+    <text top="646" left="266" width="14" height="8" font="1">20</text>
+    <text top="664" left="148" width="90" height="8" font="1">MNLI Dev Accuracy</text>
+    <text top="692" left="72" width="230" height="10" font="0">Figure 5. MNLI Dev Accuracy for masking ablations.</text>
+  </page>
+</pdf2xml>

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -393,6 +393,10 @@ impl RegionRect {
         i64::from((right - left).max(0)) * i64::from((bottom - top).max(0))
     }
 
+    fn vertically_overlaps(self, other: Self) -> bool {
+        self.page == other.page && self.top < other.bottom() && other.top < self.bottom()
+    }
+
     fn touches_within(self, other: Self, gap: i32) -> bool {
         self.page == other.page
             && self.left <= other.right().saturating_add(gap)
@@ -728,7 +732,13 @@ fn push_table_region(page: &Page, rows: &[&FragmentRow<'_>], regions: &mut Vec<M
     if rows.len() < 3 || !table_group_has_aligned_columns(rows) {
         return;
     }
-    let rect = rect_from_rows(page, rows);
+    let mut rect = rect_from_rows(page, rows);
+    if page_has_two_column_prose(page)
+        && let Some((left, right)) = column_bounds_for_table_rows(page, rows)
+        && let Some(clamped) = clamp_rect_horizontally(rect, left, right)
+    {
+        rect = clamped;
+    }
     let caption = detect_table_caption(page, rect);
     if rows.len() < 4 && caption.is_none() {
         return;
@@ -795,6 +805,26 @@ fn rect_from_rows(page: &Page, rows: &[&FragmentRow<'_>]) -> RegionRect {
         width: right - left,
         height: bottom - top,
     }
+}
+
+fn column_bounds_for_table_rows(page: &Page, rows: &[&FragmentRow<'_>]) -> Option<(i32, i32)> {
+    let mut fragments = rows
+        .iter()
+        .flat_map(|row| row.fragments.iter().copied())
+        .filter(|fragment| is_table_signal_fragment(fragment))
+        .collect::<Vec<_>>();
+    if fragments.is_empty() {
+        fragments = rows
+            .iter()
+            .flat_map(|row| row.fragments.iter().copied())
+            .collect::<Vec<_>>();
+    }
+    column_bounds_for_fragments(page, &fragments)
+}
+
+fn is_table_signal_fragment(fragment: &Fragment) -> bool {
+    let text = spans_text(&fragment.spans);
+    text.chars().any(|ch| ch.is_ascii_digit()) || text.contains('%')
 }
 
 fn equation_regions_for_page(page: &Page, excluded: &[RegionRect]) -> Vec<MediaRegion> {
@@ -930,7 +960,10 @@ fn figure_blocks_from_images(
         .iter()
         .filter_map(|region| {
             let page = pages_by_number.get(&region.rect.page).copied()?;
-            Some(snap_rect_above_caption(region.rect.padded(page, 48), region.caption).0)
+            Some(
+                snap_rect_above_caption(padded_vector_crop_rect(page, region.rect), region.caption)
+                    .0,
+            )
         })
         .collect::<Vec<_>>();
     let mut used_images = vec![false; candidates.len()];
@@ -1045,12 +1078,12 @@ fn figure_blocks_from_images(
 
     for region in vector_regions {
         figure_crop_count += 1;
-        let rect = region.rect.padded(
+        let rect = padded_vector_crop_rect(
             pages_by_number
                 .get(&region.rect.page)
                 .copied()
                 .expect("vector figure regions come from known pages"),
-            48,
+            region.rect,
         );
         let (rect, snapped) = snap_rect_above_caption(rect, region.caption);
         let asset = match render_figure_crop(
@@ -1193,7 +1226,62 @@ fn image_candidate_clusters(
         clusters.push(cluster);
     }
 
+    merge_vertically_overlapping_clusters(clusters, candidates, pages_by_number)
+}
+
+fn merge_vertically_overlapping_clusters(
+    mut clusters: Vec<Vec<usize>>,
+    candidates: &[ImageFigureCandidate<'_>],
+    pages_by_number: &HashMap<u32, &Page>,
+) -> Vec<Vec<usize>> {
+    let mut index = 0;
+    while index < clusters.len() {
+        let mut other = index + 1;
+        while other < clusters.len() {
+            if clusters_vertically_overlap(
+                &clusters[index],
+                &clusters[other],
+                candidates,
+                pages_by_number,
+            ) {
+                let mut merged = clusters.remove(other);
+                clusters[index].append(&mut merged);
+            } else {
+                other += 1;
+            }
+        }
+        index += 1;
+    }
     clusters
+}
+
+fn clusters_vertically_overlap(
+    left: &[usize],
+    right: &[usize],
+    candidates: &[ImageFigureCandidate<'_>],
+    pages_by_number: &HashMap<u32, &Page>,
+) -> bool {
+    let Some(left_rect) = cluster_rect(left, candidates, pages_by_number) else {
+        return false;
+    };
+    let Some(right_rect) = cluster_rect(right, candidates, pages_by_number) else {
+        return false;
+    };
+    left_rect.vertically_overlaps(right_rect)
+}
+
+fn cluster_rect(
+    cluster: &[usize],
+    candidates: &[ImageFigureCandidate<'_>],
+    pages_by_number: &HashMap<u32, &Page>,
+) -> Option<RegionRect> {
+    let page_number = candidates.get(*cluster.first()?)?.image.page;
+    let page = pages_by_number.get(&page_number).copied()?;
+    let regions = cluster
+        .iter()
+        .filter_map(|index| candidate_region_rect(&candidates[*index]))
+        .collect::<Vec<_>>();
+    (!regions.is_empty()).then(|| rect_from_region_rects(page, &regions))
 }
 
 fn extended_caption_key(
@@ -1425,11 +1513,25 @@ fn chart_label_fragments<'a>(
                 && is_chart_label_fragment(fragment)
         })
         .collect::<Vec<_>>();
-    if two_column && let Some((left, right)) = column_bounds_for_labels(page, &fragments) {
+    let single_column_caption = two_column && !fragment_spans_columns(page, caption);
+    if single_column_caption {
+        if let Some((left, right)) = column_bounds_for_fragments(page, &[caption]) {
+            fragments.retain(|fragment| {
+                let center = fragment.left + fragment.width / 2;
+                center >= left && center <= right
+            });
+        }
+    } else if two_column
+        && !fragments_span_columns(page, &fragments)
+        && let Some((left, right)) = column_bounds_for_labels(page, &fragments)
+    {
         fragments.retain(|fragment| {
             let center = fragment.left + fragment.width / 2;
             center >= left && center <= right
         });
+    }
+    if single_column_caption && !fragments_span_columns(page, &fragments) {
+        trim_fragments_above_large_vertical_gap(&mut fragments);
     }
     fragments
 }
@@ -1465,14 +1567,88 @@ fn vector_region_rect(
         }
     }
     let mut rect = rect_from_region_rects(page, &rects);
-    if two_column {
+    if two_column
+        && !fragment_spans_columns(page, caption)
+        && !fragments_span_columns(page, chart_fragments)
+    {
         let (left, right) = column_bounds_for_labels(page, chart_fragments)?;
         rect = clamp_rect_horizontally(rect, left, right)?;
     }
     Some(rect)
 }
 
-fn column_bounds_for_labels(page: &Page, chart_fragments: &[&Fragment]) -> Option<(i32, i32)> {
+fn trim_fragments_above_large_vertical_gap(fragments: &mut Vec<&Fragment>) {
+    if fragments.len() < 2 {
+        return;
+    }
+    fragments.sort_by_key(|fragment| (fragment.top, fragment.left));
+    let Some(split_index) = fragments
+        .windows(2)
+        .enumerate()
+        .filter_map(|(index, pair)| {
+            let previous_bottom = pair[0].top + pair[0].height;
+            let split_index = index + 1;
+            (pair[1].top.saturating_sub(previous_bottom) >= 36
+                && fragments_have_chart_signal(&fragments[split_index..]))
+            .then_some(split_index)
+        })
+        .next_back()
+    else {
+        return;
+    };
+    fragments.drain(0..split_index);
+}
+
+fn fragments_have_chart_signal(fragments: &[&Fragment]) -> bool {
+    fragments.len() >= 4
+        && fragments
+            .iter()
+            .filter(|fragment| {
+                spans_text(&fragment.spans)
+                    .chars()
+                    .any(|ch| ch.is_ascii_digit())
+            })
+            .count()
+            >= 3
+}
+
+fn fragments_span_columns(page: &Page, fragments: &[&Fragment]) -> bool {
+    if fragments.len() < 6 {
+        return false;
+    }
+    let Some((content_left, content_right)) = content_bounds(page) else {
+        return false;
+    };
+    let content_width = (content_right - content_left).max(1);
+    let mid = content_left + content_width / 2;
+    let left_count = fragments
+        .iter()
+        .filter(|fragment| fragment.left + fragment.width / 2 <= mid)
+        .count();
+    let right_count = fragments.len().saturating_sub(left_count);
+    let fragment_left = fragments
+        .iter()
+        .map(|fragment| fragment.left)
+        .min()
+        .unwrap_or(content_left);
+    let fragment_right = fragments
+        .iter()
+        .map(|fragment| fragment.right())
+        .max()
+        .unwrap_or(content_right);
+    left_count >= 3 && right_count >= 3 && fragment_right - fragment_left >= content_width * 2 / 5
+}
+
+fn fragment_spans_columns(page: &Page, fragment: &Fragment) -> bool {
+    let Some((content_left, content_right)) = content_bounds(page) else {
+        return false;
+    };
+    let content_width = (content_right - content_left).max(1);
+    let mid = content_left + content_width / 2;
+    fragment.width >= content_width * 2 / 3 || (fragment.left < mid && fragment.right() > mid)
+}
+
+fn content_bounds(page: &Page) -> Option<(i32, i32)> {
     let content_left = page.fragments.iter().map(|fragment| fragment.left).min()?;
     let content_right = page
         .fragments
@@ -1480,13 +1656,22 @@ fn column_bounds_for_labels(page: &Page, chart_fragments: &[&Fragment]) -> Optio
         .map(Fragment::right)
         .max()
         .unwrap_or(page.width);
+    Some((content_left, content_right))
+}
+
+fn column_bounds_for_labels(page: &Page, chart_fragments: &[&Fragment]) -> Option<(i32, i32)> {
+    column_bounds_for_fragments(page, chart_fragments)
+}
+
+fn column_bounds_for_fragments(page: &Page, fragments: &[&Fragment]) -> Option<(i32, i32)> {
+    let (content_left, content_right) = content_bounds(page)?;
     let content_width = (content_right - content_left).max(1);
     let mid = content_left + content_width / 2;
-    let center_sum = chart_fragments
+    let center_sum = fragments
         .iter()
         .map(|fragment| fragment.left + fragment.width / 2)
         .sum::<i32>();
-    let centroid = center_sum / i32::try_from(chart_fragments.len()).ok()?.max(1);
+    let centroid = center_sum / i32::try_from(fragments.len()).ok()?.max(1);
     if centroid <= mid {
         Some((content_left, mid))
     } else {
@@ -1562,6 +1747,16 @@ fn shrink_region_away_from_prose(
         }
     }
     rect
+}
+
+fn padded_vector_crop_rect(page: &Page, rect: RegionRect) -> RegionRect {
+    let mut crop = rect.padded(page, 48);
+    if crop.top < rect.top {
+        let bottom = crop.bottom();
+        crop.top = rect.top;
+        crop.height = (bottom - crop.top).max(1);
+    }
+    crop
 }
 
 fn is_prose_like_fragment(fragment: &Fragment) -> bool {
@@ -2293,6 +2488,88 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
     }
 
     #[test]
+    fn table_region_clamps_to_table_column_on_two_column_page() {
+        let mut page = empty_page(1);
+        page.fragments = vec![
+            fragment(
+                70,
+                72,
+                220,
+                10,
+                "Left column prose establishes a normal sentence.",
+            ),
+            fragment(
+                86,
+                72,
+                220,
+                10,
+                "Another left column sentence keeps detection stable.",
+            ),
+            fragment(
+                70,
+                330,
+                220,
+                10,
+                "Right column prose establishes a normal sentence.",
+            ),
+            fragment(
+                86,
+                330,
+                220,
+                10,
+                "Another right column sentence keeps detection stable.",
+            ),
+            fragment(130, 72, 140, 10, "Table 1. Scores."),
+            fragment(170, 72, 40, 10, "Metric"),
+            fragment(170, 150, 32, 10, "2019"),
+            fragment(170, 220, 32, 10, "2020"),
+            fragment(
+                170,
+                330,
+                220,
+                10,
+                "Right column prose should not enter this crop.",
+            ),
+            fragment(190, 72, 20, 10, "A"),
+            fragment(190, 150, 32, 10, "0.91"),
+            fragment(190, 220, 32, 10, "0.93"),
+            fragment(
+                190,
+                330,
+                220,
+                10,
+                "Neighboring body text remains ordinary prose.",
+            ),
+            fragment(210, 72, 20, 10, "B"),
+            fragment(210, 150, 32, 10, "0.81"),
+            fragment(210, 220, 32, 10, "0.84"),
+            fragment(
+                210,
+                330,
+                220,
+                10,
+                "The crop must stay within the table column.",
+            ),
+        ];
+
+        let regions = table_regions_for_page(&page, &[]);
+
+        assert_eq!(regions.len(), 1);
+        let rect = regions[0].rect;
+        assert!(
+            rect.right() <= 330,
+            "table crop must stay in the table column: {rect:?}"
+        );
+        assert!(
+            page.fragments
+                .iter()
+                .filter(|fragment| fragment.left > page.width / 2)
+                .all(|fragment| !rect.overlaps_fragment(fragment)),
+            "right-column prose must stay outside the table crop: {rect:?}"
+        );
+    }
+
+    #[test]
     fn figure_token_rows_inside_image_region_are_not_tables() {
         let pages = parse_pdf2xml(BERT_FIGURE1_TOKEN_STRIP_XML).expect("fixture parses");
         let regions = detect_media_regions(&pages, &[]);
@@ -2323,7 +2600,222 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
                 .all(|fragment| !rect.overlaps_fragment(fragment)),
             "prose fragments must stay outside vector chart text region: {rect:?}"
         );
+        let crop = padded_vector_crop_rect(page, rect);
+        assert_eq!(
+            crop.top, rect.top,
+            "vector crop must not pad upward into prose above the chart"
+        );
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn vector_chart_region_drops_short_prose_above_chart_labels() {
+        let mut page = empty_page(1);
+        page.width = 892;
+        page.height = 1262;
+        page.fragments = vec![
+            fragment(
+                100,
+                108,
+                327,
+                15,
+                "Left column prose establishes normal text for detection.",
+            ),
+            fragment(
+                120,
+                108,
+                327,
+                15,
+                "Another left column sentence keeps this page two-column.",
+            ),
+            fragment(
+                100,
+                461,
+                327,
+                15,
+                "Right column prose establishes normal text for detection.",
+            ),
+            fragment(
+                120,
+                461,
+                327,
+                15,
+                "Another right column sentence keeps this page two-column.",
+            ),
+            fragment(711, 108, 71, 15, "In Section"),
+            fragment(
+                731,
+                108,
+                327,
+                15,
+                "mixed strategy for masking the target tokens when",
+            ),
+            fragment(812, 108, 66, 15, "strategies."),
+            fragment(871, 130, 12, 9, "84"),
+            fragment(904, 130, 12, 9, "82"),
+            fragment(936, 130, 12, 9, "80"),
+            fragment(1026, 188, 18, 9, "200"),
+            fragment(1043, 205, 130, 9, "Pre-training Steps"),
+            fragment(
+                1075,
+                108,
+                327,
+                13,
+                "Figure 5: Ablation over number of training steps.",
+            ),
+        ];
+        let mut warnings = Vec::new();
+        let pages = vec![page];
+
+        let regions = vector_figure_regions(&pages, &HashSet::from([1]), &mut warnings);
+
+        assert_eq!(regions.len(), 1);
+        assert!(
+            regions[0].rect.top >= 871,
+            "chart region must start at chart labels, not short prose: {:?}",
+            regions[0].rect
+        );
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn full_width_vector_diagram_is_not_clamped_to_one_column() {
+        let mut page = empty_page(1);
+        page.width = 892;
+        page.height = 1262;
+        page.fragments = vec![
+            fragment(
+                399,
+                108,
+                327,
+                15,
+                "Left column prose establishes normal text for detection.",
+            ),
+            fragment(
+                419,
+                108,
+                327,
+                15,
+                "Another left column sentence keeps this page two-column.",
+            ),
+            fragment(
+                399,
+                461,
+                327,
+                15,
+                "Right column prose establishes normal text for detection.",
+            ),
+            fragment(
+                419,
+                461,
+                327,
+                15,
+                "Another right column sentence keeps this page two-column.",
+            ),
+            fragment(101, 167, 79, 13, "BERT (Ours)"),
+            fragment(153, 144, 12, 6, "Trm"),
+            fragment(153, 178, 12, 6, "Trm"),
+            fragment(127, 147, 6, 6, "T"),
+            fragment(131, 153, 3, 4, "1"),
+            fragment(127, 182, 4, 6, "T"),
+            fragment(131, 186, 3, 4, "2"),
+            fragment(102, 335, 79, 13, "OpenAI GPT"),
+            fragment(153, 322, 12, 6, "Trm"),
+            fragment(153, 357, 12, 6, "Trm"),
+            fragment(127, 326, 6, 6, "T"),
+            fragment(131, 332, 3, 4, "1"),
+            fragment(105, 608, 36, 13, "ELMo"),
+            fragment(165, 486, 15, 6, "Lstm"),
+            fragment(165, 683, 15, 6, "Lstm"),
+            fragment(165, 749, 15, 6, "Lstm"),
+            fragment(127, 573, 6, 6, "T"),
+            fragment(131, 579, 3, 4, "1"),
+            fragment(127, 608, 4, 6, "T"),
+            fragment(131, 612, 3, 4, "2"),
+            fragment(228, 678, 6, 6, "E"),
+            fragment(233, 685, 3, 4, "N"),
+            fragment(
+                276,
+                108,
+                680,
+                13,
+                "Figure 3: Differences in pre-training model architectures.",
+            ),
+        ];
+        let mut warnings = Vec::new();
+        let page_width = page.width;
+        let pages = vec![page];
+
+        let regions = vector_figure_regions(&pages, &HashSet::from([1]), &mut warnings);
+
+        assert_eq!(regions.len(), 1);
+        assert!(
+            regions[0].rect.right() > page_width * 3 / 4,
+            "full-width vector diagram must include the rightmost panel: {:?}",
+            regions[0].rect
+        );
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn vertically_overlapping_outer_subimage_clusters_merge() {
+        let mut page = empty_page(1);
+        page.images = vec![
+            ImageRegion {
+                top: 120,
+                left: 60,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+            ImageRegion {
+                top: 124,
+                left: 180,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+            ImageRegion {
+                top: 126,
+                left: 235,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+            ImageRegion {
+                top: 122,
+                left: 430,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+        ];
+        let pages_by_number = HashMap::from([(1, &page)]);
+        let images = (0..4)
+            .map(|index| ExtractedImage {
+                page: 1,
+                index,
+                width: Some(40),
+                height: Some(30),
+                path: PathBuf::from(format!("subimage-{index}.png")),
+                extension: "png".to_string(),
+            })
+            .collect::<Vec<_>>();
+        let candidates = image_figure_candidates(&pages_by_number, &images);
+        let clusters = image_candidate_clusters(
+            &candidates,
+            &vec![false; candidates.len()],
+            &pages_by_number,
+        );
+
+        assert_eq!(
+            clusters.len(),
+            1,
+            "expected one merged cluster: {clusters:?}"
+        );
+        let mut cluster = clusters[0].clone();
+        cluster.sort_unstable();
+        assert_eq!(cluster, vec![0, 1, 2, 3]);
     }
 
     #[test]

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -2,7 +2,7 @@
 //! EPUB + report.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -66,10 +66,12 @@ fn convert_pdf_with_tools(
     let xml = tools.pdf_to_xml(input)?;
     let pages = parse_pdf2xml(&xml)?;
     let reconstruction = reconstruct(&pages, options.columns);
+    let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
     let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
     let extracted_images = tools.extract_images(input, &image_dir)?;
-    let mut figure_blocks = figure_blocks_from_images(&pages, &extracted_images)?;
-    let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
+    let figure_result =
+        figure_blocks_from_images(input, &pages, &extracted_images, tools, &media_dir)?;
+    let mut figure_blocks = figure_result.figures;
     let media_figures = media_figure_blocks(input, &pages, tools, &media_dir);
     let _ = fs::remove_dir_all(&media_dir);
     let _ = fs::remove_dir_all(&image_dir);
@@ -96,7 +98,8 @@ fn convert_pdf_with_tools(
             &low_confidence_pages,
         )?;
     }
-    let layout_warnings = media_layout_warnings(&blocks, &block_anchors);
+    let mut layout_warnings = figure_result.warnings;
+    layout_warnings.extend(media_layout_warnings(&blocks, &block_anchors));
     let reconstructed_chars: usize = blocks.iter().map(DocBlock::char_count).sum();
     let figure_count = blocks
         .iter()
@@ -347,6 +350,30 @@ struct AnchoredFigure {
     block: DocBlock,
     anchor: BlockAnchor,
     text_region: Option<RegionRect>,
+}
+
+struct FigureBlocks {
+    figures: Vec<AnchoredFigure>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CaptionKey {
+    page: u32,
+    text: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ImageFigureCandidate<'a> {
+    image: &'a ExtractedImage,
+    region: Option<&'a ImageRegion>,
+    caption: Option<&'a Fragment>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FigureCropRegion<'a> {
+    rect: RegionRect,
+    caption: &'a Fragment,
 }
 
 fn media_figure_blocks(
@@ -735,15 +762,156 @@ fn is_math_symbol(ch: char) -> bool {
 }
 
 fn figure_blocks_from_images(
+    input: &Path,
     pages: &[Page],
     images: &[ExtractedImage],
-) -> Result<Vec<AnchoredFigure>> {
+    tools: &PopplerTools,
+    output_dir: &Path,
+) -> Result<FigureBlocks> {
     let pages_by_number = pages
         .iter()
         .map(|page| (page.number, page))
         .collect::<HashMap<_, _>>();
-    let mut page_image_counts: HashMap<u32, usize> = HashMap::new();
+    let candidates = image_figure_candidates(&pages_by_number, images);
+    let handled_captions = candidates
+        .iter()
+        .filter_map(|candidate| Some(caption_key(candidate.image.page, &candidate.caption?.spans)))
+        .collect::<HashSet<_>>();
+    let mut used_images = vec![false; candidates.len()];
     let mut figures = Vec::new();
+    let mut warnings = Vec::new();
+    let mut figure_crop_count = 0;
+
+    for (index, candidate) in candidates.iter().enumerate() {
+        if used_images[index] {
+            continue;
+        }
+        let (Some(_region), Some(caption)) = (candidate.region, candidate.caption) else {
+            continue;
+        };
+        let key = caption_key(candidate.image.page, &caption.spans);
+        let group = candidates
+            .iter()
+            .enumerate()
+            .filter(|(group_index, group_candidate)| {
+                !used_images[*group_index]
+                    && group_candidate.region.is_some()
+                    && group_candidate.caption.is_some_and(|group_caption| {
+                        caption_key(group_candidate.image.page, &group_caption.spans) == key
+                    })
+            })
+            .collect::<Vec<_>>();
+        if group.len() < 2 {
+            continue;
+        }
+
+        let Some(page) = pages_by_number.get(&candidate.image.page).copied() else {
+            continue;
+        };
+        let regions = group
+            .iter()
+            .filter_map(|(_, candidate)| candidate.region)
+            .collect::<Vec<_>>();
+        let rect = rect_from_image_regions(page, &regions).padded(page, 8);
+        let (rect, snapped) = snap_rect_above_caption(rect, caption);
+        figure_crop_count += 1;
+        let asset = render_figure_crop(
+            input,
+            tools,
+            output_dir,
+            figure_crop_count,
+            rect,
+            "pdf-figure",
+        )?;
+        if snapped {
+            warnings.push(caption_snap_warning(rect.page, caption.top));
+        }
+        figures.push(AnchoredFigure {
+            block: DocBlock::Figure {
+                image: asset,
+                caption: Some(caption.spans.clone()),
+            },
+            anchor: BlockAnchor {
+                page: rect.page,
+                top: rect.top,
+            },
+            text_region: Some(rect),
+        });
+        for (group_index, _) in group {
+            used_images[group_index] = true;
+        }
+    }
+
+    for (index, candidate) in candidates.iter().enumerate() {
+        if used_images[index] {
+            continue;
+        }
+        if let (Some(region), Some(caption)) = (candidate.region, candidate.caption)
+            && caption_overlaps_image(region, caption)
+        {
+            warnings.push(caption_overlap_warning(candidate.image.page, caption.top));
+        }
+        let top = candidate
+            .region
+            .map(|region| region.top)
+            .unwrap_or(i32::MAX);
+        let asset = image_asset(candidate.image, candidate.region)?;
+        figures.push(AnchoredFigure {
+            block: DocBlock::Figure {
+                image: asset,
+                caption: candidate.caption.map(|caption| caption.spans.clone()),
+            },
+            anchor: BlockAnchor {
+                page: candidate.image.page,
+                top,
+            },
+            text_region: None,
+        });
+    }
+
+    for region in vector_figure_regions(pages, &handled_captions) {
+        figure_crop_count += 1;
+        let rect = region.rect.padded(
+            pages_by_number
+                .get(&region.rect.page)
+                .copied()
+                .expect("vector figure regions come from known pages"),
+            48,
+        );
+        let (rect, snapped) = snap_rect_above_caption(rect, region.caption);
+        let asset = render_figure_crop(
+            input,
+            tools,
+            output_dir,
+            figure_crop_count,
+            rect,
+            "pdf-figure",
+        )?;
+        if snapped {
+            warnings.push(caption_snap_warning(rect.page, region.caption.top));
+        }
+        figures.push(AnchoredFigure {
+            block: DocBlock::Figure {
+                image: asset,
+                caption: Some(region.caption.spans.clone()),
+            },
+            anchor: BlockAnchor {
+                page: rect.page,
+                top: rect.top,
+            },
+            text_region: Some(rect),
+        });
+    }
+
+    Ok(FigureBlocks { figures, warnings })
+}
+
+fn image_figure_candidates<'a>(
+    pages_by_number: &HashMap<u32, &'a Page>,
+    images: &'a [ExtractedImage],
+) -> Vec<ImageFigureCandidate<'a>> {
+    let mut page_image_counts: HashMap<u32, usize> = HashMap::new();
+    let mut candidates = Vec::new();
 
     for image in images {
         let page = pages_by_number.get(&image.page).copied();
@@ -751,23 +919,239 @@ fn figure_blocks_from_images(
         let region = page.and_then(|page| page.images.get(*page_index));
         *page_index += 1;
 
-        let caption = page.and_then(|page| detect_caption(page, region));
-        let top = region.map(|region| region.top).unwrap_or(i32::MAX);
-        let asset = image_asset(image, region)?;
-        figures.push(AnchoredFigure {
-            block: DocBlock::Figure {
-                image: asset,
-                caption,
-            },
-            anchor: BlockAnchor {
-                page: image.page,
-                top,
-            },
-            text_region: None,
+        candidates.push(ImageFigureCandidate {
+            image,
+            region,
+            caption: page.and_then(|page| detect_caption_fragment(page, region)),
         });
     }
 
-    Ok(figures)
+    candidates
+}
+
+fn vector_figure_regions<'a>(
+    pages: &'a [Page],
+    handled_captions: &HashSet<CaptionKey>,
+) -> Vec<FigureCropRegion<'a>> {
+    let mut regions = Vec::new();
+    for page in pages {
+        for caption in figure_caption_fragments(page) {
+            let key = caption_key(page.number, &caption.spans);
+            if handled_captions.contains(&key) {
+                continue;
+            }
+            let chart_fragments = chart_label_fragments(page, caption);
+            if chart_fragments.len() < 4
+                || chart_fragments
+                    .iter()
+                    .filter(|fragment| {
+                        fragment_text(&fragment.spans)
+                            .chars()
+                            .any(|ch| ch.is_ascii_digit())
+                    })
+                    .count()
+                    < 3
+            {
+                continue;
+            }
+            regions.push(FigureCropRegion {
+                rect: rect_from_fragments(page, &chart_fragments),
+                caption,
+            });
+        }
+    }
+    regions
+}
+
+fn chart_label_fragments<'a>(page: &'a Page, caption: &Fragment) -> Vec<&'a Fragment> {
+    page.fragments
+        .iter()
+        .filter(|fragment| {
+            let bottom = fragment.top + fragment.height;
+            bottom <= caption.top
+                && caption.top.saturating_sub(bottom) <= 360
+                && is_chart_label_fragment(fragment)
+        })
+        .collect()
+}
+
+fn is_chart_label_fragment(fragment: &Fragment) -> bool {
+    let text = fragment_text(&fragment.spans);
+    let trimmed = text.trim();
+    if trimmed.is_empty() || is_caption_text(trimmed) {
+        return false;
+    }
+    let chars = trimmed.chars().count();
+    let words = trimmed.split_whitespace().count();
+    let has_digit = trimmed.chars().any(|ch| ch.is_ascii_digit());
+    let short_axis_label = words <= 3 && chars <= 24;
+    (has_digit || short_axis_label) && words <= 4 && chars <= 28
+}
+
+fn rect_from_image_regions(page: &Page, regions: &[&ImageRegion]) -> RegionRect {
+    let left = regions.iter().map(|region| region.left).min().unwrap_or(0);
+    let right = regions
+        .iter()
+        .map(|region| region.left + region.width)
+        .max()
+        .unwrap_or(page.width);
+    let top = regions.iter().map(|region| region.top).min().unwrap_or(0);
+    let bottom = regions
+        .iter()
+        .map(|region| region.bottom())
+        .max()
+        .unwrap_or(page.height);
+    RegionRect {
+        page: page.number,
+        top,
+        left,
+        width: right - left,
+        height: bottom - top,
+    }
+}
+
+fn render_figure_crop(
+    input: &Path,
+    tools: &PopplerTools,
+    output_dir: &Path,
+    index: usize,
+    rect: RegionRect,
+    prefix: &str,
+) -> Result<ImageAsset> {
+    let name = format!("{prefix}-{index:04}");
+    let rendered = tools.render_page_crop_png(
+        input,
+        PageCrop {
+            page: rect.page,
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+        },
+        output_dir,
+        &name,
+    )?;
+    figure_crop_asset(index, rect, &rendered)
+}
+
+fn figure_crop_asset(index: usize, rect: RegionRect, path: &Path) -> Result<ImageAsset> {
+    let bytes = fs::read(path)?;
+    Ok(ImageAsset {
+        id: format!("pdf-figure-{index:04}"),
+        href: format!("images/pdf-figure-{index:04}.png"),
+        media_type: "image/png".to_string(),
+        bytes,
+        page: rect.page,
+        top: Some(rect.top),
+        left: Some(rect.left),
+        width: Some(rect.width),
+        height: Some(rect.height),
+    })
+}
+
+fn snap_rect_above_caption(rect: RegionRect, caption: &Fragment) -> (RegionRect, bool) {
+    let caption_limit = caption.top.saturating_sub(2);
+    if rect.bottom() <= caption_limit {
+        return (rect, false);
+    }
+    let bottom = caption_limit.max(rect.top + 1);
+    (
+        RegionRect {
+            height: bottom - rect.top,
+            ..rect
+        },
+        true,
+    )
+}
+
+fn caption_overlaps_image(region: &ImageRegion, caption: &Fragment) -> bool {
+    caption.top < region.bottom() && caption.top + caption.height > region.top
+}
+
+fn caption_snap_warning(page: u32, caption_top: i32) -> String {
+    format!(
+        "page {page}: figure crop snapped above caption near y={caption_top}; review duplicated caption risk"
+    )
+}
+
+fn caption_overlap_warning(page: u32, caption_top: i32) -> String {
+    format!(
+        "page {page}: figure caption overlaps image bounds near y={caption_top}; review duplicated caption inside raster"
+    )
+}
+
+fn caption_key(page: u32, spans: &[Span]) -> CaptionKey {
+    CaptionKey {
+        page,
+        text: normalize_caption(&fragment_text(spans)),
+    }
+}
+
+fn figure_caption_fragments(page: &Page) -> Vec<&Fragment> {
+    page.fragments
+        .iter()
+        .filter(|fragment| is_figure_caption_text(&fragment_text(&fragment.spans)))
+        .collect()
+}
+
+fn detect_caption_fragment<'a>(
+    page: &'a Page,
+    region: Option<&ImageRegion>,
+) -> Option<&'a Fragment> {
+    let mut candidates = figure_caption_fragments(page);
+    candidates.sort_by_key(|fragment| fragment.top);
+
+    if let Some(region) = region {
+        let bottom = region.bottom();
+        candidates
+            .into_iter()
+            .filter(|fragment| fragment.top >= bottom.saturating_sub(8))
+            .min_by_key(|fragment| fragment.top.saturating_sub(bottom))
+            .filter(|fragment| fragment.top.saturating_sub(bottom) <= 160)
+    } else {
+        candidates.into_iter().next()
+    }
+}
+
+fn is_figure_caption_text(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("figure ")
+        || lower.starts_with("figure\u{00a0}")
+        || lower.starts_with("fig. ")
+        || lower.starts_with("fig.\u{00a0}")
+        || lower.starts_with("fig ")
+}
+
+fn is_caption_text(text: &str) -> bool {
+    is_figure_caption_text(text) || is_table_caption_text(text)
+}
+
+fn is_table_caption_text(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("table ") || lower.starts_with("table\u{00a0}")
+}
+
+fn detect_table_caption(page: &Page, rect: RegionRect) -> Option<Vec<Span>> {
+    let mut candidates = page
+        .fragments
+        .iter()
+        .filter(|fragment| is_table_caption_text(&fragment_text(&fragment.spans)))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|fragment| fragment.top);
+
+    candidates
+        .iter()
+        .rev()
+        .find(|fragment| {
+            let bottom = fragment.top + fragment.height;
+            bottom <= rect.top && rect.top.saturating_sub(bottom) <= 140
+        })
+        .or_else(|| {
+            candidates.iter().find(|fragment| {
+                fragment.top >= rect.bottom() && fragment.top.saturating_sub(rect.bottom()) <= 140
+            })
+        })
+        .map(|fragment| fragment.spans.clone())
 }
 
 fn image_asset(image: &ExtractedImage, region: Option<&ImageRegion>) -> Result<ImageAsset> {
@@ -796,65 +1180,6 @@ fn image_asset(image: &ExtractedImage, region: Option<&ImageRegion>) -> Result<I
             .map(|region| region.height)
             .or_else(|| image.height.map(|height| height as i32)),
     })
-}
-
-fn detect_caption(page: &Page, region: Option<&ImageRegion>) -> Option<Vec<Span>> {
-    let mut candidates = page
-        .fragments
-        .iter()
-        .filter(|fragment| is_caption_text(&fragment_text(&fragment.spans)))
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|fragment| fragment.top);
-
-    if let Some(region) = region {
-        let bottom = region.bottom();
-        candidates
-            .into_iter()
-            .filter(|fragment| fragment.top >= bottom.saturating_sub(8))
-            .min_by_key(|fragment| fragment.top.saturating_sub(bottom))
-            .filter(|fragment| fragment.top.saturating_sub(bottom) <= 160)
-            .map(|fragment| fragment.spans.clone())
-    } else {
-        candidates.first().map(|fragment| fragment.spans.clone())
-    }
-}
-
-fn detect_table_caption(page: &Page, rect: RegionRect) -> Option<Vec<Span>> {
-    let mut candidates = page
-        .fragments
-        .iter()
-        .filter(|fragment| is_table_caption_text(&fragment_text(&fragment.spans)))
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|fragment| fragment.top);
-
-    candidates
-        .iter()
-        .rev()
-        .find(|fragment| {
-            let bottom = fragment.top + fragment.height;
-            bottom <= rect.top && rect.top.saturating_sub(bottom) <= 140
-        })
-        .or_else(|| {
-            candidates.iter().find(|fragment| {
-                fragment.top >= rect.bottom() && fragment.top.saturating_sub(rect.bottom()) <= 140
-            })
-        })
-        .map(|fragment| fragment.spans.clone())
-}
-
-fn is_caption_text(text: &str) -> bool {
-    let lower = text.trim_start().to_ascii_lowercase();
-    lower.starts_with("figure ")
-        || lower.starts_with("figure\u{00a0}")
-        || lower.starts_with("fig. ")
-        || lower.starts_with("fig.\u{00a0}")
-        || lower.starts_with("fig ")
-        || is_table_caption_text(text)
-}
-
-fn is_table_caption_text(text: &str) -> bool {
-    let lower = text.trim_start().to_ascii_lowercase();
-    lower.starts_with("table ") || lower.starts_with("table\u{00a0}")
 }
 
 fn insert_figure_blocks(
@@ -974,6 +1299,15 @@ fn baseline_page_char_counts(text: &str, pages: usize) -> Vec<usize> {
 mod tests {
     use super::*;
 
+    const BERT_FIGURE1_CAPTION_BOUNDARY_XML: &str =
+        include_str!("../fixtures/bert_figure1_caption_boundary.xml");
+    const BERT_FIGURE4_MULTIPANEL_XML: &str =
+        include_str!("../fixtures/bert_figure4_multipanel.xml");
+    const BERT_FIGURE5_VECTOR_CHART_XML: &str =
+        include_str!("../fixtures/bert_figure5_vector_chart.xml");
+    const BERT_MODEL_PARAMETER_FALSE_POSITIVE_XML: &str =
+        include_str!("../fixtures/bert_model_parameter_false_positive.xml");
+
     #[cfg(unix)]
     fn write_executable(path: &Path, script: &str) {
         use std::{fs, io::Write, os::unix::fs::PermissionsExt};
@@ -983,6 +1317,34 @@ mod tests {
         file.sync_all().expect("tool fixture sync");
         drop(file);
         fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("tool executable");
+    }
+
+    #[cfg(unix)]
+    fn fake_pdftohtml_with_xml(path: &Path, xml: &str) {
+        write_executable(
+            path,
+            &format!(
+                r#"#!/bin/sh
+cat <<'XML'
+{xml}
+XML
+"#
+            ),
+        );
+    }
+
+    #[cfg(unix)]
+    fn fake_pdftotext_with_text(path: &Path, text: &str) {
+        write_executable(
+            path,
+            &format!(
+                r#"#!/bin/sh
+cat <<'TEXT'
+{text}
+TEXT
+"#
+            ),
+        );
     }
 
     #[cfg(unix)]
@@ -1006,6 +1368,29 @@ echo "$last-000-000.png"
     }
 
     #[cfg(unix)]
+    fn fake_pdfimages_two(path: &Path) {
+        write_executable(
+            path,
+            r#"#!/bin/sh
+if [ "$1" = "-list" ]; then
+cat <<'LIST'
+page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+   1     0 image     180    90  rgb     3   8  image  no        12  0    72    72  1K  1.0%
+   1     1 image     180    90  rgb     3   8  image  no        13  0    72    72  1K  1.0%
+LIST
+exit 0
+fi
+for last do :; done
+printf 'fake-panel-a' > "$last-000-000.png"
+printf 'fake-panel-b' > "$last-000-001.png"
+echo "$last-000-000.png"
+echo "$last-000-001.png"
+"#,
+        );
+    }
+
+    #[cfg(unix)]
     fn fake_pdfimages_empty(path: &Path) {
         write_executable(
             path,
@@ -1016,6 +1401,17 @@ page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-pp
 --------------------------------------------------------------------------------------------
 LIST
 fi
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn fake_pdftoppm_record_args(path: &Path) {
+        write_executable(
+            path,
+            r#"#!/bin/sh
+for last do :; done
+printf '%s\n' "$*" > "$last.png"
 "#,
         );
     }
@@ -1166,6 +1562,189 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
                 .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Caption)),
             "figcaption should remain a normal translatable caption block"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_snaps_figure_crop_above_caption_boundary_fixture() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        fake_pdftohtml_with_xml(&pdftohtml, BERT_FIGURE1_CAPTION_BOUNDARY_XML);
+        let pdftotext = dir.path().join("pdftotext");
+        fake_pdftotext_with_text(
+            &pdftotext,
+            "Results introduce a boundary-sensitive figure.\nFigure 1. Boundary-sensitive raster caption.\nThe caption should be translated once.\n",
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_two(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm_record_args(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.images, 2);
+        assert_eq!(outcome.report.figures, 1);
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("figure crop snapped above caption")),
+            "caption boundary crop should report the snap"
+        );
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("<figure id=\"pdf-figure-0001\">"));
+        assert_eq!(
+            content
+                .matches("Figure 1. Boundary-sensitive raster caption.")
+                .count(),
+            1
+        );
+
+        let mut image = String::new();
+        archive
+            .by_name("images/pdf-figure-0001.png")
+            .expect("figure crop exists")
+            .read_to_string(&mut image)
+            .expect("crop args read");
+        assert!(
+            image.contains("-H 100"),
+            "crop should stop above the caption baseline; args were {image:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_groups_multipanel_figure_fixture_as_one_captioned_crop() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        fake_pdftohtml_with_xml(&pdftohtml, BERT_FIGURE4_MULTIPANEL_XML);
+        let pdftotext = dir.path().join("pdftotext");
+        fake_pdftotext_with_text(
+            &pdftotext,
+            "A multi-panel result follows.\nFigure 4. Multi-panel activation maps.\nDiscussion resumes after the figure.\n",
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_two(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.images, 2);
+        assert_eq!(outcome.report.figures, 1);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("<figure id=\"pdf-figure-0001\">"));
+        assert!(!content.contains("pdf-image-0001"));
+        assert!(!content.contains("pdf-image-0002"));
+        assert_eq!(
+            content
+                .matches("Figure 4. Multi-panel activation maps.")
+                .count(),
+            1
+        );
+        assert!(content.contains("Discussion resumes after the figure."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_preserves_vector_chart_fixture_as_captioned_crop() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        fake_pdftohtml_with_xml(&pdftohtml, BERT_FIGURE5_VECTOR_CHART_XML);
+        let pdftotext = dir.path().join("pdftotext");
+        fake_pdftotext_with_text(
+            &pdftotext,
+            "Vector-chart results are below.\n1.0 0.5 0.0 0 10 20 Epoch\nFigure 5. Vector chart of held-out accuracy.\nThe next paragraph should stay prose.\n",
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.images, 0);
+        assert_eq!(outcome.report.figures, 1);
+        assert_eq!(outcome.report.tables, 0);
+        assert_eq!(outcome.report.equations, 0);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("<figure id=\"pdf-figure-0001\">"));
+        assert_eq!(
+            content
+                .matches("Figure 5. Vector chart of held-out accuracy.")
+                .count(),
+            1
+        );
+        assert!(content.contains("The next paragraph should stay prose."));
+        assert!(!content.contains("1.0 0.5"));
+        assert!(!content.contains("Epoch"));
     }
 
     #[cfg(unix)]
@@ -1460,26 +2039,12 @@ printf 'The energy term E = mc^2 appears inline.\n'
         fs::write(&input, b"dummy pdf").expect("input pdf fixture");
 
         let pdftohtml = dir.path().join("pdftohtml");
-        write_executable(
-            &pdftohtml,
-            r##"#!/bin/sh
-cat <<'XML'
-<pdf2xml>
-  <page number="1" width="600" height="800">
-    <fontspec id="0" size="12" family="Times" color="#000000"/>
-    <text top="100" left="80" width="440" height="12" font="0">The model = stable result used k = 3 in parentheses (n = 12).</text>
-  </page>
-</pdf2xml>
-XML
-"##,
-        );
+        fake_pdftohtml_with_xml(&pdftohtml, BERT_MODEL_PARAMETER_FALSE_POSITIVE_XML);
 
         let pdftotext = dir.path().join("pdftotext");
-        write_executable(
+        fake_pdftotext_with_text(
             &pdftotext,
-            r#"#!/bin/sh
-printf 'The model = stable result used k = 3 in parentheses (n = 12).\n'
-"#,
+            "The model = stable result used k = 3 in parentheses (n = 12).\n",
         );
         let pdfimages = dir.path().join("pdfimages");
         fake_pdfimages_empty(&pdfimages);

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -96,6 +96,7 @@ fn convert_pdf_with_tools(
             &low_confidence_pages,
         )?;
     }
+    let layout_warnings = media_layout_warnings(&blocks, &block_anchors);
     let reconstructed_chars: usize = blocks.iter().map(DocBlock::char_count).sum();
     let figure_count = blocks
         .iter()
@@ -124,6 +125,7 @@ fn convert_pdf_with_tools(
             figures: figure_count,
             tables: media_figures.counts.tables,
             equations: media_figures.counts.equations,
+            layout_warnings,
         },
     );
 
@@ -236,6 +238,36 @@ fn replace_page_with_preserved_image(
             top: 0,
         },
     );
+}
+
+fn media_layout_warnings(blocks: &[DocBlock], block_anchors: &[BlockAnchor]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for (index, block) in blocks.iter().enumerate().skip(1) {
+        if !matches!(blocks.get(index - 1), Some(DocBlock::Figure { .. }))
+            || !starts_with_lowercase_or_suffix(block)
+        {
+            continue;
+        }
+        let Some(anchor) = block_anchors.get(index) else {
+            continue;
+        };
+        warnings.push(format!(
+            "page {}: lowercase paragraph continuation follows media block near y={}; review paragraph join",
+            anchor.page, anchor.top
+        ));
+    }
+    warnings
+}
+
+fn starts_with_lowercase_or_suffix(block: &DocBlock) -> bool {
+    let DocBlock::Paragraph { spans } = block else {
+        return false;
+    };
+    let text = fragment_text(spans);
+    let trimmed = text.trim_start();
+    trimmed.chars().next().is_some_and(|ch| ch.is_lowercase())
+        || trimmed.starts_with(',')
+        || trimmed.starts_with(';')
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -944,9 +976,12 @@ mod tests {
 
     #[cfg(unix)]
     fn write_executable(path: &Path, script: &str) {
-        use std::{fs, os::unix::fs::PermissionsExt};
+        use std::{fs, io::Write, os::unix::fs::PermissionsExt};
 
-        fs::write(path, script).expect("tool fixture");
+        let mut file = fs::File::create(path).expect("tool fixture");
+        file.write_all(script.as_bytes()).expect("tool fixture");
+        file.sync_all().expect("tool fixture sync");
+        drop(file);
         fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("tool executable");
     }
 
@@ -1130,6 +1165,65 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
                 .iter()
                 .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Caption)),
             "figcaption should remain a normal translatable caption block"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_warns_on_lowercase_continuation_after_media() {
+        use std::fs;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="80" left="100" width="260" height="12" font="0">This paragraph</text>
+    <image top="130" left="120" width="120" height="80" src="paper-1_1.png"/>
+    <text top="260" left="100" width="260" height="12" font="0">continues after the figure.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'This paragraph\ncontinues after the figure.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning
+                    .contains("lowercase paragraph continuation follows media block")),
+            "media-separated lowercase continuations should be flagged"
         );
     }
 

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -1298,6 +1298,127 @@ printf 'Body before equation.\nE = mc^2\nBody after equation.\n'
 
     #[cfg(unix)]
     #[test]
+    fn convert_pdf_marks_inline_math_as_protected_span() {
+        use std::fs;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="100" width="360" height="12" font="0">The energy term E = mc^2 appears inline.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'The energy term E = mc^2 appears inline.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        let book = bookforge_epub::read_epub(&output).expect("converted EPUB should be readable");
+        assert!(
+            book.blocks.iter().any(|block| {
+                block.protected_spans.iter().any(|span| {
+                    span.kind == bookforge_core::ir::ProtectedSpanKind::Math
+                        && span.text == "E = mc^2"
+                })
+            }),
+            "inline math should become a protected span after PDF conversion"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_does_not_crop_model_parameter_prose_as_equation() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="80" width="440" height="12" font="0">The model = stable result used k = 3 in parentheses (n = 12).</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'The model = stable result used k = 3 in parentheses (n = 12).\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.tables, 0);
+        assert_eq!(outcome.report.equations, 0);
+        assert_eq!(outcome.report.figures, 0);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("The model = stable result used k = 3"));
+        assert!(!content.contains("pdf-equation-0001.png"));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn low_confidence_pages_linearize_by_default() {
         use std::{fs, io::Read};
         use zip::ZipArchive;

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -11,11 +11,13 @@ use std::{
 use crate::{
     Result,
     epub::write_epub,
-    model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span},
+    model::{
+        ColumnMode, DocBlock, Fragment, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span,
+    },
     parse::parse_pdf2xml,
     reconstruct::{BlockAnchor, PageStats, reconstruct},
     report::{ConversionReport, ReportMetrics},
-    tools::{ExtractedImage, PopplerTools},
+    tools::{ExtractedImage, PageCrop, PopplerTools},
 };
 
 const LOW_CONFIDENCE_COVERAGE: f64 = 0.95;
@@ -66,11 +68,16 @@ fn convert_pdf_with_tools(
     let reconstruction = reconstruct(&pages, options.columns);
     let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
     let extracted_images = tools.extract_images(input, &image_dir)?;
-    let figure_blocks = figure_blocks_from_images(&pages, &extracted_images)?;
+    let mut figure_blocks = figure_blocks_from_images(&pages, &extracted_images)?;
+    let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
+    let media_figures = media_figure_blocks(input, &pages, tools, &media_dir);
+    let _ = fs::remove_dir_all(&media_dir);
+    let _ = fs::remove_dir_all(&image_dir);
+    let media_figures = media_figures?;
+    figure_blocks.extend(media_figures.figures);
     let mut blocks = reconstruction.blocks;
     let mut block_anchors = reconstruction.block_anchors;
     insert_figure_blocks(&mut blocks, &mut block_anchors, figure_blocks);
-    let _ = fs::remove_dir_all(&image_dir);
     let baseline = tools.pdf_to_text(input)?;
     let baseline_chars = baseline.chars().filter(|ch| !ch.is_whitespace()).count();
     let baseline_page_chars = baseline_page_char_counts(&baseline, reconstruction.pages.len());
@@ -115,6 +122,8 @@ fn convert_pdf_with_tools(
             baseline_chars,
             images: extracted_images.len(),
             figures: figure_count,
+            tables: media_figures.counts.tables,
+            equations: media_figures.counts.equations,
         },
     );
 
@@ -229,9 +238,468 @@ fn replace_page_with_preserved_image(
     );
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MediaKind {
+    Table,
+    Equation,
+}
+
+impl MediaKind {
+    fn id_prefix(self) -> &'static str {
+        match self {
+            MediaKind::Table => "pdf-table",
+            MediaKind::Equation => "pdf-equation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RegionRect {
+    page: u32,
+    top: i32,
+    left: i32,
+    width: i32,
+    height: i32,
+}
+
+impl RegionRect {
+    fn right(self) -> i32 {
+        self.left + self.width
+    }
+
+    fn bottom(self) -> i32 {
+        self.top + self.height
+    }
+
+    fn padded(self, page: &Page, padding: i32) -> Self {
+        let left = self.left.saturating_sub(padding).max(0);
+        let top = self.top.saturating_sub(padding).max(0);
+        let right = (self.right() + padding).min(page.width).max(left + 1);
+        let bottom = (self.bottom() + padding).min(page.height).max(top + 1);
+        Self {
+            page: self.page,
+            top,
+            left,
+            width: right - left,
+            height: bottom - top,
+        }
+    }
+
+    fn overlaps_fragment(self, fragment: &crate::model::Fragment) -> bool {
+        fragment.top < self.bottom()
+            && fragment.top + fragment.height > self.top
+            && fragment.left < self.right()
+            && fragment.right() > self.left
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MediaRegion {
+    kind: MediaKind,
+    rect: RegionRect,
+    caption: Option<Vec<Span>>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct MediaCounts {
+    tables: usize,
+    equations: usize,
+}
+
+struct MediaFigures {
+    figures: Vec<AnchoredFigure>,
+    counts: MediaCounts,
+}
+
 struct AnchoredFigure {
     block: DocBlock,
     anchor: BlockAnchor,
+    text_region: Option<RegionRect>,
+}
+
+fn media_figure_blocks(
+    input: &Path,
+    pages: &[Page],
+    tools: &PopplerTools,
+    output_dir: &Path,
+) -> Result<MediaFigures> {
+    let regions = detect_media_regions(pages);
+    let mut figures = Vec::new();
+    let mut counts = MediaCounts::default();
+
+    for region in regions {
+        let index = match region.kind {
+            MediaKind::Table => {
+                counts.tables += 1;
+                counts.tables
+            }
+            MediaKind::Equation => {
+                counts.equations += 1;
+                counts.equations
+            }
+        };
+        let name = format!("{}-{index:04}", region.kind.id_prefix());
+        let rendered = tools.render_page_crop_png(
+            input,
+            PageCrop {
+                page: region.rect.page,
+                left: region.rect.left,
+                top: region.rect.top,
+                width: region.rect.width,
+                height: region.rect.height,
+            },
+            output_dir,
+            &name,
+        )?;
+        let asset = media_asset(region.kind, index, region.rect, &rendered)?;
+        figures.push(AnchoredFigure {
+            block: DocBlock::Figure {
+                image: asset,
+                caption: region.caption,
+            },
+            anchor: BlockAnchor {
+                page: region.rect.page,
+                top: region.rect.top,
+            },
+            text_region: Some(region.rect),
+        });
+    }
+
+    Ok(MediaFigures { figures, counts })
+}
+
+fn detect_media_regions(pages: &[Page]) -> Vec<MediaRegion> {
+    let mut regions = Vec::new();
+    for page in pages {
+        let mut page_regions = table_regions_for_page(page);
+        let excluded = page_regions
+            .iter()
+            .map(|region| region.rect)
+            .collect::<Vec<_>>();
+        page_regions.extend(equation_regions_for_page(page, &excluded));
+        regions.extend(page_regions);
+    }
+    regions.sort_by_key(|region| {
+        (
+            region.rect.page,
+            region.rect.top,
+            match region.kind {
+                MediaKind::Table => 0,
+                MediaKind::Equation => 1,
+            },
+        )
+    });
+    regions
+}
+
+fn media_asset(kind: MediaKind, index: usize, rect: RegionRect, path: &Path) -> Result<ImageAsset> {
+    let bytes = fs::read(path)?;
+    let prefix = kind.id_prefix();
+    Ok(ImageAsset {
+        id: format!("{prefix}-{index:04}"),
+        href: format!("images/{prefix}-{index:04}.png"),
+        media_type: "image/png".to_string(),
+        bytes,
+        page: rect.page,
+        top: Some(rect.top),
+        left: Some(rect.left),
+        width: Some(rect.width),
+        height: Some(rect.height),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct FragmentRow<'a> {
+    fragments: Vec<&'a Fragment>,
+    top: i32,
+    left: i32,
+    right: i32,
+    bottom: i32,
+}
+
+impl<'a> FragmentRow<'a> {
+    fn new(fragment: &'a Fragment) -> Self {
+        Self {
+            fragments: vec![fragment],
+            top: fragment.top,
+            left: fragment.left,
+            right: fragment.right(),
+            bottom: fragment.top + fragment.height,
+        }
+    }
+
+    fn push(&mut self, fragment: &'a Fragment) {
+        self.top = self.top.min(fragment.top);
+        self.left = self.left.min(fragment.left);
+        self.right = self.right.max(fragment.right());
+        self.bottom = self.bottom.max(fragment.top + fragment.height);
+        self.fragments.push(fragment);
+        self.fragments.sort_by_key(|fragment| fragment.left);
+    }
+
+    fn height(&self) -> i32 {
+        self.bottom - self.top
+    }
+}
+
+fn fragment_rows(page: &Page) -> Vec<FragmentRow<'_>> {
+    let mut fragments = page
+        .fragments
+        .iter()
+        .filter(|fragment| fragment.width > 0 && !fragment_text(&fragment.spans).trim().is_empty())
+        .collect::<Vec<_>>();
+    fragments.sort_by_key(|fragment| (fragment.top, fragment.left));
+
+    let mut rows: Vec<FragmentRow<'_>> = Vec::new();
+    for fragment in fragments {
+        let same_row = rows.last().is_some_and(|row| {
+            let tolerance = (row.height().max(fragment.height) / 2).max(3);
+            (fragment.top - row.top).abs() <= tolerance
+        });
+        if same_row {
+            let row = rows.last_mut().expect("checked above");
+            row.push(fragment);
+        } else {
+            rows.push(FragmentRow::new(fragment));
+        }
+    }
+    rows
+}
+
+fn table_regions_for_page(page: &Page) -> Vec<MediaRegion> {
+    let rows = fragment_rows(page);
+    let mut regions = Vec::new();
+    let mut group: Vec<&FragmentRow<'_>> = Vec::new();
+
+    for row in &rows {
+        if is_tableish_row(row) {
+            let continues = group
+                .last()
+                .is_some_and(|last| row.top - last.bottom <= (last.height().max(12) * 3).max(36));
+            if !group.is_empty() && !continues {
+                push_table_region(page, &group, &mut regions);
+                group.clear();
+            }
+            group.push(row);
+        } else if !group.is_empty() {
+            push_table_region(page, &group, &mut regions);
+            group.clear();
+        }
+    }
+    if !group.is_empty() {
+        push_table_region(page, &group, &mut regions);
+    }
+
+    regions
+}
+
+fn push_table_region(page: &Page, rows: &[&FragmentRow<'_>], regions: &mut Vec<MediaRegion>) {
+    if rows.len() < 3 || !table_group_has_aligned_columns(rows) {
+        return;
+    }
+    let rect = rect_from_rows(page, rows).padded(page, 8);
+    regions.push(MediaRegion {
+        kind: MediaKind::Table,
+        rect,
+        caption: detect_table_caption(page, rect),
+    });
+}
+
+fn is_tableish_row(row: &FragmentRow<'_>) -> bool {
+    if row.fragments.len() < 3 {
+        return false;
+    }
+    let numeric_cells = row
+        .fragments
+        .iter()
+        .filter(|fragment| {
+            let text = fragment_text(&fragment.spans);
+            text.chars().any(|ch| ch.is_ascii_digit()) || text.contains('%')
+        })
+        .count();
+    let short_cells = row
+        .fragments
+        .iter()
+        .filter(|fragment| fragment_text(&fragment.spans).trim().chars().count() <= 32)
+        .count();
+
+    numeric_cells >= 2 && short_cells >= row.fragments.len().saturating_sub(1)
+}
+
+fn table_group_has_aligned_columns(rows: &[&FragmentRow<'_>]) -> bool {
+    let mut buckets: HashMap<i32, usize> = HashMap::new();
+    for row in rows {
+        let mut seen = Vec::new();
+        for fragment in &row.fragments {
+            let bucket = fragment.left / 12;
+            if !seen.contains(&bucket) {
+                seen.push(bucket);
+            }
+        }
+        for bucket in seen {
+            *buckets.entry(bucket).or_default() += 1;
+        }
+    }
+    let min_hits = (rows.len() / 2).max(2);
+    buckets.values().filter(|hits| **hits >= min_hits).count() >= 3
+}
+
+fn rect_from_rows(page: &Page, rows: &[&FragmentRow<'_>]) -> RegionRect {
+    let left = rows.iter().map(|row| row.left).min().unwrap_or(0);
+    let right = rows.iter().map(|row| row.right).max().unwrap_or(page.width);
+    let top = rows.iter().map(|row| row.top).min().unwrap_or(0);
+    let bottom = rows
+        .iter()
+        .map(|row| row.bottom)
+        .max()
+        .unwrap_or(page.height);
+    RegionRect {
+        page: page.number,
+        top,
+        left,
+        width: right - left,
+        height: bottom - top,
+    }
+}
+
+fn equation_regions_for_page(page: &Page, excluded: &[RegionRect]) -> Vec<MediaRegion> {
+    let mut fragments = page
+        .fragments
+        .iter()
+        .filter(|fragment| {
+            !excluded
+                .iter()
+                .any(|region| region.overlaps_fragment(fragment))
+                && is_display_equation_fragment(page, fragment)
+        })
+        .collect::<Vec<_>>();
+    fragments.sort_by_key(|fragment| (fragment.top, fragment.left));
+
+    let mut regions = Vec::new();
+    let mut group: Vec<&Fragment> = Vec::new();
+    for fragment in fragments {
+        let continues = group.last().is_some_and(|last| {
+            fragment.top - (last.top + last.height)
+                <= (last.height.max(fragment.height) * 2).max(24)
+        });
+        if !group.is_empty() && !continues {
+            push_equation_region(page, &group, &mut regions);
+            group.clear();
+        }
+        group.push(fragment);
+    }
+    if !group.is_empty() {
+        push_equation_region(page, &group, &mut regions);
+    }
+
+    regions
+}
+
+fn push_equation_region(page: &Page, fragments: &[&Fragment], regions: &mut Vec<MediaRegion>) {
+    let rect = rect_from_fragments(page, fragments).padded(page, 10);
+    regions.push(MediaRegion {
+        kind: MediaKind::Equation,
+        rect,
+        caption: None,
+    });
+}
+
+fn rect_from_fragments(page: &Page, fragments: &[&Fragment]) -> RegionRect {
+    let left = fragments
+        .iter()
+        .map(|fragment| fragment.left)
+        .min()
+        .unwrap_or(0);
+    let right = fragments
+        .iter()
+        .map(|fragment| fragment.right())
+        .max()
+        .unwrap_or(page.width);
+    let top = fragments
+        .iter()
+        .map(|fragment| fragment.top)
+        .min()
+        .unwrap_or(0);
+    let bottom = fragments
+        .iter()
+        .map(|fragment| fragment.top + fragment.height)
+        .max()
+        .unwrap_or(page.height);
+    RegionRect {
+        page: page.number,
+        top,
+        left,
+        width: right - left,
+        height: bottom - top,
+    }
+}
+
+fn is_display_equation_fragment(page: &Page, fragment: &Fragment) -> bool {
+    let text = fragment_text(&fragment.spans);
+    let trimmed = text.trim();
+    if trimmed.chars().count() < 3 || is_caption_text(trimmed) {
+        return false;
+    }
+    let nonspace = trimmed.chars().filter(|ch| !ch.is_whitespace()).count();
+    let math_symbols = trimmed.chars().filter(|ch| is_math_symbol(*ch)).count();
+    let word_count = trimmed.split_whitespace().count();
+    let centered = ((fragment.left + fragment.width / 2) - page.width / 2).abs() <= page.width / 5;
+    let short = fragment.width <= page.width * 7 / 10;
+    let has_strong_operator = trimmed.contains('=')
+        || trimmed.chars().any(|ch| {
+            matches!(
+                ch,
+                '\u{2211}'
+                    | '\u{222b}'
+                    | '\u{221a}'
+                    | '\u{2264}'
+                    | '\u{2265}'
+                    | '\u{2248}'
+                    | '\u{2260}'
+            )
+        });
+
+    centered
+        && short
+        && has_strong_operator
+        && word_count <= 8
+        && math_symbols >= 2
+        && math_symbols * 3 >= nonspace
+}
+
+fn is_math_symbol(ch: char) -> bool {
+    matches!(
+        ch,
+        '=' | '+'
+            | '-'
+            | '*'
+            | '/'
+            | '^'
+            | '_'
+            | '('
+            | ')'
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '|'
+            | '<'
+            | '>'
+            | '\u{2211}'
+            | '\u{222b}'
+            | '\u{221a}'
+            | '\u{2264}'
+            | '\u{2265}'
+            | '\u{2248}'
+            | '\u{2260}'
+            | '\u{00b1}'
+            | '\u{00d7}'
+            | '\u{00f7}'
+            | '\u{2202}'
+            | '\u{2207}'
+            | '\u{221e}'
+            | '\u{2208}'
+    )
 }
 
 fn figure_blocks_from_images(
@@ -263,6 +731,7 @@ fn figure_blocks_from_images(
                 page: image.page,
                 top,
             },
+            text_region: None,
         });
     }
 
@@ -318,6 +787,29 @@ fn detect_caption(page: &Page, region: Option<&ImageRegion>) -> Option<Vec<Span>
     }
 }
 
+fn detect_table_caption(page: &Page, rect: RegionRect) -> Option<Vec<Span>> {
+    let mut candidates = page
+        .fragments
+        .iter()
+        .filter(|fragment| is_table_caption_text(&fragment_text(&fragment.spans)))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|fragment| fragment.top);
+
+    candidates
+        .iter()
+        .rev()
+        .find(|fragment| {
+            let bottom = fragment.top + fragment.height;
+            bottom <= rect.top && rect.top.saturating_sub(bottom) <= 140
+        })
+        .or_else(|| {
+            candidates.iter().find(|fragment| {
+                fragment.top >= rect.bottom() && fragment.top.saturating_sub(rect.bottom()) <= 140
+            })
+        })
+        .map(|fragment| fragment.spans.clone())
+}
+
 fn is_caption_text(text: &str) -> bool {
     let lower = text.trim_start().to_ascii_lowercase();
     lower.starts_with("figure ")
@@ -325,8 +817,12 @@ fn is_caption_text(text: &str) -> bool {
         || lower.starts_with("fig. ")
         || lower.starts_with("fig.\u{00a0}")
         || lower.starts_with("fig ")
-        || lower.starts_with("table ")
-        || lower.starts_with("table\u{00a0}")
+        || is_table_caption_text(text)
+}
+
+fn is_table_caption_text(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("table ") || lower.starts_with("table\u{00a0}")
 }
 
 fn insert_figure_blocks(
@@ -338,6 +834,9 @@ fn insert_figure_blocks(
     let count = figures.len();
 
     for figure in figures {
+        if let Some(region) = figure.text_region {
+            remove_blocks_in_region(blocks, block_anchors, region);
+        }
         if let DocBlock::Figure {
             caption: Some(caption),
             ..
@@ -363,6 +862,23 @@ fn insert_figure_blocks(
     }
 
     count
+}
+
+fn remove_blocks_in_region(
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    region: RegionRect,
+) {
+    let mut index = 0;
+    while index < block_anchors.len() {
+        let anchor = block_anchors[index];
+        if anchor.page == region.page && anchor.top >= region.top && anchor.top <= region.bottom() {
+            blocks.remove(index);
+            block_anchors.remove(index);
+        } else {
+            index += 1;
+        }
+    }
 }
 
 fn remove_duplicate_caption_block(
@@ -615,6 +1131,169 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
                 .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Caption)),
             "figcaption should remain a normal translatable caption block"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_preserves_detected_table_as_crop_with_caption() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="80" left="100" width="260" height="12" font="0">Body before table.</text>
+    <text top="120" left="100" width="220" height="12" font="0">Table 1. Scores.</text>
+    <text top="170" left="100" width="50" height="12" font="0">Metric</text>
+    <text top="170" left="240" width="40" height="12" font="0">2019</text>
+    <text top="170" left="360" width="40" height="12" font="0">2020</text>
+    <text top="190" left="100" width="20" height="12" font="0">A</text>
+    <text top="190" left="240" width="40" height="12" font="0">0.91</text>
+    <text top="190" left="360" width="40" height="12" font="0">0.93</text>
+    <text top="210" left="100" width="20" height="12" font="0">B</text>
+    <text top="210" left="240" width="40" height="12" font="0">0.81</text>
+    <text top="210" left="360" width="40" height="12" font="0">0.84</text>
+    <text top="280" left="100" width="260" height="12" font="0">Body after table.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'Body before table.\nTable 1. Scores.\nMetric 2019 2020\nA 0.91 0.93\nB 0.81 0.84\nBody after table.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.tables, 1);
+        assert_eq!(outcome.report.equations, 0);
+        assert_eq!(outcome.report.figures, 1);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("Body before table."));
+        assert!(content.contains("Body after table."));
+        assert!(content.contains("<figure id=\"pdf-table-0001\">"));
+        assert!(content.contains("<figcaption>Table 1. Scores.</figcaption>"));
+        assert_eq!(content.matches("Table 1. Scores.").count(), 1);
+        assert!(!content.contains("0.91"));
+        assert!(!content.contains("2019"));
+
+        let mut image = Vec::new();
+        archive
+            .by_name("images/pdf-table-0001.png")
+            .expect("table crop exists")
+            .read_to_end(&mut image)
+            .expect("image reads");
+        assert_eq!(image, b"fake-page");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_preserves_display_equation_as_crop() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="80" left="100" width="260" height="12" font="0">Body before equation.</text>
+    <text top="160" left="240" width="120" height="12" font="0">E = mc^2</text>
+    <text top="230" left="100" width="260" height="12" font="0">Body after equation.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'Body before equation.\nE = mc^2\nBody after equation.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.tables, 0);
+        assert_eq!(outcome.report.equations, 1);
+        assert_eq!(outcome.report.figures, 1);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("Body before equation."));
+        assert!(content.contains("Body after equation."));
+        assert!(content.contains("<figure id=\"pdf-equation-0001\">"));
+        assert!(content.contains("images/pdf-equation-0001.png"));
+        assert!(!content.contains("E = mc^2"));
+
+        let mut image = Vec::new();
+        archive
+            .by_name("images/pdf-equation-0001.png")
+            .expect("equation crop exists")
+            .read_to_end(&mut image)
+            .expect("image reads");
+        assert_eq!(image, b"fake-page");
     }
 
     #[cfg(unix)]

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -1,16 +1,21 @@
 //! End-to-end conversion orchestration: poppler → parse → reconstruct →
 //! EPUB + report.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use crate::{
     Result,
     epub::write_epub,
-    model::{ColumnMode, DocBlock},
+    model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, Page, Span},
     parse::parse_pdf2xml,
-    reconstruct::reconstruct,
-    report::ConversionReport,
-    tools::PopplerTools,
+    reconstruct::{BlockAnchor, reconstruct},
+    report::{ConversionReport, ReportMetrics},
+    tools::{ExtractedImage, PopplerTools},
 };
 
 #[derive(Debug, Clone)]
@@ -55,10 +60,17 @@ fn convert_pdf_with_tools(
     let xml = tools.pdf_to_xml(input)?;
     let pages = parse_pdf2xml(&xml)?;
     let reconstruction = reconstruct(&pages, options.columns);
+    let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
+    let extracted_images = tools.extract_images(input, &image_dir)?;
+    let figure_blocks = figure_blocks_from_images(&pages, &extracted_images)?;
+    let mut blocks = reconstruction.blocks;
+    let mut block_anchors = reconstruction.block_anchors;
+    let figure_count = insert_figure_blocks(&mut blocks, &mut block_anchors, figure_blocks);
+    let _ = fs::remove_dir_all(&image_dir);
     let baseline = tools.pdf_to_text(input)?;
     let baseline_chars = baseline.chars().filter(|ch| !ch.is_whitespace()).count();
     let baseline_page_chars = baseline_page_char_counts(&baseline, reconstruction.pages.len());
-    let reconstructed_chars: usize = reconstruction.blocks.iter().map(DocBlock::char_count).sum();
+    let reconstructed_chars: usize = blocks.iter().map(DocBlock::char_count).sum();
 
     let title = if options.title.is_empty() {
         input
@@ -68,7 +80,7 @@ fn convert_pdf_with_tools(
     } else {
         options.title.clone()
     };
-    write_epub(&reconstruction.blocks, &title, &options.language, output)?;
+    write_epub(&blocks, &title, &options.language, output)?;
 
     let mut page_stats = reconstruction.pages;
     for (stats, chars) in page_stats.iter_mut().zip(baseline_page_chars) {
@@ -79,15 +91,200 @@ fn convert_pdf_with_tools(
         &input.to_string_lossy(),
         &output.to_string_lossy(),
         page_stats,
-        reconstruction.blocks.len(),
-        reconstructed_chars,
-        baseline_chars,
+        ReportMetrics {
+            blocks: blocks.len(),
+            reconstructed_chars,
+            baseline_chars,
+            images: extracted_images.len(),
+            figures: figure_count,
+        },
     );
 
     Ok(ConvertOutcome {
         output: output.to_path_buf(),
         report,
     })
+}
+
+struct AnchoredFigure {
+    block: DocBlock,
+    anchor: BlockAnchor,
+}
+
+fn figure_blocks_from_images(
+    pages: &[Page],
+    images: &[ExtractedImage],
+) -> Result<Vec<AnchoredFigure>> {
+    let pages_by_number = pages
+        .iter()
+        .map(|page| (page.number, page))
+        .collect::<HashMap<_, _>>();
+    let mut page_image_counts: HashMap<u32, usize> = HashMap::new();
+    let mut figures = Vec::new();
+
+    for image in images {
+        let page = pages_by_number.get(&image.page).copied();
+        let page_index = page_image_counts.entry(image.page).or_default();
+        let region = page.and_then(|page| page.images.get(*page_index));
+        *page_index += 1;
+
+        let caption = page.and_then(|page| detect_caption(page, region));
+        let top = region.map(|region| region.top).unwrap_or(i32::MAX);
+        let asset = image_asset(image, region)?;
+        figures.push(AnchoredFigure {
+            block: DocBlock::Figure {
+                image: asset,
+                caption,
+            },
+            anchor: BlockAnchor {
+                page: image.page,
+                top,
+            },
+        });
+    }
+
+    Ok(figures)
+}
+
+fn image_asset(image: &ExtractedImage, region: Option<&ImageRegion>) -> Result<ImageAsset> {
+    let bytes = fs::read(&image.path)?;
+    let extension = match image.extension.as_str() {
+        "jpg" | "jpeg" => "jpg",
+        _ => "png",
+    };
+    let media_type = match extension {
+        "jpg" => "image/jpeg",
+        _ => "image/png",
+    };
+    let id = format!("pdf-image-{:04}", image.index + 1);
+    Ok(ImageAsset {
+        id,
+        href: format!("images/pdf-image-{:04}.{extension}", image.index + 1),
+        media_type: media_type.to_string(),
+        bytes,
+        page: image.page,
+        top: region.map(|region| region.top),
+        left: region.map(|region| region.left),
+        width: region
+            .map(|region| region.width)
+            .or_else(|| image.width.map(|width| width as i32)),
+        height: region
+            .map(|region| region.height)
+            .or_else(|| image.height.map(|height| height as i32)),
+    })
+}
+
+fn detect_caption(page: &Page, region: Option<&ImageRegion>) -> Option<Vec<Span>> {
+    let mut candidates = page
+        .fragments
+        .iter()
+        .filter(|fragment| is_caption_text(&fragment_text(&fragment.spans)))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|fragment| fragment.top);
+
+    if let Some(region) = region {
+        let bottom = region.bottom();
+        candidates
+            .into_iter()
+            .filter(|fragment| fragment.top >= bottom.saturating_sub(8))
+            .min_by_key(|fragment| fragment.top.saturating_sub(bottom))
+            .filter(|fragment| fragment.top.saturating_sub(bottom) <= 160)
+            .map(|fragment| fragment.spans.clone())
+    } else {
+        candidates.first().map(|fragment| fragment.spans.clone())
+    }
+}
+
+fn is_caption_text(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("figure ")
+        || lower.starts_with("figure\u{00a0}")
+        || lower.starts_with("fig. ")
+        || lower.starts_with("fig.\u{00a0}")
+        || lower.starts_with("fig ")
+        || lower.starts_with("table ")
+        || lower.starts_with("table\u{00a0}")
+}
+
+fn insert_figure_blocks(
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    mut figures: Vec<AnchoredFigure>,
+) -> usize {
+    figures.sort_by_key(|figure| (figure.anchor.page, figure.anchor.top));
+    let count = figures.len();
+
+    for figure in figures {
+        if let DocBlock::Figure {
+            caption: Some(caption),
+            ..
+        } = &figure.block
+        {
+            remove_duplicate_caption_block(
+                blocks,
+                block_anchors,
+                figure.anchor.page,
+                &fragment_text(caption),
+            );
+        }
+
+        let insert_at = block_anchors
+            .iter()
+            .position(|anchor| {
+                anchor.page > figure.anchor.page
+                    || anchor.page == figure.anchor.page && anchor.top > figure.anchor.top
+            })
+            .unwrap_or(blocks.len());
+        blocks.insert(insert_at, figure.block);
+        block_anchors.insert(insert_at, figure.anchor);
+    }
+
+    count
+}
+
+fn remove_duplicate_caption_block(
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    page: u32,
+    caption: &str,
+) {
+    let normalized = normalize_caption(caption);
+    let Some(index) = blocks.iter().enumerate().position(|(index, block)| {
+        block_anchors
+            .get(index)
+            .is_some_and(|anchor| anchor.page == page)
+            && matches!(block, DocBlock::Paragraph { .. } | DocBlock::Heading { .. })
+            && normalize_caption(&block.text()) == normalized
+    }) else {
+        return;
+    };
+
+    blocks.remove(index);
+    block_anchors.remove(index);
+}
+
+fn normalize_caption(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn fragment_text(spans: &[Span]) -> String {
+    spans
+        .iter()
+        .map(|span| span.text.as_str())
+        .collect::<String>()
+}
+
+fn scoped_temp_dir(prefix: &str) -> Result<PathBuf> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let path = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&path)?;
+    Ok(path)
 }
 
 fn baseline_page_char_counts(text: &str, pages: usize) -> Vec<usize> {
@@ -107,9 +304,37 @@ mod tests {
     use super::*;
 
     #[cfg(unix)]
+    fn write_executable(path: &Path, script: &str) {
+        use std::{fs, os::unix::fs::PermissionsExt};
+
+        fs::write(path, script).expect("tool fixture");
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("tool executable");
+    }
+
+    #[cfg(unix)]
+    fn fake_pdfimages(path: &Path) {
+        write_executable(
+            path,
+            r#"#!/bin/sh
+if [ "$1" = "-list" ]; then
+cat <<'LIST'
+page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+   1     0 image     120    80  rgb     3   8  image  no        12  0    72    72  1K  1.0%
+LIST
+exit 0
+fi
+for last do :; done
+printf 'fake-image' > "$last-000-000.png"
+echo "$last-000-000.png"
+"#,
+        );
+    }
+
+    #[cfg(unix)]
     #[test]
     fn convert_pdf_does_not_write_epub_when_baseline_fails() {
-        use std::{fs, os::unix::fs::PermissionsExt};
+        use std::fs;
 
         let dir = tempfile::tempdir().expect("temp dir");
         let input = dir.path().join("input.pdf");
@@ -117,7 +342,7 @@ mod tests {
         fs::write(&input, b"dummy pdf").expect("input pdf fixture");
 
         let pdftohtml = dir.path().join("pdftohtml");
-        fs::write(
+        write_executable(
             &pdftohtml,
             r##"#!/bin/sh
 cat <<'XML'
@@ -129,26 +354,23 @@ cat <<'XML'
 </pdf2xml>
 XML
 "##,
-        )
-        .expect("pdftohtml fixture");
-        fs::set_permissions(&pdftohtml, fs::Permissions::from_mode(0o755))
-            .expect("pdftohtml executable");
+        );
 
         let pdftotext = dir.path().join("pdftotext");
-        fs::write(
+        write_executable(
             &pdftotext,
             r#"#!/bin/sh
 echo baseline failed >&2
 exit 9
 "#,
-        )
-        .expect("pdftotext fixture");
-        fs::set_permissions(&pdftotext, fs::Permissions::from_mode(0o755))
-            .expect("pdftotext executable");
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages(&pdfimages);
 
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
+            pdfimages,
         };
 
         let result = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools);
@@ -157,6 +379,86 @@ exit 9
         assert!(
             !output.exists(),
             "output EPUB should not be written after baseline failure"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_embeds_extracted_image_with_translatable_caption() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="14" family="Times" color="#000000"/>
+    <fontspec id="1" size="12" family="Times" color="#000000"/>
+    <text top="80" left="100" width="300" height="16" font="0">Paper Title</text>
+    <image top="130" left="120" width="120" height="80" src="paper-1_1.png"/>
+    <text top="218" left="120" width="260" height="12" font="1">Figure 1. A test image.</text>
+    <text top="280" left="100" width="300" height="12" font="1">Body text after the figure.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages(&pdfimages);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.images, 1);
+        assert_eq!(outcome.report.figures, 1);
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("<figure id=\"pdf-image-0001\">"));
+        assert!(content.contains("<figcaption>Figure 1. A test image.</figcaption>"));
+        assert_eq!(content.matches("Figure 1. A test image.").count(), 1);
+
+        let mut image = Vec::new();
+        archive
+            .by_name("images/pdf-image-0001.png")
+            .expect("image exists")
+            .read_to_end(&mut image)
+            .expect("image reads");
+        assert_eq!(image, b"fake-image");
+
+        let book = bookforge_epub::read_epub(&output).expect("converted EPUB should be readable");
+        assert!(
+            book.blocks
+                .iter()
+                .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Caption)),
+            "figcaption should remain a normal translatable caption block"
         );
     }
 }

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -2,25 +2,29 @@
 //! EPUB + report.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
     fs,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
+
+use bookforge_core::math::{is_inline_math_operator, is_strong_inline_math_operator};
 
 use crate::{
     Result,
     epub::write_epub,
     model::{
         ColumnMode, DocBlock, Fragment, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span,
+        normalize_text_key, spans_text,
     },
     parse::parse_pdf2xml,
-    reconstruct::{BlockAnchor, PageStats, reconstruct},
-    report::{ConversionReport, ReportMetrics},
-    tools::{ExtractedImage, PageCrop, PopplerTools},
+    reconstruct::{AnchoredBlock, BlockAnchor, PageStats, reconstruct},
+    report::{ConversionReport, LOW_CONFIDENCE_COVERAGE_RATIO, ReportMetrics},
+    tools::{ExtractedImage, PageCrop, PopplerTools, crop_png_to_file, scoped_temp_dir},
 };
 
-const LOW_CONFIDENCE_COVERAGE: f64 = 0.95;
+const MIN_REGIONLESS_IMAGE_AREA: u32 = 16_384;
+const REPEATED_IMAGE_PAGE_THRESHOLD: usize = 3;
 
 #[derive(Debug, Clone)]
 pub struct ConvertOptions {
@@ -66,20 +70,6 @@ fn convert_pdf_with_tools(
     let xml = tools.pdf_to_xml(input)?;
     let pages = parse_pdf2xml(&xml)?;
     let reconstruction = reconstruct(&pages, options.columns);
-    let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
-    let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
-    let extracted_images = tools.extract_images(input, &image_dir)?;
-    let figure_result =
-        figure_blocks_from_images(input, &pages, &extracted_images, tools, &media_dir)?;
-    let mut figure_blocks = figure_result.figures;
-    let media_figures = media_figure_blocks(input, &pages, tools, &media_dir);
-    let _ = fs::remove_dir_all(&media_dir);
-    let _ = fs::remove_dir_all(&image_dir);
-    let media_figures = media_figures?;
-    figure_blocks.extend(media_figures.figures);
-    let mut blocks = reconstruction.blocks;
-    let mut block_anchors = reconstruction.block_anchors;
-    insert_figure_blocks(&mut blocks, &mut block_anchors, figure_blocks);
     let baseline = tools.pdf_to_text(input)?;
     let baseline_chars = baseline.chars().filter(|ch| !ch.is_whitespace()).count();
     let baseline_page_chars = baseline_page_char_counts(&baseline, reconstruction.pages.len());
@@ -88,23 +78,56 @@ fn convert_pdf_with_tools(
         stats.baseline_chars = chars;
     }
     let low_confidence_pages = mark_low_confidence_pages(&mut page_stats, options.low_confidence);
+
+    let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
+    let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
+    let page_render_dir = scoped_temp_dir("bookforge-pdf-page-renders")?;
+    let mut layout_warnings = Vec::new();
+    let extracted_images = match tools.extract_images(input, &image_dir) {
+        Ok(images) => images,
+        Err(err) => {
+            layout_warnings.push(format!(
+                "image extraction unavailable; continuing text-only for embedded images: {err}"
+            ));
+            Vec::new()
+        }
+    };
+    let mut crop_renderer = PageCropRenderer::new(input, tools, &page_render_dir);
+    let figure_result =
+        figure_blocks_from_images(&pages, &extracted_images, &mut crop_renderer, &media_dir)?;
+    let mut figure_blocks = figure_result.figures;
+    layout_warnings.extend(figure_result.warnings);
+    let media_figures = media_figure_blocks(&pages, &mut crop_renderer, &media_dir)?;
+    let _ = fs::remove_dir_all(&media_dir);
+    let _ = fs::remove_dir_all(&image_dir);
+    let _ = fs::remove_dir_all(&page_render_dir);
+    layout_warnings.extend(media_figures.warnings);
+    figure_blocks.extend(media_figures.figures);
+    let mut blocks = reconstruction.blocks;
+    let media_preserved_chars =
+        insert_figure_blocks(&mut blocks, figure_blocks, &mut layout_warnings);
     if options.low_confidence == LowConfidenceMode::Preserve {
-        preserve_low_confidence_pages(
+        layout_warnings.extend(preserve_low_confidence_pages(
             input,
             &pages,
             tools,
             &mut blocks,
-            &mut block_anchors,
             &low_confidence_pages,
-        )?;
+        )?);
     }
-    let mut layout_warnings = figure_result.warnings;
-    layout_warnings.extend(media_layout_warnings(&blocks, &block_anchors));
-    let reconstructed_chars: usize = blocks.iter().map(DocBlock::char_count).sum();
+    layout_warnings.extend(media_layout_warnings(&blocks));
+    let reconstructed_chars: usize = blocks
+        .iter()
+        .map(|anchored| anchored.block.char_count())
+        .sum();
     let figure_count = blocks
         .iter()
-        .filter(|block| matches!(block, DocBlock::Figure { .. }))
+        .filter(|anchored| matches!(anchored.block, DocBlock::Figure { .. }))
         .count();
+    let output_blocks = blocks
+        .iter()
+        .map(|anchored| anchored.block.clone())
+        .collect::<Vec<_>>();
 
     let title = if options.title.is_empty() {
         input
@@ -114,15 +137,16 @@ fn convert_pdf_with_tools(
     } else {
         options.title.clone()
     };
-    write_epub(&blocks, &title, &options.language, output)?;
+    write_epub(&output_blocks, &title, &options.language, output)?;
 
     let report = ConversionReport::build(
         &input.to_string_lossy(),
         &output.to_string_lossy(),
         page_stats,
         ReportMetrics {
-            blocks: blocks.len(),
+            blocks: output_blocks.len(),
             reconstructed_chars,
+            media_preserved_chars,
             baseline_chars,
             images: extracted_images.len(),
             figures: figure_count,
@@ -153,7 +177,7 @@ fn mark_low_confidence_pages(page_stats: &mut [PageStats], mode: LowConfidenceMo
 
 fn is_low_confidence_page(stats: &PageStats) -> bool {
     stats.baseline_chars > 0
-        && (stats.chars as f64 / stats.baseline_chars as f64) < LOW_CONFIDENCE_COVERAGE
+        && (stats.chars as f64 / stats.baseline_chars as f64) < LOW_CONFIDENCE_COVERAGE_RATIO
 }
 
 fn low_confidence_action(mode: LowConfidenceMode) -> &'static str {
@@ -167,23 +191,31 @@ fn preserve_low_confidence_pages(
     input: &Path,
     pages: &[Page],
     tools: &PopplerTools,
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
+    blocks: &mut Vec<AnchoredBlock>,
     low_confidence_pages: &[u32],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     if low_confidence_pages.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let page_dir = scoped_temp_dir("bookforge-pdf-pages")?;
+    let mut warnings = Vec::new();
     let result = (|| {
         for page_number in low_confidence_pages {
-            let rendered = tools.render_page_png(input, *page_number, &page_dir)?;
+            let rendered = match tools.render_page_png(input, *page_number, &page_dir) {
+                Ok(rendered) => rendered,
+                Err(err) => {
+                    warnings.push(format!(
+                        "page {page_number}: low-confidence page image preservation skipped because raster rendering failed: {err}"
+                    ));
+                    continue;
+                }
+            };
             let source_page = pages.iter().find(|page| page.number == *page_number);
             let asset = page_image_asset(*page_number, source_page, &rendered)?;
-            replace_page_with_preserved_image(blocks, block_anchors, *page_number, asset);
+            replace_page_with_preserved_image(blocks, *page_number, asset);
         }
-        Ok(())
+        Ok(warnings)
     })();
     let _ = fs::remove_dir_all(&page_dir);
     result
@@ -205,58 +237,56 @@ fn page_image_asset(page_number: u32, page: Option<&Page>, path: &Path) -> Resul
 }
 
 fn replace_page_with_preserved_image(
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
+    blocks: &mut Vec<AnchoredBlock>,
     page_number: u32,
     image: ImageAsset,
 ) {
     let old_blocks = std::mem::take(blocks);
-    let old_anchors = std::mem::take(block_anchors);
     let mut insert_at = None;
 
-    for (block, anchor) in old_blocks.into_iter().zip(old_anchors) {
-        if anchor.page == page_number {
+    for anchored in old_blocks {
+        if anchored.anchor.page == page_number {
             insert_at.get_or_insert(blocks.len());
             continue;
         }
-        if anchor.page > page_number {
+        if anchored.anchor.page > page_number {
             insert_at.get_or_insert(blocks.len());
         }
-        blocks.push(block);
-        block_anchors.push(anchor);
+        blocks.push(anchored);
     }
 
     let insert_at = insert_at.unwrap_or(blocks.len());
+    let width = image.width.unwrap_or(1);
     blocks.insert(
         insert_at,
-        DocBlock::Figure {
-            image,
-            caption: None,
-        },
-    );
-    block_anchors.insert(
-        insert_at,
-        BlockAnchor {
-            page: page_number,
-            top: 0,
+        AnchoredBlock {
+            block: DocBlock::Figure {
+                image,
+                caption: None,
+            },
+            anchor: BlockAnchor {
+                page: page_number,
+                top: 0,
+                left: 0,
+                width,
+            },
         },
     );
 }
 
-fn media_layout_warnings(blocks: &[DocBlock], block_anchors: &[BlockAnchor]) -> Vec<String> {
+fn media_layout_warnings(blocks: &[AnchoredBlock]) -> Vec<String> {
     let mut warnings = Vec::new();
-    for (index, block) in blocks.iter().enumerate().skip(1) {
-        if !matches!(blocks.get(index - 1), Some(DocBlock::Figure { .. }))
-            || !starts_with_lowercase_or_suffix(block)
+    for (index, anchored) in blocks.iter().enumerate().skip(1) {
+        if !matches!(
+            blocks.get(index - 1).map(|anchored| &anchored.block),
+            Some(DocBlock::Figure { .. })
+        ) || !starts_with_lowercase_or_suffix(&anchored.block)
         {
             continue;
         }
-        let Some(anchor) = block_anchors.get(index) else {
-            continue;
-        };
         warnings.push(format!(
             "page {}: lowercase paragraph continuation follows media block near y={}; review paragraph join",
-            anchor.page, anchor.top
+            anchored.anchor.page, anchored.anchor.top
         ));
     }
     warnings
@@ -266,7 +296,7 @@ fn starts_with_lowercase_or_suffix(block: &DocBlock) -> bool {
     let DocBlock::Paragraph { spans } = block else {
         return false;
     };
-    let text = fragment_text(spans);
+    let text = spans_text(spans);
     let trimmed = text.trim_start();
     trimmed.chars().next().is_some_and(|ch| ch.is_lowercase())
         || trimmed.starts_with(',')
@@ -284,6 +314,20 @@ impl MediaKind {
         match self {
             MediaKind::Table => "pdf-table",
             MediaKind::Equation => "pdf-equation",
+        }
+    }
+
+    fn crop_padding(self) -> i32 {
+        match self {
+            MediaKind::Table => 8,
+            MediaKind::Equation => 10,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            MediaKind::Table => "table",
+            MediaKind::Equation => "equation",
         }
     }
 }
@@ -344,6 +388,7 @@ struct MediaCounts {
 struct MediaFigures {
     figures: Vec<AnchoredFigure>,
     counts: MediaCounts,
+    warnings: Vec<String>,
 }
 
 struct AnchoredFigure {
@@ -376,55 +421,110 @@ struct FigureCropRegion<'a> {
     caption: &'a Fragment,
 }
 
+struct PageCropRenderer<'a> {
+    input: &'a Path,
+    tools: &'a PopplerTools,
+    page_dir: &'a Path,
+    rendered_pages: HashMap<u32, PathBuf>,
+}
+
+impl<'a> PageCropRenderer<'a> {
+    fn new(input: &'a Path, tools: &'a PopplerTools, page_dir: &'a Path) -> Self {
+        Self {
+            input,
+            tools,
+            page_dir,
+            rendered_pages: HashMap::new(),
+        }
+    }
+
+    fn render_page(&mut self, page: u32) -> Result<PathBuf> {
+        if let Some(path) = self.rendered_pages.get(&page) {
+            return Ok(path.clone());
+        }
+        let path = self
+            .tools
+            .render_page_png(self.input, page, self.page_dir)?;
+        self.rendered_pages.insert(page, path.clone());
+        Ok(path)
+    }
+
+    fn render_crop(&mut self, crop: PageCrop, output_dir: &Path, name: &str) -> Result<PathBuf> {
+        fs::create_dir_all(output_dir)?;
+        let full_page = self.render_page(crop.page)?;
+        let output = output_dir.join(format!("{name}.png"));
+        crop_png_to_file(&full_page, crop.to_render_pixels(), &output)?;
+        Ok(output)
+    }
+}
+
 fn media_figure_blocks(
-    input: &Path,
     pages: &[Page],
-    tools: &PopplerTools,
+    crop_renderer: &mut PageCropRenderer<'_>,
     output_dir: &Path,
 ) -> Result<MediaFigures> {
     let regions = detect_media_regions(pages);
     let mut figures = Vec::new();
     let mut counts = MediaCounts::default();
+    let mut warnings = Vec::new();
 
     for region in regions {
+        let Some(page) = pages.iter().find(|page| page.number == region.rect.page) else {
+            continue;
+        };
+        let crop_rect = region.rect.padded(page, region.kind.crop_padding());
         let index = match region.kind {
-            MediaKind::Table => {
-                counts.tables += 1;
-                counts.tables
-            }
-            MediaKind::Equation => {
-                counts.equations += 1;
-                counts.equations
-            }
+            MediaKind::Table => counts.tables + 1,
+            MediaKind::Equation => counts.equations + 1,
         };
         let name = format!("{}-{index:04}", region.kind.id_prefix());
-        let rendered = tools.render_page_crop_png(
-            input,
+        let rendered = match crop_renderer.render_crop(
             PageCrop {
-                page: region.rect.page,
-                left: region.rect.left,
-                top: region.rect.top,
-                width: region.rect.width,
-                height: region.rect.height,
+                page: crop_rect.page,
+                left: crop_rect.left,
+                top: crop_rect.top,
+                width: crop_rect.width,
+                height: crop_rect.height,
             },
             output_dir,
             &name,
-        )?;
-        let asset = media_asset(region.kind, index, region.rect, &rendered)?;
+        ) {
+            Ok(rendered) => rendered,
+            Err(err) => {
+                warnings.push(format!(
+                    "page {}: skipped {} crop near y={} because raster rendering failed: {err}",
+                    region.rect.page,
+                    region.kind.label(),
+                    region.rect.top
+                ));
+                continue;
+            }
+        };
+        match region.kind {
+            MediaKind::Table => counts.tables += 1,
+            MediaKind::Equation => counts.equations += 1,
+        }
+        let asset = media_asset(region.kind, index, crop_rect, &rendered)?;
         figures.push(AnchoredFigure {
             block: DocBlock::Figure {
                 image: asset,
                 caption: region.caption,
             },
             anchor: BlockAnchor {
-                page: region.rect.page,
-                top: region.rect.top,
+                page: crop_rect.page,
+                top: crop_rect.top,
+                left: crop_rect.left,
+                width: crop_rect.width,
             },
             text_region: Some(region.rect),
         });
     }
 
-    Ok(MediaFigures { figures, counts })
+    Ok(MediaFigures {
+        figures,
+        counts,
+        warnings,
+    })
 }
 
 fn detect_media_regions(pages: &[Page]) -> Vec<MediaRegion> {
@@ -505,7 +605,7 @@ fn fragment_rows(page: &Page) -> Vec<FragmentRow<'_>> {
     let mut fragments = page
         .fragments
         .iter()
-        .filter(|fragment| fragment.width > 0 && !fragment_text(&fragment.spans).trim().is_empty())
+        .filter(|fragment| fragment.width > 0 && !spans_text(&fragment.spans).trim().is_empty())
         .collect::<Vec<_>>();
     fragments.sort_by_key(|fragment| (fragment.top, fragment.left));
 
@@ -556,11 +656,15 @@ fn push_table_region(page: &Page, rows: &[&FragmentRow<'_>], regions: &mut Vec<M
     if rows.len() < 3 || !table_group_has_aligned_columns(rows) {
         return;
     }
-    let rect = rect_from_rows(page, rows).padded(page, 8);
+    let rect = rect_from_rows(page, rows);
+    let caption = detect_table_caption(page, rect);
+    if rows.len() < 4 && caption.is_none() {
+        return;
+    }
     regions.push(MediaRegion {
         kind: MediaKind::Table,
         rect,
-        caption: detect_table_caption(page, rect),
+        caption,
     });
 }
 
@@ -572,14 +676,14 @@ fn is_tableish_row(row: &FragmentRow<'_>) -> bool {
         .fragments
         .iter()
         .filter(|fragment| {
-            let text = fragment_text(&fragment.spans);
+            let text = spans_text(&fragment.spans);
             text.chars().any(|ch| ch.is_ascii_digit()) || text.contains('%')
         })
         .count();
     let short_cells = row
         .fragments
         .iter()
-        .filter(|fragment| fragment_text(&fragment.spans).trim().chars().count() <= 32)
+        .filter(|fragment| spans_text(&fragment.spans).trim().chars().count() <= 32)
         .count();
 
     numeric_cells >= 2 && short_cells >= row.fragments.len().saturating_sub(1)
@@ -655,7 +759,7 @@ fn equation_regions_for_page(page: &Page, excluded: &[RegionRect]) -> Vec<MediaR
 }
 
 fn push_equation_region(page: &Page, fragments: &[&Fragment], regions: &mut Vec<MediaRegion>) {
-    let rect = rect_from_fragments(page, fragments).padded(page, 10);
+    let rect = rect_from_fragments(page, fragments);
     regions.push(MediaRegion {
         kind: MediaKind::Equation,
         rect,
@@ -694,29 +798,23 @@ fn rect_from_fragments(page: &Page, fragments: &[&Fragment]) -> RegionRect {
 }
 
 fn is_display_equation_fragment(page: &Page, fragment: &Fragment) -> bool {
-    let text = fragment_text(&fragment.spans);
+    let text = spans_text(&fragment.spans);
     let trimmed = text.trim();
     if trimmed.chars().count() < 3 || is_caption_text(trimmed) {
         return false;
     }
+    if is_single_parenthetical(trimmed) {
+        return false;
+    }
     let nonspace = trimmed.chars().filter(|ch| !ch.is_whitespace()).count();
-    let math_symbols = trimmed.chars().filter(|ch| is_math_symbol(*ch)).count();
+    let math_symbols = trimmed
+        .chars()
+        .filter(|ch| is_inline_math_operator(*ch))
+        .count();
     let word_count = trimmed.split_whitespace().count();
     let centered = ((fragment.left + fragment.width / 2) - page.width / 2).abs() <= page.width / 5;
     let short = fragment.width <= page.width * 7 / 10;
-    let has_strong_operator = trimmed.contains('=')
-        || trimmed.chars().any(|ch| {
-            matches!(
-                ch,
-                '\u{2211}'
-                    | '\u{222b}'
-                    | '\u{221a}'
-                    | '\u{2264}'
-                    | '\u{2265}'
-                    | '\u{2248}'
-                    | '\u{2260}'
-            )
-        });
+    let has_strong_operator = trimmed.chars().any(is_strong_inline_math_operator);
 
     centered
         && short
@@ -726,46 +824,20 @@ fn is_display_equation_fragment(page: &Page, fragment: &Fragment) -> bool {
         && math_symbols * 3 >= nonspace
 }
 
-fn is_math_symbol(ch: char) -> bool {
-    matches!(
-        ch,
-        '=' | '+'
-            | '-'
-            | '*'
-            | '/'
-            | '^'
-            | '_'
-            | '('
-            | ')'
-            | '['
-            | ']'
-            | '{'
-            | '}'
-            | '|'
-            | '<'
-            | '>'
-            | '\u{2211}'
-            | '\u{222b}'
-            | '\u{221a}'
-            | '\u{2264}'
-            | '\u{2265}'
-            | '\u{2248}'
-            | '\u{2260}'
-            | '\u{00b1}'
-            | '\u{00d7}'
-            | '\u{00f7}'
-            | '\u{2202}'
-            | '\u{2207}'
-            | '\u{221e}'
-            | '\u{2208}'
-    )
+fn is_single_parenthetical(text: &str) -> bool {
+    let Some(inner) = text
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+    else {
+        return false;
+    };
+    !inner.contains('(') && !inner.contains(')')
 }
 
 fn figure_blocks_from_images(
-    input: &Path,
     pages: &[Page],
     images: &[ExtractedImage],
-    tools: &PopplerTools,
+    crop_renderer: &mut PageCropRenderer<'_>,
     output_dir: &Path,
 ) -> Result<FigureBlocks> {
     let pages_by_number = pages
@@ -773,8 +845,10 @@ fn figure_blocks_from_images(
         .map(|page| (page.number, page))
         .collect::<HashMap<_, _>>();
     let candidates = image_figure_candidates(&pages_by_number, images);
+    let repeated_regionless = repeated_regionless_image_signatures(&candidates);
     let handled_captions = candidates
         .iter()
+        .filter(|candidate| candidate.region.is_some())
         .filter_map(|candidate| Some(caption_key(candidate.image.page, &candidate.caption?.spans)))
         .collect::<HashSet<_>>();
     let mut used_images = vec![false; candidates.len()];
@@ -812,17 +886,27 @@ fn figure_blocks_from_images(
             .iter()
             .filter_map(|(_, candidate)| candidate.region)
             .collect::<Vec<_>>();
-        let rect = rect_from_image_regions(page, &regions).padded(page, 8);
+        let text_rect = rect_from_image_regions(page, &regions);
+        let rect = text_rect.padded(page, 8);
         let (rect, snapped) = snap_rect_above_caption(rect, caption);
         figure_crop_count += 1;
-        let asset = render_figure_crop(
-            input,
-            tools,
+        let asset = match render_figure_crop(
+            crop_renderer,
             output_dir,
             figure_crop_count,
             rect,
             "pdf-figure",
-        )?;
+        ) {
+            Ok(asset) => asset,
+            Err(err) => {
+                warnings.push(format!(
+                    "page {}: skipped grouped figure crop near y={} because raster rendering failed: {err}",
+                    rect.page, rect.top
+                ));
+                figure_crop_count -= 1;
+                continue;
+            }
+        };
         if snapped {
             warnings.push(caption_snap_warning(rect.page, caption.top));
         }
@@ -834,8 +918,10 @@ fn figure_blocks_from_images(
             anchor: BlockAnchor {
                 page: rect.page,
                 top: rect.top,
+                left: rect.left,
+                width: rect.width,
             },
-            text_region: Some(rect),
+            text_region: Some(text_rect),
         });
         for (group_index, _) in group {
             used_images[group_index] = true;
@@ -851,10 +937,21 @@ fn figure_blocks_from_images(
         {
             warnings.push(caption_overlap_warning(candidate.image.page, caption.top));
         }
+        if candidate.region.is_none()
+            && should_drop_regionless_image(candidate.image, &repeated_regionless, &mut warnings)
+        {
+            continue;
+        }
         let top = candidate
             .region
             .map(|region| region.top)
             .unwrap_or(i32::MAX);
+        let left = candidate.region.map(|region| region.left).unwrap_or(0);
+        let width = candidate
+            .region
+            .map(|region| region.width)
+            .or_else(|| candidate.image.width.map(|width| width as i32))
+            .unwrap_or(1);
         let asset = image_asset(candidate.image, candidate.region)?;
         figures.push(AnchoredFigure {
             block: DocBlock::Figure {
@@ -864,6 +961,8 @@ fn figure_blocks_from_images(
             anchor: BlockAnchor {
                 page: candidate.image.page,
                 top,
+                left,
+                width,
             },
             text_region: None,
         });
@@ -879,14 +978,23 @@ fn figure_blocks_from_images(
             48,
         );
         let (rect, snapped) = snap_rect_above_caption(rect, region.caption);
-        let asset = render_figure_crop(
-            input,
-            tools,
+        let asset = match render_figure_crop(
+            crop_renderer,
             output_dir,
             figure_crop_count,
             rect,
             "pdf-figure",
-        )?;
+        ) {
+            Ok(asset) => asset,
+            Err(err) => {
+                warnings.push(format!(
+                    "page {}: skipped vector figure crop near y={} because raster rendering failed: {err}",
+                    rect.page, rect.top
+                ));
+                figure_crop_count -= 1;
+                continue;
+            }
+        };
         if snapped {
             warnings.push(caption_snap_warning(rect.page, region.caption.top));
         }
@@ -898,8 +1006,10 @@ fn figure_blocks_from_images(
             anchor: BlockAnchor {
                 page: rect.page,
                 top: rect.top,
+                left: rect.left,
+                width: rect.width,
             },
-            text_region: Some(rect),
+            text_region: Some(region.rect),
         });
     }
 
@@ -910,14 +1020,18 @@ fn image_figure_candidates<'a>(
     pages_by_number: &HashMap<u32, &'a Page>,
     images: &'a [ExtractedImage],
 ) -> Vec<ImageFigureCandidate<'a>> {
-    let mut page_image_counts: HashMap<u32, usize> = HashMap::new();
+    let mut used_regions: HashMap<u32, HashSet<usize>> = HashMap::new();
     let mut candidates = Vec::new();
 
     for image in images {
         let page = pages_by_number.get(&image.page).copied();
-        let page_index = page_image_counts.entry(image.page).or_default();
-        let region = page.and_then(|page| page.images.get(*page_index));
-        *page_index += 1;
+        let region = page.and_then(|page| {
+            let used = used_regions.entry(page.number).or_default();
+            match_best_image_region(image, page, used).map(|index| {
+                used.insert(index);
+                &page.images[index]
+            })
+        });
 
         candidates.push(ImageFigureCandidate {
             image,
@@ -927,6 +1041,96 @@ fn image_figure_candidates<'a>(
     }
 
     candidates
+}
+
+fn match_best_image_region(
+    image: &ExtractedImage,
+    page: &Page,
+    used: &HashSet<usize>,
+) -> Option<usize> {
+    let (image_width, image_height) = (image.width?, image.height?);
+    if image_width == 0 || image_height == 0 {
+        return None;
+    }
+    let image_aspect = image_width as f64 / image_height as f64;
+    page.images
+        .iter()
+        .enumerate()
+        .filter(|(index, region)| !used.contains(index) && region.width > 0 && region.height > 0)
+        .filter_map(|(index, region)| {
+            let region_aspect = region.width as f64 / region.height as f64;
+            let aspect_delta = relative_delta(image_aspect, region_aspect);
+            (aspect_delta <= 0.20).then(|| {
+                let width_delta = relative_delta(image_width as f64, region.width as f64);
+                let height_delta = relative_delta(image_height as f64, region.height as f64);
+                let score = aspect_delta * 3.0 + width_delta.min(2.0) + height_delta.min(2.0);
+                (index, score)
+            })
+        })
+        .min_by(|(_, left), (_, right)| left.total_cmp(right))
+        .map(|(index, _)| index)
+}
+
+fn relative_delta(left: f64, right: f64) -> f64 {
+    if left <= 0.0 || right <= 0.0 {
+        return f64::INFINITY;
+    }
+    (left - right).abs() / left.max(right)
+}
+
+fn repeated_regionless_image_signatures(candidates: &[ImageFigureCandidate<'_>]) -> HashSet<u64> {
+    let mut pages_by_signature: HashMap<u64, HashSet<u32>> = HashMap::new();
+    for candidate in candidates {
+        if candidate.region.is_some() {
+            continue;
+        }
+        if let Some(signature) = image_byte_signature(candidate.image) {
+            pages_by_signature
+                .entry(signature)
+                .or_default()
+                .insert(candidate.image.page);
+        }
+    }
+    pages_by_signature
+        .into_iter()
+        .filter_map(|(signature, pages)| {
+            (pages.len() >= REPEATED_IMAGE_PAGE_THRESHOLD).then_some(signature)
+        })
+        .collect()
+}
+
+fn should_drop_regionless_image(
+    image: &ExtractedImage,
+    repeated_signatures: &HashSet<u64>,
+    warnings: &mut Vec<String>,
+) -> bool {
+    let area = image
+        .width
+        .unwrap_or(0)
+        .saturating_mul(image.height.unwrap_or(0));
+    if area < MIN_REGIONLESS_IMAGE_AREA {
+        warnings.push(format!(
+            "page {}: dropped regionless image {} ({} px^2 below minimum area)",
+            image.page, image.index, area
+        ));
+        return true;
+    }
+    if image_byte_signature(image).is_some_and(|signature| repeated_signatures.contains(&signature))
+    {
+        warnings.push(format!(
+            "page {}: dropped repeated regionless image {} as likely running ornament/logo",
+            image.page, image.index
+        ));
+        return true;
+    }
+    false
+}
+
+fn image_byte_signature(image: &ExtractedImage) -> Option<u64> {
+    let bytes = fs::read(&image.path).ok()?;
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some(hasher.finish())
 }
 
 fn vector_figure_regions<'a>(
@@ -945,7 +1149,7 @@ fn vector_figure_regions<'a>(
                 || chart_fragments
                     .iter()
                     .filter(|fragment| {
-                        fragment_text(&fragment.spans)
+                        spans_text(&fragment.spans)
                             .chars()
                             .any(|ch| ch.is_ascii_digit())
                     })
@@ -976,7 +1180,7 @@ fn chart_label_fragments<'a>(page: &'a Page, caption: &Fragment) -> Vec<&'a Frag
 }
 
 fn is_chart_label_fragment(fragment: &Fragment) -> bool {
-    let text = fragment_text(&fragment.spans);
+    let text = spans_text(&fragment.spans);
     let trimmed = text.trim();
     if trimmed.is_empty() || is_caption_text(trimmed) {
         return false;
@@ -1011,16 +1215,14 @@ fn rect_from_image_regions(page: &Page, regions: &[&ImageRegion]) -> RegionRect 
 }
 
 fn render_figure_crop(
-    input: &Path,
-    tools: &PopplerTools,
+    crop_renderer: &mut PageCropRenderer<'_>,
     output_dir: &Path,
     index: usize,
     rect: RegionRect,
     prefix: &str,
 ) -> Result<ImageAsset> {
     let name = format!("{prefix}-{index:04}");
-    let rendered = tools.render_page_crop_png(
-        input,
+    let rendered = crop_renderer.render_crop(
         PageCrop {
             page: rect.page,
             left: rect.left,
@@ -1083,14 +1285,14 @@ fn caption_overlap_warning(page: u32, caption_top: i32) -> String {
 fn caption_key(page: u32, spans: &[Span]) -> CaptionKey {
     CaptionKey {
         page,
-        text: normalize_caption(&fragment_text(spans)),
+        text: normalize_text_key(&spans_text(spans)),
     }
 }
 
 fn figure_caption_fragments(page: &Page) -> Vec<&Fragment> {
     page.fragments
         .iter()
-        .filter(|fragment| is_figure_caption_text(&fragment_text(&fragment.spans)))
+        .filter(|fragment| is_figure_caption_text(&spans_text(&fragment.spans)))
         .collect()
 }
 
@@ -1106,8 +1308,8 @@ fn detect_caption_fragment<'a>(
         candidates
             .into_iter()
             .filter(|fragment| fragment.top >= bottom.saturating_sub(8))
-            .min_by_key(|fragment| fragment.top.saturating_sub(bottom))
-            .filter(|fragment| fragment.top.saturating_sub(bottom) <= 160)
+            .min_by_key(|fragment| (fragment.top - bottom).abs())
+            .filter(|fragment| (fragment.top - bottom).abs() <= 160)
     } else {
         candidates.into_iter().next()
     }
@@ -1135,7 +1337,7 @@ fn detect_table_caption(page: &Page, rect: RegionRect) -> Option<Vec<Span>> {
     let mut candidates = page
         .fragments
         .iter()
-        .filter(|fragment| is_table_caption_text(&fragment_text(&fragment.spans)))
+        .filter(|fragment| is_table_caption_text(&spans_text(&fragment.spans)))
         .collect::<Vec<_>>();
     candidates.sort_by_key(|fragment| fragment.top);
 
@@ -1183,104 +1385,108 @@ fn image_asset(image: &ExtractedImage, region: Option<&ImageRegion>) -> Result<I
 }
 
 fn insert_figure_blocks(
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
+    blocks: &mut Vec<AnchoredBlock>,
     mut figures: Vec<AnchoredFigure>,
+    warnings: &mut Vec<String>,
 ) -> usize {
     figures.sort_by_key(|figure| (figure.anchor.page, figure.anchor.top));
-    let count = figures.len();
+    let mut removed_chars = 0;
 
     for figure in figures {
         if let Some(region) = figure.text_region {
-            remove_blocks_in_region(blocks, block_anchors, region);
+            removed_chars += remove_blocks_in_region(blocks, region, warnings);
         }
         if let DocBlock::Figure {
             caption: Some(caption),
             ..
         } = &figure.block
         {
-            remove_duplicate_caption_block(
-                blocks,
-                block_anchors,
-                figure.anchor.page,
-                &fragment_text(caption),
-            );
+            remove_duplicate_caption_block(blocks, figure.anchor.page, &spans_text(caption));
         }
 
-        let insert_at = block_anchors
+        let insert_at = blocks
             .iter()
-            .position(|anchor| {
-                anchor.page > figure.anchor.page
-                    || anchor.page == figure.anchor.page && anchor.top > figure.anchor.top
+            .position(|anchored| {
+                anchored.anchor.page > figure.anchor.page
+                    || anchored.anchor.page == figure.anchor.page
+                        && anchored.anchor.top > figure.anchor.top
             })
             .unwrap_or(blocks.len());
-        blocks.insert(insert_at, figure.block);
-        block_anchors.insert(insert_at, figure.anchor);
+        blocks.insert(
+            insert_at,
+            AnchoredBlock {
+                block: figure.block,
+                anchor: figure.anchor,
+            },
+        );
     }
 
-    count
+    removed_chars
 }
 
 fn remove_blocks_in_region(
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
+    blocks: &mut Vec<AnchoredBlock>,
     region: RegionRect,
-) {
+    warnings: &mut Vec<String>,
+) -> usize {
     let mut index = 0;
-    while index < block_anchors.len() {
-        let anchor = block_anchors[index];
-        if anchor.page == region.page && anchor.top >= region.top && anchor.top <= region.bottom() {
-            blocks.remove(index);
-            block_anchors.remove(index);
+    let mut removed_chars = 0;
+    while index < blocks.len() {
+        let anchor = blocks[index].anchor;
+        if anchor.page == region.page
+            && anchor.top >= region.top
+            && anchor.top < region.bottom()
+            && anchor_overlaps_region_horizontally(anchor, region)
+        {
+            let removed = blocks.remove(index);
+            let chars = removed.block.char_count();
+            removed_chars += chars;
+            let text = removed.block.text();
+            if !text.trim().is_empty() {
+                warnings.push(format!(
+                    "page {}: preserved as image near y={} ({} chars): {}",
+                    region.page,
+                    region.top,
+                    chars,
+                    audit_snippet(&text)
+                ));
+            }
         } else {
             index += 1;
         }
     }
+    removed_chars
 }
 
-fn remove_duplicate_caption_block(
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
-    page: u32,
-    caption: &str,
-) {
-    let normalized = normalize_caption(caption);
-    let Some(index) = blocks.iter().enumerate().position(|(index, block)| {
-        block_anchors
-            .get(index)
-            .is_some_and(|anchor| anchor.page == page)
-            && matches!(block, DocBlock::Paragraph { .. } | DocBlock::Heading { .. })
-            && normalize_caption(&block.text()) == normalized
+fn remove_duplicate_caption_block(blocks: &mut Vec<AnchoredBlock>, page: u32, caption: &str) {
+    let normalized = normalize_text_key(caption);
+    let Some(index) = blocks.iter().position(|anchored| {
+        anchored.anchor.page == page
+            && matches!(
+                &anchored.block,
+                DocBlock::Paragraph { .. } | DocBlock::Heading { .. }
+            )
+            && normalize_text_key(&anchored.block.text()) == normalized
     }) else {
         return;
     };
 
     blocks.remove(index);
-    block_anchors.remove(index);
 }
 
-fn normalize_caption(text: &str) -> String {
-    text.split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase()
+fn anchor_overlaps_region_horizontally(anchor: BlockAnchor, region: RegionRect) -> bool {
+    anchor.left < region.right() && anchor.left + anchor.width.max(1) > region.left
 }
 
-fn fragment_text(spans: &[Span]) -> String {
-    spans
-        .iter()
-        .map(|span| span.text.as_str())
-        .collect::<String>()
-}
-
-fn scoped_temp_dir(prefix: &str) -> Result<PathBuf> {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let path = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
-    fs::create_dir_all(&path)?;
-    Ok(path)
+fn audit_snippet(text: &str) -> String {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    const LIMIT: usize = 140;
+    if normalized.chars().count() <= LIMIT {
+        return normalized;
+    }
+    let mut snippet = normalized.chars().take(LIMIT).collect::<String>();
+    snippet.push_str("...");
+    snippet
 }
 
 fn baseline_page_char_counts(text: &str, pages: usize) -> Vec<usize> {
@@ -1307,6 +1513,36 @@ mod tests {
         include_str!("../fixtures/bert_figure5_vector_chart.xml");
     const BERT_MODEL_PARAMETER_FALSE_POSITIVE_XML: &str =
         include_str!("../fixtures/bert_model_parameter_false_positive.xml");
+
+    fn span(text: &str) -> Span {
+        Span {
+            text: text.to_string(),
+            bold: false,
+            italic: false,
+        }
+    }
+
+    fn fragment(top: i32, left: i32, width: i32, height: i32, text: &str) -> Fragment {
+        Fragment {
+            top,
+            left,
+            width,
+            height,
+            font: 0,
+            spans: vec![span(text)],
+        }
+    }
+
+    fn empty_page(number: u32) -> Page {
+        Page {
+            number,
+            width: 600,
+            height: 800,
+            fragments: Vec::new(),
+            images: Vec::new(),
+            font_sizes: HashMap::new(),
+        }
+    }
 
     #[cfg(unix)]
     fn write_executable(path: &Path, script: &str) {
@@ -1406,25 +1642,225 @@ fi
     }
 
     #[cfg(unix)]
-    fn fake_pdftoppm_record_args(path: &Path) {
+    fn fake_pdftoppm(path: &Path) {
+        let fixture = path.with_file_name("pdftoppm.fixture.png");
+        crate::tools::write_solid_rgb_png(&fixture, 1600, 2200, [240, 240, 240])
+            .expect("pdftoppm PNG fixture");
         write_executable(
             path,
             r#"#!/bin/sh
 for last do :; done
-printf '%s\n' "$*" > "$last.png"
+script_dir=$(dirname "$0")
+cp "$script_dir/pdftoppm.fixture.png" "$last.png"
 "#,
         );
     }
 
-    #[cfg(unix)]
-    fn fake_pdftoppm(path: &Path) {
-        write_executable(
-            path,
-            r#"#!/bin/sh
-for last do :; done
-printf 'fake-page' > "$last.png"
-"#,
+    #[test]
+    fn remove_blocks_in_region_requires_horizontal_overlap() {
+        let mut blocks = vec![
+            AnchoredBlock {
+                block: DocBlock::Paragraph {
+                    spans: vec![span("left table text 2019 2020")],
+                },
+                anchor: BlockAnchor {
+                    page: 1,
+                    top: 120,
+                    left: 100,
+                    width: 180,
+                },
+            },
+            AnchoredBlock {
+                block: DocBlock::Paragraph {
+                    spans: vec![span("right column prose must remain")],
+                },
+                anchor: BlockAnchor {
+                    page: 1,
+                    top: 120,
+                    left: 420,
+                    width: 160,
+                },
+            },
+        ];
+        let mut warnings = Vec::new();
+
+        let removed = remove_blocks_in_region(
+            &mut blocks,
+            RegionRect {
+                page: 1,
+                top: 100,
+                left: 90,
+                width: 220,
+                height: 80,
+            },
+            &mut warnings,
         );
+
+        assert!(removed > 0);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block.text(), "right column prose must remain");
+        assert!(warnings[0].contains("left table text"));
+    }
+
+    #[test]
+    fn image_regions_match_by_dimensions_not_position() {
+        let page = Page {
+            number: 1,
+            width: 600,
+            height: 800,
+            fragments: vec![
+                fragment(210, 100, 240, 12, "Figure 1. Wide image."),
+                fragment(575, 100, 240, 12, "Figure 2. Tall image."),
+            ],
+            images: vec![
+                ImageRegion {
+                    top: 100,
+                    left: 100,
+                    width: 270,
+                    height: 90,
+                    src: None,
+                },
+                ImageRegion {
+                    top: 300,
+                    left: 100,
+                    width: 90,
+                    height: 270,
+                    src: None,
+                },
+            ],
+            font_sizes: HashMap::new(),
+        };
+        let pages_by_number = HashMap::from([(1, &page)]);
+        let images = vec![
+            ExtractedImage {
+                page: 1,
+                index: 0,
+                width: Some(100),
+                height: Some(300),
+                path: PathBuf::from("tall.png"),
+                extension: "png".to_string(),
+            },
+            ExtractedImage {
+                page: 1,
+                index: 1,
+                width: Some(300),
+                height: Some(100),
+                path: PathBuf::from("wide.png"),
+                extension: "png".to_string(),
+            },
+        ];
+
+        let candidates = image_figure_candidates(&pages_by_number, &images);
+
+        assert_eq!(candidates[0].region.expect("tall region").top, 300);
+        assert_eq!(
+            spans_text(&candidates[0].caption.expect("caption").spans),
+            "Figure 2. Tall image."
+        );
+        assert_eq!(candidates[1].region.expect("wide region").top, 100);
+    }
+
+    #[test]
+    fn regionless_small_and_repeated_images_are_reported_not_emitted() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let repeated = b"repeated ornament bytes";
+        let mut images = Vec::new();
+        let mut pages = Vec::new();
+        for page_number in 1..=3 {
+            pages.push(empty_page(page_number));
+            let path = dir.path().join(format!("repeat-{page_number}.png"));
+            fs::write(&path, repeated).expect("image bytes");
+            images.push(ExtractedImage {
+                page: page_number,
+                index: page_number as usize - 1,
+                width: Some(200),
+                height: Some(200),
+                path,
+                extension: "png".to_string(),
+            });
+        }
+        pages.push(empty_page(4));
+        let small_path = dir.path().join("small.png");
+        fs::write(&small_path, b"small").expect("small image bytes");
+        images.push(ExtractedImage {
+            page: 4,
+            index: 3,
+            width: Some(20),
+            height: Some(20),
+            path: small_path,
+            extension: "png".to_string(),
+        });
+        let tools = PopplerTools {
+            pdftohtml: PathBuf::from("pdftohtml"),
+            pdftotext: PathBuf::from("pdftotext"),
+            pdfimages: None,
+            pdftoppm: None,
+        };
+        let page_dir = dir.path().join("pages");
+        let mut renderer = PageCropRenderer::new(Path::new("input.pdf"), &tools, &page_dir);
+
+        let result = figure_blocks_from_images(&pages, &images, &mut renderer, dir.path())
+            .expect("figure pass");
+
+        assert!(result.figures.is_empty());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("repeated regionless image"))
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("below minimum area"))
+        );
+    }
+
+    #[test]
+    fn parenthetical_stats_fragment_is_not_display_equation() {
+        let page = empty_page(1);
+        let stats = fragment(200, 245, 110, 12, "(p = 0.05)");
+
+        assert!(!is_display_equation_fragment(&page, &stats));
+    }
+
+    #[test]
+    fn three_row_aligned_stats_without_caption_are_not_tables() {
+        let mut page = empty_page(1);
+        page.fragments = vec![
+            fragment(100, 100, 40, 12, "Mean"),
+            fragment(100, 180, 30, 12, "12"),
+            fragment(100, 240, 30, 12, "14"),
+            fragment(120, 100, 40, 12, "SD"),
+            fragment(120, 180, 30, 12, "3"),
+            fragment(120, 240, 30, 12, "4"),
+            fragment(140, 100, 40, 12, "N"),
+            fragment(140, 180, 30, 12, "20"),
+            fragment(140, 240, 30, 12, "21"),
+        ];
+
+        assert!(table_regions_for_page(&page).is_empty());
+    }
+
+    #[test]
+    fn caption_ranking_prefers_closer_caption_below_image_bottom() {
+        let mut page = empty_page(1);
+        page.fragments = vec![
+            fragment(193, 100, 220, 12, "Figure 1. Above decoy."),
+            fragment(202, 100, 220, 12, "Figure 2. True caption."),
+        ];
+        let region = ImageRegion {
+            top: 100,
+            left: 100,
+            width: 100,
+            height: 100,
+            src: None,
+        };
+
+        let caption = detect_caption_fragment(&page, Some(&region)).expect("caption");
+
+        assert_eq!(spans_text(&caption.spans), "Figure 2. True caption.");
     }
 
     #[cfg(unix)]
@@ -1468,8 +1904,8 @@ exit 9
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
 
         let result = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools);
@@ -1479,6 +1915,62 @@ exit 9
             !output.exists(),
             "output EPUB should not be written after baseline failure"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn convert_pdf_continues_text_only_without_optional_image_tools() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="100" width="180" height="12" font="0">Text only PDF.</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+        let pdftotext = dir.path().join("pdftotext");
+        fake_pdftotext_with_text(&pdftotext, "Text only PDF.\n");
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages: None,
+            pdftoppm: None,
+        };
+
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed without optional image tools");
+
+        assert!(output.exists());
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("image extraction unavailable"))
+        );
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("Text only PDF."));
     }
 
     #[cfg(unix)]
@@ -1526,8 +2018,8 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1585,13 +2077,13 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         let pdfimages = dir.path().join("pdfimages");
         fake_pdfimages_two(&pdfimages);
         let pdftoppm = dir.path().join("pdftoppm");
-        fake_pdftoppm_record_args(&pdftoppm);
+        fake_pdftoppm(&pdftoppm);
 
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1623,16 +2115,13 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
             1
         );
 
-        let mut image = String::new();
+        let mut image = Vec::new();
         archive
             .by_name("images/pdf-figure-0001.png")
             .expect("figure crop exists")
-            .read_to_string(&mut image)
-            .expect("crop args read");
-        assert!(
-            image.contains("-H 100"),
-            "crop should stop above the caption baseline; args were {image:?}"
-        );
+            .read_to_end(&mut image)
+            .expect("crop reads");
+        assert!(image.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 
     #[cfg(unix)]
@@ -1661,8 +2150,8 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1716,8 +2205,8 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1789,8 +2278,8 @@ printf 'This paragraph\ncontinues after the figure.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1858,8 +2347,8 @@ printf 'Body before table.\nTable 1. Scores.\nMetric 2019 2020\nA 0.91 0.93\nB 0
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1867,6 +2356,22 @@ printf 'Body before table.\nTable 1. Scores.\nMetric 2019 2020\nA 0.91 0.93\nB 0
         assert_eq!(outcome.report.tables, 1);
         assert_eq!(outcome.report.equations, 0);
         assert_eq!(outcome.report.figures, 1);
+        assert!(outcome.report.media_preserved_chars > 0);
+        assert_eq!(outcome.report.coverage_percent, 100.0);
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("preserved as image near y="))
+        );
+        assert!(
+            !outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("reconstructed text covers only"))
+        );
 
         let mut archive =
             ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
@@ -1890,7 +2395,7 @@ printf 'Body before table.\nTable 1. Scores.\nMetric 2019 2020\nA 0.91 0.93\nB 0
             .expect("table crop exists")
             .read_to_end(&mut image)
             .expect("image reads");
-        assert_eq!(image, b"fake-page");
+        assert!(image.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 
     #[cfg(unix)]
@@ -1936,8 +2441,8 @@ printf 'Body before equation.\nE = mc^2\nBody after equation.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -1966,7 +2471,7 @@ printf 'Body before equation.\nE = mc^2\nBody after equation.\n'
             .expect("equation crop exists")
             .read_to_end(&mut image)
             .expect("image reads");
-        assert_eq!(image, b"fake-page");
+        assert!(image.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 
     #[cfg(unix)]
@@ -2009,8 +2514,8 @@ printf 'The energy term E = mc^2 appears inline.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -2054,8 +2559,8 @@ printf 'The energy term E = mc^2 appears inline.\n'
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -2117,8 +2622,8 @@ printf 'Tiny plus many baseline characters that the XML reconstruction did not r
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -2192,8 +2697,8 @@ printf 'Tiny plus many baseline characters that the XML reconstruction did not r
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
-            pdfimages,
-            pdftoppm,
+            pdfimages: Some(pdfimages),
+            pdftoppm: Some(pdftoppm),
         };
         let options = ConvertOptions {
             low_confidence: LowConfidenceMode::Preserve,
@@ -2236,6 +2741,6 @@ printf 'Tiny plus many baseline characters that the XML reconstruction did not r
             .expect("preserved page image exists")
             .read_to_end(&mut image)
             .expect("image reads");
-        assert_eq!(image, b"fake-page");
+        assert!(image.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 }

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -93,11 +93,18 @@ fn convert_pdf_with_tools(
         }
     };
     let mut crop_renderer = PageCropRenderer::new(input, tools, &page_render_dir);
-    let figure_result =
-        figure_blocks_from_images(&pages, &extracted_images, &mut crop_renderer, &media_dir)?;
+    let figure_result = figure_blocks_from_images(
+        &pages,
+        &page_stats,
+        &extracted_images,
+        &mut crop_renderer,
+        &media_dir,
+    )?;
+    let media_exclusions = figure_result.exclusions.clone();
     let mut figure_blocks = figure_result.figures;
     layout_warnings.extend(figure_result.warnings);
-    let media_figures = media_figure_blocks(&pages, &mut crop_renderer, &media_dir)?;
+    let media_figures =
+        media_figure_blocks(&pages, &media_exclusions, &mut crop_renderer, &media_dir)?;
     let _ = fs::remove_dir_all(&media_dir);
     let _ = fs::remove_dir_all(&image_dir);
     let _ = fs::remove_dir_all(&page_render_dir);
@@ -370,6 +377,39 @@ impl RegionRect {
             && fragment.left < self.right()
             && fragment.right() > self.left
     }
+
+    fn area(self) -> i64 {
+        i64::from(self.width.max(0)) * i64::from(self.height.max(0))
+    }
+
+    fn overlap_area(self, other: Self) -> i64 {
+        if self.page != other.page {
+            return 0;
+        }
+        let left = self.left.max(other.left);
+        let right = self.right().min(other.right());
+        let top = self.top.max(other.top);
+        let bottom = self.bottom().min(other.bottom());
+        i64::from((right - left).max(0)) * i64::from((bottom - top).max(0))
+    }
+
+    fn touches_within(self, other: Self, gap: i32) -> bool {
+        self.page == other.page
+            && self.left <= other.right().saturating_add(gap)
+            && other.left <= self.right().saturating_add(gap)
+            && self.top <= other.bottom().saturating_add(gap)
+            && other.top <= self.bottom().saturating_add(gap)
+    }
+}
+
+fn region_rect_from_image_region(page: u32, region: &ImageRegion) -> RegionRect {
+    RegionRect {
+        page,
+        top: region.top,
+        left: region.left,
+        width: region.width,
+        height: region.height,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -400,12 +440,7 @@ struct AnchoredFigure {
 struct FigureBlocks {
     figures: Vec<AnchoredFigure>,
     warnings: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct CaptionKey {
-    page: u32,
-    text: String,
+    exclusions: Vec<RegionRect>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -460,10 +495,11 @@ impl<'a> PageCropRenderer<'a> {
 
 fn media_figure_blocks(
     pages: &[Page],
+    figure_exclusions: &[RegionRect],
     crop_renderer: &mut PageCropRenderer<'_>,
     output_dir: &Path,
 ) -> Result<MediaFigures> {
-    let regions = detect_media_regions(pages);
+    let regions = detect_media_regions(pages, figure_exclusions);
     let mut figures = Vec::new();
     let mut counts = MediaCounts::default();
     let mut warnings = Vec::new();
@@ -527,14 +563,17 @@ fn media_figure_blocks(
     })
 }
 
-fn detect_media_regions(pages: &[Page]) -> Vec<MediaRegion> {
+fn detect_media_regions(pages: &[Page], figure_exclusions: &[RegionRect]) -> Vec<MediaRegion> {
     let mut regions = Vec::new();
     for page in pages {
-        let mut page_regions = table_regions_for_page(page);
-        let excluded = page_regions
-            .iter()
-            .map(|region| region.rect)
-            .collect::<Vec<_>>();
+        let mut excluded = media_exclusion_regions_for_page(page, figure_exclusions);
+        let mut page_regions = table_regions_for_page(page, &excluded);
+        excluded.extend(
+            page_regions
+                .iter()
+                .map(|region| region.rect)
+                .collect::<Vec<_>>(),
+        );
         page_regions.extend(equation_regions_for_page(page, &excluded));
         regions.extend(page_regions);
     }
@@ -549,6 +588,24 @@ fn detect_media_regions(pages: &[Page]) -> Vec<MediaRegion> {
         )
     });
     regions
+}
+
+fn media_exclusion_regions_for_page(
+    page: &Page,
+    figure_exclusions: &[RegionRect],
+) -> Vec<RegionRect> {
+    let mut excluded = page
+        .images
+        .iter()
+        .map(|region| region_rect_from_image_region(page.number, region))
+        .collect::<Vec<_>>();
+    excluded.extend(
+        figure_exclusions
+            .iter()
+            .filter(|region| region.page == page.number)
+            .copied(),
+    );
+    excluded
 }
 
 fn media_asset(kind: MediaKind, index: usize, rect: RegionRect, path: &Path) -> Result<ImageAsset> {
@@ -625,12 +682,19 @@ fn fragment_rows(page: &Page) -> Vec<FragmentRow<'_>> {
     rows
 }
 
-fn table_regions_for_page(page: &Page) -> Vec<MediaRegion> {
+fn table_regions_for_page(page: &Page, excluded: &[RegionRect]) -> Vec<MediaRegion> {
     let rows = fragment_rows(page);
     let mut regions = Vec::new();
     let mut group: Vec<&FragmentRow<'_>> = Vec::new();
 
     for row in &rows {
+        if row_overlaps_excluded_region(row, excluded) {
+            if !group.is_empty() {
+                push_table_region(page, &group, &mut regions);
+                group.clear();
+            }
+            continue;
+        }
         if is_tableish_row(row) {
             let continues = group
                 .last()
@@ -650,6 +714,14 @@ fn table_regions_for_page(page: &Page) -> Vec<MediaRegion> {
     }
 
     regions
+}
+
+fn row_overlaps_excluded_region(row: &FragmentRow<'_>, excluded: &[RegionRect]) -> bool {
+    excluded.iter().any(|region| {
+        row.fragments
+            .iter()
+            .any(|fragment| region.overlaps_fragment(fragment))
+    })
 }
 
 fn push_table_region(page: &Page, rows: &[&FragmentRow<'_>], regions: &mut Vec<MediaRegion>) {
@@ -836,6 +908,7 @@ fn is_single_parenthetical(text: &str) -> bool {
 
 fn figure_blocks_from_images(
     pages: &[Page],
+    page_stats: &[PageStats],
     images: &[ExtractedImage],
     crop_renderer: &mut PageCropRenderer<'_>,
     output_dir: &Path,
@@ -846,49 +919,50 @@ fn figure_blocks_from_images(
         .collect::<HashMap<_, _>>();
     let candidates = image_figure_candidates(&pages_by_number, images);
     let repeated_regionless = repeated_regionless_image_signatures(&candidates);
-    let handled_captions = candidates
+    let two_column_pages = page_stats
         .iter()
-        .filter(|candidate| candidate.region.is_some())
-        .filter_map(|candidate| Some(caption_key(candidate.image.page, &candidate.caption?.spans)))
+        .filter(|stats| stats.two_column)
+        .map(|stats| stats.page)
         .collect::<HashSet<_>>();
-    let mut used_images = vec![false; candidates.len()];
-    let mut figures = Vec::new();
     let mut warnings = Vec::new();
+    let vector_regions = vector_figure_regions(pages, &two_column_pages, &mut warnings);
+    let vector_rects = vector_regions
+        .iter()
+        .filter_map(|region| {
+            let page = pages_by_number.get(&region.rect.page).copied()?;
+            Some(snap_rect_above_caption(region.rect.padded(page, 48), region.caption).0)
+        })
+        .collect::<Vec<_>>();
+    let mut used_images = vec![false; candidates.len()];
+    for (index, candidate) in candidates.iter().enumerate() {
+        if candidate_region_rect(candidate)
+            .is_some_and(|rect| region_covered_by_any(rect, &vector_rects))
+        {
+            used_images[index] = true;
+        }
+    }
+    let mut figures = Vec::new();
+    let mut exclusions = Vec::new();
     let mut figure_crop_count = 0;
 
-    for (index, candidate) in candidates.iter().enumerate() {
-        if used_images[index] {
+    for cluster in image_candidate_clusters(&candidates, &used_images, &pages_by_number) {
+        if cluster.len() < 2 {
             continue;
         }
-        let (Some(_region), Some(caption)) = (candidate.region, candidate.caption) else {
+        let page_number = candidates[cluster[0]].image.page;
+        let Some(page) = pages_by_number.get(&page_number).copied() else {
             continue;
         };
-        let key = caption_key(candidate.image.page, &caption.spans);
-        let group = candidates
+        let regions = cluster
             .iter()
-            .enumerate()
-            .filter(|(group_index, group_candidate)| {
-                !used_images[*group_index]
-                    && group_candidate.region.is_some()
-                    && group_candidate.caption.is_some_and(|group_caption| {
-                        caption_key(group_candidate.image.page, &group_caption.spans) == key
-                    })
-            })
+            .filter_map(|index| candidate_region_rect(&candidates[*index]))
             .collect::<Vec<_>>();
-        if group.len() < 2 {
-            continue;
-        }
-
-        let Some(page) = pages_by_number.get(&candidate.image.page).copied() else {
-            continue;
-        };
-        let regions = group
-            .iter()
-            .filter_map(|(_, candidate)| candidate.region)
-            .collect::<Vec<_>>();
-        let text_rect = rect_from_image_regions(page, &regions);
+        let text_rect = rect_from_region_rects(page, &regions);
         let rect = text_rect.padded(page, 8);
-        let (rect, snapped) = snap_rect_above_caption(rect, caption);
+        let caption = detect_caption_fragment_for_rect(page, Some(text_rect));
+        let (rect, snapped) = caption
+            .map(|caption| snap_rect_above_caption(rect, caption))
+            .unwrap_or((rect, false));
         figure_crop_count += 1;
         let asset = match render_figure_crop(
             crop_renderer,
@@ -907,13 +981,13 @@ fn figure_blocks_from_images(
                 continue;
             }
         };
-        if snapped {
+        if snapped && let Some(caption) = caption {
             warnings.push(caption_snap_warning(rect.page, caption.top));
         }
         figures.push(AnchoredFigure {
             block: DocBlock::Figure {
                 image: asset,
-                caption: Some(caption.spans.clone()),
+                caption: caption.map(|caption| caption.spans.clone()),
             },
             anchor: BlockAnchor {
                 page: rect.page,
@@ -923,7 +997,8 @@ fn figure_blocks_from_images(
             },
             text_region: Some(text_rect),
         });
-        for (group_index, _) in group {
+        exclusions.push(text_rect);
+        for group_index in cluster {
             used_images[group_index] = true;
         }
     }
@@ -968,7 +1043,7 @@ fn figure_blocks_from_images(
         });
     }
 
-    for region in vector_figure_regions(pages, &handled_captions) {
+    for region in vector_regions {
         figure_crop_count += 1;
         let rect = region.rect.padded(
             pages_by_number
@@ -1011,9 +1086,164 @@ fn figure_blocks_from_images(
             },
             text_region: Some(region.rect),
         });
+        exclusions.push(region.rect);
+    }
+    drop_overlapping_uncaptioned_figures(&mut figures);
+
+    Ok(FigureBlocks {
+        figures,
+        warnings,
+        exclusions,
+    })
+}
+
+fn drop_overlapping_uncaptioned_figures(figures: &mut Vec<AnchoredFigure>) {
+    let captioned = figures
+        .iter()
+        .filter(|figure| {
+            matches!(
+                &figure.block,
+                DocBlock::Figure {
+                    caption: Some(_),
+                    ..
+                }
+            )
+        })
+        .filter_map(anchored_figure_rect)
+        .collect::<Vec<_>>();
+    figures.retain(|figure| {
+        if matches!(
+            &figure.block,
+            DocBlock::Figure {
+                caption: Some(_),
+                ..
+            }
+        ) {
+            return true;
+        }
+        let Some(rect) = anchored_figure_rect(figure) else {
+            return true;
+        };
+        !region_covered_by_any(rect, &captioned)
+            && !captioned.iter().any(|captioned| {
+                captioned.page == rect.page
+                    && rect.top <= captioned.bottom().saturating_add(320)
+                    && rect.bottom().saturating_add(320) >= captioned.top
+            })
+    });
+}
+
+fn anchored_figure_rect(figure: &AnchoredFigure) -> Option<RegionRect> {
+    let DocBlock::Figure { image, .. } = &figure.block else {
+        return None;
+    };
+    Some(RegionRect {
+        page: image.page,
+        top: image.top?,
+        left: image.left?,
+        width: image.width?,
+        height: image.height?,
+    })
+}
+
+const IMAGE_CLUSTER_GAP: i32 = 28;
+
+fn image_candidate_clusters(
+    candidates: &[ImageFigureCandidate<'_>],
+    already_used: &[bool],
+    pages_by_number: &HashMap<u32, &Page>,
+) -> Vec<Vec<usize>> {
+    let mut visited = already_used.to_vec();
+    let caption_keys = candidates
+        .iter()
+        .map(|candidate| extended_caption_key(candidate, pages_by_number))
+        .collect::<Vec<_>>();
+    let mut clusters = Vec::new();
+
+    for index in 0..candidates.len() {
+        if visited[index] || candidate_region_rect(&candidates[index]).is_none() {
+            continue;
+        }
+        visited[index] = true;
+        let mut cluster = vec![index];
+        let mut stack = vec![index];
+
+        while let Some(current) = stack.pop() {
+            let current_rect =
+                candidate_region_rect(&candidates[current]).expect("clustered candidate has rect");
+            for other in 0..candidates.len() {
+                if visited[other] {
+                    continue;
+                }
+                let Some(other_rect) = candidate_region_rect(&candidates[other]) else {
+                    continue;
+                };
+                if current_rect.touches_within(other_rect, IMAGE_CLUSTER_GAP)
+                    || candidates_share_caption(&candidates[current], &candidates[other])
+                    || caption_keys[current].is_some()
+                        && caption_keys[current] == caption_keys[other]
+                {
+                    visited[other] = true;
+                    stack.push(other);
+                    cluster.push(other);
+                }
+            }
+        }
+
+        clusters.push(cluster);
     }
 
-    Ok(FigureBlocks { figures, warnings })
+    clusters
+}
+
+fn extended_caption_key(
+    candidate: &ImageFigureCandidate<'_>,
+    pages_by_number: &HashMap<u32, &Page>,
+) -> Option<(u32, i32, String)> {
+    let rect = candidate_region_rect(candidate)?;
+    let page = pages_by_number.get(&candidate.image.page).copied()?;
+    let mut captions = figure_caption_fragments(page);
+    captions.sort_by_key(|caption| caption.top);
+    captions
+        .into_iter()
+        .filter(|caption| {
+            rect.bottom() <= caption.top && caption.top.saturating_sub(rect.bottom()) <= 320
+        })
+        .min_by_key(|caption| caption.top.saturating_sub(rect.bottom()))
+        .map(|caption| {
+            (
+                candidate.image.page,
+                caption.top,
+                normalize_text_key(&spans_text(&caption.spans)),
+            )
+        })
+}
+
+fn candidate_region_rect(candidate: &ImageFigureCandidate<'_>) -> Option<RegionRect> {
+    candidate
+        .region
+        .map(|region| region_rect_from_image_region(candidate.image.page, region))
+}
+
+fn candidates_share_caption(
+    left: &ImageFigureCandidate<'_>,
+    right: &ImageFigureCandidate<'_>,
+) -> bool {
+    left.image.page == right.image.page
+        && left
+            .caption
+            .zip(right.caption)
+            .is_some_and(|(left, right)| {
+                normalize_text_key(&spans_text(&left.spans))
+                    == normalize_text_key(&spans_text(&right.spans))
+            })
+}
+
+fn region_covered_by_any(rect: RegionRect, regions: &[RegionRect]) -> bool {
+    regions.iter().any(|region| {
+        let overlap = rect.overlap_area(*region);
+        overlap > 0 && overlap * 5 >= rect.area()
+    })
 }
 
 fn image_figure_candidates<'a>(
@@ -1135,16 +1365,15 @@ fn image_byte_signature(image: &ExtractedImage) -> Option<u64> {
 
 fn vector_figure_regions<'a>(
     pages: &'a [Page],
-    handled_captions: &HashSet<CaptionKey>,
+    two_column_pages: &HashSet<u32>,
+    warnings: &mut Vec<String>,
 ) -> Vec<FigureCropRegion<'a>> {
     let mut regions = Vec::new();
     for page in pages {
         for caption in figure_caption_fragments(page) {
-            let key = caption_key(page.number, &caption.spans);
-            if handled_captions.contains(&key) {
-                continue;
-            }
-            let chart_fragments = chart_label_fragments(page, caption);
+            let two_column =
+                two_column_pages.contains(&page.number) && page_has_two_column_prose(page);
+            let chart_fragments = chart_label_fragments(page, caption, two_column);
             if chart_fragments.len() < 4
                 || chart_fragments
                     .iter()
@@ -1158,17 +1387,36 @@ fn vector_figure_regions<'a>(
             {
                 continue;
             }
-            regions.push(FigureCropRegion {
-                rect: rect_from_fragments(page, &chart_fragments),
-                caption,
-            });
+            let Some(mut rect) = vector_region_rect(page, caption, &chart_fragments, two_column)
+            else {
+                continue;
+            };
+            rect = shrink_region_away_from_prose(page, rect, &chart_fragments);
+            if chart_fragments
+                .iter()
+                .filter(|fragment| rect.overlaps_fragment(fragment))
+                .count()
+                < 4
+            {
+                warnings.push(format!(
+                    "page {}: skipped vector figure near y={} because prose-like text intersects the candidate region",
+                    page.number, caption.top
+                ));
+                continue;
+            }
+            regions.push(FigureCropRegion { rect, caption });
         }
     }
     regions
 }
 
-fn chart_label_fragments<'a>(page: &'a Page, caption: &Fragment) -> Vec<&'a Fragment> {
-    page.fragments
+fn chart_label_fragments<'a>(
+    page: &'a Page,
+    caption: &Fragment,
+    two_column: bool,
+) -> Vec<&'a Fragment> {
+    let mut fragments = page
+        .fragments
         .iter()
         .filter(|fragment| {
             let bottom = fragment.top + fragment.height;
@@ -1176,13 +1424,20 @@ fn chart_label_fragments<'a>(page: &'a Page, caption: &Fragment) -> Vec<&'a Frag
                 && caption.top.saturating_sub(bottom) <= 360
                 && is_chart_label_fragment(fragment)
         })
-        .collect()
+        .collect::<Vec<_>>();
+    if two_column && let Some((left, right)) = column_bounds_for_labels(page, &fragments) {
+        fragments.retain(|fragment| {
+            let center = fragment.left + fragment.width / 2;
+            center >= left && center <= right
+        });
+    }
+    fragments
 }
 
 fn is_chart_label_fragment(fragment: &Fragment) -> bool {
     let text = spans_text(&fragment.spans);
     let trimmed = text.trim();
-    if trimmed.is_empty() || is_caption_text(trimmed) {
+    if trimmed.is_empty() || is_caption_text(trimmed) || is_prose_like_fragment(fragment) {
         return false;
     }
     let chars = trimmed.chars().count();
@@ -1192,11 +1447,139 @@ fn is_chart_label_fragment(fragment: &Fragment) -> bool {
     (has_digit || short_axis_label) && words <= 4 && chars <= 28
 }
 
-fn rect_from_image_regions(page: &Page, regions: &[&ImageRegion]) -> RegionRect {
+fn vector_region_rect(
+    page: &Page,
+    caption: &Fragment,
+    chart_fragments: &[&Fragment],
+    two_column: bool,
+) -> Option<RegionRect> {
+    let label_rect = rect_from_fragments(page, chart_fragments);
+    let mut rects = vec![label_rect];
+    for image in &page.images {
+        let image_rect = region_rect_from_image_region(page.number, image);
+        if image_rect.bottom() <= caption.top
+            && caption.top.saturating_sub(image_rect.bottom()) <= 360
+            && image_rect.touches_within(label_rect, 48)
+        {
+            rects.push(image_rect);
+        }
+    }
+    let mut rect = rect_from_region_rects(page, &rects);
+    if two_column {
+        let (left, right) = column_bounds_for_labels(page, chart_fragments)?;
+        rect = clamp_rect_horizontally(rect, left, right)?;
+    }
+    Some(rect)
+}
+
+fn column_bounds_for_labels(page: &Page, chart_fragments: &[&Fragment]) -> Option<(i32, i32)> {
+    let content_left = page.fragments.iter().map(|fragment| fragment.left).min()?;
+    let content_right = page
+        .fragments
+        .iter()
+        .map(Fragment::right)
+        .max()
+        .unwrap_or(page.width);
+    let content_width = (content_right - content_left).max(1);
+    let mid = content_left + content_width / 2;
+    let center_sum = chart_fragments
+        .iter()
+        .map(|fragment| fragment.left + fragment.width / 2)
+        .sum::<i32>();
+    let centroid = center_sum / i32::try_from(chart_fragments.len()).ok()?.max(1);
+    if centroid <= mid {
+        Some((content_left, mid))
+    } else {
+        Some((mid, content_right))
+    }
+}
+
+fn page_has_two_column_prose(page: &Page) -> bool {
+    let Some(content_left) = page.fragments.iter().map(|fragment| fragment.left).min() else {
+        return false;
+    };
+    let content_right = page
+        .fragments
+        .iter()
+        .map(Fragment::right)
+        .max()
+        .unwrap_or(page.width);
+    let mid = content_left + (content_right - content_left).max(1) / 2;
+    let mut left = 0;
+    let mut right = 0;
+    for fragment in page
+        .fragments
+        .iter()
+        .filter(|fragment| is_prose_like_fragment(fragment))
+    {
+        if fragment.left + fragment.width / 2 <= mid {
+            left += 1;
+        } else {
+            right += 1;
+        }
+    }
+    left >= 2 && right >= 2
+}
+
+fn clamp_rect_horizontally(rect: RegionRect, left: i32, right: i32) -> Option<RegionRect> {
+    let clamped_left = rect.left.max(left);
+    let clamped_right = rect.right().min(right);
+    (clamped_right > clamped_left).then_some(RegionRect {
+        left: clamped_left,
+        width: clamped_right - clamped_left,
+        ..rect
+    })
+}
+
+fn shrink_region_away_from_prose(
+    page: &Page,
+    mut rect: RegionRect,
+    chart_fragments: &[&Fragment],
+) -> RegionRect {
+    let label_top = chart_fragments
+        .iter()
+        .map(|fragment| fragment.top)
+        .min()
+        .unwrap_or(rect.top);
+    let label_bottom = chart_fragments
+        .iter()
+        .map(|fragment| fragment.top + fragment.height)
+        .max()
+        .unwrap_or(rect.bottom());
+    let original_bottom = rect.bottom();
+    for fragment in &page.fragments {
+        if !rect.overlaps_fragment(fragment) || !is_prose_like_fragment(fragment) {
+            continue;
+        }
+        let fragment_bottom = fragment.top + fragment.height;
+        if fragment_bottom <= label_top {
+            let new_top = fragment_bottom.saturating_add(2).min(original_bottom - 1);
+            rect.height = original_bottom - new_top;
+            rect.top = new_top;
+        } else if fragment.top >= label_bottom {
+            let new_bottom = fragment.top.saturating_sub(2).max(rect.top + 1);
+            rect.height = new_bottom - rect.top;
+        }
+    }
+    rect
+}
+
+fn is_prose_like_fragment(fragment: &Fragment) -> bool {
+    let text = spans_text(&fragment.spans);
+    let trimmed = text.trim();
+    let words = trimmed.split_whitespace().count();
+    words > 6
+        && trimmed
+            .chars()
+            .any(|ch| matches!(ch, '.' | '!' | '?' | ';' | ':'))
+        && trimmed.chars().any(|ch| ch.is_alphabetic())
+}
+
+fn rect_from_region_rects(page: &Page, regions: &[RegionRect]) -> RegionRect {
     let left = regions.iter().map(|region| region.left).min().unwrap_or(0);
     let right = regions
         .iter()
-        .map(|region| region.left + region.width)
+        .map(|region| region.right())
         .max()
         .unwrap_or(page.width);
     let top = regions.iter().map(|region| region.top).min().unwrap_or(0);
@@ -1282,13 +1665,6 @@ fn caption_overlap_warning(page: u32, caption_top: i32) -> String {
     )
 }
 
-fn caption_key(page: u32, spans: &[Span]) -> CaptionKey {
-    CaptionKey {
-        page,
-        text: normalize_text_key(&spans_text(spans)),
-    }
-}
-
 fn figure_caption_fragments(page: &Page) -> Vec<&Fragment> {
     page.fragments
         .iter()
@@ -1300,6 +1676,11 @@ fn detect_caption_fragment<'a>(
     page: &'a Page,
     region: Option<&ImageRegion>,
 ) -> Option<&'a Fragment> {
+    let region = region.map(|region| region_rect_from_image_region(page.number, region));
+    detect_caption_fragment_for_rect(page, region)
+}
+
+fn detect_caption_fragment_for_rect(page: &Page, region: Option<RegionRect>) -> Option<&Fragment> {
     let mut candidates = figure_caption_fragments(page);
     candidates.sort_by_key(|fragment| fragment.top);
 
@@ -1438,10 +1819,21 @@ fn remove_blocks_in_region(
             && anchor.top < region.bottom()
             && anchor_overlaps_region_horizontally(anchor, region)
         {
+            let text = blocks[index].block.text();
+            if is_prose_like_text(&text) {
+                warnings.push(format!(
+                    "page {}: kept overlapping prose as text near image region y={} ({} chars): {}",
+                    region.page,
+                    region.top,
+                    blocks[index].block.char_count(),
+                    audit_snippet(&text)
+                ));
+                index += 1;
+                continue;
+            }
             let removed = blocks.remove(index);
             let chars = removed.block.char_count();
             removed_chars += chars;
-            let text = removed.block.text();
             if !text.trim().is_empty() {
                 warnings.push(format!(
                     "page {}: preserved as image near y={} ({} chars): {}",
@@ -1456,6 +1848,16 @@ fn remove_blocks_in_region(
         }
     }
     removed_chars
+}
+
+fn is_prose_like_text(text: &str) -> bool {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    normalized.chars().count() >= 60
+        && normalized
+            .chars()
+            .any(|ch| matches!(ch, '.' | '!' | '?' | ';' | ':'))
+        && normalized.split_whitespace().count() > 8
+        && normalized.chars().any(|ch| ch.is_alphabetic())
 }
 
 fn remove_duplicate_caption_block(blocks: &mut Vec<AnchoredBlock>, page: u32, caption: &str) {
@@ -1511,6 +1913,10 @@ mod tests {
         include_str!("../fixtures/bert_figure4_multipanel.xml");
     const BERT_FIGURE5_VECTOR_CHART_XML: &str =
         include_str!("../fixtures/bert_figure5_vector_chart.xml");
+    const BERT_PAGE16_VECTOR_CHART_TWOCOL_XML: &str =
+        include_str!("../fixtures/bert_page16_vector_chart_twocol.xml");
+    const BERT_FIGURE1_TOKEN_STRIP_XML: &str =
+        include_str!("../fixtures/bert_figure1_token_strip.xml");
     const BERT_MODEL_PARAMETER_FALSE_POSITIVE_XML: &str =
         include_str!("../fixtures/bert_model_parameter_false_positive.xml");
 
@@ -1703,6 +2109,41 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
     }
 
     #[test]
+    fn remove_blocks_in_region_keeps_prose_like_blocks_as_text() {
+        let mut blocks = vec![AnchoredBlock {
+            block: DocBlock::Paragraph {
+                spans: vec![span(
+                    "This prose sentence should remain translatable even when a table crop overlaps its anchor and geometry.",
+                )],
+            },
+            anchor: BlockAnchor {
+                page: 1,
+                top: 120,
+                left: 100,
+                width: 320,
+            },
+        }];
+        let mut warnings = Vec::new();
+
+        let removed = remove_blocks_in_region(
+            &mut blocks,
+            RegionRect {
+                page: 1,
+                top: 100,
+                left: 90,
+                width: 340,
+                height: 80,
+            },
+            &mut warnings,
+        );
+
+        assert_eq!(removed, 0);
+        assert_eq!(blocks.len(), 1);
+        assert!(warnings[0].contains("kept overlapping prose as text"));
+        assert!(!warnings[0].contains("preserved as image"));
+    }
+
+    #[test]
     fn image_regions_match_by_dimensions_not_position() {
         let page = Page {
             number: 1,
@@ -1799,7 +2240,7 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
         let page_dir = dir.path().join("pages");
         let mut renderer = PageCropRenderer::new(Path::new("input.pdf"), &tools, &page_dir);
 
-        let result = figure_blocks_from_images(&pages, &images, &mut renderer, dir.path())
+        let result = figure_blocks_from_images(&pages, &[], &images, &mut renderer, dir.path())
             .expect("figure pass");
 
         assert!(result.figures.is_empty());
@@ -1826,6 +2267,14 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
     }
 
     #[test]
+    fn mnli_table_header_fragment_is_not_display_equation() {
+        let page = empty_page(1);
+        let header = fragment(200, 220, 160, 12, "MNLI-(m/mm) 392k");
+
+        assert!(!is_display_equation_fragment(&page, &header));
+    }
+
+    #[test]
     fn three_row_aligned_stats_without_caption_are_not_tables() {
         let mut page = empty_page(1);
         page.fragments = vec![
@@ -1840,7 +2289,114 @@ cp "$script_dir/pdftoppm.fixture.png" "$last.png"
             fragment(140, 240, 30, 12, "21"),
         ];
 
-        assert!(table_regions_for_page(&page).is_empty());
+        assert!(table_regions_for_page(&page, &[]).is_empty());
+    }
+
+    #[test]
+    fn figure_token_rows_inside_image_region_are_not_tables() {
+        let pages = parse_pdf2xml(BERT_FIGURE1_TOKEN_STRIP_XML).expect("fixture parses");
+        let regions = detect_media_regions(&pages, &[]);
+
+        assert!(
+            regions.iter().all(|region| region.kind != MediaKind::Table),
+            "token rows inside Figure 1 image bounds must not become table crops"
+        );
+    }
+
+    #[test]
+    fn vector_chart_region_clamps_to_chart_column_and_excludes_prose() {
+        let pages = parse_pdf2xml(BERT_PAGE16_VECTOR_CHART_TWOCOL_XML).expect("fixture parses");
+        let page = &pages[0];
+        let mut warnings = Vec::new();
+        let regions = vector_figure_regions(&pages, &HashSet::from([page.number]), &mut warnings);
+
+        assert_eq!(regions.len(), 1);
+        let rect = regions[0].rect;
+        assert!(
+            rect.right() <= page.width / 2,
+            "two-column chart region must stay in the caption column: {rect:?}"
+        );
+        assert!(
+            page.fragments
+                .iter()
+                .filter(|fragment| is_prose_like_fragment(fragment))
+                .all(|fragment| !rect.overlaps_fragment(fragment)),
+            "prose fragments must stay outside vector chart text region: {rect:?}"
+        );
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn nearby_raster_subimages_cluster_into_one_figure() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut page = empty_page(1);
+        page.images = vec![
+            ImageRegion {
+                top: 120,
+                left: 100,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+            ImageRegion {
+                top: 124,
+                left: 160,
+                width: 42,
+                height: 30,
+                src: None,
+            },
+            ImageRegion {
+                top: 126,
+                left: 222,
+                width: 40,
+                height: 30,
+                src: None,
+            },
+        ];
+        page.fragments = vec![fragment(
+            190,
+            100,
+            320,
+            12,
+            "Figure 1. A diagram composed of raster sub-images.",
+        )];
+        let mut images = Vec::new();
+        for index in 0..3 {
+            let path = dir.path().join(format!("subimage-{index}.png"));
+            fs::write(&path, format!("subimage-{index}")).expect("image bytes");
+            images.push(ExtractedImage {
+                page: 1,
+                index,
+                width: Some(40),
+                height: Some(30),
+                path,
+                extension: "png".to_string(),
+            });
+        }
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+        let tools = PopplerTools {
+            pdftohtml: PathBuf::from("pdftohtml"),
+            pdftotext: PathBuf::from("pdftotext"),
+            pdfimages: None,
+            pdftoppm: Some(pdftoppm),
+        };
+        let page_dir = dir.path().join("pages");
+        let mut renderer = PageCropRenderer::new(Path::new("input.pdf"), &tools, &page_dir);
+
+        let result = figure_blocks_from_images(&[page], &[], &images, &mut renderer, dir.path())
+            .expect("figure pass");
+
+        assert_eq!(result.figures.len(), 1);
+        assert_eq!(result.exclusions.len(), 1);
+        let DocBlock::Figure { image, caption } = &result.figures[0].block else {
+            panic!("cluster should emit a figure block");
+        };
+        assert_eq!(image.id, "pdf-figure-0001");
+        assert_eq!(
+            caption.as_ref().map(|spans| spans_text(spans)).as_deref(),
+            Some("Figure 1. A diagram composed of raster sub-images.")
+        );
     }
 
     #[test]
@@ -2025,7 +2581,7 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
             .expect("conversion should succeed");
 
         assert_eq!(outcome.report.images, 1);
-        assert_eq!(outcome.report.figures, 1);
+        assert_eq!(outcome.report.figures, 1, "{}", outcome.report.summary());
 
         let mut archive =
             ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
@@ -2089,7 +2645,7 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
             .expect("conversion should succeed");
 
         assert_eq!(outcome.report.images, 2);
-        assert_eq!(outcome.report.figures, 1);
+        assert_eq!(outcome.report.figures, 1, "{}", outcome.report.summary());
         assert!(
             outcome
                 .report
@@ -2157,7 +2713,7 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
             .expect("conversion should succeed");
 
         assert_eq!(outcome.report.images, 2);
-        assert_eq!(outcome.report.figures, 1);
+        assert_eq!(outcome.report.figures, 1, "{}", outcome.report.summary());
 
         let mut archive =
             ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
@@ -2212,7 +2768,7 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
             .expect("conversion should succeed");
 
         assert_eq!(outcome.report.images, 0);
-        assert_eq!(outcome.report.figures, 1);
+        assert_eq!(outcome.report.figures, 1, "{}", outcome.report.summary());
         assert_eq!(outcome.report.tables, 0);
         assert_eq!(outcome.report.equations, 0);
 

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -11,16 +11,19 @@ use std::{
 use crate::{
     Result,
     epub::write_epub,
-    model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, Page, Span},
+    model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span},
     parse::parse_pdf2xml,
-    reconstruct::{BlockAnchor, reconstruct},
+    reconstruct::{BlockAnchor, PageStats, reconstruct},
     report::{ConversionReport, ReportMetrics},
     tools::{ExtractedImage, PopplerTools},
 };
 
+const LOW_CONFIDENCE_COVERAGE: f64 = 0.95;
+
 #[derive(Debug, Clone)]
 pub struct ConvertOptions {
     pub columns: ColumnMode,
+    pub low_confidence: LowConfidenceMode,
     /// dc:language for the produced EPUB (source language of the PDF).
     pub language: String,
     /// dc:title; defaults to the input file stem when empty.
@@ -31,6 +34,7 @@ impl Default for ConvertOptions {
     fn default() -> Self {
         Self {
             columns: ColumnMode::Auto,
+            low_confidence: LowConfidenceMode::Linearize,
             language: "en".to_string(),
             title: String::new(),
         }
@@ -65,12 +69,31 @@ fn convert_pdf_with_tools(
     let figure_blocks = figure_blocks_from_images(&pages, &extracted_images)?;
     let mut blocks = reconstruction.blocks;
     let mut block_anchors = reconstruction.block_anchors;
-    let figure_count = insert_figure_blocks(&mut blocks, &mut block_anchors, figure_blocks);
+    insert_figure_blocks(&mut blocks, &mut block_anchors, figure_blocks);
     let _ = fs::remove_dir_all(&image_dir);
     let baseline = tools.pdf_to_text(input)?;
     let baseline_chars = baseline.chars().filter(|ch| !ch.is_whitespace()).count();
     let baseline_page_chars = baseline_page_char_counts(&baseline, reconstruction.pages.len());
+    let mut page_stats = reconstruction.pages;
+    for (stats, chars) in page_stats.iter_mut().zip(baseline_page_chars) {
+        stats.baseline_chars = chars;
+    }
+    let low_confidence_pages = mark_low_confidence_pages(&mut page_stats, options.low_confidence);
+    if options.low_confidence == LowConfidenceMode::Preserve {
+        preserve_low_confidence_pages(
+            input,
+            &pages,
+            tools,
+            &mut blocks,
+            &mut block_anchors,
+            &low_confidence_pages,
+        )?;
+    }
     let reconstructed_chars: usize = blocks.iter().map(DocBlock::char_count).sum();
+    let figure_count = blocks
+        .iter()
+        .filter(|block| matches!(block, DocBlock::Figure { .. }))
+        .count();
 
     let title = if options.title.is_empty() {
         input
@@ -81,11 +104,6 @@ fn convert_pdf_with_tools(
         options.title.clone()
     };
     write_epub(&blocks, &title, &options.language, output)?;
-
-    let mut page_stats = reconstruction.pages;
-    for (stats, chars) in page_stats.iter_mut().zip(baseline_page_chars) {
-        stats.baseline_chars = chars;
-    }
 
     let report = ConversionReport::build(
         &input.to_string_lossy(),
@@ -104,6 +122,111 @@ fn convert_pdf_with_tools(
         output: output.to_path_buf(),
         report,
     })
+}
+
+fn mark_low_confidence_pages(page_stats: &mut [PageStats], mode: LowConfidenceMode) -> Vec<u32> {
+    let action = low_confidence_action(mode);
+    let mut pages = Vec::new();
+    for stats in page_stats {
+        if is_low_confidence_page(stats) {
+            stats.low_confidence = true;
+            stats.low_confidence_action = Some(action.to_string());
+            pages.push(stats.page);
+        }
+    }
+    pages
+}
+
+fn is_low_confidence_page(stats: &PageStats) -> bool {
+    stats.baseline_chars > 0
+        && (stats.chars as f64 / stats.baseline_chars as f64) < LOW_CONFIDENCE_COVERAGE
+}
+
+fn low_confidence_action(mode: LowConfidenceMode) -> &'static str {
+    match mode {
+        LowConfidenceMode::Preserve => "preserve",
+        LowConfidenceMode::Linearize => "linearize",
+    }
+}
+
+fn preserve_low_confidence_pages(
+    input: &Path,
+    pages: &[Page],
+    tools: &PopplerTools,
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    low_confidence_pages: &[u32],
+) -> Result<()> {
+    if low_confidence_pages.is_empty() {
+        return Ok(());
+    }
+
+    let page_dir = scoped_temp_dir("bookforge-pdf-pages")?;
+    let result = (|| {
+        for page_number in low_confidence_pages {
+            let rendered = tools.render_page_png(input, *page_number, &page_dir)?;
+            let source_page = pages.iter().find(|page| page.number == *page_number);
+            let asset = page_image_asset(*page_number, source_page, &rendered)?;
+            replace_page_with_preserved_image(blocks, block_anchors, *page_number, asset);
+        }
+        Ok(())
+    })();
+    let _ = fs::remove_dir_all(&page_dir);
+    result
+}
+
+fn page_image_asset(page_number: u32, page: Option<&Page>, path: &Path) -> Result<ImageAsset> {
+    let bytes = fs::read(path)?;
+    Ok(ImageAsset {
+        id: format!("pdf-page-{page_number:04}"),
+        href: format!("images/pdf-page-{page_number:04}.png"),
+        media_type: "image/png".to_string(),
+        bytes,
+        page: page_number,
+        top: Some(0),
+        left: Some(0),
+        width: page.map(|page| page.width),
+        height: page.map(|page| page.height),
+    })
+}
+
+fn replace_page_with_preserved_image(
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    page_number: u32,
+    image: ImageAsset,
+) {
+    let old_blocks = std::mem::take(blocks);
+    let old_anchors = std::mem::take(block_anchors);
+    let mut insert_at = None;
+
+    for (block, anchor) in old_blocks.into_iter().zip(old_anchors) {
+        if anchor.page == page_number {
+            insert_at.get_or_insert(blocks.len());
+            continue;
+        }
+        if anchor.page > page_number {
+            insert_at.get_or_insert(blocks.len());
+        }
+        blocks.push(block);
+        block_anchors.push(anchor);
+    }
+
+    let insert_at = insert_at.unwrap_or(blocks.len());
+    blocks.insert(
+        insert_at,
+        DocBlock::Figure {
+            image,
+            caption: None,
+        },
+    );
+    block_anchors.insert(
+        insert_at,
+        BlockAnchor {
+            page: page_number,
+            top: 0,
+        },
+    );
 }
 
 struct AnchoredFigure {
@@ -332,6 +455,32 @@ echo "$last-000-000.png"
     }
 
     #[cfg(unix)]
+    fn fake_pdfimages_empty(path: &Path) {
+        write_executable(
+            path,
+            r#"#!/bin/sh
+if [ "$1" = "-list" ]; then
+cat <<'LIST'
+page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+LIST
+fi
+"#,
+        );
+    }
+
+    #[cfg(unix)]
+    fn fake_pdftoppm(path: &Path) {
+        write_executable(
+            path,
+            r#"#!/bin/sh
+for last do :; done
+printf 'fake-page' > "$last.png"
+"#,
+        );
+    }
+
+    #[cfg(unix)]
     #[test]
     fn convert_pdf_does_not_write_epub_when_baseline_fails() {
         use std::fs;
@@ -366,11 +515,14 @@ exit 9
         );
         let pdfimages = dir.path().join("pdfimages");
         fake_pdfimages(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
 
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
             pdfimages,
+            pdftoppm,
         };
 
         let result = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools);
@@ -421,11 +573,14 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         );
         let pdfimages = dir.path().join("pdfimages");
         fake_pdfimages(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
 
         let tools = PopplerTools {
             pdftohtml,
             pdftotext,
             pdfimages,
+            pdftoppm,
         };
         let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
             .expect("conversion should succeed");
@@ -460,5 +615,168 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
                 .any(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Caption)),
             "figcaption should remain a normal translatable caption block"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn low_confidence_pages_linearize_by_default() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="100" width="20" height="12" font="0">Tiny</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'Tiny plus many baseline characters that the XML reconstruction did not recover.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.low_confidence_pages, 1);
+        assert_eq!(
+            outcome.report.page_stats[0]
+                .low_confidence_action
+                .as_deref(),
+            Some("linearize")
+        );
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("page 1: low-confidence")
+                    && warning.contains("action=linearize"))
+        );
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("Tiny"));
+        assert!(!content.contains("pdf-page-0001.png"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn low_confidence_pages_can_be_preserved_as_page_images() {
+        use std::{fs, io::Read};
+        use zip::ZipArchive;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.pdf");
+        let output = dir.path().join("output.epub");
+        fs::write(&input, b"dummy pdf").expect("input pdf fixture");
+
+        let pdftohtml = dir.path().join("pdftohtml");
+        write_executable(
+            &pdftohtml,
+            r##"#!/bin/sh
+cat <<'XML'
+<pdf2xml>
+  <page number="1" width="600" height="800">
+    <fontspec id="0" size="12" family="Times" color="#000000"/>
+    <text top="100" left="100" width="20" height="12" font="0">Tiny</text>
+  </page>
+</pdf2xml>
+XML
+"##,
+        );
+
+        let pdftotext = dir.path().join("pdftotext");
+        write_executable(
+            &pdftotext,
+            r#"#!/bin/sh
+printf 'Tiny plus many baseline characters that the XML reconstruction did not recover.\n'
+"#,
+        );
+        let pdfimages = dir.path().join("pdfimages");
+        fake_pdfimages_empty(&pdfimages);
+        let pdftoppm = dir.path().join("pdftoppm");
+        fake_pdftoppm(&pdftoppm);
+
+        let tools = PopplerTools {
+            pdftohtml,
+            pdftotext,
+            pdfimages,
+            pdftoppm,
+        };
+        let options = ConvertOptions {
+            low_confidence: LowConfidenceMode::Preserve,
+            ..ConvertOptions::default()
+        };
+        let outcome = convert_pdf_with_tools(&input, &output, &options, &tools)
+            .expect("conversion should succeed");
+
+        assert_eq!(outcome.report.low_confidence_pages, 1);
+        assert_eq!(
+            outcome.report.page_stats[0]
+                .low_confidence_action
+                .as_deref(),
+            Some("preserve")
+        );
+        assert!(
+            outcome
+                .report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("page 1: low-confidence")
+                    && warning.contains("action=preserve"))
+        );
+
+        let mut archive =
+            ZipArchive::new(fs::File::open(&output).expect("epub opens")).expect("zip opens");
+        let mut content = String::new();
+        archive
+            .by_name("content.xhtml")
+            .expect("content exists")
+            .read_to_string(&mut content)
+            .expect("content reads");
+        assert!(content.contains("<figure id=\"pdf-page-0001\">"));
+        assert!(content.contains("images/pdf-page-0001.png"));
+        assert!(!content.contains("Tiny"));
+
+        let mut image = Vec::new();
+        archive
+            .by_name("images/pdf-page-0001.png")
+            .expect("preserved page image exists")
+            .read_to_end(&mut image)
+            .expect("image reads");
+        assert_eq!(image, b"fake-page");
     }
 }

--- a/crates/bookforge-pdf/src/epub.rs
+++ b/crates/bookforge-pdf/src/epub.rs
@@ -8,7 +8,7 @@ use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
 
 use crate::{
     Result,
-    model::{DocBlock, Span},
+    model::{DocBlock, ImageAsset, Span},
 };
 
 const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -29,16 +29,38 @@ pub fn write_epub(blocks: &[DocBlock], title: &str, language: &str, output: &Pat
     zip.start_file("META-INF/container.xml", deflated)?;
     zip.write_all(CONTAINER_XML.as_bytes())?;
     zip.start_file("content.opf", deflated)?;
-    zip.write_all(opf(title, language).as_bytes())?;
+    zip.write_all(opf(title, language, figure_assets(blocks)).as_bytes())?;
     zip.start_file("content.xhtml", deflated)?;
     zip.write_all(chapter_xhtml(blocks, title).as_bytes())?;
     zip.start_file("nav.xhtml", deflated)?;
     zip.write_all(nav_xhtml(title).as_bytes())?;
+    for asset in figure_assets(blocks) {
+        zip.start_file(asset.href.as_str(), deflated)?;
+        zip.write_all(&asset.bytes)?;
+    }
     zip.finish()?;
     Ok(())
 }
 
-fn opf(title: &str, language: &str) -> String {
+fn opf(title: &str, language: &str, assets: Vec<&ImageAsset>) -> String {
+    let asset_items = assets
+        .iter()
+        .map(|asset| {
+            format!(
+                r#"    <item id="{}" href="{}" media-type="{}"/>"#,
+                escape_attr(&asset.id),
+                escape_attr(&asset.href),
+                escape_attr(&asset.media_type)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let asset_items = if asset_items.is_empty() {
+        String::new()
+    } else {
+        format!("{asset_items}\n")
+    };
+
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
@@ -51,6 +73,7 @@ fn opf(title: &str, language: &str) -> String {
   <manifest>
     <item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+{asset_items}
   </manifest>
   <spine>
     <itemref idref="content"/>
@@ -88,6 +111,21 @@ fn chapter_xhtml(blocks: &[DocBlock], title: &str) -> String {
             DocBlock::Paragraph { spans } => {
                 body.push_str(&format!("<p>{}</p>\n", render_spans(spans)));
             }
+            DocBlock::Figure { image, caption } => {
+                body.push_str(&format!(
+                    "<figure id=\"{}\"><img src=\"{}\" alt=\"PDF image from page {}\"/>",
+                    escape_attr(&image.id),
+                    escape_attr(&image.href),
+                    image.page
+                ));
+                if let Some(caption) = caption {
+                    body.push_str(&format!(
+                        "<figcaption>{}</figcaption>",
+                        render_spans(caption)
+                    ));
+                }
+                body.push_str("</figure>\n");
+            }
         }
     }
     format!(
@@ -99,6 +137,16 @@ fn chapter_xhtml(blocks: &[DocBlock], title: &str) -> String {
 </html>"#,
         escape_text(title)
     )
+}
+
+fn figure_assets(blocks: &[DocBlock]) -> Vec<&ImageAsset> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            DocBlock::Figure { image, .. } => Some(image),
+            _ => None,
+        })
+        .collect()
 }
 
 fn render_spans(spans: &[Span]) -> String {
@@ -122,6 +170,21 @@ fn escape_text(text: &str) -> String {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn escape_attr(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
             _ => out.push(ch),
         }
     }

--- a/crates/bookforge-pdf/src/lib.rs
+++ b/crates/bookforge-pdf/src/lib.rs
@@ -1,4 +1,4 @@
-//! PDF ingestion for BookForge (ROADMAP §9b).
+//! PDF ingestion for BookForge (ROADMAP §9).
 //!
 //! Layout extraction is delegated to poppler's command-line tools;
 //! everything after the `pdftohtml -xml` output is deterministic Rust:
@@ -16,7 +16,7 @@ pub mod report;
 pub mod tools;
 
 pub use convert::{ConvertOptions, ConvertOutcome, convert_pdf};
-pub use model::{ColumnMode, DocBlock, Line, Page, Span};
+pub use model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, Line, Page, Span};
 pub use parse::parse_pdf2xml;
 pub use reconstruct::reconstruct;
 pub use report::ConversionReport;

--- a/crates/bookforge-pdf/src/lib.rs
+++ b/crates/bookforge-pdf/src/lib.rs
@@ -16,7 +16,9 @@ pub mod report;
 pub mod tools;
 
 pub use convert::{ConvertOptions, ConvertOutcome, convert_pdf};
-pub use model::{ColumnMode, DocBlock, ImageAsset, ImageRegion, Line, Page, Span};
+pub use model::{
+    ColumnMode, DocBlock, ImageAsset, ImageRegion, Line, LowConfidenceMode, Page, Span,
+};
 pub use parse::parse_pdf2xml;
 pub use reconstruct::reconstruct;
 pub use report::ConversionReport;

--- a/crates/bookforge-pdf/src/model.rs
+++ b/crates/bookforge-pdf/src/model.rs
@@ -102,6 +102,13 @@ pub enum ColumnMode {
     Two,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LowConfidenceMode {
+    Preserve,
+    #[default]
+    Linearize,
+}
+
 /// A reconstructed, reading-ordered document block ready for XHTML
 /// emission.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/bookforge-pdf/src/model.rs
+++ b/crates/bookforge-pdf/src/model.rs
@@ -22,6 +22,22 @@ pub struct Fragment {
     pub spans: Vec<Span>,
 }
 
+/// A positioned image anchor from `pdftohtml -xml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageRegion {
+    pub top: i32,
+    pub left: i32,
+    pub width: i32,
+    pub height: i32,
+    pub src: Option<String>,
+}
+
+impl ImageRegion {
+    pub fn bottom(&self) -> i32 {
+        self.top + self.height
+    }
+}
+
 impl Fragment {
     pub fn right(&self) -> i32 {
         self.left + self.width
@@ -72,6 +88,7 @@ pub struct Page {
     pub width: i32,
     pub height: i32,
     pub fragments: Vec<Fragment>,
+    pub images: Vec<ImageRegion>,
     /// font id -> point size, from `<fontspec>` declarations.
     pub font_sizes: std::collections::HashMap<u32, u32>,
 }
@@ -89,8 +106,17 @@ pub enum ColumnMode {
 /// emission.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DocBlock {
-    Heading { level: u8, spans: Vec<Span> },
-    Paragraph { spans: Vec<Span> },
+    Heading {
+        level: u8,
+        spans: Vec<Span>,
+    },
+    Paragraph {
+        spans: Vec<Span>,
+    },
+    Figure {
+        image: ImageAsset,
+        caption: Option<Vec<Span>>,
+    },
 }
 
 impl DocBlock {
@@ -98,6 +124,11 @@ impl DocBlock {
         match self {
             DocBlock::Heading { spans, .. } => spans,
             DocBlock::Paragraph { spans } => spans,
+            DocBlock::Figure {
+                caption: Some(spans),
+                ..
+            } => spans,
+            DocBlock::Figure { caption: None, .. } => &[],
         }
     }
 
@@ -114,4 +145,17 @@ impl DocBlock {
             .map(|span| span.text.chars().filter(|ch| !ch.is_whitespace()).count())
             .sum()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageAsset {
+    pub id: String,
+    pub href: String,
+    pub media_type: String,
+    pub bytes: Vec<u8>,
+    pub page: u32,
+    pub top: Option<i32>,
+    pub left: Option<i32>,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
 }

--- a/crates/bookforge-pdf/src/model.rs
+++ b/crates/bookforge-pdf/src/model.rs
@@ -68,10 +68,7 @@ impl Line {
     }
 
     pub fn text(&self) -> String {
-        self.spans
-            .iter()
-            .map(|span| span.text.as_str())
-            .collect::<String>()
+        spans_text(&self.spans)
     }
 
     pub fn char_count(&self) -> usize {
@@ -140,10 +137,7 @@ impl DocBlock {
     }
 
     pub fn text(&self) -> String {
-        self.spans()
-            .iter()
-            .map(|span| span.text.as_str())
-            .collect::<String>()
+        spans_text(self.spans())
     }
 
     pub fn char_count(&self) -> usize {
@@ -152,6 +146,20 @@ impl DocBlock {
             .map(|span| span.text.chars().filter(|ch| !ch.is_whitespace()).count())
             .sum()
     }
+}
+
+pub(crate) fn spans_text(spans: &[Span]) -> String {
+    spans
+        .iter()
+        .map(|span| span.text.as_str())
+        .collect::<String>()
+}
+
+pub(crate) fn normalize_text_key(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/bookforge-pdf/src/parse.rs
+++ b/crates/bookforge-pdf/src/parse.rs
@@ -6,6 +6,7 @@
 //! <page number="1" width="918" height="1188" ...>
 //!   <fontspec id="0" size="17" family="Times" color="#000000"/>
 //!   <text top="246" left="261" width="394" height="18" font="0">Line with <b>bold</b></text>
+//!   <image top="320" left="120" width="300" height="180" src="paper-1_1.png"/>
 //! </page>
 //! ```
 //!
@@ -18,7 +19,7 @@ use quick_xml::{Reader, events::Event};
 
 use crate::{
     PdfError, Result,
-    model::{Fragment, Page, Span},
+    model::{Fragment, ImageRegion, Page, Span},
 };
 
 pub fn parse_pdf2xml(xml: &str) -> Result<Vec<Page>> {
@@ -59,6 +60,7 @@ pub fn parse_pdf2xml(xml: &str) -> Result<Vec<Page>> {
                     width,
                     height,
                     fragments: Vec::new(),
+                    images: Vec::new(),
                     font_sizes: HashMap::new(),
                 });
             }
@@ -109,6 +111,35 @@ pub fn parse_pdf2xml(xml: &str) -> Result<Vec<Page>> {
                 current_fragment = Some(fragment);
                 bold_depth = 0;
                 italic_depth = 0;
+            }
+            Event::Start(element) | Event::Empty(element)
+                if local(element.name().as_ref()) == b"image" =>
+            {
+                let Some(page) = current_page.as_mut() else {
+                    continue;
+                };
+                let mut region = ImageRegion {
+                    top: 0,
+                    left: 0,
+                    width: 0,
+                    height: 0,
+                    src: None,
+                };
+                for attr in element.attributes() {
+                    let attr = attr.map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    let value = attr
+                        .decode_and_unescape_value(reader.decoder())
+                        .map_err(|err| PdfError::InvalidInput(err.to_string()))?;
+                    match local(attr.key.as_ref()) {
+                        b"top" => region.top = parse_coord(&value),
+                        b"left" => region.left = parse_coord(&value),
+                        b"width" => region.width = parse_coord(&value),
+                        b"height" => region.height = parse_coord(&value),
+                        b"src" => region.src = Some(value.into_owned()),
+                        _ => {}
+                    }
+                }
+                page.images.push(region);
             }
             Event::Start(element) if current_fragment.is_some() => {
                 match local(element.name().as_ref()) {
@@ -215,6 +246,7 @@ mod tests {
   <fontspec id="0" size="22" family="Times" color="#000000"/>
   <fontspec id="1" size="11" family="Times" color="#000000"/>
   <text top="100" left="200" width="500" height="24" font="0">A <b>Bold</b> Title</text>
+  <image top="150" left="210" width="120" height="80" src="fig-1.png"/>
   <text top="200" left="100" width="350" height="12" font="1">Left column line with <i>italics</i>.</text>
   <text top="200" left="480" width="350" height="12" font="1">Right column &amp; more.</text>
 </page>
@@ -229,6 +261,9 @@ mod tests {
         assert_eq!(page.width, 918);
         assert_eq!(page.font_sizes.get(&0), Some(&22));
         assert_eq!(page.fragments.len(), 3);
+        assert_eq!(page.images.len(), 1);
+        assert_eq!(page.images[0].top, 150);
+        assert_eq!(page.images[0].src.as_deref(), Some("fig-1.png"));
 
         let title = &page.fragments[0];
         assert_eq!(title.font, 0);

--- a/crates/bookforge-pdf/src/reconstruct.rs
+++ b/crates/bookforge-pdf/src/reconstruct.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::model::{ColumnMode, DocBlock, Fragment, Line, Page, Span};
+use crate::model::{ColumnMode, DocBlock, Fragment, Line, Page, Span, normalize_text_key};
 
 /// Per-page reconstruction diagnostics for the conversion report.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -24,8 +24,7 @@ pub struct PageStats {
 }
 
 pub struct Reconstruction {
-    pub blocks: Vec<DocBlock>,
-    pub block_anchors: Vec<BlockAnchor>,
+    pub blocks: Vec<AnchoredBlock>,
     pub pages: Vec<PageStats>,
 }
 
@@ -33,12 +32,22 @@ pub struct Reconstruction {
 pub struct BlockAnchor {
     pub page: u32,
     pub top: i32,
+    pub left: i32,
+    pub width: i32,
 }
 
 #[derive(Debug, Clone)]
-struct AnchoredBlock {
+pub struct AnchoredBlock {
+    pub block: DocBlock,
+    pub anchor: BlockAnchor,
+}
+
+#[derive(Debug, Clone)]
+struct PendingBlock {
     block: DocBlock,
     top: i32,
+    left: i32,
+    right: i32,
 }
 
 pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
@@ -46,8 +55,7 @@ pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
     let heading_levels = heading_levels(pages, body_size);
     let running_margin_texts = running_margin_texts(pages, body_size);
 
-    let mut blocks: Vec<DocBlock> = Vec::new();
-    let mut block_anchors = Vec::new();
+    let mut blocks: Vec<AnchoredBlock> = Vec::new();
     let mut stats = Vec::new();
 
     for page in pages {
@@ -78,12 +86,11 @@ pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
         });
 
         let page_blocks = cluster_paragraphs(&ordered, body_size, &heading_levels);
-        append_with_continuation(&mut blocks, &mut block_anchors, page.number, page_blocks);
+        append_with_continuation(&mut blocks, page.number, page_blocks);
     }
 
     Reconstruction {
         blocks,
-        block_anchors,
         pages: stats,
     }
 }
@@ -96,7 +103,7 @@ fn running_margin_texts(pages: &[Page], body_size: u32) -> HashSet<String> {
             if line.font_size > body_size + 1 || !near_vertical_margin(page, &line) {
                 continue;
             }
-            let normalized = normalize_running_text(&line.text());
+            let normalized = normalize_text_key(&line.text());
             if normalized.len() >= 4 && normalized.chars().any(|ch| ch.is_alphabetic()) {
                 seen_on_page.insert(normalized);
             }
@@ -123,19 +130,12 @@ fn is_running_margin_line(
 ) -> bool {
     line.font_size <= body_size + 1
         && near_vertical_margin(page, line)
-        && running_margin_texts.contains(&normalize_running_text(&line.text()))
+        && running_margin_texts.contains(&normalize_text_key(&line.text()))
 }
 
 fn near_vertical_margin(page: &Page, line: &Line) -> bool {
     let margin = (page.height / 8).max(line.height * 3);
     line.top <= margin || line.top + line.height >= page.height - margin
-}
-
-fn normalize_running_text(text: &str) -> String {
-    text.split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase()
 }
 
 /// Group fragments that share a baseline into one visual line, joining
@@ -342,18 +342,22 @@ fn cluster_paragraphs(
     lines: &[Line],
     body_size: u32,
     heading_levels: &HashMap<u32, u8>,
-) -> Vec<AnchoredBlock> {
+) -> Vec<PendingBlock> {
     let median_gap = median_line_gap(lines);
     let mut blocks = Vec::new();
     let mut current: Vec<Span> = Vec::new();
     let mut current_heading: Option<u8> = None;
     let mut current_top: Option<i32> = None;
+    let mut current_left: Option<i32> = None;
+    let mut current_right: Option<i32> = None;
     let mut previous: Option<&Line> = None;
 
     let flush = |spans: &mut Vec<Span>,
                  heading: &mut Option<u8>,
                  top: &mut Option<i32>,
-                 blocks: &mut Vec<AnchoredBlock>| {
+                 left: &mut Option<i32>,
+                 right: &mut Option<i32>,
+                 blocks: &mut Vec<PendingBlock>| {
         if spans.is_empty() {
             return;
         }
@@ -362,9 +366,13 @@ fn cluster_paragraphs(
             Some(level) => DocBlock::Heading { level, spans },
             None => DocBlock::Paragraph { spans },
         };
-        blocks.push(AnchoredBlock {
+        let left = left.take().unwrap_or_default();
+        let right = right.take().unwrap_or(left + 1).max(left + 1);
+        blocks.push(PendingBlock {
             block,
             top: top.take().unwrap_or_default(),
+            left,
+            right,
         });
     };
 
@@ -390,10 +398,17 @@ fn cluster_paragraphs(
                 &mut current,
                 &mut current_heading,
                 &mut current_top,
+                &mut current_left,
+                &mut current_right,
                 &mut blocks,
             );
             current_heading = heading;
             current_top = Some(line.top);
+            current_left = Some(line.left);
+            current_right = Some(line.right);
+        } else {
+            current_left = Some(current_left.map_or(line.left, |left| left.min(line.left)));
+            current_right = Some(current_right.map_or(line.right, |right| right.max(line.right)));
         }
         join_line_into(&mut current, line);
         previous = Some(line);
@@ -402,6 +417,8 @@ fn cluster_paragraphs(
         &mut current,
         &mut current_heading,
         &mut current_top,
+        &mut current_left,
+        &mut current_right,
         &mut blocks,
     );
 
@@ -465,14 +482,16 @@ fn median_line_gap(lines: &[Line]) -> i32 {
 /// the previous page's last one when the earlier text does not end a
 /// sentence and the new text starts lowercase.
 fn append_with_continuation(
-    blocks: &mut Vec<DocBlock>,
-    block_anchors: &mut Vec<BlockAnchor>,
+    blocks: &mut Vec<AnchoredBlock>,
     page: u32,
-    mut incoming: Vec<AnchoredBlock>,
+    mut incoming: Vec<PendingBlock>,
 ) {
     if let (
-        Some(DocBlock::Paragraph { spans: tail }),
         Some(AnchoredBlock {
+            block: DocBlock::Paragraph { spans: tail },
+            ..
+        }),
+        Some(PendingBlock {
             block: DocBlock::Paragraph { spans: head },
             ..
         }),
@@ -501,11 +520,15 @@ fn append_with_continuation(
         }
     }
     for anchored in incoming {
-        block_anchors.push(BlockAnchor {
-            page,
-            top: anchored.top,
+        blocks.push(AnchoredBlock {
+            block: anchored.block,
+            anchor: BlockAnchor {
+                page,
+                top: anchored.top,
+                left: anchored.left,
+                width: (anchored.right - anchored.left).max(1),
+            },
         });
-        blocks.push(anchored.block);
     }
 }
 
@@ -571,10 +594,14 @@ mod tests {
         let result = reconstruct(&pages, ColumnMode::Auto);
 
         assert!(result.pages[0].two_column, "page must detect two columns");
-        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        let texts: Vec<String> = result
+            .blocks
+            .iter()
+            .map(|anchored| anchored.block.text())
+            .collect();
 
         assert!(
-            matches!(&result.blocks[0], DocBlock::Heading { level: 1, .. }),
+            matches!(&result.blocks[0].block, DocBlock::Heading { level: 1, .. }),
             "title should be an h1, got {:?}",
             result.blocks[0]
         );
@@ -604,7 +631,11 @@ mod tests {
         let pages = parse_pdf2xml(xml).expect("fixture parses");
         let result = reconstruct(&pages, ColumnMode::Auto);
 
-        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        let texts: Vec<String> = result
+            .blocks
+            .iter()
+            .map(|anchored| anchored.block.text())
+            .collect();
         assert_eq!(
             texts,
             vec![
@@ -638,7 +669,7 @@ mod tests {
         let all_text: String = result
             .blocks
             .iter()
-            .map(|block| block.text())
+            .map(|anchored| anchored.block.text())
             .collect::<Vec<_>>()
             .join("\n");
         let left_pos = all_text.find("left four").expect("left text present");
@@ -669,7 +700,11 @@ mod tests {
         let pages = parse_pdf2xml(xml).expect("fixture parses");
         let result = reconstruct(&pages, ColumnMode::Auto);
 
-        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        let texts: Vec<String> = result
+            .blocks
+            .iter()
+            .map(|anchored| anchored.block.text())
+            .collect();
         assert_eq!(
             texts,
             vec!["This sentence does not end until the following page.".to_string()]
@@ -703,7 +738,11 @@ mod tests {
         let pages = parse_pdf2xml(xml).expect("fixture parses");
         let result = reconstruct(&pages, ColumnMode::Auto);
 
-        let texts: Vec<String> = result.blocks.iter().map(DocBlock::text).collect();
+        let texts: Vec<String> = result
+            .blocks
+            .iter()
+            .map(|anchored| anchored.block.text())
+            .collect();
 
         assert_eq!(texts[0], "THIS SOVIET WORLD");
         assert_eq!(

--- a/crates/bookforge-pdf/src/reconstruct.rs
+++ b/crates/bookforge-pdf/src/reconstruct.rs
@@ -19,6 +19,8 @@ pub struct PageStats {
     pub chars: usize,
     pub baseline_chars: usize,
     pub two_column: bool,
+    pub low_confidence: bool,
+    pub low_confidence_action: Option<String>,
 }
 
 pub struct Reconstruction {
@@ -71,6 +73,8 @@ pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
             chars: ordered.iter().map(Line::char_count).sum(),
             baseline_chars: 0,
             two_column,
+            low_confidence: false,
+            low_confidence_action: None,
         });
 
         let page_blocks = cluster_paragraphs(&ordered, body_size, &heading_levels);

--- a/crates/bookforge-pdf/src/reconstruct.rs
+++ b/crates/bookforge-pdf/src/reconstruct.rs
@@ -23,7 +23,20 @@ pub struct PageStats {
 
 pub struct Reconstruction {
     pub blocks: Vec<DocBlock>,
+    pub block_anchors: Vec<BlockAnchor>,
     pub pages: Vec<PageStats>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockAnchor {
+    pub page: u32,
+    pub top: i32,
+}
+
+#[derive(Debug, Clone)]
+struct AnchoredBlock {
+    block: DocBlock,
+    top: i32,
 }
 
 pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
@@ -32,6 +45,7 @@ pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
     let running_margin_texts = running_margin_texts(pages, body_size);
 
     let mut blocks: Vec<DocBlock> = Vec::new();
+    let mut block_anchors = Vec::new();
     let mut stats = Vec::new();
 
     for page in pages {
@@ -60,11 +74,12 @@ pub fn reconstruct(pages: &[Page], columns: ColumnMode) -> Reconstruction {
         });
 
         let page_blocks = cluster_paragraphs(&ordered, body_size, &heading_levels);
-        append_with_continuation(&mut blocks, page_blocks);
+        append_with_continuation(&mut blocks, &mut block_anchors, page.number, page_blocks);
     }
 
     Reconstruction {
         blocks,
+        block_anchors,
         pages: stats,
     }
 }
@@ -323,22 +338,30 @@ fn cluster_paragraphs(
     lines: &[Line],
     body_size: u32,
     heading_levels: &HashMap<u32, u8>,
-) -> Vec<DocBlock> {
+) -> Vec<AnchoredBlock> {
     let median_gap = median_line_gap(lines);
     let mut blocks = Vec::new();
     let mut current: Vec<Span> = Vec::new();
     let mut current_heading: Option<u8> = None;
+    let mut current_top: Option<i32> = None;
     let mut previous: Option<&Line> = None;
 
-    let flush = |spans: &mut Vec<Span>, heading: &mut Option<u8>, blocks: &mut Vec<DocBlock>| {
+    let flush = |spans: &mut Vec<Span>,
+                 heading: &mut Option<u8>,
+                 top: &mut Option<i32>,
+                 blocks: &mut Vec<AnchoredBlock>| {
         if spans.is_empty() {
             return;
         }
         let spans = std::mem::take(spans);
-        match heading.take() {
-            Some(level) => blocks.push(DocBlock::Heading { level, spans }),
-            None => blocks.push(DocBlock::Paragraph { spans }),
-        }
+        let block = match heading.take() {
+            Some(level) => DocBlock::Heading { level, spans },
+            None => DocBlock::Paragraph { spans },
+        };
+        blocks.push(AnchoredBlock {
+            block,
+            top: top.take().unwrap_or_default(),
+        });
     };
 
     for line in lines {
@@ -359,13 +382,24 @@ fn cluster_paragraphs(
         };
 
         if new_block {
-            flush(&mut current, &mut current_heading, &mut blocks);
+            flush(
+                &mut current,
+                &mut current_heading,
+                &mut current_top,
+                &mut blocks,
+            );
             current_heading = heading;
+            current_top = Some(line.top);
         }
         join_line_into(&mut current, line);
         previous = Some(line);
     }
-    flush(&mut current, &mut current_heading, &mut blocks);
+    flush(
+        &mut current,
+        &mut current_heading,
+        &mut current_top,
+        &mut blocks,
+    );
 
     blocks
 }
@@ -426,9 +460,19 @@ fn median_line_gap(lines: &[Line]) -> i32 {
 /// Cross-page paragraph continuation: a page's first paragraph continues
 /// the previous page's last one when the earlier text does not end a
 /// sentence and the new text starts lowercase.
-fn append_with_continuation(blocks: &mut Vec<DocBlock>, mut incoming: Vec<DocBlock>) {
-    if let (Some(DocBlock::Paragraph { spans: tail }), Some(DocBlock::Paragraph { spans: head })) =
-        (blocks.last_mut(), incoming.first_mut())
+fn append_with_continuation(
+    blocks: &mut Vec<DocBlock>,
+    block_anchors: &mut Vec<BlockAnchor>,
+    page: u32,
+    mut incoming: Vec<AnchoredBlock>,
+) {
+    if let (
+        Some(DocBlock::Paragraph { spans: tail }),
+        Some(AnchoredBlock {
+            block: DocBlock::Paragraph { spans: head },
+            ..
+        }),
+    ) = (blocks.last_mut(), incoming.first_mut())
     {
         let tail_text: String = tail.iter().map(|span| span.text.as_str()).collect();
         let head_text: String = head.iter().map(|span| span.text.as_str()).collect();
@@ -452,7 +496,13 @@ fn append_with_continuation(blocks: &mut Vec<DocBlock>, mut incoming: Vec<DocBlo
             incoming.remove(0);
         }
     }
-    blocks.append(&mut incoming);
+    for anchored in incoming {
+        block_anchors.push(BlockAnchor {
+            page,
+            top: anchored.top,
+        });
+        blocks.push(anchored.block);
+    }
 }
 
 #[cfg(test)]

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -22,6 +22,7 @@ pub struct ConversionReport {
     pub two_column_pages: usize,
     pub images: usize,
     pub figures: usize,
+    pub low_confidence_pages: usize,
     pub page_stats: Vec<PageStats>,
     pub warnings: Vec<String>,
 }
@@ -55,7 +56,14 @@ impl ConversionReport {
             ));
         }
         for page in &page_stats {
-            if page.chars == 0 && page.baseline_chars > 0 {
+            if page.low_confidence {
+                let action = page.low_confidence_action.as_deref().unwrap_or("linearize");
+                let page_coverage = page_coverage_percent(page.chars, page.baseline_chars);
+                warnings.push(format!(
+                    "page {}: low-confidence reconstruction ({page_coverage:.1}% of pdftotext baseline, {} reconstructed / {} baseline characters); action={action}",
+                    page.page, page.chars, page.baseline_chars
+                ));
+            } else if page.chars == 0 && page.baseline_chars > 0 {
                 warnings.push(format!(
                     "page {}: no text reconstructed, but pdftotext found {} baseline characters",
                     page.page, page.baseline_chars
@@ -74,6 +82,7 @@ impl ConversionReport {
             two_column_pages: page_stats.iter().filter(|page| page.two_column).count(),
             images: metrics.images,
             figures: metrics.figures,
+            low_confidence_pages: page_stats.iter().filter(|page| page.low_confidence).count(),
             page_stats,
             warnings,
         }
@@ -81,12 +90,13 @@ impl ConversionReport {
 
     pub fn summary(&self) -> String {
         let mut out = format!(
-            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
             self.pages,
             self.blocks,
             self.two_column_pages,
             self.images,
             self.figures,
+            self.low_confidence_pages,
             self.coverage_percent,
             self.reconstructed_chars,
             self.baseline_chars,
@@ -100,6 +110,14 @@ impl ConversionReport {
             }
         }
         out
+    }
+}
+
+fn page_coverage_percent(chars: usize, baseline_chars: usize) -> f64 {
+    if baseline_chars == 0 {
+        100.0
+    } else {
+        (chars as f64 / baseline_chars as f64 * 100.0).min(100.0)
     }
 }
 
@@ -142,6 +160,8 @@ mod tests {
                 chars: 0,
                 baseline_chars: 0,
                 two_column: false,
+                low_confidence: false,
+                low_confidence_action: None,
             }],
             ReportMetrics {
                 blocks: 0,
@@ -167,6 +187,8 @@ mod tests {
                 chars: 0,
                 baseline_chars: 42,
                 two_column: false,
+                low_confidence: false,
+                low_confidence_action: None,
             }],
             ReportMetrics {
                 blocks: 0,
@@ -181,5 +203,39 @@ mod tests {
         assert!(
             report.warnings[1].contains("page 7: no text reconstructed, but pdftotext found 42")
         );
+    }
+
+    #[test]
+    fn low_confidence_pages_warn_with_action() {
+        let report = ConversionReport::build(
+            "in.pdf",
+            "out.epub",
+            vec![PageStats {
+                page: 4,
+                lines: 1,
+                chars: 4,
+                baseline_chars: 100,
+                two_column: false,
+                low_confidence: true,
+                low_confidence_action: Some("preserve".to_string()),
+            }],
+            ReportMetrics {
+                blocks: 0,
+                reconstructed_chars: 4,
+                baseline_chars: 100,
+                images: 0,
+                figures: 1,
+            },
+        );
+
+        assert_eq!(report.low_confidence_pages, 1);
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("page 4: low-confidence")
+                    && warning.contains("action=preserve"))
+        );
+        assert!(report.summary().contains("Low-confidence pages: 1"));
     }
 }

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 
 use crate::reconstruct::PageStats;
 
+pub const LOW_CONFIDENCE_COVERAGE_RATIO: f64 = 0.95;
+pub const LOW_CONFIDENCE_COVERAGE_PERCENT: f64 = LOW_CONFIDENCE_COVERAGE_RATIO * 100.0;
+
 #[derive(Debug, Serialize)]
 pub struct ConversionReport {
     pub input: String,
@@ -13,6 +16,9 @@ pub struct ConversionReport {
     pub blocks: usize,
     /// Non-whitespace characters in reconstructed blocks.
     pub reconstructed_chars: usize,
+    /// Non-whitespace characters removed from text blocks because the same
+    /// content was preserved in table/equation/figure raster crops.
+    pub media_preserved_chars: usize,
     /// Non-whitespace characters in the raw `pdftotext` baseline.
     pub baseline_chars: usize,
     /// reconstructed/baseline, capped at 100. Above ~100 means the
@@ -33,6 +39,7 @@ pub struct ConversionReport {
 pub struct ReportMetrics {
     pub blocks: usize,
     pub reconstructed_chars: usize,
+    pub media_preserved_chars: usize,
     pub baseline_chars: usize,
     pub images: usize,
     pub figures: usize,
@@ -48,14 +55,15 @@ impl ConversionReport {
         page_stats: Vec<PageStats>,
         metrics: ReportMetrics,
     ) -> Self {
+        let credited_chars = metrics.reconstructed_chars + metrics.media_preserved_chars;
         let coverage_percent = if metrics.baseline_chars == 0 {
             100.0
         } else {
-            (metrics.reconstructed_chars as f64 / metrics.baseline_chars as f64 * 100.0).min(100.0)
+            (credited_chars as f64 / metrics.baseline_chars as f64 * 100.0).min(100.0)
         };
 
         let mut warnings = Vec::new();
-        if coverage_percent < 95.0 {
+        if coverage_percent < LOW_CONFIDENCE_COVERAGE_PERCENT {
             warnings.push(format!(
                 "reconstructed text covers only {coverage_percent:.1}% of the pdftotext baseline; some content was not captured"
             ));
@@ -83,6 +91,7 @@ impl ConversionReport {
             pages: page_stats.len(),
             blocks: metrics.blocks,
             reconstructed_chars: metrics.reconstructed_chars,
+            media_preserved_chars: metrics.media_preserved_chars,
             baseline_chars: metrics.baseline_chars,
             coverage_percent,
             two_column_pages: page_stats.iter().filter(|page| page.two_column).count(),
@@ -98,7 +107,7 @@ impl ConversionReport {
 
     pub fn summary(&self) -> String {
         let mut out = format!(
-            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nTables: {} crop(s)\nEquations: {} crop(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nTables: {} crop(s)\nEquations: {} crop(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed + {} preserved as images / {} baseline characters)\n",
             self.pages,
             self.blocks,
             self.two_column_pages,
@@ -109,6 +118,7 @@ impl ConversionReport {
             self.low_confidence_pages,
             self.coverage_percent,
             self.reconstructed_chars,
+            self.media_preserved_chars,
             self.baseline_chars,
         );
         if self.warnings.is_empty() {
@@ -144,6 +154,7 @@ mod tests {
             ReportMetrics {
                 blocks: 1,
                 reconstructed_chars: 101,
+                media_preserved_chars: 0,
                 baseline_chars: 100,
                 images: 0,
                 figures: 0,
@@ -157,7 +168,7 @@ mod tests {
         assert!(
             report
                 .summary()
-                .contains("101 reconstructed / 100 baseline characters")
+                .contains("101 reconstructed + 0 preserved as images / 100 baseline characters")
         );
         assert!(!report.summary().contains("101 of 100"));
     }
@@ -179,6 +190,7 @@ mod tests {
             ReportMetrics {
                 blocks: 0,
                 reconstructed_chars: 0,
+                media_preserved_chars: 0,
                 baseline_chars: 0,
                 images: 0,
                 figures: 0,
@@ -209,6 +221,7 @@ mod tests {
             ReportMetrics {
                 blocks: 0,
                 reconstructed_chars: 0,
+                media_preserved_chars: 0,
                 baseline_chars: 42,
                 images: 0,
                 figures: 0,
@@ -241,6 +254,7 @@ mod tests {
             ReportMetrics {
                 blocks: 0,
                 reconstructed_chars: 4,
+                media_preserved_chars: 0,
                 baseline_chars: 100,
                 images: 0,
                 figures: 1,
@@ -262,6 +276,30 @@ mod tests {
     }
 
     #[test]
+    fn media_preserved_chars_credit_coverage() {
+        let report = ConversionReport::build(
+            "in.pdf",
+            "out.epub",
+            Vec::new(),
+            ReportMetrics {
+                blocks: 1,
+                reconstructed_chars: 80,
+                media_preserved_chars: 20,
+                baseline_chars: 100,
+                images: 0,
+                figures: 1,
+                tables: 1,
+                equations: 0,
+                layout_warnings: Vec::new(),
+            },
+        );
+
+        assert_eq!(report.coverage_percent, 100.0);
+        assert!(report.warnings.is_empty());
+        assert!(report.summary().contains("20 preserved as images"));
+    }
+
+    #[test]
     fn summary_includes_layout_warnings() {
         let report = ConversionReport::build(
             "in.pdf",
@@ -270,6 +308,7 @@ mod tests {
             ReportMetrics {
                 blocks: 0,
                 reconstructed_chars: 0,
+                media_preserved_chars: 0,
                 baseline_chars: 0,
                 images: 0,
                 figures: 1,

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -29,7 +29,7 @@ pub struct ConversionReport {
     pub warnings: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ReportMetrics {
     pub blocks: usize,
     pub reconstructed_chars: usize,
@@ -38,6 +38,7 @@ pub struct ReportMetrics {
     pub figures: usize,
     pub tables: usize,
     pub equations: usize,
+    pub layout_warnings: Vec<String>,
 }
 
 impl ConversionReport {
@@ -74,6 +75,7 @@ impl ConversionReport {
                 ));
             }
         }
+        warnings.extend(metrics.layout_warnings);
 
         Self {
             input: input.to_string(),
@@ -147,6 +149,7 @@ mod tests {
                 figures: 0,
                 tables: 0,
                 equations: 0,
+                layout_warnings: Vec::new(),
             },
         );
 
@@ -181,6 +184,7 @@ mod tests {
                 figures: 0,
                 tables: 0,
                 equations: 0,
+                layout_warnings: Vec::new(),
             },
         );
 
@@ -210,6 +214,7 @@ mod tests {
                 figures: 0,
                 tables: 0,
                 equations: 0,
+                layout_warnings: Vec::new(),
             },
         );
 
@@ -241,6 +246,7 @@ mod tests {
                 figures: 1,
                 tables: 0,
                 equations: 0,
+                layout_warnings: Vec::new(),
             },
         );
 
@@ -253,5 +259,39 @@ mod tests {
                     && warning.contains("action=preserve"))
         );
         assert!(report.summary().contains("Low-confidence pages: 1"));
+    }
+
+    #[test]
+    fn summary_includes_layout_warnings() {
+        let report = ConversionReport::build(
+            "in.pdf",
+            "out.epub",
+            Vec::new(),
+            ReportMetrics {
+                blocks: 0,
+                reconstructed_chars: 0,
+                baseline_chars: 0,
+                images: 0,
+                figures: 1,
+                tables: 0,
+                equations: 0,
+                layout_warnings: vec![
+                    "page 1: lowercase paragraph continuation follows media block near y=120"
+                        .to_string(),
+                ],
+            },
+        );
+
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("lowercase paragraph continuation"))
+        );
+        assert!(
+            report
+                .summary()
+                .contains("lowercase paragraph continuation follows media block")
+        );
     }
 }

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -22,6 +22,8 @@ pub struct ConversionReport {
     pub two_column_pages: usize,
     pub images: usize,
     pub figures: usize,
+    pub tables: usize,
+    pub equations: usize,
     pub low_confidence_pages: usize,
     pub page_stats: Vec<PageStats>,
     pub warnings: Vec<String>,
@@ -34,6 +36,8 @@ pub struct ReportMetrics {
     pub baseline_chars: usize,
     pub images: usize,
     pub figures: usize,
+    pub tables: usize,
+    pub equations: usize,
 }
 
 impl ConversionReport {
@@ -82,6 +86,8 @@ impl ConversionReport {
             two_column_pages: page_stats.iter().filter(|page| page.two_column).count(),
             images: metrics.images,
             figures: metrics.figures,
+            tables: metrics.tables,
+            equations: metrics.equations,
             low_confidence_pages: page_stats.iter().filter(|page| page.low_confidence).count(),
             page_stats,
             warnings,
@@ -90,12 +96,14 @@ impl ConversionReport {
 
     pub fn summary(&self) -> String {
         let mut out = format!(
-            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nTables: {} crop(s)\nEquations: {} crop(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
             self.pages,
             self.blocks,
             self.two_column_pages,
             self.images,
             self.figures,
+            self.tables,
+            self.equations,
             self.low_confidence_pages,
             self.coverage_percent,
             self.reconstructed_chars,
@@ -137,6 +145,8 @@ mod tests {
                 baseline_chars: 100,
                 images: 0,
                 figures: 0,
+                tables: 0,
+                equations: 0,
             },
         );
 
@@ -169,6 +179,8 @@ mod tests {
                 baseline_chars: 0,
                 images: 0,
                 figures: 0,
+                tables: 0,
+                equations: 0,
             },
         );
 
@@ -196,6 +208,8 @@ mod tests {
                 baseline_chars: 42,
                 images: 0,
                 figures: 0,
+                tables: 0,
+                equations: 0,
             },
         );
 
@@ -225,6 +239,8 @@ mod tests {
                 baseline_chars: 100,
                 images: 0,
                 figures: 1,
+                tables: 0,
+                equations: 0,
             },
         );
 

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -20,8 +20,19 @@ pub struct ConversionReport {
     /// dropped content and the page list below says where.
     pub coverage_percent: f64,
     pub two_column_pages: usize,
+    pub images: usize,
+    pub figures: usize,
     pub page_stats: Vec<PageStats>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReportMetrics {
+    pub blocks: usize,
+    pub reconstructed_chars: usize,
+    pub baseline_chars: usize,
+    pub images: usize,
+    pub figures: usize,
 }
 
 impl ConversionReport {
@@ -29,14 +40,12 @@ impl ConversionReport {
         input: &str,
         output: &str,
         page_stats: Vec<PageStats>,
-        blocks: usize,
-        reconstructed_chars: usize,
-        baseline_chars: usize,
+        metrics: ReportMetrics,
     ) -> Self {
-        let coverage_percent = if baseline_chars == 0 {
+        let coverage_percent = if metrics.baseline_chars == 0 {
             100.0
         } else {
-            (reconstructed_chars as f64 / baseline_chars as f64 * 100.0).min(100.0)
+            (metrics.reconstructed_chars as f64 / metrics.baseline_chars as f64 * 100.0).min(100.0)
         };
 
         let mut warnings = Vec::new();
@@ -58,11 +67,13 @@ impl ConversionReport {
             input: input.to_string(),
             output: output.to_string(),
             pages: page_stats.len(),
-            blocks,
-            reconstructed_chars,
-            baseline_chars,
+            blocks: metrics.blocks,
+            reconstructed_chars: metrics.reconstructed_chars,
+            baseline_chars: metrics.baseline_chars,
             coverage_percent,
             two_column_pages: page_stats.iter().filter(|page| page.two_column).count(),
+            images: metrics.images,
+            figures: metrics.figures,
             page_stats,
             warnings,
         }
@@ -70,10 +81,12 @@ impl ConversionReport {
 
     pub fn summary(&self) -> String {
         let mut out = format!(
-            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nText coverage vs pdftotext: {:.1}% ({} reconstructed / {} baseline characters)\n",
             self.pages,
             self.blocks,
             self.two_column_pages,
+            self.images,
+            self.figures,
             self.coverage_percent,
             self.reconstructed_chars,
             self.baseline_chars,
@@ -96,7 +109,18 @@ mod tests {
 
     #[test]
     fn summary_does_not_describe_over_baseline_reconstruction_as_of_total() {
-        let report = ConversionReport::build("in.pdf", "out.epub", Vec::new(), 1, 101, 100);
+        let report = ConversionReport::build(
+            "in.pdf",
+            "out.epub",
+            Vec::new(),
+            ReportMetrics {
+                blocks: 1,
+                reconstructed_chars: 101,
+                baseline_chars: 100,
+                images: 0,
+                figures: 0,
+            },
+        );
 
         assert_eq!(report.coverage_percent, 100.0);
         assert!(
@@ -119,9 +143,13 @@ mod tests {
                 baseline_chars: 0,
                 two_column: false,
             }],
-            0,
-            0,
-            0,
+            ReportMetrics {
+                blocks: 0,
+                reconstructed_chars: 0,
+                baseline_chars: 0,
+                images: 0,
+                figures: 0,
+            },
         );
 
         assert!(report.warnings.is_empty());
@@ -140,9 +168,13 @@ mod tests {
                 baseline_chars: 42,
                 two_column: false,
             }],
-            0,
-            0,
-            42,
+            ReportMetrics {
+                blocks: 0,
+                reconstructed_chars: 0,
+                baseline_chars: 42,
+                images: 0,
+                figures: 0,
+            },
         );
 
         assert_eq!(report.warnings.len(), 2);

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -35,6 +35,7 @@ pub struct PopplerTools {
     pub pdftohtml: PathBuf,
     pub pdftotext: PathBuf,
     pub pdfimages: PathBuf,
+    pub pdftoppm: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +55,7 @@ impl PopplerTools {
             pdftohtml: find_tool("pdftohtml")?,
             pdftotext: find_tool("pdftotext")?,
             pdfimages: find_tool("pdfimages")?,
+            pdftoppm: find_tool("pdftoppm")?,
         })
     }
 
@@ -157,6 +159,39 @@ impl PopplerTools {
                 }
             })
             .collect())
+    }
+
+    pub fn render_page_png(
+        &self,
+        pdf: &Path,
+        page: u32,
+        output_dir: &Path,
+    ) -> Result<PathBuf, ToolError> {
+        fs::create_dir_all(output_dir)?;
+        let root = output_dir.join(format!("page-{page:04}"));
+        let page_arg = page.to_string();
+        let output = Command::new(&self.pdftoppm)
+            .args([
+                "-f",
+                &page_arg,
+                "-l",
+                &page_arg,
+                "-singlefile",
+                "-png",
+                "-r",
+                "150",
+            ])
+            .arg(pdf)
+            .arg(&root)
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdftoppm",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        Ok(root.with_extension("png"))
     }
 
     fn list_images(&self, pdf: &Path) -> Result<Vec<ListedImage>, ToolError> {

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -6,12 +6,22 @@
 //! are acceptable, embedded runtimes are not.
 
 use std::{
-    fs, io,
+    collections::HashMap,
+    fs,
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     process::{Command, Output},
     thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
+
+pub const PDF_RENDER_DPI: u32 = 150;
+const PDF_XML_ZOOM: &str = "1.5";
+const PDF_XML_ZOOM_NUM: i64 = 3;
+const PDF_XML_ZOOM_DEN: i64 = 2;
+const PDF_POINTS_PER_INCH: i64 = 72;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
@@ -27,6 +37,12 @@ pub enum ToolError {
         stderr: String,
     },
 
+    #[error("pdfimages output did not match its -list rows: {0}")]
+    ImageListMismatch(String),
+
+    #[error("unsupported PNG produced by pdftoppm: {0}")]
+    UnsupportedPng(String),
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
@@ -35,8 +51,8 @@ pub enum ToolError {
 pub struct PopplerTools {
     pub pdftohtml: PathBuf,
     pub pdftotext: PathBuf,
-    pub pdfimages: PathBuf,
-    pub pdftoppm: PathBuf,
+    pub pdfimages: Option<PathBuf>,
+    pub pdftoppm: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -58,15 +74,39 @@ pub struct PageCrop {
     pub height: i32,
 }
 
+impl PageCrop {
+    pub(crate) fn to_render_pixels(self) -> Self {
+        Self {
+            page: self.page,
+            left: scale_xml_to_render_px(self.left).max(0),
+            top: scale_xml_to_render_px(self.top).max(0),
+            width: scale_xml_to_render_px(self.width).max(1),
+            height: scale_xml_to_render_px(self.height).max(1),
+        }
+    }
+}
+
 impl PopplerTools {
     /// Locate the required poppler binaries or explain what is missing.
     pub fn discover() -> Result<Self, ToolError> {
         Ok(Self {
             pdftohtml: find_tool("pdftohtml")?,
             pdftotext: find_tool("pdftotext")?,
-            pdfimages: find_tool("pdfimages")?,
-            pdftoppm: find_tool("pdftoppm")?,
+            pdfimages: find_tool("pdfimages").ok(),
+            pdftoppm: find_tool("pdftoppm").ok(),
         })
+    }
+
+    fn pdfimages_path(&self) -> Result<&Path, ToolError> {
+        self.pdfimages
+            .as_deref()
+            .ok_or(ToolError::NotFound("pdfimages"))
+    }
+
+    fn pdftoppm_path(&self) -> Result<&Path, ToolError> {
+        self.pdftoppm
+            .as_deref()
+            .ok_or(ToolError::NotFound("pdftoppm"))
     }
 
     /// `pdftohtml -v` prints its version banner on stderr.
@@ -83,10 +123,18 @@ impl PopplerTools {
         let work_dir = scoped_temp_dir("bookforge-pdftohtml")?;
         let pdf = absolute_path(pdf)?;
         let mut command = Command::new(&self.pdftohtml);
-        command
-            .current_dir(&work_dir)
-            .args(["-xml", "-stdout", "-q", "-enc", "UTF-8", "-fmt", "png"])
-            .arg(pdf);
+        command.current_dir(&work_dir).args([
+            "-xml",
+            "-stdout",
+            "-q",
+            "-enc",
+            "UTF-8",
+            "-fmt",
+            "png",
+            "-zoom",
+            PDF_XML_ZOOM,
+        ]);
+        command.arg(pdf);
         let output = command_output(&mut command)?;
         let _ = fs::remove_dir_all(&work_dir);
         if !output.status.success() {
@@ -128,7 +176,7 @@ impl PopplerTools {
         }
 
         let root = output_dir.join("image");
-        let mut command = Command::new(&self.pdfimages);
+        let mut command = Command::new(self.pdfimages_path()?);
         command
             .args(["-png", "-p", "-print-filenames", "-q"])
             .arg(pdf)
@@ -151,26 +199,7 @@ impl PopplerTools {
             paths = extracted_image_paths(output_dir)?;
         }
         paths.sort();
-
-        Ok(paths
-            .into_iter()
-            .enumerate()
-            .map(|(index, path)| {
-                let listed = listed.get(index);
-                ExtractedImage {
-                    page: listed.map(|image| image.page).unwrap_or(0),
-                    index,
-                    width: listed.and_then(|image| image.width),
-                    height: listed.and_then(|image| image.height),
-                    extension: path
-                        .extension()
-                        .and_then(|ext| ext.to_str())
-                        .unwrap_or("png")
-                        .to_ascii_lowercase(),
-                    path,
-                }
-            })
-            .collect())
+        pair_extracted_images_with_list_rows(paths, &listed)
     }
 
     pub fn render_page_png(
@@ -182,7 +211,8 @@ impl PopplerTools {
         fs::create_dir_all(output_dir)?;
         let root = output_dir.join(format!("page-{page:04}"));
         let page_arg = page.to_string();
-        let mut command = Command::new(&self.pdftoppm);
+        let dpi_arg = PDF_RENDER_DPI.to_string();
+        let mut command = Command::new(self.pdftoppm_path()?);
         command
             .args([
                 "-f",
@@ -192,7 +222,7 @@ impl PopplerTools {
                 "-singlefile",
                 "-png",
                 "-r",
-                "150",
+                &dpi_arg,
             ])
             .arg(pdf)
             .arg(&root);
@@ -216,12 +246,14 @@ impl PopplerTools {
     ) -> Result<PathBuf, ToolError> {
         fs::create_dir_all(output_dir)?;
         let root = output_dir.join(name);
+        let crop = crop.to_render_pixels();
         let page_arg = crop.page.to_string();
         let left_arg = crop.left.to_string();
         let top_arg = crop.top.to_string();
         let width_arg = crop.width.to_string();
         let height_arg = crop.height.to_string();
-        let mut command = Command::new(&self.pdftoppm);
+        let dpi_arg = PDF_RENDER_DPI.to_string();
+        let mut command = Command::new(self.pdftoppm_path()?);
         command
             .args([
                 "-f",
@@ -231,7 +263,7 @@ impl PopplerTools {
                 "-singlefile",
                 "-png",
                 "-r",
-                "150",
+                &dpi_arg,
                 "-x",
                 &left_arg,
                 "-y",
@@ -255,7 +287,7 @@ impl PopplerTools {
     }
 
     fn list_images(&self, pdf: &Path) -> Result<Vec<ListedImage>, ToolError> {
-        let mut command = Command::new(&self.pdfimages);
+        let mut command = Command::new(self.pdfimages_path()?);
         command.args(["-list"]).arg(pdf);
         let output = command_output(&mut command)?;
         if !output.status.success() {
@@ -286,9 +318,284 @@ fn command_output(command: &mut Command) -> io::Result<Output> {
     command.output()
 }
 
-#[derive(Debug, Clone, Copy)]
+fn scale_xml_to_render_px(value: i32) -> i32 {
+    let numerator = value as i64 * PDF_RENDER_DPI as i64 * PDF_XML_ZOOM_DEN;
+    let denominator = PDF_POINTS_PER_INCH * PDF_XML_ZOOM_NUM;
+    ((numerator + denominator / 2) / denominator) as i32
+}
+
+#[derive(Debug)]
+struct PngImage {
+    width: u32,
+    height: u32,
+    color_type: u8,
+    bit_depth: u8,
+    bytes_per_pixel: usize,
+    pixels: Vec<u8>,
+}
+
+pub(crate) fn crop_png_to_file(
+    input: &Path,
+    crop: PageCrop,
+    output: &Path,
+) -> Result<(), ToolError> {
+    let image = read_png(input)?;
+    let left = (crop.left.max(0) as u32).min(image.width.saturating_sub(1));
+    let top = (crop.top.max(0) as u32).min(image.height.saturating_sub(1));
+    let right = left
+        .saturating_add(crop.width.max(1) as u32)
+        .min(image.width)
+        .max(left + 1);
+    let bottom = top
+        .saturating_add(crop.height.max(1) as u32)
+        .min(image.height)
+        .max(top + 1);
+    let width = right - left;
+    let height = bottom - top;
+    let row_stride = image.width as usize * image.bytes_per_pixel;
+    let crop_stride = width as usize * image.bytes_per_pixel;
+    let mut pixels = Vec::with_capacity(crop_stride * height as usize);
+    for row in top as usize..bottom as usize {
+        let start = row * row_stride + left as usize * image.bytes_per_pixel;
+        pixels.extend_from_slice(&image.pixels[start..start + crop_stride]);
+    }
+    write_png(
+        output,
+        width,
+        height,
+        image.color_type,
+        image.bit_depth,
+        image.bytes_per_pixel,
+        &pixels,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn write_solid_rgb_png(
+    output: &Path,
+    width: u32,
+    height: u32,
+    rgb: [u8; 3],
+) -> Result<(), ToolError> {
+    let mut pixels = Vec::with_capacity(width as usize * height as usize * 3);
+    for _ in 0..width as usize * height as usize {
+        pixels.extend_from_slice(&rgb);
+    }
+    write_png(output, width, height, 2, 8, 3, &pixels)
+}
+
+fn read_png(path: &Path) -> Result<PngImage, ToolError> {
+    let bytes = fs::read(path)?;
+    if bytes.len() < 8 || &bytes[..8] != b"\x89PNG\r\n\x1a\n" {
+        return Err(ToolError::UnsupportedPng(format!(
+            "{} is not a PNG file",
+            path.display()
+        )));
+    }
+
+    let mut offset = 8;
+    let mut width = None;
+    let mut height = None;
+    let mut bit_depth = None;
+    let mut color_type = None;
+    let mut idat = Vec::new();
+    while offset + 8 <= bytes.len() {
+        let length = u32::from_be_bytes(
+            bytes[offset..offset + 4]
+                .try_into()
+                .expect("slice length checked"),
+        ) as usize;
+        let kind = &bytes[offset + 4..offset + 8];
+        let data_start = offset + 8;
+        let data_end = data_start + length;
+        if data_end + 4 > bytes.len() {
+            return Err(ToolError::UnsupportedPng(format!(
+                "{} has a truncated chunk",
+                path.display()
+            )));
+        }
+        let data = &bytes[data_start..data_end];
+        match kind {
+            b"IHDR" => {
+                if data.len() != 13 {
+                    return Err(ToolError::UnsupportedPng("invalid IHDR length".to_string()));
+                }
+                width = Some(u32::from_be_bytes(
+                    data[0..4].try_into().expect("IHDR width"),
+                ));
+                height = Some(u32::from_be_bytes(
+                    data[4..8].try_into().expect("IHDR height"),
+                ));
+                bit_depth = Some(data[8]);
+                color_type = Some(data[9]);
+                if data[10] != 0 || data[11] != 0 || data[12] != 0 {
+                    return Err(ToolError::UnsupportedPng(
+                        "compressed, filtered, or interlaced variant is unsupported".to_string(),
+                    ));
+                }
+            }
+            b"IDAT" => idat.extend_from_slice(data),
+            b"IEND" => break,
+            _ => {}
+        }
+        offset = data_end + 4;
+    }
+
+    let width = width.ok_or_else(|| ToolError::UnsupportedPng("missing IHDR".to_string()))?;
+    let height = height.ok_or_else(|| ToolError::UnsupportedPng("missing IHDR".to_string()))?;
+    let bit_depth = bit_depth.unwrap_or_default();
+    let color_type = color_type.unwrap_or_default();
+    if bit_depth != 8 {
+        return Err(ToolError::UnsupportedPng(format!(
+            "bit depth {bit_depth} is unsupported"
+        )));
+    }
+    let bytes_per_pixel = match color_type {
+        0 => 1,
+        2 => 3,
+        4 => 2,
+        6 => 4,
+        other => {
+            return Err(ToolError::UnsupportedPng(format!(
+                "color type {other} is unsupported"
+            )));
+        }
+    };
+    let mut decoder = ZlibDecoder::new(idat.as_slice());
+    let mut inflated = Vec::new();
+    decoder.read_to_end(&mut inflated)?;
+    let row_stride = width as usize * bytes_per_pixel;
+    let expected = (row_stride + 1) * height as usize;
+    if inflated.len() != expected {
+        return Err(ToolError::UnsupportedPng(format!(
+            "inflated data length {} did not match expected {expected}",
+            inflated.len()
+        )));
+    }
+
+    let mut pixels = vec![0; row_stride * height as usize];
+    for row in 0..height as usize {
+        let raw_offset = row * (row_stride + 1);
+        let filter = inflated[raw_offset];
+        let raw = &inflated[raw_offset + 1..raw_offset + 1 + row_stride];
+        let out_offset = row * row_stride;
+        for column in 0..row_stride {
+            let a = if column >= bytes_per_pixel {
+                pixels[out_offset + column - bytes_per_pixel]
+            } else {
+                0
+            };
+            let b = if row > 0 {
+                pixels[out_offset + column - row_stride]
+            } else {
+                0
+            };
+            let c = if row > 0 && column >= bytes_per_pixel {
+                pixels[out_offset + column - row_stride - bytes_per_pixel]
+            } else {
+                0
+            };
+            let predictor = match filter {
+                0 => 0,
+                1 => a,
+                2 => b,
+                3 => ((a as u16 + b as u16) / 2) as u8,
+                4 => paeth(a, b, c),
+                other => {
+                    return Err(ToolError::UnsupportedPng(format!(
+                        "filter type {other} is unsupported"
+                    )));
+                }
+            };
+            pixels[out_offset + column] = raw[column].wrapping_add(predictor);
+        }
+    }
+
+    Ok(PngImage {
+        width,
+        height,
+        color_type,
+        bit_depth,
+        bytes_per_pixel,
+        pixels,
+    })
+}
+
+fn write_png(
+    path: &Path,
+    width: u32,
+    height: u32,
+    color_type: u8,
+    bit_depth: u8,
+    bytes_per_pixel: usize,
+    pixels: &[u8],
+) -> Result<(), ToolError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let row_stride = width as usize * bytes_per_pixel;
+    if pixels.len() != row_stride * height as usize {
+        return Err(ToolError::UnsupportedPng(
+            "pixel buffer length did not match PNG dimensions".to_string(),
+        ));
+    }
+    let mut filtered = Vec::with_capacity((row_stride + 1) * height as usize);
+    for row in 0..height as usize {
+        filtered.push(0);
+        let start = row * row_stride;
+        filtered.extend_from_slice(&pixels[start..start + row_stride]);
+    }
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&filtered)?;
+    let compressed = encoder.finish()?;
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"\x89PNG\r\n\x1a\n");
+    let mut ihdr = Vec::with_capacity(13);
+    ihdr.extend_from_slice(&width.to_be_bytes());
+    ihdr.extend_from_slice(&height.to_be_bytes());
+    ihdr.push(bit_depth);
+    ihdr.push(color_type);
+    ihdr.extend_from_slice(&[0, 0, 0]);
+    write_chunk(&mut bytes, b"IHDR", &ihdr);
+    write_chunk(&mut bytes, b"IDAT", &compressed);
+    write_chunk(&mut bytes, b"IEND", &[]);
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn write_chunk(output: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) {
+    output.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    output.extend_from_slice(kind);
+    output.extend_from_slice(data);
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(kind);
+    hasher.update(data);
+    output.extend_from_slice(&hasher.finalize().to_be_bytes());
+}
+
+fn paeth(a: u8, b: u8, c: u8) -> u8 {
+    let a = a as i32;
+    let b = b as i32;
+    let c = c as i32;
+    let p = a + b - c;
+    let pa = (p - a).abs();
+    let pb = (p - b).abs();
+    let pc = (p - c).abs();
+    if pa <= pb && pa <= pc {
+        a as u8
+    } else if pb <= pc {
+        b as u8
+    } else {
+        c as u8
+    }
+}
+
+#[derive(Debug, Clone)]
 struct ListedImage {
+    num: usize,
     page: u32,
+    kind: String,
     width: Option<u32>,
     height: Option<u32>,
 }
@@ -299,18 +606,76 @@ fn parse_pdfimages_list(output: &str) -> Vec<ListedImage> {
         .filter_map(|line| {
             let columns = line.split_whitespace().collect::<Vec<_>>();
             let page = columns.first()?.parse::<u32>().ok()?;
-            if columns.get(2) != Some(&"image") {
-                return None;
-            }
+            let num = columns.get(1)?.parse::<usize>().ok()?;
+            let kind = columns.get(2)?.to_string();
             let width = columns.get(3).and_then(|value| value.parse::<u32>().ok());
             let height = columns.get(4).and_then(|value| value.parse::<u32>().ok());
             Some(ListedImage {
+                num,
                 page,
+                kind,
                 width,
                 height,
             })
         })
         .collect()
+}
+
+fn pair_extracted_images_with_list_rows(
+    paths: Vec<PathBuf>,
+    listed: &[ListedImage],
+) -> Result<Vec<ExtractedImage>, ToolError> {
+    if paths.len() != listed.len() {
+        return Err(ToolError::ImageListMismatch(format!(
+            "{} emitted file(s), {} listed row(s)",
+            paths.len(),
+            listed.len()
+        )));
+    }
+
+    let listed_by_num = listed
+        .iter()
+        .map(|image| (image.num, image))
+        .collect::<HashMap<_, _>>();
+    let mut images = Vec::new();
+    for path in paths {
+        let num = image_file_index(&path).ok_or_else(|| {
+            ToolError::ImageListMismatch(format!(
+                "could not parse image index from {}",
+                path.display()
+            ))
+        })?;
+        let listed = listed_by_num.get(&num).ok_or_else(|| {
+            ToolError::ImageListMismatch(format!(
+                "emitted file {} has no -list row for num {num}",
+                path.display()
+            ))
+        })?;
+        if listed.kind != "image" {
+            continue;
+        }
+        let index = images.len();
+        images.push(ExtractedImage {
+            page: listed.page,
+            index,
+            width: listed.width,
+            height: listed.height,
+            extension: path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or("png")
+                .to_ascii_lowercase(),
+            path,
+        });
+    }
+    Ok(images)
+}
+
+fn image_file_index(path: &Path) -> Option<usize> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.rsplit('-').next())
+        .and_then(|index| index.parse::<usize>().ok())
 }
 
 fn extracted_image_paths(output_dir: &Path) -> Result<Vec<PathBuf>, ToolError> {
@@ -335,7 +700,7 @@ fn absolute_path(path: &Path) -> Result<PathBuf, ToolError> {
     Ok(std::env::current_dir()?.join(path))
 }
 
-fn scoped_temp_dir(prefix: &str) -> Result<PathBuf, ToolError> {
+pub(crate) fn scoped_temp_dir(prefix: &str) -> Result<PathBuf, ToolError> {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
@@ -385,8 +750,96 @@ mod tests {
 "#,
         );
 
-        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].page, 1);
+        assert_eq!(rows[0].num, 0);
+        assert_eq!(rows[0].kind, "image");
         assert_eq!(rows[0].width, Some(640));
+        assert_eq!(rows[1].page, 3);
+        assert_eq!(rows[1].num, 1);
+        assert_eq!(rows[1].kind, "smask");
+    }
+
+    #[test]
+    fn pairs_pdfimages_files_by_num_before_discarding_masks() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let image = dir.path().join("image-000-000.png");
+        let mask = dir.path().join("image-000-001.png");
+        let second = dir.path().join("image-000-002.png");
+        let rows = vec![
+            ListedImage {
+                num: 0,
+                page: 1,
+                kind: "image".to_string(),
+                width: Some(120),
+                height: Some(80),
+            },
+            ListedImage {
+                num: 1,
+                page: 1,
+                kind: "smask".to_string(),
+                width: Some(120),
+                height: Some(80),
+            },
+            ListedImage {
+                num: 2,
+                page: 4,
+                kind: "image".to_string(),
+                width: Some(300),
+                height: Some(100),
+            },
+        ];
+
+        let paired =
+            pair_extracted_images_with_list_rows(vec![image, mask, second], &rows).expect("paired");
+
+        assert_eq!(paired.len(), 2);
+        assert_eq!(paired[0].page, 1);
+        assert_eq!(paired[0].width, Some(120));
+        assert_eq!(paired[1].page, 4);
+        assert_eq!(paired[1].width, Some(300));
+    }
+
+    #[test]
+    fn scales_pdftohtml_xml_crop_units_to_render_pixels() {
+        let crop = PageCrop {
+            page: 2,
+            left: 72,
+            top: 108,
+            width: 216,
+            height: 54,
+        }
+        .to_render_pixels();
+
+        assert_eq!(crop.left, 100);
+        assert_eq!(crop.top, 150);
+        assert_eq!(crop.width, 300);
+        assert_eq!(crop.height, 75);
+    }
+
+    #[test]
+    fn crops_png_pixels_locally() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let full = dir.path().join("full.png");
+        let cropped = dir.path().join("cropped.png");
+        write_solid_rgb_png(&full, 20, 20, [12, 34, 56]).expect("png writes");
+
+        crop_png_to_file(
+            &full,
+            PageCrop {
+                page: 1,
+                left: 5,
+                top: 6,
+                width: 7,
+                height: 8,
+            },
+            &cropped,
+        )
+        .expect("crop writes");
+
+        let image = read_png(&cropped).expect("cropped png reads");
+        assert_eq!(image.width, 7);
+        assert_eq!(image.height, 8);
+        assert_eq!(image.pixels[..3], [12, 34, 56]);
     }
 }

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -48,6 +48,15 @@ pub struct ExtractedImage {
     pub extension: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageCrop {
+    pub page: u32,
+    pub left: i32,
+    pub top: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
 impl PopplerTools {
     /// Locate the required poppler binaries or explain what is missing.
     pub fn discover() -> Result<Self, ToolError> {
@@ -180,6 +189,52 @@ impl PopplerTools {
                 "-png",
                 "-r",
                 "150",
+            ])
+            .arg(pdf)
+            .arg(&root)
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdftoppm",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        Ok(root.with_extension("png"))
+    }
+
+    pub fn render_page_crop_png(
+        &self,
+        pdf: &Path,
+        crop: PageCrop,
+        output_dir: &Path,
+        name: &str,
+    ) -> Result<PathBuf, ToolError> {
+        fs::create_dir_all(output_dir)?;
+        let root = output_dir.join(name);
+        let page_arg = crop.page.to_string();
+        let left_arg = crop.left.to_string();
+        let top_arg = crop.top.to_string();
+        let width_arg = crop.width.to_string();
+        let height_arg = crop.height.to_string();
+        let output = Command::new(&self.pdftoppm)
+            .args([
+                "-f",
+                &page_arg,
+                "-l",
+                &page_arg,
+                "-singlefile",
+                "-png",
+                "-r",
+                "150",
+                "-x",
+                &left_arg,
+                "-y",
+                &top_arg,
+                "-W",
+                &width_arg,
+                "-H",
+                &height_arg,
             ])
             .arg(pdf)
             .arg(&root)

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -6,8 +6,10 @@
 //! are acceptable, embedded runtimes are not.
 
 use std::{
+    fs,
     path::{Path, PathBuf},
     process::Command,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -32,6 +34,17 @@ pub enum ToolError {
 pub struct PopplerTools {
     pub pdftohtml: PathBuf,
     pub pdftotext: PathBuf,
+    pub pdfimages: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtractedImage {
+    pub page: u32,
+    pub index: usize,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub path: PathBuf,
+    pub extension: String,
 }
 
 impl PopplerTools {
@@ -40,6 +53,7 @@ impl PopplerTools {
         Ok(Self {
             pdftohtml: find_tool("pdftohtml")?,
             pdftotext: find_tool("pdftotext")?,
+            pdfimages: find_tool("pdfimages")?,
         })
     }
 
@@ -52,10 +66,14 @@ impl PopplerTools {
 
     /// Run `pdftohtml -xml` and return the XML document.
     pub fn pdf_to_xml(&self, pdf: &Path) -> Result<String, ToolError> {
+        let work_dir = scoped_temp_dir("bookforge-pdftohtml")?;
+        let pdf = absolute_path(pdf)?;
         let output = Command::new(&self.pdftohtml)
-            .args(["-xml", "-i", "-stdout", "-q", "-enc", "UTF-8"])
+            .current_dir(&work_dir)
+            .args(["-xml", "-stdout", "-q", "-enc", "UTF-8", "-fmt", "png"])
             .arg(pdf)
             .output()?;
+        let _ = fs::remove_dir_all(&work_dir);
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdftohtml",
@@ -84,6 +102,138 @@ impl PopplerTools {
         }
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }
+
+    pub fn extract_images(
+        &self,
+        pdf: &Path,
+        output_dir: &Path,
+    ) -> Result<Vec<ExtractedImage>, ToolError> {
+        fs::create_dir_all(output_dir)?;
+        let listed = self.list_images(pdf)?;
+        if listed.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let root = output_dir.join("image");
+        let output = Command::new(&self.pdfimages)
+            .args(["-png", "-p", "-print-filenames", "-q"])
+            .arg(pdf)
+            .arg(&root)
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdfimages",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+
+        let mut paths = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|line| PathBuf::from(line.trim()))
+            .filter(|path| !path.as_os_str().is_empty())
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
+            paths = extracted_image_paths(output_dir)?;
+        }
+        paths.sort();
+
+        Ok(paths
+            .into_iter()
+            .enumerate()
+            .map(|(index, path)| {
+                let listed = listed.get(index);
+                ExtractedImage {
+                    page: listed.map(|image| image.page).unwrap_or(0),
+                    index,
+                    width: listed.and_then(|image| image.width),
+                    height: listed.and_then(|image| image.height),
+                    extension: path
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .unwrap_or("png")
+                        .to_ascii_lowercase(),
+                    path,
+                }
+            })
+            .collect())
+    }
+
+    fn list_images(&self, pdf: &Path) -> Result<Vec<ListedImage>, ToolError> {
+        let output = Command::new(&self.pdfimages)
+            .args(["-list"])
+            .arg(pdf)
+            .output()?;
+        if !output.status.success() {
+            return Err(ToolError::Failed {
+                tool: "pdfimages",
+                code: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        Ok(parse_pdfimages_list(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ListedImage {
+    page: u32,
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+fn parse_pdfimages_list(output: &str) -> Vec<ListedImage> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let columns = line.split_whitespace().collect::<Vec<_>>();
+            let page = columns.first()?.parse::<u32>().ok()?;
+            if columns.get(2) != Some(&"image") {
+                return None;
+            }
+            let width = columns.get(3).and_then(|value| value.parse::<u32>().ok());
+            let height = columns.get(4).and_then(|value| value.parse::<u32>().ok());
+            Some(ListedImage {
+                page,
+                width,
+                height,
+            })
+        })
+        .collect()
+}
+
+fn extracted_image_paths(output_dir: &Path) -> Result<Vec<PathBuf>, ToolError> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(output_dir)? {
+        let path = entry?.path();
+        let is_image = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| matches!(ext.to_ascii_lowercase().as_str(), "png" | "jpg" | "jpeg"));
+        if is_image {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf, ToolError> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()?.join(path))
+}
+
+fn scoped_temp_dir(prefix: &str) -> Result<PathBuf, ToolError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let path = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+    fs::create_dir_all(&path)?;
+    Ok(path)
 }
 
 fn find_tool(name: &'static str) -> Result<PathBuf, ToolError> {
@@ -110,4 +260,24 @@ fn find_tool(name: &'static str) -> Result<PathBuf, ToolError> {
     }
 
     Err(ToolError::NotFound(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pdfimages_list_rows() {
+        let rows = parse_pdfimages_list(
+            r#"page   num  type   width height color comp bpc  enc interp  object ID x-ppi y-ppi size ratio
+--------------------------------------------------------------------------------------------
+   1     0 image     640   480  rgb     3   8  image  no        12  0    72    72  12K 2.0%
+   3     1 smask     120    80  gray    1   8  image  no        13  0    72    72  1K  1.0%
+"#,
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].page, 1);
+        assert_eq!(rows[0].width, Some(640));
+    }
 }

--- a/crates/bookforge-pdf/src/tools.rs
+++ b/crates/bookforge-pdf/src/tools.rs
@@ -6,10 +6,11 @@
 //! are acceptable, embedded runtimes are not.
 
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
-    process::Command,
-    time::{SystemTime, UNIX_EPOCH},
+    process::{Command, Output},
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -70,7 +71,9 @@ impl PopplerTools {
 
     /// `pdftohtml -v` prints its version banner on stderr.
     pub fn version(&self) -> Option<String> {
-        let output = Command::new(&self.pdftohtml).arg("-v").output().ok()?;
+        let mut command = Command::new(&self.pdftohtml);
+        command.arg("-v");
+        let output = command_output(&mut command).ok()?;
         let banner = String::from_utf8_lossy(&output.stderr);
         banner.lines().next().map(|line| line.trim().to_string())
     }
@@ -79,11 +82,12 @@ impl PopplerTools {
     pub fn pdf_to_xml(&self, pdf: &Path) -> Result<String, ToolError> {
         let work_dir = scoped_temp_dir("bookforge-pdftohtml")?;
         let pdf = absolute_path(pdf)?;
-        let output = Command::new(&self.pdftohtml)
+        let mut command = Command::new(&self.pdftohtml);
+        command
             .current_dir(&work_dir)
             .args(["-xml", "-stdout", "-q", "-enc", "UTF-8", "-fmt", "png"])
-            .arg(pdf)
-            .output()?;
+            .arg(pdf);
+        let output = command_output(&mut command)?;
         let _ = fs::remove_dir_all(&work_dir);
         if !output.status.success() {
             return Err(ToolError::Failed {
@@ -99,11 +103,9 @@ impl PopplerTools {
     /// no layout decisions, so its character count approximates "all the
     /// text poppler can see".
     pub fn pdf_to_text(&self, pdf: &Path) -> Result<String, ToolError> {
-        let output = Command::new(&self.pdftotext)
-            .args(["-enc", "UTF-8", "-q"])
-            .arg(pdf)
-            .arg("-")
-            .output()?;
+        let mut command = Command::new(&self.pdftotext);
+        command.args(["-enc", "UTF-8", "-q"]).arg(pdf).arg("-");
+        let output = command_output(&mut command)?;
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdftotext",
@@ -126,11 +128,12 @@ impl PopplerTools {
         }
 
         let root = output_dir.join("image");
-        let output = Command::new(&self.pdfimages)
+        let mut command = Command::new(&self.pdfimages);
+        command
             .args(["-png", "-p", "-print-filenames", "-q"])
             .arg(pdf)
-            .arg(&root)
-            .output()?;
+            .arg(&root);
+        let output = command_output(&mut command)?;
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdfimages",
@@ -179,7 +182,8 @@ impl PopplerTools {
         fs::create_dir_all(output_dir)?;
         let root = output_dir.join(format!("page-{page:04}"));
         let page_arg = page.to_string();
-        let output = Command::new(&self.pdftoppm)
+        let mut command = Command::new(&self.pdftoppm);
+        command
             .args([
                 "-f",
                 &page_arg,
@@ -191,8 +195,8 @@ impl PopplerTools {
                 "150",
             ])
             .arg(pdf)
-            .arg(&root)
-            .output()?;
+            .arg(&root);
+        let output = command_output(&mut command)?;
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdftoppm",
@@ -217,7 +221,8 @@ impl PopplerTools {
         let top_arg = crop.top.to_string();
         let width_arg = crop.width.to_string();
         let height_arg = crop.height.to_string();
-        let output = Command::new(&self.pdftoppm)
+        let mut command = Command::new(&self.pdftoppm);
+        command
             .args([
                 "-f",
                 &page_arg,
@@ -237,8 +242,8 @@ impl PopplerTools {
                 &height_arg,
             ])
             .arg(pdf)
-            .arg(&root)
-            .output()?;
+            .arg(&root);
+        let output = command_output(&mut command)?;
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdftoppm",
@@ -250,10 +255,9 @@ impl PopplerTools {
     }
 
     fn list_images(&self, pdf: &Path) -> Result<Vec<ListedImage>, ToolError> {
-        let output = Command::new(&self.pdfimages)
-            .args(["-list"])
-            .arg(pdf)
-            .output()?;
+        let mut command = Command::new(&self.pdfimages);
+        command.args(["-list"]).arg(pdf);
+        let output = command_output(&mut command)?;
         if !output.status.success() {
             return Err(ToolError::Failed {
                 tool: "pdfimages",
@@ -265,6 +269,21 @@ impl PopplerTools {
             &output.stdout,
         )))
     }
+}
+
+fn command_output(command: &mut Command) -> io::Result<Output> {
+    let mut delay = Duration::from_millis(5);
+    for attempt in 0..4 {
+        match command.output() {
+            Ok(output) => return Ok(output),
+            Err(err) if err.raw_os_error() == Some(26) && attempt < 3 => {
+                thread::sleep(delay);
+                delay *= 2;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    command.output()
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/docs/codex-handoff-2026-07-02.md
+++ b/docs/codex-handoff-2026-07-02.md
@@ -281,6 +281,94 @@ step below, not just more stub tests.
 3. Text-only degraded mode: rename pdfimages away, convert a text PDF,
    confirm an EPUB is still produced with a warning.
 
+## Task 5 (added 2026-07-03) — heuristic fixes from the real BERT acceptance run
+
+Task 4 shipped and was verified end-to-end against arXiv 1810.04805 with
+real poppler (commit 682aa8f): crop geometry, coverage crediting, and the
+degraded text-only mode are all confirmed good. The visual read-through
+found three remaining heuristic problems. The test PDF is available at
+`/tmp/claude-1000/-home-junjo-Desktop-tRustTheProcess/0e5a3f15-2fec-4135-967b-aea61ff5e4d7/scratchpad/bert.pdf`
+(775166 bytes, 16 pages, A4) — use it for the acceptance re-run; if
+unreadable from the sandbox, distill XML fixtures from it as before.
+
+### 5.1 Vector-figure regions are too greedy (page 16 evidence)
+
+`pdf-figure-0005.png` captured the intended chart (bottom-left column,
+"MNLI Dev Accuracy" plot) PLUS the section heading "C.2 Ablation for
+Different Masking Procedures" and full paragraphs from BOTH text columns.
+Those paragraphs (one of 119 chars) were then removed as "preserved as
+image" — translatable prose became untranslatable pixels. The audit
+warnings from Task 4 itemize exactly which text was absorbed (grep the
+convert output for "preserved as image").
+
+Fix direction, in `vector_figure_regions` / region growth:
+- Build the region from the chart-label fragments and drawn-graphic
+  extents only; do not let caption width or the 360px lookback drag in
+  full-width bands.
+- On pages detected as two-column (`two_column` per-page stat already
+  exists), clamp the region horizontally to the column that contains the
+  labels' centroid.
+- Never absorb prose-like fragments into a region: a fragment with (say)
+  > 6 words and sentence punctuation is prose; if it would fall inside a
+  candidate region, shrink the region below it rather than swallow it.
+  If shrinking is impossible, keep the block as text and warn — for a
+  translation tool, wrongly-imaged prose is worse than a slightly
+  cropped chart.
+
+### 5.2 Table/equation detectors fire inside figures
+
+Evidence: `pdf-table-0007.png` and `pdf-table-0008.png` are horizontal
+strips sliced out of Figure 1's diagram (aligned E_[CLS]/E_1/…/E_N token
+boxes read as "aligned numeric cells"); the single equation crop
+`pdf-equation-0001.png` is actually the table header cell "MNLI-(m/mm)
+392k" — no display equation at all.
+
+Fix direction:
+- Exclude any row/fragment that intersects an extracted-image region or
+  a detected figure region from table and equation candidacy — media
+  regions must be disjoint by construction (one classification per area,
+  figures win over tables over equations).
+- Investigate which gate admitted "MNLI-(m/mm)": determine what counted
+  as the strong operator ('/'? '-'?) and tighten `has_strong_operator`
+  to genuine relational/aggregation operators (=, <, >, ≤, ≥, ∑, ∫, …) —
+  not slashes, hyphens, or parens. Add "MNLI-(m/mm) 392k" as a negative
+  fixture.
+- Diagram token rows: add the Figure 1 strip as a negative fixture for
+  the table detector (distill from the BERT XML).
+
+### 5.3 Cluster diagram sub-images into one figure
+
+The paper's ~5 real figures became 52 figure blocks because each vector
+diagram is drawn with many small raster XObjects (38 extracted images:
+arrows, ellipsis dots, colored boxes — see `pdf-image-0035.png`, a strip
+of ellipses). Each currently becomes its own Figure block in the reading
+flow.
+
+Fix direction:
+- Cluster image regions on the same page whose rects overlap or sit
+  within ~24 XML units of each other into one composite region; render
+  ONE crop for the cluster (the padded union rect) and emit ONE figure
+  block.
+- If a cluster (or single image) falls inside an already-detected
+  vector-figure region, it is part of that figure — drop it, don't emit
+  it separately.
+- Keep the Task 4 decorative/repeated-raster filtering for what remains.
+
+### Acceptance for task 5 (blocking)
+
+1. Unit fixtures: page-16 two-column chart (region must exclude both
+   prose columns), Figure 1 token-row strip (not a table), "MNLI-(m/mm)
+   392k" (not an equation), and a multi-raster diagram page (one figure
+   block out).
+2. Re-run the BERT conversion (command as in Task 4 acceptance): report
+   must show roughly 5-8 figure blocks (not 52), tables only for the real
+   tables, no equation crops unless a real display equation is found, and
+   no "preserved as image" warning containing a prose paragraph (> ~60
+   chars with sentence punctuation) — chart labels and captions are fine.
+3. Full workspace check/test/clippy/fmt clean. Commit in logical units.
+   Claude does the final visual pass on the crops before the PR leaves
+   draft.
+
 ## Verification expectations (all tasks)
 
 - `cargo check --workspace --all-features`, `cargo test --workspace`,

--- a/docs/codex-handoff-2026-07-02.md
+++ b/docs/codex-handoff-2026-07-02.md
@@ -369,6 +369,56 @@ Fix direction:
    Claude does the final visual pass on the crops before the PR leaves
    draft.
 
+## Task 6 (added 2026-07-03) — cosmetic crop polish (final v1.6 pass)
+
+Task 5 verified good end-to-end (BERT: figures 52→11, no prose imaged;
+Fisher's Acid Communism 100% clean; Flatline Constructs 99.3% with correct
+spread reading order). Three cosmetic items remain from the visual pass —
+none lose text, all are crop-quality. Fix on `v1.6-pdf-hardening`.
+
+### 6.1 Clamp table regions to their column
+
+Table crops on two-column pages span the full page width, pulling the
+neighboring column's content into the image (BERT `pdf-table-0002.png`
+mixes two different tables; `pdf-table-0005.png` shows body prose from
+the other column). Apply the same column-clamping Task 5.1 added for
+vector figures: clamp the table region horizontally to the column
+containing the tableish rows. The neighboring text is NOT removed from
+the flow (coverage unaffected) — this is purely about the crop rect.
+
+### 6.2 Shrink vector-figure crops above prose
+
+The page-16 chart crop (`pdf-figure-0009.png`) still *shows* the section
+heading and intro paragraph above the chart (the text correctly stays in
+the flow, so it appears twice: once as pixels, once as text). Task 5.1
+stopped absorbing prose into the region for removal purposes; also shrink
+the crop rect itself: the region's top should start at the topmost
+chart-label/graphic fragment, not at prose above it.
+
+### 6.3 Include outermost sub-images in cluster unions
+
+Two BERT diagrams are clipped at the edges: `pdf-figure-0006.png` loses
+Figure 2's leftmost token column, `pdf-figure-0007.png` loses Figure 3's
+third panel (ELMo). Likely the outermost raster sub-images fall outside
+the cluster distance threshold or land in a second cluster that then gets
+dropped/merged wrong. Diagnose against the BERT XML (pages 3 and 13-ish);
+fix so a diagram's full horizontal extent is covered — consider unioning
+clusters whose rects vertically overlap on the same page.
+
+### Acceptance for task 6 (blocking)
+
+1. BERT re-run: table crops contain a single column's content; the
+   page-16 figure crop starts at the chart (no heading/prose visible);
+   Figures 2 and 3 crops show the complete diagrams (all panels/columns).
+   Counts stay in the Task 5 ranges (figures ~5-11, tables ~6, 0
+   equations) and coverage stays 100.0%.
+2. Fisher regression: converting `test/Acid_Communism.pdf` and
+   `test/Flatline_Constructs.pdf` yields coverage >= the current values
+   (100.0% / 99.3%) with no new warnings.
+3. Full workspace check/test/clippy/fmt clean; fixtures for 6.1-6.3 where
+   distillable. Commit in logical units; do not push; PR #22 stays as-is
+   (already ready) — Claude re-verifies visually before pushing.
+
 ## Verification expectations (all tasks)
 
 - `cargo check --workspace --all-features`, `cargo test --workspace`,

--- a/docs/codex-handoff-2026-07-02.md
+++ b/docs/codex-handoff-2026-07-02.md
@@ -1,0 +1,288 @@
+# Handoff to Codex — 2026-07-02
+
+Written by Claude Code on behalf of the maintainer. Four tasks. Order:
+task 1 (commit/release) first, then task 1b (translated-book whitespace
+bug — **the maintainer's top bug**), then 2 and 3. Task 1 must land before
+task 3 starts (task 3 creates a lot of new diff and the in-flight work
+should not be tangled into it). Task 1b is a real output-quality bug and
+may justify folding into the v2.0.3 release or a fast-follow v2.0.4.
+
+Ground rules (from `docs/ROADMAP.md` §1, non-negotiable):
+
+- The LLM never sees or produces raw XHTML/PDF structure — only validated
+  JSON prose payloads. Reassembly is deterministic pure code.
+- No dependencies that break single-static-binary distribution.
+- CLI flags and JSONL event fields follow semver within a major line.
+
+---
+
+## Task 1 — Commit the in-flight work, cut v2.0.3
+
+The working tree currently has two independent, finished changes. Commit
+them as **separate commits**:
+
+1. **Broken-pipe / CLI-parse hardening** — `crates/bookforge-cli/src/main.rs`
+   and `crates/bookforge-cli/src/progress.rs`. Adds `parse_cli()` with
+   broken-pipe-tolerant error printing, `write_default_help()`, and
+   `is_broken_pipe()`, plus tests. Also the `docs/ROADMAP.md` update
+   (status header + v2.0 row) can ride with this or go in its own
+   `docs:` commit.
+2. **Dashboard library-layout fix** — `crates/bookforge-cli/src/commands/serve.rs`,
+   three CSS changes already made:
+   - `.book-grid` → `repeat(auto-fill,minmax(320px,1fr))` (was rigid `1fr 1fr`)
+   - `.pagehead` → added `flex-wrap:wrap`
+   - `.add-card` → `min-height:112px` (was 140px, mismatched book-card height)
+
+Verify before committing: `cargo check -p bookforge-cli --all-features`
+(already passing) and `cargo test -p bookforge-cli`.
+
+Then cut a patch release. Release process for this repo:
+
+- `cargo set-version --workspace 2.0.3` (workspace version bump)
+- Update `CHANGELOG.md` following its existing format
+- Commit as `chore(release): v2.0.3` (see `git log` for precedent)
+- Tag `v2.0.3` and push the tag — **the tag push triggers cargo-dist CI**,
+  which builds and publishes the release artifacts. No manual release steps.
+
+Fold task 2 into this release if you do task 2 first; otherwise v2.0.3 with
+tasks 1's content is fine and task 2 can wait for the next patch.
+
+## Task 1b — Fix whitespace loss at inline-marker boundaries (translated EPUBs)
+
+**Symptom (maintainer report: "translated book layout seems odd sometimes").**
+In translated output, words glue together across inline formatting
+boundaries — e.g. the source `…let's head to</span> <span><i>Thanatos</i>`
+becomes `…verso<span><i>Thanatos</i>` (no space, renders as
+"versoThanatos"). The inverse also appears: a trailing space kept inside
+`<i>…Culture </i>` followed by LLM-placed punctuation yields "Culture ,".
+
+**Measured repro.** Source `~/Downloads/CCRU_Abstract_Culture_2024.epub`
+vs its translation
+`~/Downloads/Telegram Desktop/ccru-abstract-culture-2024.it.deepseek-v4-flash.epub`.
+Unzip both; count glued inline boundaries with:
+
+```
+grep -oE "[a-zàèéìòù]</span><span[^>]*>(<i[^>]*>)?[A-Za-zÀ-ù]" <dir>/index_split_*.html | wc -l
+```
+
+Source: 1 hit. Translation: **47 hits**. Paragraph counts per file match
+exactly (structure preservation is working; only inter-marker whitespace
+is lost).
+
+**Root cause.** `crates/bookforge-epub/src/reader.rs`,
+`BlockBuilder::push_text` (~line 753): a whitespace-only text node
+between two inline elements is not emitted as its own run *between* the
+marker tokens — instead the fallback appends a space to the last
+non-marker run, i.e. **inside** the preceding marker span. The marked
+text sent to the model becomes `…verso </m5><m6>…`; models routinely trim
+trailing whitespace before a closing marker, and the writer
+(`render_marked_translation`, `crates/bookforge-epub/src/writer.rs:568`)
+reassembles exactly what the model returned, so the word boundary is gone.
+
+**Fix direction (both halves, belt and suspenders):**
+
+1. Reader: emit the separating space as its own text run positioned
+   *between* the two marker tokens (`</m5> <m6>`) instead of appending it
+   inside the previous span.
+2. Writer: deterministic guard after reassembly — for each adjacent
+   inline-element boundary that had intervening whitespace in the original
+   events, if the rendered translation butts a word character directly
+   against that boundary, reinsert a single space. This protects against
+   the model eating the space regardless of where the reader puts it.
+
+Cache note: if the reader change alters the marked text sent to the model,
+it changes prompt payloads — check whether `CACHE_KEY_SCHEMA_VERSION` /
+prompt-contract versioning (ROADMAP §1.3) needs a bump per the project's
+own rules.
+
+**Acceptance:** unit tests in bookforge-epub covering `a</span> <span>b`,
+`a</i> <i>b`, and `&nbsp;`-only nodes round-tripping with a mock
+translation that strips marker-adjacent whitespace; re-translating the
+CCRU book (or a fixture distilled from it) produces a glued-boundary
+count comparable to the source. Existing tests stay green.
+
+**Related but separate (do NOT fix here):** the CCRU source is a
+PDF-conversion EPUB where every printed *line* is its own `<p>`, so the
+translation inherits English line-lengths and reads ragged in Italian
+(mid-clause paragraph breaks). That is structure-faithful behavior, not a
+bug; the fix is an opt-in reflow/paragraph-merge pass and belongs in the
+v1.6 design discussion (task 3) — raise it there with the maintainer
+before implementing anything.
+
+## Task 2 — Responsive sweep over the remaining dashboard grids
+
+The dashboard is a single embedded HTML/CSS/JS string in
+`crates/bookforge-cli/src/commands/serve.rs` (CSS starts ~line 1229).
+It has **zero `@media` queries**. The library grid is fixed (task 1),
+but these are still rigid and cramp on narrow windows:
+
+- `serve.rs:1388` `.stat-grid` — `repeat(4,1fr)` (progress screen stats)
+- `serve.rs:1345` `.facts` — `1fr 1fr` (wizard review step)
+- `serve.rs:1356` `.adv-grid` — `1fr 1fr` (wizard advanced options)
+- `serve.rs:1363` `.modelcards` — `1fr 1fr` (wizard model picker)
+- `serve.rs:1302-1303` `.wiz` / `.rail` — fixed 236px side rail; below
+  ~700px the wizard panel gets too narrow. Stack the rail on top
+  (or collapse it) under a breakpoint.
+
+Approach: prefer `repeat(auto-fill,minmax(<sane-min>,1fr))` where the
+children are uniform cards (stat tiles ~150px min, model cards ~220px min);
+use one `@media (max-width:~720px)` block for the wizard rail and anything
+auto-fill can't express. Match the existing CSS style exactly: single-line
+rules, no spaces after `:` or `,`, CSS variables from the `:root` block.
+
+Verify visually: `cargo run -p bookforge-cli --features serve -- serve`,
+open the printed URL, and check library/wizard/progress screens at full
+width and at a ~500px-wide window. The wizard and progress screens are
+reachable without running a real job (progress needs an existing job in
+`.bookforge/`; if none, at minimum check the wizard).
+
+## Task 3 — Start v1.6: PDF ingestion hardening
+
+This is the next roadmap milestone and the maintainer's top priority
+(scientific papers with figures/tables, and unorthodox-layout scanned
+books). **The spec is `docs/ROADMAP.md` §9 (lines ~1827-1985) — read it
+in full before writing code; it defines goal, phases, deliverables, CLI
+surface, out-of-scope, and acceptance criteria.** Existing code lives in
+`crates/bookforge-pdf`.
+
+Instructions from the maintainer's process doc: follow the phases in §9.4
+in order, do not skip ahead, and if a needed detail is missing from the
+roadmap, stop and ask the maintainer rather than inventing it.
+
+Work on a branch (e.g. `v1.6-pdf-hardening`) and open a PR; do not push
+this to `main` directly. Respect the §9.6 out-of-scope list strictly.
+
+## Task 4 (added 2026-07-03) — PR #22 fix pass, from Claude's code review
+
+A multi-angle review of `main...v1.6-pdf-hardening` found 7 confirmed and
+3 plausible correctness bugs plus confirmed cleanup items. Fix on the same
+branch; PR #22 stays draft until the acceptance step at the end passes.
+
+**Common theme — read this first.** Every confirmed bug lives beyond the
+stubbed-poppler test boundary: the tests stub pdftoppm/pdfimages and assert
+the *arguments* passed to them, so real-tool geometry, file counts, and
+enumeration order are never exercised. Fixes must come with the acceptance
+step below, not just more stub tests.
+
+### Confirmed bugs (fix all, in this order)
+
+1. **Crop coordinate mismatch (`tools.rs:234`, `render_page_crop_png`).**
+   Crop rects are in pdftohtml XML units (default zoom 1.5 ≈ 108 dpi; a
+   US-Letter page is 918 units wide, see `parse.rs` fixture), but they are
+   passed verbatim as pdftoppm `-x/-y/-W/-H` pixel flags at `-r 150`
+   (1275 px wide) — every crop is misplaced/mis-scaled by 150/108 ≈ 1.389×.
+   Fix: scale coords by (render_dpi / 108) before passing, or pass
+   `-zoom 1.5`-consistent dpi to pdftoppm (`-r 108`); either way derive both
+   numbers from ONE shared constant, and pin pdftohtml's zoom explicitly
+   (`-zoom 1.5`) so the assumption is stated in the invocation.
+
+2. **`remove_blocks_in_region` deletes unrelated text (`convert.rs:1232`).**
+   Removal keys only on `anchor.top` within the region's *padded* vertical
+   band; `BlockAnchor` has no horizontal fields, so on two-column pages it
+   deletes the other column's paragraphs, and the 8–48px padding swallows
+   the following paragraph. The crop PNG is horizontally bounded, so the
+   deleted text is NOT preserved anywhere. Fix: add left/width to
+   `BlockAnchor` (populate in `reconstruct.rs` where anchors are built) and
+   require horizontal overlap with the *unpadded* region; use the padded
+   rect only for the raster crop, not for deletion.
+
+3. **pdfimages page misalignment (`tools.rs:159`).** `parse_pdfimages_list`
+   keeps only `type=="image"` rows, but `pdfimages -png` also writes files
+   for smask/stencil/mask objects; paths are then zipped positionally with
+   no length check, so one mask shifts every later image's page/dims (and
+   overflow gets page 0). Fix: don't filter the -list rows — keep all rows
+   aligned with the emitted files, pair by the `num` column / filename index
+   (`-NNN.png` suffix), then discard non-"image" entries AFTER pairing.
+   Add a hard error (or at minimum a report warning) if counts still diverge.
+
+4. **Positional image↔region pairing (`convert.rs:919`).** The Nth
+   extracted image on a page is paired with `page.images[N]`; pdfimages
+   enumerates in object order, pdftohtml in draw order. Fix: match by best
+   dimension/aspect-ratio fit (extracted image width/height vs region
+   width/height) with a sanity threshold, falling back to unmatched
+   (region=None) rather than a wrong pairing.
+
+5. **Region-less images become spurious figures (`convert.rs:857`).**
+   Candidates with no pdftohtml region are emitted as caption-less figures
+   anchored at `top=i32::MAX` with no size/decorative filter — masks,
+   logos, and background rasters get appended to every page. Fix: drop
+   region-less images below a minimum pixel area, drop images whose bytes
+   repeat across many pages (running ornament/logo), and record dropped
+   ones in the conversion report instead of the EPUB.
+
+6. **Image tooling is now a fatal dependency (`tools.rs:67`,
+   `convert.rs:71`).** `discover()` hard-requires pdfimages+pdftoppm, and
+   `extract_images()?` runs before the text baseline — a minimal poppler
+   install or one malformed embedded image aborts conversions that
+   succeeded on v2.0.3 text-only. Fix: make the two image tools optional
+   in `PopplerTools` (Option<PathBuf>); when missing or when extraction
+   fails, log/report a degraded-mode warning and continue text-only.
+   `doctor` should list them as "recommended (figure preservation)", not
+   required.
+
+7. **Coverage under-report (`convert.rs:103`).** `reconstructed_chars` is
+   summed after `remove_blocks_in_region` deleted table/equation text that
+   IS preserved (as crops), so `coverage_percent` drops and the sub-95%
+   warning fires about content that survived. Fix: count removed-to-media
+   chars separately and either credit them to coverage or report them as
+   an explicit "preserved as images: N chars" line; do not let media
+   preservation read as text loss. (Note: per-page `stats.chars` is
+   pre-removal, so low-confidence detection is unaffected — keep it so.)
+
+### Plausible bugs (fix or consciously accept with a comment + report warning)
+
+8. **Equation detector rasterizes math-dense prose (`convert.rs:705`).**
+   "(p = 0.05)" centered on its own line passes every gate (3 symbols, 8
+   nonspace, 9≥8). Tighten: require at least one *strong* operator beyond
+   parens/hyphens for the density rule, or exempt fragments that parse as
+   a single parenthetical.
+9. **Table detector on aligned non-table content (`convert.rs:567`).**
+   Aligned author/affiliation blocks or stats lists (3+ fragments/row, 3+
+   rows, digits) rasterize and delete real prose. Consider requiring a
+   nearby table caption OR ≥4 rows, and always report which text was
+   removed so the user can audit.
+10. **Caption ranking saturation (`convert.rs:1109`).**
+    `top.saturating_sub(bottom)` gives distance 0 to fragments in the
+    [bottom-8, bottom) window, beating the true caption below. Rank by
+    absolute distance from the image bottom instead.
+
+### Confirmed cleanup (same pass, keeps the above fixed-for-good)
+
+- Replace the hand-synchronized parallel `Vec<DocBlock>` +
+  `Vec<BlockAnchor>` with one `Vec<AnchoredBlock>` (mutation sites:
+  `convert.rs:1217/1234/1258/214`, `reconstruct.rs:504`) — this is the
+  root enabler of anchor-desync bugs and makes fix #2 safer.
+- One low-confidence threshold: `convert.rs:23` (0.95) and `report.rs:58`
+  (95.0) must derive from a single shared constant.
+- Batch pdftoppm: render each page with regions once and crop in memory
+  (or one range render for preserved pages) instead of one subprocess per
+  region/page (`convert.rs:401/1022/181`).
+- Deduplicate `scoped_temp_dir` (convert.rs:1276 vs tools.rs:338 — make
+  the tools.rs one pub(crate)), `normalize_caption` (vs
+  `reconstruct::normalize_running_text`), and `fragment_text` (vs
+  `Line::text()`/`DocBlock::text()`).
+- Unify math-symbol classification: `convert.rs:729 is_math_symbol` vs
+  `bookforge-epub reader.rs:1361 is_inline_math_operator` diverge (minus,
+  brackets, ∑∫√∂∇∞∈ missing on the epub side), so an expression can be
+  rasterized by one stage and left unprotected by the other. Share one
+  definition (bookforge-core is the natural home).
+
+### Acceptance for task 4 (blocking)
+
+1. All existing tests green; new regression tests for fixes 1–5 and 7
+   that assert real geometry/pairing (not just stub argv).
+2. **Real-poppler end-to-end run:** convert an actual scientific PDF
+   (the BERT paper, arXiv 1810.04805 — the fixtures are modeled on it)
+   with real pdftohtml/pdfimages/pdftoppm installed; open the EPUB and
+   confirm figure/table/equation crops show the right content at the
+   right size, no spurious logo/mask figures, no missing paragraphs
+   around tables in the two-column layout, and a sane coverage number in
+   the report. Record the result in the PR description.
+3. Text-only degraded mode: rename pdfimages away, convert a text PDF,
+   confirm an EPUB is still produced with a warning.
+
+## Verification expectations (all tasks)
+
+- `cargo check --workspace --all-features`, `cargo test --workspace`,
+  `cargo clippy --workspace --all-features` clean before each commit.
+- Conventional-commit style messages matching `git log` precedent.


### PR DESCRIPTION
## Summary

Starts the v1.6 PDF hardening work at P2 by preserving extracted PDF figures in the converted EPUB.

- Parses `<image>` anchors from Poppler `pdftohtml -xml` output.
- Requires and reports `pdfimages` through PDF tool discovery and `bookforge doctor --pdf`.
- Extracts PDF images, embeds them in the synthetic EPUB manifest/ZIP, and renders `<figure><img .../></figure>` blocks.
- Detects nearby `Figure`, `Fig.`, and `Table` caption text, moves it into `<figcaption>`, and removes the duplicate paragraph block.
- Adds conversion report image/figure counts.
- Adds fake-poppler tests that run without real Poppler installed and verify the generated EPUB keeps a translatable caption block.

## Validation

- `cargo test -p bookforge-pdf`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-features`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --workspace` (unsandboxed, needed for the existing loopback provider test)
- `cargo run -p bookforge-cli -- doctor --pdf`

## Notes

This is the first P2 slice. It preserves embedded raster images and caption text, but does not yet implement P3 table/equation crop policy or P3.5 caption-crop hardening for duplicated caption text inside raster crops.