### PR TITLE
feat: bilingual EPUB output modes (v1.7 milestone)

### DIFF
--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -14,7 +14,7 @@ use bookforge_core::{
     },
     select_glossary_for_segments,
 };
-use bookforge_epub::{read_epub, rebuild_epub};
+use bookforge_epub::{read_epub, rebuild_epub_with_options};
 use bookforge_llm::{
     ContextRegistry, ContextRunConfig, EntityRunConfig, GlossaryRunConfig, MockProvider,
     OpenAiCompatibleConfig, OpenAiCompatibleProvider, QaSegmentReview, SegmentTranslation,
@@ -406,7 +406,8 @@ async fn run_inner(
     .await?;
     let block_translations =
         rebuild_block_translations(&segments, &stored_blocks, &cached_translations);
-    rebuild_epub(&book, &block_translations, &output)?;
+    let rebuild_options = super::translate::rebuild_options_from_snapshot(snapshot);
+    rebuild_epub_with_options(&book, &block_translations, &output, &rebuild_options)?;
 
     let job = store
         .get_job(&job.id)?
@@ -1302,6 +1303,10 @@ mod tests {
             style_rendered_block: String::new(),
             entities_fingerprint: String::new(),
             entities_rendered_block: String::new(),
+            bilingual_mode: bookforge_core::BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_css: None,
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
         store

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -215,6 +215,10 @@ mod tests {
             style_rendered_block: String::new(),
             entities_fingerprint: String::new(),
             entities_rendered_block: String::new(),
+            bilingual_mode: bookforge_core::BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_css: None,
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/tail.rs
+++ b/crates/bookforge-cli/src/commands/tail.rs
@@ -234,6 +234,10 @@ mod tests {
             style_rendered_block: String::new(),
             entities_fingerprint: String::new(),
             entities_rendered_block: String::new(),
+            bilingual_mode: bookforge_core::BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_css: None,
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         }
     }

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 
 use bookforge_core::{
     GlossaryFormat, JsonMode, ProviderPreset,
-    config::{ContextScope, DoubleCheckMode, FallbackScope, TranslationProfile},
+    config::{
+        BilingualMode, BilingualStyle, ContextScope, DoubleCheckMode, FallbackScope,
+        TranslationProfile,
+    },
 };
 use clap::Args;
 
@@ -59,6 +62,18 @@ pub struct TranslateArgs {
 
     #[arg(long)]
     pub out: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = BilingualMode::Replace)]
+    pub mode: BilingualMode,
+
+    #[arg(long)]
+    pub bilingual_css: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = BilingualStyle::Minimal)]
+    pub bilingual_style: BilingualStyle,
+
+    #[arg(long, default_value = " / ")]
+    pub bilingual_separator: String,
 
     /// Run BookForge validators and EPUBCheck on the rebuilt EPUB.
     #[arg(long, default_value_t = false)]

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -51,6 +51,7 @@ pub(crate) use cache::{CacheContext, apply_cached_translations, pending_segments
 use checkpointing::finalize_writer;
 pub(crate) use engine::{CheckpointRunContext, run_checkpointed_translation};
 use reporting::print_summary_rebuild_and_report;
+pub(crate) use reporting::rebuild_options_from_snapshot;
 use settings::{apply_provider_preset, resolve_settings, retry_amplification_warning};
 use snapshot::persist_snapshot;
 
@@ -537,7 +538,7 @@ async fn run_mock_translation(
             ""
         },
     );
-    persist_snapshot(
+    let snapshot = persist_snapshot(
         &store,
         &job,
         input,
@@ -557,6 +558,7 @@ async fn run_mock_translation(
         None,
         None,
     )?;
+    let rebuild_options = rebuild_options_from_snapshot(&snapshot);
     store.insert_segments(
         &job.id,
         &segments,
@@ -641,6 +643,7 @@ async fn run_mock_translation(
         &translations,
         &qa_reviews,
         config,
+        &rebuild_options,
         cli_args.validate_output,
         cli_args.strict_epubcheck,
         human_stdout_enabled(cli_args.ui),
@@ -826,7 +829,7 @@ async fn run_openai_compatible_translation(
             ""
         },
     );
-    persist_snapshot(
+    let snapshot = persist_snapshot(
         &store,
         &job,
         input,
@@ -846,6 +849,7 @@ async fn run_openai_compatible_translation(
         Some(provider_config.base_url.clone()),
         Some(provider_config.api_key_env.clone()),
     )?;
+    let rebuild_options = rebuild_options_from_snapshot(&snapshot);
     store.insert_segments(
         &job.id,
         &segments,
@@ -925,6 +929,7 @@ async fn run_openai_compatible_translation(
         settings,
         &run_config,
         config,
+        &rebuild_options,
         &book,
         progress.clone(),
         started,
@@ -960,6 +965,7 @@ async fn finish_translation_pipeline(
     settings: &ResolvedRunSettings,
     run_config: &TranslationRunConfig,
     config: &TranslationConfig,
+    rebuild_options: &bookforge_epub::RebuildOptions,
     book: &bookforge_core::ir::Book,
     progress: Arc<dyn bookforge_core::ProgressSink>,
     started: std::time::Instant,
@@ -1012,6 +1018,7 @@ async fn finish_translation_pipeline(
         translations,
         &qa_reviews,
         config,
+        rebuild_options,
         cli_args.validate_output,
         cli_args.strict_epubcheck,
         human_stdout_enabled(cli_args.ui),
@@ -2623,6 +2630,10 @@ case_sensitive = true
             provider_max_attempts: None,
             validation_max_attempts: None,
             out: None,
+            mode: bookforge_core::BilingualMode::Replace,
+            bilingual_css: None,
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_separator: " / ".to_string(),
             validate_output: false,
             strict_epubcheck: false,
             book_id: None,

--- a/crates/bookforge-cli/src/commands/translate/reporting.rs
+++ b/crates/bookforge-cli/src/commands/translate/reporting.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use bookforge_core::{
+    RunConfigSnapshot,
     config::TranslationConfig,
     segment::{BlockTranslation, Segment},
 };
-use bookforge_epub::rebuild_epub_with_language;
+use bookforge_epub::{RebuildOptions, rebuild_epub_with_options};
 use bookforge_llm::{QaSegmentReview, SegmentTranslation};
 use bookforge_store::{JobRecord, JobStore};
 
@@ -30,17 +31,13 @@ pub fn print_summary_rebuild_and_report(
     translations: &[SegmentTranslation],
     qa_reviews: &[QaSegmentReview],
     config: &TranslationConfig,
+    rebuild_options: &RebuildOptions,
     validate_output: bool,
     strict_epubcheck: bool,
     print_stdout: bool,
 ) -> Result<()> {
     let block_translations = block_translations(translations);
-    rebuild_epub_with_language(
-        book,
-        &block_translations,
-        &config.output,
-        Some(&config.target_language),
-    )?;
+    rebuild_epub_with_options(book, &block_translations, &config.output, rebuild_options)?;
     let mut validation_failure = None;
     if validate_output || strict_epubcheck {
         let validation_path = validate::default_report_path(&config.output);
@@ -111,4 +108,14 @@ pub fn print_summary_rebuild_and_report(
     }
 
     Ok(())
+}
+
+pub fn rebuild_options_from_snapshot(snapshot: &RunConfigSnapshot) -> RebuildOptions {
+    RebuildOptions {
+        target_language: Some(snapshot.target_language.clone()),
+        mode: snapshot.bilingual_mode,
+        bilingual_separator: snapshot.bilingual_separator.clone(),
+        bilingual_style: snapshot.bilingual_style,
+        bilingual_css: snapshot.bilingual_css.clone(),
+    }
 }

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -47,6 +47,7 @@ pub(crate) fn persist_snapshot(
         .clone()
         .unwrap_or_else(|| default_event_path(&job.id));
     let input_snapshot = snapshot_input_epub(store, job, input)?;
+    let bilingual_css = read_bilingual_css(cli_args)?;
     let snapshot = RunConfigSnapshot {
         input_path: input.to_path_buf(),
         input_snapshot_path: Some(input_snapshot.epub_path.clone()),
@@ -79,11 +80,24 @@ pub(crate) fn persist_snapshot(
         style_rendered_block: style_rendered_block.to_string(),
         entities_fingerprint: entities_fingerprint.to_string(),
         entities_rendered_block: entities_rendered_block.to_string(),
+        bilingual_mode: cli_args.mode,
+        bilingual_separator: cli_args.bilingual_separator.clone(),
+        bilingual_style: cli_args.bilingual_style,
+        bilingual_css,
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),
     };
     store.update_job_config_snapshot(&job.id, &snapshot)?;
     store.update_job_event_path(&job.id, &events_path)?;
     Ok(snapshot)
+}
+
+fn read_bilingual_css(cli_args: &TranslateArgs) -> anyhow::Result<Option<String>> {
+    let Some(path) = cli_args.bilingual_css.as_ref() else {
+        return Ok(None);
+    };
+    std::fs::read_to_string(path)
+        .map(Some)
+        .map_err(|err| anyhow::anyhow!("failed to read --bilingual-css {}: {err}", path.display()))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -277,6 +277,147 @@ fn cli_translate_context_window_persists_snapshot_settings() {
 }
 
 #[test]
+fn cli_translate_bilingual_options_persist_in_snapshot() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    let css_path = temp.path().join("bilingual.css");
+    fs::write(&css_path, ".bookforge-translation { color: #123456; }\n")
+        .expect("custom bilingual CSS should write");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--mode",
+            "append-text",
+            "--bilingual-separator",
+            " -- ",
+            "--bilingual-style",
+            "prominent",
+            "--bilingual-css",
+            css_path.to_str().unwrap(),
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let job_id = job_id_from_events(&events);
+    let store =
+        JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store should open");
+    let snapshot = store
+        .load_job_config_snapshot(&job_id)
+        .expect("snapshot load")
+        .expect("snapshot present");
+    assert_eq!(
+        snapshot.bilingual_mode,
+        bookforge_core::BilingualMode::AppendText
+    );
+    assert_eq!(snapshot.bilingual_separator, " -- ");
+    assert_eq!(
+        snapshot.bilingual_style,
+        bookforge_core::BilingualStyle::Prominent
+    );
+    assert_eq!(
+        snapshot.bilingual_css.as_deref(),
+        Some(".bookforge-translation { color: #123456; }\n")
+    );
+}
+
+#[test]
+fn cli_translate_append_block_keeps_glossary_terms_in_run_snapshot() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let output = temp.path().join("out.epub");
+    let events = temp.path().join("events.jsonl");
+    let glossary = temp.path().join("glossary.toml");
+    fs::write(
+        &glossary,
+        r#"[meta]
+schema_version = 1
+source_language = "English"
+target_language = "Italian"
+
+[meta.scope]
+kind = "book"
+id = "fellowship"
+
+[[term]]
+source = "Ivan Ilych"
+target = "Ivan Ilic"
+category = "person"
+case_sensitive = true
+"#,
+    )
+    .expect("glossary should write");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "translate",
+            input.to_str().unwrap(),
+            "--source",
+            "English",
+            "--target",
+            "Italian",
+            "--provider",
+            "mock",
+            "--model",
+            "mock-prefix-target",
+            "--profile",
+            "v1-fast",
+            "--book-id",
+            "fellowship",
+            "--glossary",
+            glossary.to_str().unwrap(),
+            "--mode",
+            "append-block",
+            "--ui",
+            "quiet",
+            "--progress-jsonl",
+            events.to_str().unwrap(),
+            "--out",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let job_id = job_id_from_events(&events);
+    let store =
+        JobStore::open(temp.path().join(".bookforge/jobs.sqlite")).expect("store should open");
+    let snapshot = store
+        .load_job_config_snapshot(&job_id)
+        .expect("snapshot load")
+        .expect("snapshot present");
+    assert_eq!(
+        snapshot.bilingual_mode,
+        bookforge_core::BilingualMode::AppendBlock
+    );
+    assert!(
+        snapshot
+            .glossary_terms
+            .iter()
+            .any(|term| term.source_text == "Ivan Ilych" && term.target_text == "Ivan Ilic"),
+        "append-block runs should retain selected glossary terms in the same snapshot used for prompts"
+    );
+}
+
+#[test]
 fn cli_translate_with_style_sheet_persists_rendered_block_in_snapshot() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let input = fixture_input();

--- a/crates/bookforge-cli/tests/roundtrip.rs
+++ b/crates/bookforge-cli/tests/roundtrip.rs
@@ -266,28 +266,38 @@ struct RoundtripRun {
 
 /// Translate `chapters` with the given mock model and return the output EPUB.
 fn translate(chapters: &[(&str, &str)], model: &str) -> RoundtripRun {
+    translate_with_extra_args(chapters, model, &[])
+}
+
+fn translate_with_extra_args(
+    chapters: &[(&str, &str)],
+    model: &str,
+    extra: &[&str],
+) -> RoundtripRun {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let input = build_epub(temp.path(), "in.epub", chapters);
     let output = temp.path().join("out.epub");
+    let mut args = vec![
+        "translate",
+        input.to_str().unwrap(),
+        "--source",
+        "English",
+        "--target",
+        "Italian",
+        "--provider",
+        "mock",
+        "--model",
+        model,
+        "--ui",
+        "quiet",
+        "--out",
+        output.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
     Command::cargo_bin("bookforge")
         .expect("bookforge binary should be built")
         .current_dir(temp.path())
-        .args([
-            "translate",
-            input.to_str().unwrap(),
-            "--source",
-            "English",
-            "--target",
-            "Italian",
-            "--provider",
-            "mock",
-            "--model",
-            model,
-            "--ui",
-            "quiet",
-            "--out",
-            output.to_str().unwrap(),
-        ])
+        .args(args)
         .assert()
         .success();
     assert!(output.exists(), "translated EPUB should exist");
@@ -657,6 +667,63 @@ fn coverage_epub3_nav_document_not_in_spine() {
         nav.contains(r#"<a href="ch1.xhtml">[Italian] Chapter One</a>"#),
         "EPUB3 nav link label should be translated even when nav is not in spine, got: {nav}"
     );
+}
+
+#[test]
+fn bilingual_append_block_mock_e2e_preserves_source_and_adds_translation_block() {
+    let body = r#"<p>BILINGUAL_BLOCK_SENTINEL text.</p>"#;
+    let run = translate_with_extra_args(
+        &[("ch1.xhtml", body)],
+        "mock-prefix-target",
+        &["--mode", "append-block"],
+    );
+
+    let chapter = read_zip_text(&run.output, "ch1.xhtml");
+    assert!(
+        chapter.contains("<p>BILINGUAL_BLOCK_SENTINEL text.</p>"),
+        "source paragraph should remain visible, got: {chapter}"
+    );
+    assert!(
+        chapter.contains(
+            r#"<p class="bookforge-translation" lang="it">[Italian] BILINGUAL_BLOCK_SENTINEL text.</p>"#
+        ),
+        "translated sibling paragraph should be appended, got: {chapter}"
+    );
+    assert!(
+        chapter
+            .contains(r#"<link rel="stylesheet" type="text/css" href="bookforge-bilingual.css"/>"#),
+        "chapter should link the generated bilingual stylesheet, got: {chapter}"
+    );
+
+    let opf = read_zip_text(&run.output, "content.opf");
+    assert!(opf.contains("<dc:language>en</dc:language>"));
+    assert!(opf.contains("<dc:language>it</dc:language>"));
+    assert!(opf.contains(r#"href="bookforge-bilingual.css" media-type="text/css""#));
+    assert!(
+        read_zip_text(&run.output, "bookforge-bilingual.css").contains(".bookforge-translation")
+    );
+}
+
+#[test]
+fn bilingual_append_text_mock_e2e_preserves_source_and_adds_inline_span() {
+    let body = r#"<p>BILINGUAL_TEXT_SENTINEL text.</p>"#;
+    let run = translate_with_extra_args(
+        &[("ch1.xhtml", body)],
+        "mock-prefix-target",
+        &["--mode", "append-text", "--bilingual-separator", " -- "],
+    );
+
+    let chapter = read_zip_text(&run.output, "ch1.xhtml");
+    assert!(
+        chapter.contains(
+            r#"<p>BILINGUAL_TEXT_SENTINEL text. -- <span class="bookforge-translation" lang="it">[Italian] BILINGUAL_TEXT_SENTINEL text.</span></p>"#
+        ),
+        "translated inline span should be appended with the requested separator, got: {chapter}"
+    );
+
+    let opf = read_zip_text(&run.output, "content.opf");
+    assert!(opf.contains("<dc:language>en</dc:language>"));
+    assert!(opf.contains("<dc:language>it</dc:language>"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bookforge-cli/tests/roundtrip.rs
+++ b/crates/bookforge-cli/tests/roundtrip.rs
@@ -308,28 +308,38 @@ fn translate_with_extra_args(
 }
 
 fn translate_with_ncx(chapters: &[(&str, &str)], model: &str) -> RoundtripRun {
+    translate_with_ncx_extra_args(chapters, model, &[])
+}
+
+fn translate_with_ncx_extra_args(
+    chapters: &[(&str, &str)],
+    model: &str,
+    extra: &[&str],
+) -> RoundtripRun {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let input = build_epub_with_ncx(temp.path(), "in.epub", chapters);
     let output = temp.path().join("out.epub");
+    let mut args = vec![
+        "translate",
+        input.to_str().unwrap(),
+        "--source",
+        "English",
+        "--target",
+        "Italian",
+        "--provider",
+        "mock",
+        "--model",
+        model,
+        "--ui",
+        "quiet",
+        "--out",
+        output.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
     Command::cargo_bin("bookforge")
         .expect("bookforge binary should be built")
         .current_dir(temp.path())
-        .args([
-            "translate",
-            input.to_str().unwrap(),
-            "--source",
-            "English",
-            "--target",
-            "Italian",
-            "--provider",
-            "mock",
-            "--model",
-            model,
-            "--ui",
-            "quiet",
-            "--out",
-            output.to_str().unwrap(),
-        ])
+        .args(args)
         .assert()
         .success();
     assert!(output.exists(), "translated EPUB should exist");
@@ -724,6 +734,86 @@ fn bilingual_append_text_mock_e2e_preserves_source_and_adds_inline_span() {
     let opf = read_zip_text(&run.output, "content.opf");
     assert!(opf.contains("<dc:language>en</dc:language>"));
     assert!(opf.contains("<dc:language>it</dc:language>"));
+}
+
+#[test]
+fn bilingual_append_modes_do_not_inject_stylesheet_into_ncx() {
+    let body = r#"<p>NCX_APPEND_SENTINEL text.</p>"#;
+    for mode in ["append-block", "append-text"] {
+        let run = translate_with_ncx_extra_args(
+            &[("ch1.xhtml", body)],
+            "mock-prefix-target",
+            &["--mode", mode],
+        );
+
+        let toc = read_zip_text(&run.output, "toc.ncx");
+        assert!(
+            !toc.contains("stylesheet") && !toc.contains("bookforge-bilingual.css"),
+            "{mode} must not inject an XHTML stylesheet link into toc.ncx, got: {toc}"
+        );
+
+        let chapter = read_zip_text(&run.output, "ch1.xhtml");
+        assert!(
+            chapter.contains(
+                r#"<link rel="stylesheet" type="text/css" href="bookforge-bilingual.css"/>"#
+            ),
+            "{mode} should still link the generated stylesheet from XHTML resources, got: {chapter}"
+        );
+    }
+}
+
+#[test]
+fn bilingual_append_block_mock_e2e_keeps_caption_and_child_blocks_epub_shaped() {
+    let body = r#"<table><caption>CAPTION_SENTINEL text.</caption><tr><td>CELL_SENTINEL</td></tr></table><blockquote><p>QUOTE_ONE_SENTINEL.</p><p>QUOTE_TWO_SENTINEL.</p></blockquote><ul><li><p>LIST_ONE_SENTINEL.</p><p>LIST_TWO_SENTINEL.</p></li></ul>"#;
+    let run = translate_with_extra_args(
+        &[("ch1.xhtml", body)],
+        "mock-prefix-target",
+        &["--mode", "append-block"],
+    );
+
+    let chapter = read_zip_text(&run.output, "ch1.xhtml");
+    assert!(
+        chapter.contains(
+            r#"<caption>CAPTION_SENTINEL text.<p class="bookforge-translation" lang="it">[Italian] CAPTION_SENTINEL text.</p></caption>"#
+        ),
+        "caption translation should stay inside caption, got: {chapter}"
+    );
+    assert!(
+        !chapter.contains(r#"<p class="bookforge-translation" lang="it"><p>"#),
+        "append-block translation wrappers must not contain child p elements, got: {chapter}"
+    );
+    assert!(
+        chapter.contains("[Italian] QUOTE_ONE_SENTINEL. QUOTE_TWO_SENTINEL."),
+        "flattened blockquote translation should join child paragraphs with a space, got: {chapter}"
+    );
+    assert!(
+        chapter.contains("[Italian] LIST_ONE_SENTINEL. LIST_TWO_SENTINEL."),
+        "flattened list-item translation should join child paragraphs with a space, got: {chapter}"
+    );
+}
+
+#[test]
+fn bilingual_append_text_mock_e2e_flattens_child_blocks_inside_spans() {
+    let body = r#"<blockquote><p>QUOTE_TEXT_ONE_SENTINEL.</p><p>QUOTE_TEXT_TWO_SENTINEL.</p></blockquote><ul><li><p>LIST_TEXT_ONE_SENTINEL.</p><p>LIST_TEXT_TWO_SENTINEL.</p></li></ul>"#;
+    let run = translate_with_extra_args(
+        &[("ch1.xhtml", body)],
+        "mock-prefix-target",
+        &["--mode", "append-text"],
+    );
+
+    let chapter = read_zip_text(&run.output, "ch1.xhtml");
+    assert!(
+        !chapter.contains(r#"<span class="bookforge-translation" lang="it"><p>"#),
+        "append-text translation spans must not contain child p elements, got: {chapter}"
+    );
+    assert!(
+        chapter.contains("[Italian] QUOTE_TEXT_ONE_SENTINEL. QUOTE_TEXT_TWO_SENTINEL."),
+        "flattened blockquote translation should join child paragraphs with a space, got: {chapter}"
+    );
+    assert!(
+        chapter.contains("[Italian] LIST_TEXT_ONE_SENTINEL. LIST_TEXT_TWO_SENTINEL."),
+        "flattened list-item translation should join child paragraphs with a space, got: {chapter}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bookforge-core/src/config.rs
+++ b/crates/bookforge-core/src/config.rs
@@ -13,6 +13,50 @@ pub struct TranslationConfig {
     pub output: PathBuf,
 }
 
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BilingualMode {
+    #[default]
+    Replace,
+    AppendText,
+    AppendBlock,
+}
+
+impl BilingualMode {
+    pub fn is_append(self) -> bool {
+        matches!(self, Self::AppendText | Self::AppendBlock)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Replace => "replace",
+            Self::AppendText => "append-text",
+            Self::AppendBlock => "append-block",
+        }
+    }
+}
+
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BilingualStyle {
+    #[default]
+    Minimal,
+    Prominent,
+    InlineOnly,
+}
+
+impl BilingualStyle {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Prominent => "prominent",
+            Self::InlineOnly => "inline-only",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SegmentationConfig {
     pub max_segment_tokens: usize,

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -12,11 +12,11 @@ pub mod segment;
 pub mod style;
 
 pub use config::{
-    BatchConfig, DoubleCheckConfig, DoubleCheckMode, FallbackScope, JsonMode, ModelEndpoint,
-    ModelRouteConfig, PromptVersion, ProviderErrorKind, ProviderPreset, ProviderPresetResolved,
-    ProviderPresetRuntimeOverrides, ProviderRequestMetric, ProviderRuntimeConfig, QaRunConfig,
-    ResolvedRunSettings, RetryAfterPolicy, SegmentationConfig, TranslationConfig,
-    TranslationProfile, cap_output_tokens,
+    BatchConfig, BilingualMode, BilingualStyle, DoubleCheckConfig, DoubleCheckMode, FallbackScope,
+    JsonMode, ModelEndpoint, ModelRouteConfig, PromptVersion, ProviderErrorKind, ProviderPreset,
+    ProviderPresetResolved, ProviderPresetRuntimeOverrides, ProviderRequestMetric,
+    ProviderRuntimeConfig, QaRunConfig, ResolvedRunSettings, RetryAfterPolicy, SegmentationConfig,
+    TranslationConfig, TranslationProfile, cap_output_tokens,
 };
 pub use entity::{
     Entity, EntityGender, entities_fingerprint, merge_scope_entities, render_entity_agreement_block,

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use crate::{
-    BatchConfig, DoubleCheckConfig, JsonMode, ProviderPreset, ProviderRuntimeConfig, QaRunConfig,
-    ResolvedRunSettings, RetryAfterPolicy, SchedulerConfig, SegmentationConfig, TranslationProfile,
+    BatchConfig, BilingualMode, BilingualStyle, DoubleCheckConfig, JsonMode, ProviderPreset,
+    ProviderRuntimeConfig, QaRunConfig, ResolvedRunSettings, RetryAfterPolicy, SchedulerConfig,
+    SegmentationConfig, TranslationProfile,
     config::ContextScope,
     glossary::{GlossaryFormat, GlossaryTerm},
 };
@@ -65,6 +66,14 @@ pub struct RunConfigSnapshot {
     /// Pre-rendered entity grammatical-agreement block.
     #[serde(default)]
     pub entities_rendered_block: String,
+    #[serde(default)]
+    pub bilingual_mode: BilingualMode,
+    #[serde(default = "default_bilingual_separator")]
+    pub bilingual_separator: String,
+    #[serde(default)]
+    pub bilingual_style: BilingualStyle,
+    #[serde(default)]
+    pub bilingual_css: Option<String>,
     pub settings: ResolvedRunSettingsSnapshot,
 }
 
@@ -78,6 +87,10 @@ fn default_glossary_budget_tokens() -> usize {
 
 fn default_glossary_format() -> GlossaryFormat {
     GlossaryFormat::Json
+}
+
+fn default_bilingual_separator() -> String {
+    " / ".to_string()
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/crates/bookforge-epub/src/lib.rs
+++ b/crates/bookforge-epub/src/lib.rs
@@ -9,4 +9,6 @@ pub use validate::{
     EpubValidationIssue, EpubValidationReport, ValidationSeverity, validate_block_translations,
     validate_translated_epub,
 };
-pub use writer::{rebuild_epub, rebuild_epub_with_language};
+pub use writer::{
+    RebuildOptions, rebuild_epub, rebuild_epub_with_language, rebuild_epub_with_options,
+};

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -10,7 +10,7 @@ use bookforge_core::{
     BookforgeError, Result,
     config::{BilingualMode, BilingualStyle},
     ir::{Block, Book, DomPath, TEXT_NODE_PATH_BASE},
-    marker::{parse_empty_marker, parse_paired_marker_open, strip_marker_tokens},
+    marker::{parse_empty_marker, parse_paired_marker_open},
     segment::BlockTranslation,
 };
 use quick_xml::{
@@ -167,7 +167,10 @@ fn write_rebuilt_epub(
                     options,
                     stylesheet.as_ref().map(|plan| plan.opf_href.as_str()),
                 )?
-            } else if let Some(plan) = stylesheet.as_ref() {
+            } else if let Some(plan) = stylesheet
+                .as_ref()
+                .filter(|_| is_xhtml_resource_name(name.as_str()))
+            {
                 inject_stylesheet_link(
                     &outcome.xhtml,
                     &relative_href(name.as_str(), plan.archive_path.as_str()),
@@ -437,6 +440,17 @@ fn relative_href(from_file: &str, target_file: &str) -> String {
     } else {
         out.join("/")
     }
+}
+
+fn is_xhtml_resource_name(name: &str) -> bool {
+    name.rsplit_once('.')
+        .map(|(_, extension)| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "xhtml" | "html" | "htm"
+            )
+        })
+        .unwrap_or(false)
 }
 
 fn patches_by_href<'a>(
@@ -1317,15 +1331,15 @@ fn append_action(
     match mode {
         BilingualMode::Replace => AppendAction::Skip,
         BilingualMode::AppendBlock => match name {
-            b"p" | b"blockquote" | b"figcaption" | b"caption" | b"aside" => {
-                AppendAction::SiblingParagraph {
-                    classes: vec![TRANSLATION_CLASS.to_string()],
-                }
-            }
+            b"p" | b"blockquote" | b"figcaption" | b"aside" => AppendAction::SiblingParagraph {
+                classes: vec![TRANSLATION_CLASS.to_string()],
+            },
             b"h1" | b"h2" | b"h3" | b"h4" | b"h5" | b"h6" => AppendAction::SiblingParagraph {
                 classes: heading_translation_classes(original_start),
             },
-            b"li" | b"td" | b"th" => AppendAction::NestedParagraph,
+            // A sibling of <caption> sits directly inside <table>, where
+            // <p> is invalid; captions allow flow content, so nest instead.
+            b"li" | b"td" | b"th" | b"caption" => AppendAction::NestedParagraph,
             _ => AppendAction::Skip,
         },
         BilingualMode::AppendText => match name {
@@ -1397,43 +1411,38 @@ fn write_events_with_inline_in_last_paragraph(
     if let Some(insert_at) = insert_at {
         for (index, event) in events.iter().enumerate() {
             if index == insert_at {
-                let _ = write_plain_inline_translation_span(writer, patch, options)
-                    .inspect_err(|error| {
-                        *skipped_blocks += 1;
-                        tracing::warn!(
-                            block_path = ?path,
-                            error = %error,
-                            "preserving source-only block: inline translation could not be rendered",
-                        );
-                    });
+                let _ = write_inline_translation_span(
+                    writer,
+                    patch,
+                    events,
+                    options,
+                    skipped_blocks,
+                )
+                .inspect_err(|error| {
+                    *skipped_blocks += 1;
+                    tracing::warn!(
+                        block_path = ?path,
+                        error = %error,
+                        "preserving source-only block: inline translation could not be rendered",
+                    );
+                });
             }
             writer.write_event(event.borrow())?;
         }
     } else {
         write_events(writer, events)?;
-        let _ = write_plain_inline_translation_span(writer, patch, options).inspect_err(|error| {
-            *skipped_blocks += 1;
-            tracing::warn!(
-                block_path = ?path,
-                error = %error,
-                "preserving source-only block: inline translation could not be rendered",
-            );
-        });
+        let _ = write_inline_translation_span(writer, patch, events, options, skipped_blocks)
+            .inspect_err(|error| {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    error = %error,
+                    "preserving source-only block: inline translation could not be rendered",
+                );
+            });
     }
 
     Ok(())
-}
-
-fn write_plain_inline_translation_span(
-    writer: &mut Writer<Vec<u8>>,
-    patch: PatchSpec<'_>,
-    options: &RebuildOptions,
-) -> Result<()> {
-    let normalized = normalize_marker_whitespace(patch.translation);
-    let stripped = strip_marker_tokens(&normalized);
-    let rendered = [Event::Text(BytesText::new(stripped.trim()).into_owned())];
-    writer.write_event(Event::Text(BytesText::new(&options.bilingual_separator)))?;
-    write_translation_element(writer, "span", &[TRANSLATION_CLASS], options, &rendered)
 }
 
 fn write_inline_translation_span(
@@ -1466,11 +1475,104 @@ fn render_translation_for_append(
     original_events: &[Event<'static>],
 ) -> Result<Vec<Event<'static>>> {
     if let Some(block) = patch.block {
-        return render_marked_translation(block, patch.translation, original_events);
+        let rendered = render_marked_translation(block, patch.translation, original_events)?;
+        return Ok(flatten_block_level_events(rendered));
     }
     Ok(vec![Event::Text(
         BytesText::new(patch.translation).into_owned(),
     )])
+}
+
+/// Appended translations are wrapped in a single `<p>` or `<span>`.
+/// When the source block owns child block markup (a `<blockquote>` with
+/// child `<p>`s, an `<li>` with a nested paragraph), the inline-marker
+/// template reproduces those block elements inside the wrapper, emitting
+/// invalid nestings like `<p><p>…</p></p>` or `<span><p>…</p></span>`.
+/// Drop block-level tags from the rendered translation, keep their
+/// content, and separate former siblings with a single space.
+fn flatten_block_level_events(events: Vec<Event<'static>>) -> Vec<Event<'static>> {
+    let mut output: Vec<Event<'static>> = Vec::with_capacity(events.len());
+    let mut dropped_any = false;
+    for event in events {
+        let block_level = match &event {
+            Event::Start(element) | Event::Empty(element) => {
+                is_block_level_name(local_name(element.name().as_ref()))
+            }
+            Event::End(element) => is_block_level_name(local_name(element.name().as_ref())),
+            _ => false,
+        };
+        if block_level {
+            dropped_any = true;
+            if matches!(event, Event::End(_) | Event::Empty(_)) {
+                push_flatten_separator(&mut output);
+            }
+            continue;
+        }
+        output.push(event);
+    }
+    if dropped_any {
+        while matches!(
+            output.last(),
+            Some(Event::Text(text))
+                if text.html_content().is_ok_and(|value| value.trim().is_empty())
+        ) {
+            output.pop();
+        }
+    }
+    output
+}
+
+fn push_flatten_separator(output: &mut Vec<Event<'static>>) {
+    if !output.is_empty() && !last_event_ends_with_whitespace(output) {
+        output.push(Event::Text(BytesText::new(" ").into_owned()));
+    }
+}
+
+fn last_event_ends_with_whitespace(events: &[Event<'static>]) -> bool {
+    matches!(
+        events.last(),
+        Some(Event::Text(text)) if text_ends_with_whitespace(text)
+    )
+}
+
+fn text_ends_with_whitespace(text: &BytesText<'_>) -> bool {
+    text.html_content()
+        .is_ok_and(|value| value.chars().next_back().is_some_and(char::is_whitespace))
+}
+
+fn is_block_level_name(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"p" | b"div"
+            | b"blockquote"
+            | b"li"
+            | b"ul"
+            | b"ol"
+            | b"dl"
+            | b"dt"
+            | b"dd"
+            | b"table"
+            | b"thead"
+            | b"tbody"
+            | b"tfoot"
+            | b"tr"
+            | b"td"
+            | b"th"
+            | b"caption"
+            | b"h1"
+            | b"h2"
+            | b"h3"
+            | b"h4"
+            | b"h5"
+            | b"h6"
+            | b"section"
+            | b"article"
+            | b"aside"
+            | b"figure"
+            | b"figcaption"
+            | b"pre"
+            | b"hr"
+    )
 }
 
 fn write_translation_element(
@@ -2066,6 +2168,16 @@ mod tests {
     }
 
     #[test]
+    fn xhtml_resource_name_matches_html_extensions_case_insensitively() {
+        assert!(is_xhtml_resource_name("chapter.xhtml"));
+        assert!(is_xhtml_resource_name("OPS/Text/CHAPTER.HTML"));
+        assert!(is_xhtml_resource_name("Text/chapter.HtM"));
+        assert!(!is_xhtml_resource_name("toc.ncx"));
+        assert!(!is_xhtml_resource_name("styles/bookforge-bilingual.css"));
+        assert!(!is_xhtml_resource_name("chapter"));
+    }
+
+    #[test]
     fn append_block_adds_paragraph_sibling_with_lang() {
         let xhtml = "<root><p>Original</p></root>";
         let block = plain_block(
@@ -2236,14 +2348,59 @@ mod tests {
     }
 
     #[test]
-    fn append_text_blockquote_inserts_span_inside_last_paragraph() {
-        let xhtml = "<root><blockquote><p>Quote</p></blockquote></root>";
-        let block = plain_block("b_000000", DomPath(vec![0, 0]), BlockKind::Quote, "Quote");
+    fn append_block_table_caption_uses_nested_translation_paragraph() {
+        let xhtml = "<root><table><caption>Caption</caption><tr><td>Cell</td></tr></table></root>";
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0, 0]),
+            BlockKind::Caption,
+            "Caption",
+        );
         let outcome = patch_xhtml_blocks_with_options(
             xhtml,
             &[BlockPatch {
                 block: &block,
-                translation: "Citazione",
+                translation: "Didascalia",
+            }],
+            &append_options(BilingualMode::AppendBlock),
+        )
+        .expect("caption patch should succeed");
+
+        assert!(
+            outcome.xhtml.contains(
+                r#"<caption>Caption<p class="bookforge-translation" lang="it">Didascalia</p></caption>"#
+            ),
+            "caption translation should be nested inside caption, got: {}",
+            outcome.xhtml
+        );
+        assert!(
+            !outcome
+                .xhtml
+                .contains(r#"</caption><p class="bookforge-translation""#),
+            "caption translation must not become a table-child sibling, got: {}",
+            outcome.xhtml
+        );
+        validate_xml(&outcome.xhtml).expect("caption append output should re-parse");
+    }
+
+    #[test]
+    fn append_text_blockquote_inserts_span_inside_last_paragraph() {
+        let xhtml = "<root><blockquote><p>Quote</p></blockquote></root>";
+        let block = marked_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Quote,
+            "<m1>Quote</m1>",
+            vec![InlineMark {
+                id: "m1".to_string(),
+                kind: "p".to_string(),
+            }],
+        );
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "<m1>Citazione</m1>",
             }],
             &append_options(BilingualMode::AppendText),
         )
@@ -2257,6 +2414,83 @@ mod tests {
             outcome.xhtml
         );
         validate_xml(&outcome.xhtml).expect("blockquote append output should re-parse");
+    }
+
+    #[test]
+    fn append_modes_flatten_child_paragraphs_inside_translation_wrappers() {
+        let xhtml = "<root><blockquote><p>Quote one</p><p>Quote two</p></blockquote><ul><li><p>List one</p><p>List two</p></li></ul></root>";
+        let quote = marked_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Quote,
+            "<m1>Quote one</m1><m2>Quote two</m2>",
+            paragraph_marks(),
+        );
+        let list_item = marked_block(
+            "b_000001",
+            DomPath(vec![0, 1, 0]),
+            BlockKind::ListItem,
+            "<m1>List one</m1><m2>List two</m2>",
+            paragraph_marks(),
+        );
+
+        for mode in [BilingualMode::AppendBlock, BilingualMode::AppendText] {
+            let outcome = patch_xhtml_blocks_with_options(
+                xhtml,
+                &[
+                    BlockPatch {
+                        block: &quote,
+                        translation: "<m1>Quote uno</m1><m2>Quote due</m2>",
+                    },
+                    BlockPatch {
+                        block: &list_item,
+                        translation: "<m1>Lista uno</m1><m2>Lista due</m2>",
+                    },
+                ],
+                &append_options(mode),
+            )
+            .expect("nested child paragraph patch should succeed");
+
+            assert!(
+                !outcome
+                    .xhtml
+                    .contains(r#"<p class="bookforge-translation" lang="it"><p>"#),
+                "{mode:?} must not nest child paragraphs inside translation paragraphs: {}",
+                outcome.xhtml
+            );
+            assert!(
+                !outcome
+                    .xhtml
+                    .contains(r#"<span class="bookforge-translation" lang="it"><p>"#),
+                "{mode:?} must not nest child paragraphs inside translation spans: {}",
+                outcome.xhtml
+            );
+            assert!(
+                outcome.xhtml.contains("Quote uno Quote due"),
+                "{mode:?} should join flattened blockquote paragraphs with a space: {}",
+                outcome.xhtml
+            );
+            assert!(
+                outcome.xhtml.contains("Lista uno Lista due"),
+                "{mode:?} should join flattened list-item paragraphs with a space: {}",
+                outcome.xhtml
+            );
+            validate_xml(&outcome.xhtml).expect("nested append output should re-parse");
+        }
+    }
+
+    #[test]
+    fn flatten_block_level_events_separates_empty_block_markers() {
+        let flattened = flatten_block_level_events(vec![
+            Event::Text(BytesText::new("Before").into_owned()),
+            Event::Empty(quick_xml::events::BytesStart::new("hr").into_owned()),
+            Event::Text(BytesText::new("After").into_owned()),
+        ]);
+        let mut writer = Writer::new(Vec::new());
+        write_events(&mut writer, &flattened).expect("flattened events should write");
+        let output = String::from_utf8(writer.into_inner()).expect("output should be UTF-8");
+
+        assert_eq!(output, "Before After");
     }
 
     #[test]
@@ -2579,5 +2813,40 @@ mod tests {
             protected_spans: Vec::<ProtectedSpan>::new(),
             token_estimate: 4,
         }
+    }
+
+    fn marked_block(
+        id: &str,
+        dom_path: DomPath,
+        kind: BlockKind,
+        text: &str,
+        inline_marks: Vec<InlineMark>,
+    ) -> Block {
+        Block {
+            id: BlockId(id.to_string()),
+            section_id: SectionId("sec_000000".to_string()),
+            kind,
+            dom_path,
+            text_runs: vec![TextRun {
+                id: "r000000_000".to_string(),
+                text: text.to_string(),
+            }],
+            inline_marks,
+            protected_spans: Vec::<ProtectedSpan>::new(),
+            token_estimate: 4,
+        }
+    }
+
+    fn paragraph_marks() -> Vec<InlineMark> {
+        vec![
+            InlineMark {
+                id: "m1".to_string(),
+                kind: "p".to_string(),
+            },
+            InlineMark {
+                id: "m2".to_string(),
+                kind: "p".to_string(),
+            },
+        ]
     }
 }

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -8,8 +8,9 @@ use std::{
 
 use bookforge_core::{
     BookforgeError, Result,
+    config::{BilingualMode, BilingualStyle},
     ir::{Block, Book, DomPath, TEXT_NODE_PATH_BASE},
-    marker::{parse_empty_marker, parse_paired_marker_open},
+    marker::{parse_empty_marker, parse_paired_marker_open, strip_marker_tokens},
     segment::BlockTranslation,
 };
 use quick_xml::{
@@ -18,8 +19,44 @@ use quick_xml::{
 };
 use zip::{CompressionMethod, DateTime, ZipArchive, ZipWriter, write::SimpleFileOptions};
 
+const TRANSLATION_CLASS: &str = "bookforge-translation";
+const HEADING_TRANSLATION_CLASS: &str = "bookforge-heading-translation";
+const BILINGUAL_STYLESHEET_BASENAME: &str = "bookforge-bilingual";
+const BILINGUAL_STYLESHEET_EXTENSION: &str = "css";
+const DEFAULT_APPEND_TEXT_SEPARATOR: &str = " / ";
+
+#[derive(Debug, Clone)]
+pub struct RebuildOptions {
+    pub target_language: Option<String>,
+    pub mode: BilingualMode,
+    pub bilingual_separator: String,
+    pub bilingual_style: BilingualStyle,
+    pub bilingual_css: Option<String>,
+}
+
+impl Default for RebuildOptions {
+    fn default() -> Self {
+        Self {
+            target_language: None,
+            mode: BilingualMode::Replace,
+            bilingual_separator: DEFAULT_APPEND_TEXT_SEPARATOR.to_string(),
+            bilingual_style: BilingualStyle::Minimal,
+            bilingual_css: None,
+        }
+    }
+}
+
+impl RebuildOptions {
+    pub fn replace_with_target_language(target_language: Option<&str>) -> Self {
+        Self {
+            target_language: target_language.map(ToOwned::to_owned),
+            ..Self::default()
+        }
+    }
+}
+
 pub fn rebuild_epub(book: &Book, translations: &[BlockTranslation], output: &Path) -> Result<()> {
-    rebuild_epub_with_language(book, translations, output, None)
+    rebuild_epub_with_options(book, translations, output, &RebuildOptions::default())
 }
 
 pub fn rebuild_epub_with_language(
@@ -28,8 +65,22 @@ pub fn rebuild_epub_with_language(
     output: &Path,
     target_language: Option<&str>,
 ) -> Result<()> {
+    rebuild_epub_with_options(
+        book,
+        translations,
+        output,
+        &RebuildOptions::replace_with_target_language(target_language),
+    )
+}
+
+pub fn rebuild_epub_with_options(
+    book: &Book,
+    translations: &[BlockTranslation],
+    output: &Path,
+    options: &RebuildOptions,
+) -> Result<()> {
     let staged = sibling_work_path(output, "tmp");
-    let result = write_rebuilt_epub(book, translations, &staged, target_language);
+    let result = write_rebuilt_epub(book, translations, &staged, options);
     let skipped = match result {
         Ok(skipped) => skipped,
         Err(error) => {
@@ -56,7 +107,7 @@ fn write_rebuilt_epub(
     book: &Book,
     translations: &[BlockTranslation],
     output: &Path,
-    target_language: Option<&str>,
+    options: &RebuildOptions,
 ) -> Result<usize> {
     let source_path = book.source_path.as_deref().ok_or_else(|| {
         BookforgeError::InvalidInput("book IR does not include a source EPUB path".to_string())
@@ -80,6 +131,8 @@ fn write_rebuilt_epub(
         })
         .collect::<Vec<_>>();
     let patches_by_href = patches_by_href(book, &patches);
+    let archive_names = archive_entry_names(&mut archive)?;
+    let stylesheet = stylesheet_plan(book.id.0.as_str(), &archive_names, options);
 
     write_mimetype_first(&mut archive, &mut writer)?;
 
@@ -106,14 +159,19 @@ fn write_rebuilt_epub(
             let xhtml = String::from_utf8(bytes).map_err(|err| {
                 BookforgeError::InvalidInput(format!("XHTML resource '{name}' is not UTF-8: {err}"))
             })?;
-            let outcome = patch_xhtml_blocks(&xhtml, file_patches)?;
+            let outcome = patch_xhtml_blocks_with_options(&xhtml, file_patches, options)?;
             total_skipped += outcome.skipped_blocks;
             let xhtml = if name == book.id.0 {
-                if let Some(target_language) = target_language {
-                    patch_opf_language(&outcome.xhtml, target_language)?
-                } else {
-                    outcome.xhtml
-                }
+                patch_opf_for_rebuild(
+                    &outcome.xhtml,
+                    options,
+                    stylesheet.as_ref().map(|plan| plan.opf_href.as_str()),
+                )?
+            } else if let Some(plan) = stylesheet.as_ref() {
+                inject_stylesheet_link(
+                    &outcome.xhtml,
+                    &relative_href(name.as_str(), plan.archive_path.as_str()),
+                )?
             } else {
                 outcome.xhtml
             };
@@ -124,13 +182,17 @@ fn write_rebuilt_epub(
             })?;
             xhtml.into_bytes()
         } else if name == book.id.0 {
-            if let Some(target_language) = target_language {
+            if options.target_language.is_some() || stylesheet.is_some() {
                 let opf = String::from_utf8(bytes).map_err(|err| {
                     BookforgeError::InvalidInput(format!(
                         "OPF resource '{name}' is not UTF-8: {err}"
                     ))
                 })?;
-                let opf = patch_opf_language(&opf, target_language)?;
+                let opf = patch_opf_for_rebuild(
+                    &opf,
+                    options,
+                    stylesheet.as_ref().map(|plan| plan.opf_href.as_str()),
+                )?;
                 validate_xml(&opf).map_err(|err| {
                     BookforgeError::InvalidInput(format!(
                         "patched OPF '{name}' failed validation: {err}"
@@ -146,6 +208,11 @@ fn write_rebuilt_epub(
 
         writer.start_file(name, deflated)?;
         writer.write_all(&output_bytes)?;
+    }
+
+    if let Some(plan) = stylesheet {
+        writer.start_file(plan.archive_path, deflated)?;
+        writer.write_all(plan.content.as_bytes())?;
     }
 
     writer.finish()?;
@@ -211,8 +278,165 @@ fn write_mimetype_first(source: &mut ZipArchive<File>, writer: &mut ZipWriter<Fi
     Ok(())
 }
 
+fn archive_entry_names(archive: &mut ZipArchive<File>) -> Result<HashSet<String>> {
+    let mut names = HashSet::new();
+    for index in 0..archive.len() {
+        names.insert(archive.by_index(index)?.name().to_string());
+    }
+    Ok(names)
+}
+
 fn deterministic_zip_time() -> DateTime {
     DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).expect("DOS epoch timestamp should be valid")
+}
+
+#[derive(Debug, Clone)]
+struct StylesheetPlan {
+    archive_path: String,
+    opf_href: String,
+    content: String,
+}
+
+fn stylesheet_plan(
+    package_path: &str,
+    archive_names: &HashSet<String>,
+    options: &RebuildOptions,
+) -> Option<StylesheetPlan> {
+    if !options.mode.is_append() {
+        return None;
+    }
+
+    let package_dir = package_base_dir(package_path);
+    let mut ordinal = 1usize;
+    loop {
+        let filename = if ordinal == 1 {
+            format!("{BILINGUAL_STYLESHEET_BASENAME}.{BILINGUAL_STYLESHEET_EXTENSION}")
+        } else {
+            format!("{BILINGUAL_STYLESHEET_BASENAME}-{ordinal}.{BILINGUAL_STYLESHEET_EXTENSION}")
+        };
+        let archive_path = join_epub_path(&package_dir, &filename);
+        if !archive_names.contains(&archive_path) {
+            return Some(StylesheetPlan {
+                archive_path,
+                opf_href: filename,
+                content: options
+                    .bilingual_css
+                    .clone()
+                    .unwrap_or_else(|| builtin_bilingual_css(options.bilingual_style).to_string()),
+            });
+        }
+        ordinal += 1;
+    }
+}
+
+fn builtin_bilingual_css(style: BilingualStyle) -> &'static str {
+    match style {
+        BilingualStyle::Minimal => {
+            r#".bookforge-translation {
+  color: #555;
+  font-style: italic;
+  margin-top: 0.2em;
+}
+
+.bookforge-translation[lang="ja"],
+.bookforge-translation[lang="zh"],
+.bookforge-translation[lang="ko"] {
+  font-style: normal;
+}
+
+p.bookforge-translation {
+}
+
+span.bookforge-translation {
+}
+"#
+        }
+        BilingualStyle::Prominent => {
+            r#".bookforge-translation {
+  color: #333;
+  font-style: italic;
+  margin-top: 0.35em;
+  padding-left: 0.75em;
+  border-left: 0.18em solid #777;
+}
+
+.bookforge-translation[lang="ja"],
+.bookforge-translation[lang="zh"],
+.bookforge-translation[lang="ko"] {
+  font-style: normal;
+}
+
+span.bookforge-translation {
+  padding-left: 0;
+  border-left: 0;
+}
+"#
+        }
+        BilingualStyle::InlineOnly => {
+            r#".bookforge-translation {
+  color: inherit;
+  font-style: normal;
+  margin-top: 0;
+}
+
+span.bookforge-translation {
+  color: #555;
+  font-style: italic;
+}
+
+span.bookforge-translation[lang="ja"],
+span.bookforge-translation[lang="zh"],
+span.bookforge-translation[lang="ko"] {
+  font-style: normal;
+}
+"#
+        }
+    }
+}
+
+fn package_base_dir(path: &str) -> String {
+    path.rsplit_once('/')
+        .map(|(base, _)| base.to_string())
+        .unwrap_or_default()
+}
+
+fn join_epub_path(base: &str, href: &str) -> String {
+    if base.is_empty() {
+        href.to_string()
+    } else {
+        format!("{base}/{href}")
+    }
+}
+
+fn relative_href(from_file: &str, target_file: &str) -> String {
+    let from_parts = from_file.split('/').collect::<Vec<_>>();
+    let target_parts = target_file.split('/').collect::<Vec<_>>();
+    let from_dir_len = from_parts.len().saturating_sub(1);
+    let from_dir = &from_parts[..from_dir_len];
+
+    let mut common = 0usize;
+    while common < from_dir.len()
+        && common < target_parts.len()
+        && from_dir[common] == target_parts[common]
+    {
+        common += 1;
+    }
+
+    let mut out = Vec::new();
+    out.extend(std::iter::repeat_n(
+        "..",
+        from_dir.len().saturating_sub(common),
+    ));
+    out.extend(target_parts[common..].iter().copied());
+    if out.is_empty() {
+        target_parts
+            .last()
+            .copied()
+            .unwrap_or(target_file)
+            .to_string()
+    } else {
+        out.join("/")
+    }
 }
 
 fn patches_by_href<'a>(
@@ -236,6 +460,28 @@ fn patches_by_href<'a>(
     }
 
     by_href
+}
+
+fn patch_opf_for_rebuild(
+    opf: &str,
+    options: &RebuildOptions,
+    stylesheet_href: Option<&str>,
+) -> Result<String> {
+    let mut patched = match options.target_language.as_deref() {
+        Some(target_language) if options.mode == BilingualMode::Replace => {
+            patch_opf_language(opf, target_language)?
+        }
+        Some(target_language) if options.mode.is_append() => {
+            patch_opf_bilingual_language(opf, target_language)?
+        }
+        _ => opf.to_string(),
+    };
+
+    if let Some(href) = stylesheet_href {
+        patched = patch_opf_stylesheet_manifest(&patched, href)?;
+    }
+
+    Ok(patched)
 }
 
 fn patch_opf_language(opf: &str, target_language: &str) -> Result<String> {
@@ -290,6 +536,231 @@ fn patch_opf_language(opf: &str, target_language: &str) -> Result<String> {
     })
 }
 
+fn patch_opf_bilingual_language(opf: &str, target_language: &str) -> Result<String> {
+    let language_tag = epub_language_tag(target_language);
+    if opf_language_tags(opf)?
+        .iter()
+        .any(|existing| existing.eq_ignore_ascii_case(&language_tag))
+    {
+        return Ok(opf.to_string());
+    }
+
+    let mut reader = Reader::from_str(opf);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut in_language = false;
+    let mut found_language = false;
+    let mut inserted = false;
+    let mut language_end_name: Option<Vec<u8>> = None;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) if local_name(element.name().as_ref()) == b"language" => {
+                found_language = true;
+                in_language = true;
+                language_end_name = Some(element.name().as_ref().to_vec());
+                writer.write_event(Event::Start(element))?;
+            }
+            Event::Empty(element) if local_name(element.name().as_ref()) == b"language" => {
+                found_language = true;
+                let end = element.to_end();
+                let end_name = end.name().as_ref().to_vec();
+                writer.write_event(Event::Start(element.to_owned()))?;
+                writer.write_event(Event::End(end))?;
+                if !inserted {
+                    write_language_element(&mut writer, &end_name, &language_tag)?;
+                    inserted = true;
+                }
+            }
+            Event::End(element)
+                if in_language && local_name(element.name().as_ref()) == b"language" =>
+            {
+                in_language = false;
+                let end_name = language_end_name
+                    .take()
+                    .unwrap_or_else(|| element.name().as_ref().to_vec());
+                writer.write_event(Event::End(element))?;
+                if !inserted {
+                    write_language_element(&mut writer, &end_name, &language_tag)?;
+                    inserted = true;
+                }
+            }
+            Event::Eof => break,
+            event => writer.write_event(event)?,
+        }
+    }
+
+    if !found_language {
+        return Ok(opf.to_string());
+    }
+
+    String::from_utf8(writer.into_inner()).map_err(|err| {
+        BookforgeError::InvalidInput(format!(
+            "patched bilingual OPF language is not valid UTF-8: {err}"
+        ))
+    })
+}
+
+fn opf_language_tags(opf: &str) -> Result<Vec<String>> {
+    let mut reader = Reader::from_str(opf);
+    reader.config_mut().trim_text(false);
+    let mut in_language = false;
+    let mut tags = Vec::new();
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) if local_name(element.name().as_ref()) == b"language" => {
+                in_language = true;
+            }
+            Event::Text(text) if in_language => {
+                let value = text
+                    .html_content()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                let value = value.trim();
+                if !value.is_empty() {
+                    tags.push(value.to_string());
+                }
+            }
+            Event::CData(text) if in_language => {
+                let value = text
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                let value = value.trim();
+                if !value.is_empty() {
+                    tags.push(value.to_string());
+                }
+            }
+            Event::End(element) if local_name(element.name().as_ref()) == b"language" => {
+                in_language = false;
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(tags)
+}
+
+fn write_language_element(
+    writer: &mut Writer<Vec<u8>>,
+    name: &[u8],
+    language_tag: &str,
+) -> Result<()> {
+    let name = String::from_utf8_lossy(name);
+    writer.write_event(Event::Start(quick_xml::events::BytesStart::new(
+        name.as_ref(),
+    )))?;
+    writer.write_event(Event::Text(BytesText::new(language_tag)))?;
+    writer.write_event(Event::End(BytesEnd::new(name.as_ref())))?;
+    Ok(())
+}
+
+fn patch_opf_stylesheet_manifest(opf: &str, href: &str) -> Result<String> {
+    if opf_manifest_has_href(opf, href)? {
+        return Ok(opf.to_string());
+    }
+
+    let mut reader = Reader::from_str(opf);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut in_manifest = false;
+    let mut inserted = false;
+    let item_id = unique_manifest_id(opf, "bookforge-bilingual-css")?;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) if local_name(element.name().as_ref()) == b"manifest" => {
+                in_manifest = true;
+                writer.write_event(Event::Start(element))?;
+            }
+            Event::End(element)
+                if in_manifest && local_name(element.name().as_ref()) == b"manifest" =>
+            {
+                write_stylesheet_manifest_item(&mut writer, &item_id, href)?;
+                inserted = true;
+                in_manifest = false;
+                writer.write_event(Event::End(element))?;
+            }
+            Event::Eof => break,
+            event => writer.write_event(event)?,
+        }
+    }
+
+    if !inserted {
+        return Ok(opf.to_string());
+    }
+
+    String::from_utf8(writer.into_inner()).map_err(|err| {
+        BookforgeError::InvalidInput(format!("patched OPF manifest is not valid UTF-8: {err}"))
+    })
+}
+
+fn opf_manifest_has_href(opf: &str, href: &str) -> Result<bool> {
+    let mut reader = Reader::from_str(opf);
+    reader.config_mut().trim_text(false);
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) | Event::Empty(element)
+                if local_name(element.name().as_ref()) == b"item" =>
+            {
+                if attr_value_unescaped(&element, b"href")?.as_deref() == Some(href) {
+                    return Ok(true);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(false)
+}
+
+fn unique_manifest_id(opf: &str, base: &str) -> Result<String> {
+    let mut ids = HashSet::new();
+    let mut reader = Reader::from_str(opf);
+    reader.config_mut().trim_text(false);
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) | Event::Empty(element)
+                if local_name(element.name().as_ref()) == b"item" =>
+            {
+                if let Some(id) = attr_value_unescaped(&element, b"id")? {
+                    ids.insert(id);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    if !ids.contains(base) {
+        return Ok(base.to_string());
+    }
+    for ordinal in 2usize.. {
+        let candidate = format!("{base}-{ordinal}");
+        if !ids.contains(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    unreachable!("unbounded manifest id search should always return")
+}
+
+fn write_stylesheet_manifest_item(
+    writer: &mut Writer<Vec<u8>>,
+    item_id: &str,
+    href: &str,
+) -> Result<()> {
+    let mut item = quick_xml::events::BytesStart::new("item");
+    item.push_attribute(("id", item_id));
+    item.push_attribute(("href", href));
+    item.push_attribute(("media-type", "text/css"));
+    writer.write_event(Event::Empty(item))?;
+    Ok(())
+}
+
 fn epub_language_tag(language: &str) -> String {
     let trimmed = language.trim();
     if trimmed.is_empty() {
@@ -331,6 +802,80 @@ fn local_name(name: &[u8]) -> &[u8] {
     name.rsplit(|byte| *byte == b':').next().unwrap_or(name)
 }
 
+fn attr_value_unescaped(
+    element: &quick_xml::events::BytesStart<'_>,
+    attr_name: &[u8],
+) -> Result<Option<String>> {
+    for attr in element.attributes() {
+        let attr = attr.map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+        if local_name(attr.key.as_ref()) == attr_name {
+            return Ok(Some(attr.unescape_value()?.into_owned()));
+        }
+    }
+    Ok(None)
+}
+
+fn inject_stylesheet_link(xhtml: &str, href: &str) -> Result<String> {
+    if xhtml_has_stylesheet_href(xhtml, href)? {
+        return Ok(xhtml.to_string());
+    }
+
+    let mut reader = Reader::from_str(xhtml);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut inserted = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::End(element) if local_name(element.name().as_ref()) == b"head" => {
+                write_stylesheet_link(&mut writer, href)?;
+                inserted = true;
+                writer.write_event(Event::End(element))?;
+            }
+            Event::Eof => break,
+            event => writer.write_event(event)?,
+        }
+    }
+
+    if !inserted {
+        return Ok(xhtml.to_string());
+    }
+
+    String::from_utf8(writer.into_inner()).map_err(|err| {
+        BookforgeError::InvalidInput(format!("stylesheet-linked XHTML is not valid UTF-8: {err}"))
+    })
+}
+
+fn xhtml_has_stylesheet_href(xhtml: &str, href: &str) -> Result<bool> {
+    let mut reader = Reader::from_str(xhtml);
+    reader.config_mut().trim_text(false);
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) | Event::Empty(element)
+                if local_name(element.name().as_ref()) == b"link" =>
+            {
+                if attr_value_unescaped(&element, b"href")?.as_deref() == Some(href) {
+                    return Ok(true);
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(false)
+}
+
+fn write_stylesheet_link(writer: &mut Writer<Vec<u8>>, href: &str) -> Result<()> {
+    let mut link = quick_xml::events::BytesStart::new("link");
+    link.push_attribute(("rel", "stylesheet"));
+    link.push_attribute(("type", "text/css"));
+    link.push_attribute(("href", href));
+    writer.write_event(Event::Empty(link))?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy)]
 struct BlockPatch<'a> {
     block: &'a Block,
@@ -367,10 +912,19 @@ pub(crate) fn patch_xhtml(xhtml: &str, patches: &[(&DomPath, &str)]) -> Result<P
             translation,
         })
         .collect::<Vec<_>>();
-    patch_xhtml_with_specs(xhtml, &specs)
+    patch_xhtml_with_specs(xhtml, &specs, &RebuildOptions::default())
 }
 
+#[cfg(test)]
 fn patch_xhtml_blocks(xhtml: &str, patches: &[BlockPatch<'_>]) -> Result<PatchOutcome> {
+    patch_xhtml_blocks_with_options(xhtml, patches, &RebuildOptions::default())
+}
+
+fn patch_xhtml_blocks_with_options(
+    xhtml: &str,
+    patches: &[BlockPatch<'_>],
+    options: &RebuildOptions,
+) -> Result<PatchOutcome> {
     let specs = patches
         .iter()
         .map(|patch| PatchSpec {
@@ -379,10 +933,14 @@ fn patch_xhtml_blocks(xhtml: &str, patches: &[BlockPatch<'_>]) -> Result<PatchOu
             translation: patch.translation,
         })
         .collect::<Vec<_>>();
-    patch_xhtml_with_specs(xhtml, &specs)
+    patch_xhtml_with_specs(xhtml, &specs, options)
 }
 
-fn patch_xhtml_with_specs(xhtml: &str, patches: &[PatchSpec<'_>]) -> Result<PatchOutcome> {
+fn patch_xhtml_with_specs(
+    xhtml: &str,
+    patches: &[PatchSpec<'_>],
+    options: &RebuildOptions,
+) -> Result<PatchOutcome> {
     let patch_map = patches
         .iter()
         .map(|patch| (patch.dom_path.0.as_slice(), *patch))
@@ -396,59 +954,53 @@ fn patch_xhtml_with_specs(xhtml: &str, patches: &[PatchSpec<'_>]) -> Result<Patc
     loop {
         match reader.read_event()? {
             Event::Start(element) => {
-                let path = enter_element(&mut stack);
+                let name = local_name(element.name().as_ref()).to_vec();
+                let path = enter_element(&mut stack, &name);
                 writer.write_event(Event::Start(element.borrow()))?;
 
                 if let Some(patch) = patch_map.get(path.as_slice()).copied() {
                     let buffered = buffer_until_matching_end(&mut reader)?;
-                    if buffered.has_inline_children {
-                        match patch.block.map(|block| {
-                            render_marked_translation(block, patch.translation, &buffered.events)
-                        }) {
-                            Some(Ok(events)) => {
-                                for event in &events {
-                                    writer.write_event(event.borrow())?;
-                                }
-                            }
-                            Some(Err(error)) => {
-                                skipped_blocks += 1;
-                                tracing::warn!(
-                                    block_path = ?path,
-                                    error = %error,
-                                    "preserving original block contents: translated inline markers \
-                                     could not be applied",
-                                );
-                                for event in &buffered.events {
-                                    writer.write_event(event.borrow())?;
-                                }
-                            }
-                            None => {
-                                skipped_blocks += 1;
-                                tracing::warn!(
-                                    block_path = ?path,
-                                    "preserving original block contents: inline patch did not include \
-                                     block marker metadata",
-                                );
-                                for event in &buffered.events {
-                                    writer.write_event(event.borrow())?;
-                                }
-                            }
+                    match options.mode {
+                        BilingualMode::Replace => {
+                            write_replace_block(
+                                &mut writer,
+                                patch,
+                                &buffered,
+                                &path,
+                                &mut skipped_blocks,
+                            )?;
+                            writer.write_event(Event::End(buffered.end.borrow()))?;
                         }
-                    } else {
-                        writer.write_event(Event::Text(BytesText::new(patch.translation)))?;
+                        BilingualMode::AppendBlock | BilingualMode::AppendText => {
+                            write_append_block(
+                                &mut writer,
+                                element.borrow(),
+                                patch,
+                                &buffered,
+                                options,
+                                &path,
+                                &mut skipped_blocks,
+                            )?;
+                        }
                     }
-                    writer.write_event(Event::End(buffered.end.borrow()))?;
                     stack.pop();
                 }
             }
             Event::Empty(element) => {
                 let path = next_child_path(&mut stack);
                 if let Some(patch) = patch_map.get(path.as_slice()).copied() {
-                    let name = element.name();
-                    let name_str = String::from_utf8_lossy(name.as_ref()).into_owned();
-                    writer.write_event(Event::Start(element.borrow()))?;
-                    writer.write_event(Event::Text(BytesText::new(patch.translation)))?;
-                    writer.write_event(Event::End(BytesEnd::new(name_str)))?;
+                    match options.mode {
+                        BilingualMode::Replace => {
+                            let name = element.name();
+                            let name_str = String::from_utf8_lossy(name.as_ref()).into_owned();
+                            writer.write_event(Event::Start(element.borrow()))?;
+                            writer.write_event(Event::Text(BytesText::new(patch.translation)))?;
+                            writer.write_event(Event::End(BytesEnd::new(name_str)))?;
+                        }
+                        BilingualMode::AppendBlock | BilingualMode::AppendText => {
+                            writer.write_event(Event::Empty(element.borrow()))?;
+                        }
+                    }
                 } else {
                     writer.write_event(Event::Empty(element.borrow()))?;
                 }
@@ -469,9 +1021,33 @@ fn patch_xhtml_with_specs(xhtml: &str, patches: &[PatchSpec<'_>]) -> Result<Patc
                     .map(|value| !value.trim().is_empty())
                     .unwrap_or(true);
                 match text_node_patch(&patch_map, &mut stack, non_whitespace) {
-                    Some(translation) => {
-                        writer.write_event(Event::Text(BytesText::new(translation)))?
-                    }
+                    Some(patch) => match options.mode {
+                        BilingualMode::Replace => {
+                            writer.write_event(Event::Text(BytesText::new(patch.translation)))?
+                        }
+                        BilingualMode::AppendText => {
+                            writer.write_event(Event::Text(text.borrow()))?;
+                            write_inline_translation_span(
+                                &mut writer,
+                                patch,
+                                &[],
+                                options,
+                                &mut skipped_blocks,
+                            )?;
+                        }
+                        BilingualMode::AppendBlock => {
+                            writer.write_event(Event::Text(text.borrow()))?;
+                            write_translation_element_for_patch(
+                                &mut writer,
+                                "p",
+                                &[TRANSLATION_CLASS],
+                                patch,
+                                &[],
+                                options,
+                                &mut skipped_blocks,
+                            )?;
+                        }
+                    },
                     None => writer.write_event(Event::Text(text.borrow()))?,
                 }
             }
@@ -481,9 +1057,33 @@ fn patch_xhtml_with_specs(xhtml: &str, patches: &[PatchSpec<'_>]) -> Result<Patc
                     .map(|value| !value.trim().is_empty())
                     .unwrap_or(true);
                 match text_node_patch(&patch_map, &mut stack, non_whitespace) {
-                    Some(translation) => {
-                        writer.write_event(Event::Text(BytesText::new(translation)))?
-                    }
+                    Some(patch) => match options.mode {
+                        BilingualMode::Replace => {
+                            writer.write_event(Event::Text(BytesText::new(patch.translation)))?
+                        }
+                        BilingualMode::AppendText => {
+                            writer.write_event(Event::CData(text.borrow()))?;
+                            write_inline_translation_span(
+                                &mut writer,
+                                patch,
+                                &[],
+                                options,
+                                &mut skipped_blocks,
+                            )?;
+                        }
+                        BilingualMode::AppendBlock => {
+                            writer.write_event(Event::CData(text.borrow()))?;
+                            write_translation_element_for_patch(
+                                &mut writer,
+                                "p",
+                                &[TRANSLATION_CLASS],
+                                patch,
+                                &[],
+                                options,
+                                &mut skipped_blocks,
+                            )?;
+                        }
+                    },
                     None => writer.write_event(Event::CData(text.borrow()))?,
                 }
             }
@@ -545,6 +1145,367 @@ fn buffer_until_matching_end(reader: &mut Reader<&[u8]>) -> Result<BufferedBlock
             event => events.push(event.into_owned()),
         }
     }
+}
+
+fn write_replace_block(
+    writer: &mut Writer<Vec<u8>>,
+    patch: PatchSpec<'_>,
+    buffered: &BufferedBlock,
+    path: &[usize],
+    skipped_blocks: &mut usize,
+) -> Result<()> {
+    if buffered.has_inline_children {
+        match patch
+            .block
+            .map(|block| render_marked_translation(block, patch.translation, &buffered.events))
+        {
+            Some(Ok(events)) => {
+                for event in &events {
+                    writer.write_event(event.borrow())?;
+                }
+            }
+            Some(Err(error)) => {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    error = %error,
+                    "preserving original block contents: translated inline markers could not be applied",
+                );
+                write_events(writer, &buffered.events)?;
+            }
+            None => {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    "preserving original block contents: inline patch did not include block marker metadata",
+                );
+                write_events(writer, &buffered.events)?;
+            }
+        }
+    } else {
+        writer.write_event(Event::Text(BytesText::new(patch.translation)))?;
+    }
+    Ok(())
+}
+
+fn write_append_block(
+    writer: &mut Writer<Vec<u8>>,
+    original_start: quick_xml::events::BytesStart<'_>,
+    patch: PatchSpec<'_>,
+    buffered: &BufferedBlock,
+    options: &RebuildOptions,
+    path: &[usize],
+    skipped_blocks: &mut usize,
+) -> Result<()> {
+    if !source_has_visible_text(&buffered.events) || patch.translation.trim().is_empty() {
+        write_events(writer, &buffered.events)?;
+        writer.write_event(Event::End(buffered.end.borrow()))?;
+        return Ok(());
+    }
+
+    let action = append_action(&original_start, patch, options.mode);
+    match action {
+        AppendAction::Skip => {
+            write_events(writer, &buffered.events)?;
+            writer.write_event(Event::End(buffered.end.borrow()))?;
+        }
+        AppendAction::SiblingParagraph { classes } => {
+            write_events(writer, &buffered.events)?;
+            writer.write_event(Event::End(buffered.end.borrow()))?;
+            let _ = write_translation_element_for_patch(
+                writer,
+                "p",
+                &classes,
+                patch,
+                &buffered.events,
+                options,
+                skipped_blocks,
+            )
+            .inspect_err(|error| {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    error = %error,
+                    "preserving source-only block: appended translation could not be rendered",
+                );
+            });
+        }
+        AppendAction::NestedParagraph => {
+            write_events(writer, &buffered.events)?;
+            let _ = write_translation_element_for_patch(
+                writer,
+                "p",
+                &[TRANSLATION_CLASS],
+                patch,
+                &buffered.events,
+                options,
+                skipped_blocks,
+            )
+            .inspect_err(|error| {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    error = %error,
+                    "preserving source-only block: nested translation could not be rendered",
+                );
+            });
+            writer.write_event(Event::End(buffered.end.borrow()))?;
+        }
+        AppendAction::InlineAtEnd => {
+            write_events(writer, &buffered.events)?;
+            let _ = write_inline_translation_span(
+                writer,
+                patch,
+                &buffered.events,
+                options,
+                skipped_blocks,
+            )
+            .inspect_err(|error| {
+                *skipped_blocks += 1;
+                tracing::warn!(
+                    block_path = ?path,
+                    error = %error,
+                    "preserving source-only block: inline translation could not be rendered",
+                );
+            });
+            writer.write_event(Event::End(buffered.end.borrow()))?;
+        }
+        AppendAction::InlineInLastParagraph => {
+            write_events_with_inline_in_last_paragraph(
+                writer,
+                patch,
+                &buffered.events,
+                options,
+                skipped_blocks,
+                path,
+            )?;
+            writer.write_event(Event::End(buffered.end.borrow()))?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+enum AppendAction {
+    Skip,
+    SiblingParagraph { classes: Vec<String> },
+    NestedParagraph,
+    InlineAtEnd,
+    InlineInLastParagraph,
+}
+
+fn append_action(
+    original_start: &quick_xml::events::BytesStart<'_>,
+    patch: PatchSpec<'_>,
+    mode: BilingualMode,
+) -> AppendAction {
+    if patch
+        .block
+        .is_some_and(|block| matches!(block.kind, bookforge_core::ir::BlockKind::Code))
+    {
+        return AppendAction::Skip;
+    }
+
+    let element_name = original_start.name();
+    let name = local_name(element_name.as_ref());
+    match mode {
+        BilingualMode::Replace => AppendAction::Skip,
+        BilingualMode::AppendBlock => match name {
+            b"p" | b"blockquote" | b"figcaption" | b"caption" | b"aside" => {
+                AppendAction::SiblingParagraph {
+                    classes: vec![TRANSLATION_CLASS.to_string()],
+                }
+            }
+            b"h1" | b"h2" | b"h3" | b"h4" | b"h5" | b"h6" => AppendAction::SiblingParagraph {
+                classes: heading_translation_classes(original_start),
+            },
+            b"li" | b"td" | b"th" => AppendAction::NestedParagraph,
+            _ => AppendAction::Skip,
+        },
+        BilingualMode::AppendText => match name {
+            b"p" | b"li" | b"h1" | b"h2" | b"h3" | b"h4" | b"h5" | b"h6" | b"figcaption"
+            | b"caption" | b"td" | b"th" => AppendAction::InlineAtEnd,
+            b"blockquote" | b"aside" => AppendAction::InlineInLastParagraph,
+            _ => AppendAction::Skip,
+        },
+    }
+}
+
+fn heading_translation_classes(original_start: &quick_xml::events::BytesStart<'_>) -> Vec<String> {
+    let mut classes = attr_value_unescaped(original_start, b"class")
+        .ok()
+        .flatten()
+        .map(|value| {
+            value
+                .split_whitespace()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    classes.push(TRANSLATION_CLASS.to_string());
+    classes.push(HEADING_TRANSLATION_CLASS.to_string());
+    dedupe_classes(classes)
+}
+
+fn dedupe_classes(classes: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    classes
+        .into_iter()
+        .filter(|class| !class.is_empty() && seen.insert(class.clone()))
+        .collect()
+}
+
+fn write_events(writer: &mut Writer<Vec<u8>>, events: &[Event<'static>]) -> Result<()> {
+    for event in events {
+        writer.write_event(event.borrow())?;
+    }
+    Ok(())
+}
+
+fn source_has_visible_text(events: &[Event<'static>]) -> bool {
+    events.iter().any(|event| match event {
+        Event::Text(text) => text
+            .html_content()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(true),
+        Event::CData(text) => text
+            .decode()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(true),
+        _ => false,
+    })
+}
+
+fn write_events_with_inline_in_last_paragraph(
+    writer: &mut Writer<Vec<u8>>,
+    patch: PatchSpec<'_>,
+    events: &[Event<'static>],
+    options: &RebuildOptions,
+    skipped_blocks: &mut usize,
+    path: &[usize],
+) -> Result<()> {
+    let insert_at = events.iter().rposition(
+        |event| matches!(event, Event::End(end) if local_name(end.name().as_ref()) == b"p"),
+    );
+
+    if let Some(insert_at) = insert_at {
+        for (index, event) in events.iter().enumerate() {
+            if index == insert_at {
+                let _ = write_plain_inline_translation_span(writer, patch, options)
+                    .inspect_err(|error| {
+                        *skipped_blocks += 1;
+                        tracing::warn!(
+                            block_path = ?path,
+                            error = %error,
+                            "preserving source-only block: inline translation could not be rendered",
+                        );
+                    });
+            }
+            writer.write_event(event.borrow())?;
+        }
+    } else {
+        write_events(writer, events)?;
+        let _ = write_plain_inline_translation_span(writer, patch, options).inspect_err(|error| {
+            *skipped_blocks += 1;
+            tracing::warn!(
+                block_path = ?path,
+                error = %error,
+                "preserving source-only block: inline translation could not be rendered",
+            );
+        });
+    }
+
+    Ok(())
+}
+
+fn write_plain_inline_translation_span(
+    writer: &mut Writer<Vec<u8>>,
+    patch: PatchSpec<'_>,
+    options: &RebuildOptions,
+) -> Result<()> {
+    let normalized = normalize_marker_whitespace(patch.translation);
+    let stripped = strip_marker_tokens(&normalized);
+    let rendered = [Event::Text(BytesText::new(stripped.trim()).into_owned())];
+    writer.write_event(Event::Text(BytesText::new(&options.bilingual_separator)))?;
+    write_translation_element(writer, "span", &[TRANSLATION_CLASS], options, &rendered)
+}
+
+fn write_inline_translation_span(
+    writer: &mut Writer<Vec<u8>>,
+    patch: PatchSpec<'_>,
+    original_events: &[Event<'static>],
+    options: &RebuildOptions,
+    _skipped_blocks: &mut usize,
+) -> Result<()> {
+    let rendered = render_translation_for_append(patch, original_events)?;
+    writer.write_event(Event::Text(BytesText::new(&options.bilingual_separator)))?;
+    write_translation_element(writer, "span", &[TRANSLATION_CLASS], options, &rendered)
+}
+
+fn write_translation_element_for_patch(
+    writer: &mut Writer<Vec<u8>>,
+    element_name: &str,
+    classes: &[impl AsRef<str>],
+    patch: PatchSpec<'_>,
+    original_events: &[Event<'static>],
+    options: &RebuildOptions,
+    _skipped_blocks: &mut usize,
+) -> Result<()> {
+    let rendered = render_translation_for_append(patch, original_events)?;
+    write_translation_element(writer, element_name, classes, options, &rendered)
+}
+
+fn render_translation_for_append(
+    patch: PatchSpec<'_>,
+    original_events: &[Event<'static>],
+) -> Result<Vec<Event<'static>>> {
+    if let Some(block) = patch.block {
+        return render_marked_translation(block, patch.translation, original_events);
+    }
+    Ok(vec![Event::Text(
+        BytesText::new(patch.translation).into_owned(),
+    )])
+}
+
+fn write_translation_element(
+    writer: &mut Writer<Vec<u8>>,
+    element_name: &str,
+    classes: &[impl AsRef<str>],
+    options: &RebuildOptions,
+    content: &[Event<'static>],
+) -> Result<()> {
+    let class_attr = classes
+        .iter()
+        .map(|class| class.as_ref())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut element = quick_xml::events::BytesStart::new(element_name);
+    element.push_attribute(("class", class_attr.as_str()));
+    let lang_attr = options
+        .target_language
+        .as_deref()
+        .map(epub_language_tag)
+        .unwrap_or_default();
+    if !lang_attr.is_empty() {
+        element.push_attribute(("lang", lang_attr.as_str()));
+        if is_rtl_language_tag(&lang_attr) {
+            element.push_attribute(("dir", "rtl"));
+        }
+    }
+    writer.write_event(Event::Start(element))?;
+    write_events(writer, content)?;
+    writer.write_event(Event::End(BytesEnd::new(element_name)))?;
+    Ok(())
+}
+
+fn is_rtl_language_tag(language_tag: &str) -> bool {
+    let primary = language_tag
+        .split('-')
+        .next()
+        .unwrap_or(language_tag)
+        .to_ascii_lowercase();
+    matches!(primary.as_str(), "ar" | "he" | "fa")
 }
 
 #[derive(Debug, Clone)]
@@ -1031,7 +1992,7 @@ fn text_node_patch<'a>(
     patch_map: &HashMap<&[usize], PatchSpec<'a>>,
     stack: &mut [ElementFrame],
     non_whitespace: bool,
-) -> Option<&'a str> {
+) -> Option<PatchSpec<'a>> {
     if !non_whitespace {
         return None;
     }
@@ -1039,12 +2000,10 @@ fn text_node_patch<'a>(
     let mut path = frame.path.clone();
     path.push(TEXT_NODE_PATH_BASE + frame.text_count);
     frame.text_count += 1;
-    patch_map
-        .get(path.as_slice())
-        .map(|patch| patch.translation)
+    patch_map.get(path.as_slice()).copied()
 }
 
-fn enter_element(stack: &mut Vec<ElementFrame>) -> Vec<usize> {
+fn enter_element(stack: &mut Vec<ElementFrame>, _name: &[u8]) -> Vec<usize> {
     let path = next_child_path(stack);
     stack.push(ElementFrame {
         path: path.clone(),
@@ -1083,6 +2042,256 @@ mod tests {
 
         assert!(patched.contains("<dc:language>it</dc:language>"));
         validate_xml(&patched).expect("patched OPF should remain XML");
+    }
+
+    #[test]
+    fn patch_opf_bilingual_language_adds_secondary_target_language() {
+        let opf = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:language>en</dc:language>
+  </metadata>
+</package>"#;
+
+        let patched = patch_opf_bilingual_language(opf, "Italian").expect("language should patch");
+
+        assert!(patched.contains("<dc:language>en</dc:language>"));
+        assert!(patched.contains("<dc:language>it</dc:language>"));
+        validate_xml(&patched).expect("patched OPF should remain XML");
+    }
+
+    #[test]
+    fn append_block_adds_paragraph_sibling_with_lang() {
+        let xhtml = "<root><p>Original</p></root>";
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Paragraph,
+            "Original",
+        );
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "Tradotto",
+            }],
+            &append_options(BilingualMode::AppendBlock),
+        )
+        .expect("patch should succeed");
+
+        assert!(
+            outcome.xhtml.contains(
+                r#"<p>Original</p><p class="bookforge-translation" lang="it">Tradotto</p>"#
+            )
+        );
+        validate_xml(&outcome.xhtml).expect("append-block output should re-parse");
+    }
+
+    #[test]
+    fn append_text_adds_inline_span_with_configured_separator() {
+        let xhtml = "<root><p>Original</p></root>";
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Paragraph,
+            "Original",
+        );
+        let mut options = append_options(BilingualMode::AppendText);
+        options.bilingual_separator = " -- ".to_string();
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "Tradotto",
+            }],
+            &options,
+        )
+        .expect("patch should succeed");
+
+        assert!(outcome.xhtml.contains(
+            r#"<p>Original -- <span class="bookforge-translation" lang="it">Tradotto</span></p>"#
+        ));
+        validate_xml(&outcome.xhtml).expect("append-text output should re-parse");
+    }
+
+    #[test]
+    fn append_translation_for_rtl_target_sets_dir_attribute() {
+        let xhtml = "<root><p>Original</p></root>";
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Paragraph,
+            "Original",
+        );
+        let mut options = append_options(BilingualMode::AppendBlock);
+        options.target_language = Some("Arabic".to_string());
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "Target",
+            }],
+            &options,
+        )
+        .expect("patch should succeed");
+
+        assert!(
+            outcome
+                .xhtml
+                .contains(r#"<p class="bookforge-translation" lang="ar" dir="rtl">Target</p>"#)
+        );
+        validate_xml(&outcome.xhtml).expect("rtl append output should re-parse");
+    }
+
+    #[test]
+    fn append_block_heading_uses_paragraph_with_original_and_heading_classes() {
+        let xhtml = r#"<root><h2 class="title">Chapter</h2></root>"#;
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Heading(2),
+            "Chapter",
+        );
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "Capitolo",
+            }],
+            &append_options(BilingualMode::AppendBlock),
+        )
+        .expect("patch should succeed");
+
+        assert!(outcome.xhtml.contains(
+            r#"<p class="title bookforge-translation bookforge-heading-translation" lang="it">Capitolo</p>"#
+        ));
+        validate_xml(&outcome.xhtml).expect("heading append output should re-parse");
+    }
+
+    #[test]
+    fn append_block_list_item_and_table_cell_use_nested_paragraphs() {
+        let options = append_options(BilingualMode::AppendBlock);
+        let list = "<root><ul><li>Item</li></ul></root>";
+        let list_block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0, 0]),
+            BlockKind::ListItem,
+            "Item",
+        );
+        let list_outcome = patch_xhtml_blocks_with_options(
+            list,
+            &[BlockPatch {
+                block: &list_block,
+                translation: "Elemento",
+            }],
+            &options,
+        )
+        .expect("list patch should succeed");
+        assert!(
+            list_outcome.xhtml.contains(
+                r#"<li>Item<p class="bookforge-translation" lang="it">Elemento</p></li>"#
+            )
+        );
+
+        let table = "<root><table><tr><td>Cell</td></tr></table></root>";
+        let cell_block = plain_block(
+            "b_000001",
+            DomPath(vec![0, 0, 0, 0]),
+            BlockKind::TableCell,
+            "Cell",
+        );
+        let table_outcome = patch_xhtml_blocks_with_options(
+            table,
+            &[BlockPatch {
+                block: &cell_block,
+                translation: "Cella",
+            }],
+            &options,
+        )
+        .expect("table patch should succeed");
+        assert!(
+            table_outcome
+                .xhtml
+                .contains(r#"<td>Cell<p class="bookforge-translation" lang="it">Cella</p></td>"#)
+        );
+        validate_xml(&list_outcome.xhtml).expect("list append output should re-parse");
+        validate_xml(&table_outcome.xhtml).expect("table append output should re-parse");
+    }
+
+    #[test]
+    fn append_text_blockquote_inserts_span_inside_last_paragraph() {
+        let xhtml = "<root><blockquote><p>Quote</p></blockquote></root>";
+        let block = plain_block("b_000000", DomPath(vec![0, 0]), BlockKind::Quote, "Quote");
+        let outcome = patch_xhtml_blocks_with_options(
+            xhtml,
+            &[BlockPatch {
+                block: &block,
+                translation: "Citazione",
+            }],
+            &append_options(BilingualMode::AppendText),
+        )
+        .expect("patch should succeed");
+
+        assert!(
+            outcome.xhtml.contains(
+                r#"<blockquote><p>Quote / <span class="bookforge-translation" lang="it">Citazione</span></p></blockquote>"#
+            ),
+            "got: {}",
+            outcome.xhtml
+        );
+        validate_xml(&outcome.xhtml).expect("blockquote append output should re-parse");
+    }
+
+    #[test]
+    fn append_modes_skip_code_pre_and_empty_blocks() {
+        let options = append_options(BilingualMode::AppendBlock);
+        let code = "<root><pre>literal</pre></root>";
+        let code_block = plain_block("b_000000", DomPath(vec![0, 0]), BlockKind::Code, "literal");
+        let code_outcome = patch_xhtml_blocks_with_options(
+            code,
+            &[BlockPatch {
+                block: &code_block,
+                translation: "tradotto",
+            }],
+            &options,
+        )
+        .expect("code patch should succeed");
+        assert_eq!(code_outcome.xhtml, code);
+
+        let empty = "<root><p></p></root>";
+        let empty_block = plain_block("b_000001", DomPath(vec![0, 0]), BlockKind::Paragraph, "");
+        let empty_outcome = patch_xhtml_blocks_with_options(
+            empty,
+            &[BlockPatch {
+                block: &empty_block,
+                translation: "tradotto",
+            }],
+            &options,
+        )
+        .expect("empty patch should succeed");
+        assert_eq!(empty_outcome.xhtml, empty);
+    }
+
+    #[test]
+    fn replace_mode_options_match_default_patch_output() {
+        let xhtml = "<root><p>Original</p></root>";
+        let block = plain_block(
+            "b_000000",
+            DomPath(vec![0, 0]),
+            BlockKind::Paragraph,
+            "Original",
+        );
+        let patches = [BlockPatch {
+            block: &block,
+            translation: "Tradotto",
+        }];
+
+        let default = patch_xhtml_blocks(xhtml, &patches).expect("default patch should succeed");
+        let replace = patch_xhtml_blocks_with_options(xhtml, &patches, &RebuildOptions::default())
+            .expect("replace patch should succeed");
+
+        assert_eq!(replace.xhtml, default.xhtml);
+        assert_eq!(replace.skipped_blocks, default.skipped_blocks);
     }
 
     #[test]
@@ -1307,6 +2516,36 @@ mod tests {
     #[test]
     fn validate_xml_rejects_malformed_input() {
         assert!(validate_xml("<root><p>oops</root>").is_err());
+    }
+
+    fn append_options(mode: BilingualMode) -> RebuildOptions {
+        RebuildOptions {
+            target_language: Some("Italian".to_string()),
+            mode,
+            bilingual_separator: DEFAULT_APPEND_TEXT_SEPARATOR.to_string(),
+            bilingual_style: BilingualStyle::Minimal,
+            bilingual_css: None,
+        }
+    }
+
+    fn plain_block(id: &str, dom_path: DomPath, kind: BlockKind, text: &str) -> Block {
+        Block {
+            id: BlockId(id.to_string()),
+            section_id: SectionId("sec_000000".to_string()),
+            kind,
+            dom_path,
+            text_runs: if text.is_empty() {
+                Vec::new()
+            } else {
+                vec![TextRun {
+                    id: "r000000_000".to_string(),
+                    text: text.to_string(),
+                }]
+            },
+            inline_marks: Vec::new(),
+            protected_spans: Vec::<ProtectedSpan>::new(),
+            token_estimate: 4,
+        }
     }
 
     fn block(id: &str, dom_path: DomPath, inline_marks: Vec<InlineMark>) -> Block {

--- a/crates/bookforge-epub/src/writer.rs
+++ b/crates/bookforge-epub/src/writer.rs
@@ -793,7 +793,12 @@ fn epub_language_tag(language: &str) -> String {
         "norwegian" => "no",
         "danish" => "da",
         "finnish" => "fi",
-        _ => trimmed,
+        // Unknown language names (multi-word, non-ASCII, unmapped) cannot
+        // be emitted verbatim: `lang="Haitian Creole"` is not a valid
+        // BCP 47 tag and fails EPUBCheck. `und` is the BCP 47 code for
+        // "undetermined", which keeps the attribute present (§9b.9) and
+        // the document valid.
+        _ => "und",
     }
     .to_string()
 }
@@ -2112,6 +2117,18 @@ mod tests {
             r#"<p>Original -- <span class="bookforge-translation" lang="it">Tradotto</span></p>"#
         ));
         validate_xml(&outcome.xhtml).expect("append-text output should re-parse");
+    }
+
+    #[test]
+    fn epub_language_tag_maps_known_names_and_falls_back_to_und() {
+        assert_eq!(epub_language_tag("Italian"), "it");
+        assert_eq!(epub_language_tag("Brazilian Portuguese"), "pt-BR");
+        assert_eq!(epub_language_tag("it"), "it");
+        assert_eq!(epub_language_tag("pt-BR"), "pt-br");
+        assert_eq!(epub_language_tag(""), "");
+        // Unmapped multi-word names must not leak into lang attributes.
+        assert_eq!(epub_language_tag("Haitian Creole"), "und");
+        assert_eq!(epub_language_tag("Neapolitan"), "und");
     }
 
     #[test]

--- a/crates/bookforge-epub/tests/inspect.rs
+++ b/crates/bookforge-epub/tests/inspect.rs
@@ -6,11 +6,14 @@ use std::{
 };
 
 use bookforge_core::{
+    config::BilingualMode,
     config::SegmentationConfig,
     ir::BlockKind,
     segment::{BlockTranslation, build_segments},
 };
-use bookforge_epub::{inspect_epub, read_epub, rebuild_epub};
+use bookforge_epub::{
+    RebuildOptions, inspect_epub, read_epub, rebuild_epub, rebuild_epub_with_options,
+};
 use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
 
 #[test]
@@ -152,6 +155,49 @@ fn rebuild_can_safely_replace_the_source_path() {
         .read_to_string(&mut chapter)
         .expect("chapter should read");
     assert!(chapter.contains("Safely replaced in place."));
+}
+
+#[test]
+fn rebuild_replace_options_are_byte_identical_to_default_rebuild() {
+    let fixture = create_minimal_epub();
+    let book = read_epub(&fixture).expect("fixture should parse into IR");
+    let body_block = book
+        .blocks
+        .iter()
+        .find(|block| block_text(block) == "Hello from chapter 1.")
+        .expect("body paragraph should be extracted");
+    let translations = [BlockTranslation {
+        block_id: body_block.id.clone(),
+        text: "Ciao da un EPUB minimo.".to_string(),
+    }];
+    let output_default = std::env::temp_dir().join(format!(
+        "bookforge-replace-default-{}.epub",
+        std::process::id()
+    ));
+    let output_options = std::env::temp_dir().join(format!(
+        "bookforge-replace-options-{}.epub",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&output_default);
+    let _ = std::fs::remove_file(&output_options);
+
+    rebuild_epub(&book, &translations, &output_default).expect("default rebuild should succeed");
+    rebuild_epub_with_options(
+        &book,
+        &translations,
+        &output_options,
+        &RebuildOptions {
+            mode: BilingualMode::Replace,
+            ..RebuildOptions::default()
+        },
+    )
+    .expect("explicit replace rebuild should succeed");
+
+    assert_eq!(
+        std::fs::read(&output_default).expect("default output should read"),
+        std::fs::read(&output_options).expect("options output should read"),
+        "replace mode must remain byte-identical to the default rebuild path"
+    );
 }
 
 #[test]

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -2901,6 +2901,10 @@ mod tests {
             style_rendered_block: String::new(),
             entities_fingerprint: String::new(),
             entities_rendered_block: String::new(),
+            bilingual_mode: bookforge_core::BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_css: None,
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 
@@ -2989,6 +2993,10 @@ mod tests {
             style_rendered_block: String::new(),
             entities_fingerprint: String::new(),
             entities_rendered_block: String::new(),
+            bilingual_mode: bookforge_core::BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: bookforge_core::BilingualStyle::Minimal,
+            bilingual_css: None,
             settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
         };
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2341,21 +2341,57 @@ So this section is a **sketch**, not a commitment. Re-evaluate after v1.8 ships.
   it is now mainline ingestion, spec'd as v1.6 in §9 (decision 2026-06).
 - **Glossary auto-extraction (v1.2.x)** — already mentioned, file here as
   a reminder if it didn't ship as a point release.
-- **Proper Pause + Stop for in-flight translations.** The v2 web redesign
-  (`bookforge serve`, `BookForge App` UI) exposes Library/Wizard/Progress/
-  Review/Validation/Glossary at CLI parity, but the Progress screen is
-  **monitor-only** because the engine has no live control surface:
-  - *Stop* — runs are spawned **detached** (`serve` drops the child handle) and
-    CLI runs aren't `serve`'s children at all, so there is no PID to signal.
-    Needs `serve` to track child handles (and/or a store-recorded PID) so a Stop
-    can terminate the run; the existing per-chapter checkpoints already make the
-    stopped job resumable via `bookforge resume`.
-  - *Pause* — there is **no cooperative pause primitive** in `bookforge-core`'s
-    run loop. Needs a real pause/resume signal (cooperative checkpoint-and-halt
-    at a segment boundary) plumbed through the engine, then surfaced as
-    `POST /api/jobs/{id}/pause|resume|cancel` and wired into the Progress screen's
-    Pause/Stop/Resume controls. Until then the UI omits these controls rather
-    than faking them.
+- **Proper Pause + Stop for in-flight translations.** Promoted from a
+  sketch to a scheduled mini-spec — see §10.1.1 below.
+
+#### 10.1.1 Mini-spec: Pause + Stop (added 2026-07-03, ready to schedule)
+
+**Goal.** The Progress surfaces (CLI `--ui`, `watch`, and the `serve`
+dashboard) gain working Pause / Resume / Stop controls. Today they are
+monitor-only; the de-facto pause is "kill the process and `bookforge
+resume`", which works (checkpointing guarantees at most the in-flight
+segments are re-paid) but is graceless and invisible to the dashboard.
+
+**Design — three small pieces, in dependency order:**
+
+1. **Cooperative pause in the scheduler (`bookforge-llm`).** A shared
+   `PauseSignal` (an `Arc<AtomicU8>`-style tri-state run/pause/stop,
+   sibling to the existing `CancellationToken` plumbing) checked before
+   each new segment dispatch. On *pause*: stop dispatching, let in-flight
+   requests complete and checkpoint, then park. On *stop*: same, then
+   exit the run loop cleanly. Job status gains `paused` (store enum +
+   JSONL event `JobPaused` / `JobResumed` — additive, §1.5-compatible).
+2. **Control channel for detached runs.** Runs spawned by `serve` (and
+   CLI runs generally) are not children of the controller, so signal the
+   engine via a file the run loop polls at segment boundaries:
+   `.bookforge/runs/<job-id>/control` containing `pause|resume|stop`.
+   Filesystem-based control matches the existing events.jsonl tailing
+   architecture, works across unrelated processes, and needs no new
+   dependencies (§1.6). Poll cost is one small read per segment boundary.
+3. **Surfaces.** CLI: `bookforge pause <job-id>` / `resume` (extend the
+   existing command to also clear a paused control file) / `stop <job-id>`.
+   Serve: `POST /api/jobs/{id}/pause|resume|stop` writing the same control
+   file (CSRF-protected like existing POSTs), and the Progress screen's
+   Pause/Stop/Resume buttons wired up. TUI: keybindings on `watch`.
+
+**Acceptance.**
+1. Pausing mid-run stops new provider requests within one segment
+   boundary; in-flight segments checkpoint; job shows `paused` in
+   `status`, `watch`, and the dashboard.
+2. Resume (CLI or dashboard) continues without re-translating any
+   succeeded segment (cache/checkpoint identical to today's resume).
+3. Stop terminates the run cleanly; `bookforge resume` afterwards works
+   exactly as it does after a kill today.
+4. A pre-feature job (no control file) runs unchanged.
+5. Un-mockable criterion (§15.6): pause/resume/stop a real DeepSeek run
+   from the dashboard, verify token spend stops while paused.
+
+**Out of scope:** per-segment abort of in-flight requests (let them
+finish; they're checkpointed), scheduling/queueing multiple jobs, pause
+across machine reboots beyond what the control file naturally provides.
+
+**Effort:** 1–2 days engine + 1 day surfaces. **Priority:** after v1.7
+ships; pairs naturally with §9c in a quality-of-life release.
 
 ### 10.2 Explicit non-goals (still)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,17 +1,26 @@
 # BookForge — Technical Roadmap, v1.0.1 through v2.0
 
-**Document version:** 1.1.2
-**Last updated:** 2026-07-02
+**Document version:** 1.2.0
+**Last updated:** 2026-07-03
 **Status:** historical roadmap plus active follow-up notes
 **Audience:** project maintainer + Claude Code (or any other coding agent) implementing
 the milestones below.
 
-> **Current status:** v2.0 has shipped; the current release line is v2.0.2
-> as of 2026-07-02. This document is kept for architectural invariants,
-> shipped-milestone context, and deferred follow-up work. For current user
-> behavior, start with `README.md`, `CHANGELOG.md`, and
-> `docs/v2-web-dashboard-plan.md`; older milestone sections below are
-> historical unless explicitly marked as follow-up.
+> **Current status:** the current release line is v2.1.0 (2026-07-03).
+> This document is kept for architectural invariants, shipped-milestone
+> context, and deferred follow-up work. For current user behavior, start
+> with `README.md`, `CHANGELOG.md`, and `docs/v2-web-dashboard-plan.md`;
+> older milestone sections below are historical unless explicitly marked
+> as follow-up.
+>
+> **Milestone numbers vs. release versions.** The `v1.x` labels below are
+> roadmap *milestone names*, frozen when this plan was written; they no
+> longer track released product versions (semver `v2.x`), and milestones
+> shipped out of order. Read them as feature names. Mapping so far:
+> milestone v1.8 → releases v1.8.x (2026-06-20); v2.0 milestone →
+> releases v2.0.0–v2.0.3; milestone v1.6 (PDF hardening) → release
+> v2.1.0 (2026-07-03); milestone v1.7 (bilingual output) → in progress,
+> expected v2.2.0.
 
 ---
 
@@ -72,7 +81,7 @@ pattern is an architectural smell, not a feature.
 
 A cached translation is reused if and only if `(source_hash, prompt_contract_version,
 provider, model, source_language, target_language)` all match. Prompt
-versioning has a major/minor split (see §12.3); cache is keyed on major only,
+versioning has a major/minor split (see §11.3); cache is keyed on major only,
 so prose-level prompt revisions don't invalidate cache.
 
 ### 1.4 Quality is measured by reader experience, not by feature count.
@@ -107,8 +116,8 @@ via `java`, but the BookForge binary itself does not need Java to run.
 | v1.3 | Context + style | 8–12 days | none (explicit "no promotion" rule) | shipped |
 | v1.4 | Distribution + writeup | 5–7 days | one technical post, two or three venues; cargo-dist binaries land here | shipped |
 | v1.5 | Extraction + scheduling overhaul (shipped scope; see §8 post-ship note) | — | none | shipped 2026-06-12 |
-| v1.6 | PDF ingestion hardening (§9) | 8–14 days | release notes; maybe a short writeup if layout reconstruction turns out interesting | **next** |
-| v1.7 | Bilingual output (§9b) | 5–8 days | passive (release notes only) | planned |
+| v1.6 | PDF ingestion hardening (§9) | 8–14 days | release notes; maybe a short writeup if layout reconstruction turns out interesting | **shipped 2026-07-03 as release v2.1.0** |
+| v1.7 | Bilingual output (§9b) | 5–8 days | passive (release notes only) | **in progress (2026-07-03)** |
 | v1.8 | Structural credibility (EPUBCheck + corpus; was the planned v1.5 scope, §8) | 10–14 days | README final rewrite citing corpus | **shipped 2026-06-20** |
 | v2.0 | Monitoring UI (`RunState`, `watch`, `--ui tui`, local `serve`) | shipped scope | release notes | shipped; current patch v2.0.2 (2026-07-02) |
 
@@ -820,6 +829,13 @@ order and truncated at the token budget (default 800 tokens, configurable
 via `--glossary-budget-tokens`). A `tracing::warn!()` line fires if
 truncation drops any `user_seeded` or `always_active` entries.
 
+**Post-ship note (2026-07-03).** Ranking rules 3 and 4 (recently-active,
+high-frequency anchors) were specified before any usage evidence existed,
+and nothing instruments whether they ever fire usefully. Before extending
+this machinery further, add counters (per rule: entries injected /
+entries honored in output) to a real translation run and check the data;
+if rules 3–4 contribute nothing measurable, simplify rather than extend.
+
 **Token estimator.** v1.2 uses a conservative `chars / 3` heuristic
 (rounded up) instead of a real BPE tokenizer. The heuristic over-counts
 slightly on Latin scripts and under-counts on Asian scripts; both
@@ -1416,6 +1432,14 @@ clean equivalent), keep them and document why. Don't compromise correctness
 for compatibility; do compromise tooling-bleed for compatibility.
 
 ### 7.8 The writeup
+
+> **Status note (2026-07-03):** the writeup was never published — the
+> rest of v1.4 (cargo-dist, distribution) shipped without it. It remains
+> the only intentional marketing event in the roadmap and is now
+> *stronger* than originally scoped: §9's layout-reconstruction work
+> ("maybe a short writeup if it turns out interesting" — it did) and the
+> measured whitespace-boundary fix are concrete war stories the original
+> outline lacked. Treat as open, unscheduled work.
 
 Title (suggested): **"BookForge: Translating EPUBs Without Letting the LLM Near the Structure"**
 
@@ -2075,6 +2099,15 @@ Not every element should be appended to. Default policy table:
 This policy is hardcoded for v1.7. Make it configurable via a TOML file
 (`--bilingual-policy <file>`) only if real users ask for it.
 
+**Insertion-point ruling (2026-07-03, clarifying an ambiguity).** In
+`append-text` mode the translation is inserted as **exactly one span per
+block, at the end of the block's inline content** (or, per the table
+above, inside the last `<p>` for blockquote/aside). It is NOT inserted
+after each individual text run — a paragraph with mid-sentence inline
+markup gets one trailing span, never interleaved fragments. The §9b.4
+example is normative; the older "after each source text run" phrasing in
+§9b.12.3 was a spec bug and has been corrected.
+
 ### 9b.6 CSS
 
 Default stylesheet (injected into the EPUB if not already present):
@@ -2224,8 +2257,10 @@ bookforge translate origin.epub \
    Italian-translated `<p class="bookforge-translation" lang="it">...</p>` sibling.
 2. The output passes EPUBCheck.
 3. `bookforge translate book.epub --target Italian --mode append-text`
-   produces inline bilingual content with `<span class="bookforge-translation"
-   lang="it">...</span>` after each source text run.
+   produces inline bilingual content with exactly one
+   `<span class="bookforge-translation" lang="it">...</span>` appended at
+   the end of each block's inline content (see the insertion-point ruling
+   in §9b.5; the §9b.4 example is normative).
 4. `--mode replace` produces output identical to v1.5 (no behavior regression).
 5. Glossary, context, and style sheets all apply in bilingual modes.
 6. Token usage in bilingual modes is roughly equal to that in replace
@@ -2247,7 +2282,35 @@ wait until the PDF ingestion surface is useful on real documents.
 
 ---
 
+## 9c. Follow-up (proposed 2026-07-03) — source-EPUB reflow
+
+**Not yet scheduled; flagged during v1.6 validation.** The owner's
+library contains many EPUBs produced by *third-party* PDF conversions
+(Calibre et al.) where every printed line is its own `<p>`. BookForge
+correctly preserves that structure, so translations inherit
+English-line-length paragraph breaks and read ragged in the target
+language (observed on the CCRU Abstract Culture book, 2026-07-03). This
+is distinct from §9: it is a *source-quality repair* concern for EPUBs
+BookForge did not create.
+
+Sketch: an opt-in `--reflow` preprocessing pass (or `bookforge reflow`
+command) that merges consecutive blocks when the first lacks terminal
+punctuation and the next starts lowercase, with conservative guards
+(same class/style, no intervening headings/images) and a report of every
+merge. Because it deliberately changes structure, it must stay opt-in
+and must never run as part of default translation. Effort guess:
+2–4 days. Priority: high relative to remaining unscheduled work — it
+addresses the most visible reader-facing defect in the owner's actual
+library.
+
+---
+
 ## 10. v2 — open-ended (sketched, not committed)
+
+> **Status note (2026-07-03):** "v2" shipped (releases v2.0.0–v2.1.0)
+> with a scope chosen at the time — the monitoring UI plus web dashboard.
+> The candidates sketched below were written before that decision; read
+> them as a v2.x/v3 idea list, not as the shipped v2's contents.
 
 The v2 list is what's interesting *as of writing*. The real v2
 priorities will be informed by:
@@ -2529,6 +2592,17 @@ This roadmap is a living document. After each milestone ships:
    milestones, update those milestones' specs.
 4. After v1.4 ships and the writeup is published, recompute v2 from
    the feedback received. Replace §10 with whatever the new v2 actually is.
+
+5. Decisions made in working documents (e.g. `docs/codex-handoff-*.md`
+   task specs, review fix-pass rulings) must be folded back into the
+   relevant milestone section here once the work ships. Handoff docs are
+   scratch; this document is the record. A ruling that only lives in a
+   handoff doc will be lost.
+6. Every milestone's acceptance criteria must include at least one
+   **un-mockable** criterion — a real end-to-end run on a real input with
+   real external tools, verified by inspection. The v1.6 review found
+   that every confirmed bug lived beyond the stubbed-tool boundary;
+   unit-test-shaped criteria alone would have shipped all of them.
 
 The maintainer is the source of truth; this document is the maintainer's
 externalized memory. When in doubt, ask.

--- a/docs/codex-handoff-v1.7.md
+++ b/docs/codex-handoff-v1.7.md
@@ -1,0 +1,100 @@
+# Handoff to Codex — v1.7 Bilingual output (2026-07-03)
+
+Written by Claude Code on behalf of the maintainer. This is the next
+roadmap milestone after v1.6 shipped in v2.1.0.
+
+**The authoritative spec is `docs/ROADMAP.md` §9b (lines ~1987–2140) —
+read it in full before writing code.** It defines the three modes, the
+per-element-type append policy table, the default CSS, the reassembly
+design, edge cases, and acceptance criteria. If a needed detail is
+missing from §9b, stop and ask the maintainer rather than inventing it.
+This handoff only adds workflow constraints and pointers.
+
+## Non-negotiables (ROADMAP §1 + §9b.7)
+
+- **Bilingual mode is a reassembly concern, not a model-output concern.**
+  No new LLM contracts; the model still emits exactly one target string
+  per segment. The reassembler in `bookforge-epub` splices source +
+  target per `--mode`. If you find yourself changing prompts or
+  `bookforge-llm` response parsing, you have gone off-spec.
+- `--mode replace` remains the default and must be byte-identical to
+  current behavior (acceptance §9b.12.4). The cache key must NOT change
+  for replace mode; check whether mode needs to factor into the cache
+  namespace at all (translations are mode-independent — the same cached
+  target serves all three modes, which is the correct and desirable
+  outcome; reassembly mode should NOT invalidate cache).
+- Every inserted element carries `class="bookforge-translation"` and
+  `lang="<target>"`; RTL targets (ar/he/fa) also get `dir="rtl"`.
+- EPUBCheck-valid output in every mode (§9b.9). The corpus/EPUBCheck
+  test infrastructure from v1.8 is in the repo — wire the new modes into
+  it (see `tests/` and the corpus CI job).
+
+## Where the work lives
+
+- `crates/bookforge-epub/src/writer.rs` — the reassembly layer. The
+  existing replace path patches translated text into the original event
+  stream; append-block/append-text add sibling events instead of
+  replacing. Study `render_marked_translation` and the block patching
+  flow (`text_node_patch`) before designing.
+- `crates/bookforge-cli` — `--mode`, `--bilingual-css`,
+  `--bilingual-style`, `--bilingual-separator` flags per §9b.10, plumbed
+  through translate/resume/retry (resume must remember the mode: store it
+  in the jobs table like other run config; a migration will be needed).
+- The web dashboard wizard (`serve.rs`) and `estimate` do NOT need
+  bilingual support in this milestone — CLI only. Do not touch serve.rs.
+- Default stylesheet injection: see how nav.xhtml/content.opf are
+  generated for where a CSS asset belongs; keep it out of the way if the
+  EPUB already has one (§9b.8 generation-suffix note is explicitly
+  deferred — skip it).
+
+## Working agreement
+
+- Branch: `v1.7-bilingual-output` (already created and checked out).
+- Follow §9b exactly; §9b.11 out-of-scope list is binding.
+- Commit in logical units, conventional commits, tests with each commit.
+- Full workspace check/test/clippy/fmt clean before each commit.
+- Unit tests: per-element policy table cases (p, blockquote, li,
+  headings, figcaption, table cells, code/pre exclusion, empty-block
+  skip), lang/dir attributes, separator handling, replace-mode
+  byte-identity regression.
+- End-to-end: run a MOCK-provider bilingual translation of a fixture
+  EPUB in both append modes and validate with the BookForge validators
+  (+ EPUBCheck if available on PATH).
+- Do not push; leave the branch ready for Claude's review pass.
+
+## Review fix pass (added 2026-07-03 late, IN PROGRESS — three blocking findings)
+
+Implementation landed as 37f5886 + lang-tag fix 962aaed. Review (Claude
+inline + Codex `exec review`) confirmed three EPUBCheck-blocking bugs,
+all in `crates/bookforge-epub/src/writer.rs`, ALL STILL UNFIXED:
+
+1. **NCX stylesheet injection (writer.rs ~170-174).** In append modes the
+   stylesheet `<link>` is injected into every patched non-OPF resource,
+   including `toc.ncx`; NCX `<head>` only allows `<meta>`, so EPUBs with
+   an NCX toc fail EPUBCheck. Fix: inject only into XHTML resources
+   (check media-type/extension before the `inject_stylesheet_link` branch).
+2. **Table `<caption>` gets a `<p>` sibling inside `<table>` (writer.rs
+   ~1320).** `caption` is in the `SiblingParagraph` list for AppendBlock;
+   the appended `<p>` lands directly inside `<table>` — invalid. Fix:
+   captions take the inline-span treatment (append the span INSIDE the
+   caption; HTML allows flow content there) in both append modes.
+3. **Nested block children wrapped inside translation elements
+   (writer.rs ~1469).** For `<blockquote><p>…</p></blockquote>` /
+   `<li><p>…</p></li>`, preserved child `<p>` marker events get wrapped
+   inside the new translation `<p>`/`<span>`, emitting `<p><p>…</p></p>`
+   or `<span><p>…</p></span>`. Fix: flatten block-level elements out of
+   the copied inline template when building the translation wrapper
+   (keep inline markup only), or append inside the existing child block.
+
+Then: add regression tests for all three (NCX fixture, table-caption
+fixture, blockquote/li-with-child-p fixtures), full workspace
+check/test/clippy/fmt, mock-provider e2e in both append modes with the
+output XHTML inspected, THEN push branch + open PR to main.
+
+## Acceptance (from §9b.12, condensed)
+
+append-block and append-text produce spec-shaped siblings/spans with
+class+lang; EPUBCheck passes; replace mode unchanged; glossary/context/
+style still apply (they're upstream of reassembly — verify with one test
+that a glossary term still injects in append-block mode); token usage
+unchanged vs replace.


### PR DESCRIPTION
Implements ROADMAP §9b: `--mode replace|append-text|append-block` with per-element append policy, stable `bookforge-translation` classes, `lang`/`dir` attributes, bundled/custom bilingual stylesheets, secondary `dc:language`, and mode persistence for resume/retry.

**Invariants held:** no LLM contract changes (reassembly-only per §9b.7); `replace` remains default with a byte-identity regression test; translation cache is mode-independent (same cached targets serve all three modes); serve dashboard untouched.

**Review:** implementation by Codex; reviewed via Claude inline pass + Codex `exec review`. Findings fixed on-branch: invalid lang tags for unmappable language names (→ `und`), stylesheet link injected into NCX, table `<caption>` sibling `<p>` inside `<table>`, and nested block markup inside translation wrappers (now flattened). Insertion-point ambiguity in the spec was resolved and codified in ROADMAP §9b.5 (one span per block; the §9b.4 example is normative).

**Verification:** full workspace test/clippy/fmt clean (476+ tests incl. new policy-table, RTL, NCX, caption, and nested-block regressions); mock-provider end-to-end on a real converted book (Acid Communism) in both append modes — 205 translation elements each, zero invalid nestings, BookForge validation ok, output XHTML inspected by eye.

Also rides along: ROADMAP accuracy pass (milestone↔release mapping, §9c reflow proposal, §10.1.1 pause/stop mini-spec, §15 process rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)