### PR TITLE
feat: source-EPUB reflow pass (ROADMAP §9c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ version = "2.2.0"
 dependencies = [
  "bookforge-core",
  "quick-xml",
+ "serde",
  "tracing",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "bookforge-core",
  "quick-xml",
  "serde",
+ "serde_json",
  "tracing",
  "zip",
 ]

--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod estimate;
 pub mod glossary;
 pub mod ingest_flags;
 pub mod inspect;
+pub mod reflow;
 pub mod resume;
 pub mod retry;
 pub mod review;

--- a/crates/bookforge-cli/src/commands/reflow.rs
+++ b/crates/bookforge-cli/src/commands/reflow.rs
@@ -1,0 +1,96 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use bookforge_epub::{ReflowOptions, ReflowReport, reflow_epub};
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct ReflowArgs {
+    /// Input source EPUB.
+    pub input: PathBuf,
+
+    /// Output repaired EPUB path.
+    #[arg(long)]
+    pub output: PathBuf,
+
+    /// JSON reflow report path. Defaults to `<output>.reflow-report.json`.
+    #[arg(long)]
+    pub report: Option<PathBuf>,
+
+    /// Write the report and summary without producing an output EPUB.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+pub async fn run(args: ReflowArgs) -> Result<()> {
+    if !args.input.exists() {
+        bail!("input EPUB does not exist: {}", args.input.display());
+    }
+
+    let report_path = args
+        .report
+        .clone()
+        .unwrap_or_else(|| default_report_path(&args.output));
+    let outcome = reflow_epub(
+        &args.input,
+        &args.output,
+        &ReflowOptions {
+            dry_run: args.dry_run,
+        },
+    )
+    .with_context(|| format!("reflowing {}", args.input.display()))?;
+
+    write_report(&report_path, &outcome.report)?;
+
+    println!("Input: {}", args.input.display());
+    println!("Output: {}", args.output.display());
+    println!("Files checked: {}", outcome.report.totals.files_checked);
+    println!("Files touched: {}", outcome.report.totals.files_touched);
+    println!("Merges: {}", outcome.report.totals.merge_count);
+    println!(
+        "Paragraphs: {} -> {}",
+        outcome.report.totals.paragraphs_before, outcome.report.totals.paragraphs_after
+    );
+    println!("Report: {}", report_path.display());
+    if args.dry_run {
+        println!("Dry run: no EPUB written");
+    }
+
+    Ok(())
+}
+
+fn write_report(path: &Path, report: &ReflowReport) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating report directory {}", parent.display()))?;
+    }
+    fs::write(path, serde_json::to_string_pretty(report)?)
+        .with_context(|| format!("writing report {}", path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn default_report_path(output: &Path) -> PathBuf {
+    let stem = output
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("book");
+    output.with_file_name(format!("{stem}.reflow-report.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_report_path_uses_output_stem() {
+        assert_eq!(
+            default_report_path(Path::new("out/repaired.epub")),
+            PathBuf::from("out/repaired.reflow-report.json")
+        );
+    }
+}

--- a/crates/bookforge-cli/src/commands/reflow.rs
+++ b/crates/bookforge-cli/src/commands/reflow.rs
@@ -23,6 +23,10 @@ pub struct ReflowArgs {
     /// Write the report and summary without producing an output EPUB.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Enable opt-in relaxed paragraph merging for proper-noun and quoted continuations.
+    #[arg(long)]
+    pub aggressive: bool,
 }
 
 pub async fn run(args: ReflowArgs) -> Result<()> {
@@ -39,6 +43,7 @@ pub async fn run(args: ReflowArgs) -> Result<()> {
         &args.output,
         &ReflowOptions {
             dry_run: args.dry_run,
+            aggressive: args.aggressive,
         },
     )
     .with_context(|| format!("reflowing {}", args.input.display()))?;

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -259,6 +259,7 @@ mod tests {
             "--output",
             "reflowed.epub",
             "--dry-run",
+            "--aggressive",
         ]);
 
         match cli.command {
@@ -266,6 +267,7 @@ mod tests {
                 assert_eq!(args.input, PathBuf::from("source.epub"));
                 assert_eq!(args.output, PathBuf::from("reflowed.epub"));
                 assert!(args.dry_run);
+                assert!(args.aggressive);
             }
             _ => panic!("expected reflow command"),
         }

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -18,8 +18,8 @@ use commands::serve;
 #[cfg(feature = "tui")]
 use commands::watch;
 use commands::{
-    convert, doctor, entity, estimate, glossary, ingest_flags, inspect, resume, retry, review,
-    status, style, tail, translate, validate,
+    convert, doctor, entity, estimate, glossary, ingest_flags, inspect, reflow, resume, retry,
+    review, status, style, tail, translate, validate,
 };
 #[cfg(any(test, not(feature = "serve")))]
 use std::io::Write;
@@ -52,6 +52,7 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     Convert(convert::ConvertArgs),
+    Reflow(reflow::ReflowArgs),
     Inspect(inspect::InspectArgs),
     Estimate(estimate::EstimateArgs),
     Translate(Box<translate::TranslateArgs>),
@@ -109,6 +110,7 @@ fn parse_cli() -> Result<Cli> {
 async fn run_command(command: Command, cancel_token: CancellationToken) -> Result<()> {
     match command {
         Command::Convert(args) => convert::run(args).await,
+        Command::Reflow(args) => reflow::run(args).await,
         Command::Inspect(args) => inspect::run(args).await,
         Command::Estimate(args) => estimate::run(args).await,
         Command::Translate(args) => translate::run(*args, cancel_token).await,
@@ -245,6 +247,27 @@ mod tests {
                 assert_eq!(args.profile, TranslationProfile::V1Fast);
             }
             _ => panic!("expected translate command"),
+        }
+    }
+
+    #[test]
+    fn reflow_requires_output_and_accepts_dry_run() {
+        let cli = Cli::parse_from([
+            "bookforge",
+            "reflow",
+            "source.epub",
+            "--output",
+            "reflowed.epub",
+            "--dry-run",
+        ]);
+
+        match cli.command {
+            Some(Command::Reflow(args)) => {
+                assert_eq!(args.input, PathBuf::from("source.epub"));
+                assert_eq!(args.output, PathBuf::from("reflowed.epub"));
+                assert!(args.dry_run);
+            }
+            _ => panic!("expected reflow command"),
         }
     }
 

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -13,3 +13,6 @@ quick-xml.workspace = true
 serde.workspace = true
 tracing.workspace = true
 zip.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -10,5 +10,6 @@ rust-version.workspace = true
 [dependencies]
 bookforge-core = { version = "2.2.0", path = "../bookforge-core" }
 quick-xml.workspace = true
+serde.workspace = true
 tracing.workspace = true
 zip.workspace = true

--- a/crates/bookforge-epub/src/lib.rs
+++ b/crates/bookforge-epub/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod reader;
+pub mod reflow;
 pub mod validate;
 pub mod writer;
 
 pub use reader::{
     EpubInspection, FileTextCoverage, TextCoverage, inspect_epub, read_epub, text_coverage,
 };
+pub use reflow::{ReflowMergeRecord, ReflowOptions, ReflowOutcome, ReflowReport, reflow_epub};
 pub use validate::{
     EpubValidationIssue, EpubValidationReport, ValidationSeverity, validate_block_translations,
     validate_translated_epub,

--- a/crates/bookforge-epub/src/reflow.rs
+++ b/crates/bookforge-epub/src/reflow.rs
@@ -461,6 +461,7 @@ fn append_merged_children(
 ) -> Result<()> {
     if dehyphenated {
         trim_trailing_whitespace(&mut left.children)?;
+        trim_leading_whitespace(&mut right.children)?;
         let _ = remove_trailing_hyphen(&mut left.children)?;
     } else {
         trim_trailing_whitespace(&mut left.children)?;
@@ -1088,6 +1089,18 @@ mod tests {
         assert_eq!(outcome.merges.len(), 1);
         assert!(outcome.xhtml.contains("<p>translation.</p>"));
         assert!(outcome.merges[0].dehyphenated);
+    }
+
+    #[test]
+    fn dehyphenation_trims_right_leading_whitespace() {
+        let outcome = reflow_snippet("<p>trans-</p><p>\n  lation.</p>");
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(
+            outcome.xhtml.contains("<p>translation.</p>"),
+            "got: {}",
+            outcome.xhtml
+        );
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reflow.rs
+++ b/crates/bookforge-epub/src/reflow.rs
@@ -16,6 +16,7 @@ use zip::{CompressionMethod, DateTime, ZipArchive, ZipWriter, write::SimpleFileO
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReflowOptions {
     pub dry_run: bool,
+    pub aggressive: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,14 +51,20 @@ pub struct ReflowMergeRecord {
     pub left_preview: String,
     pub right_preview: String,
     pub dehyphenated: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub aggressive: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right_class: Option<String>,
 }
 
 pub fn reflow_epub(input: &Path, output: &Path, options: &ReflowOptions) -> Result<ReflowOutcome> {
     let result = if options.dry_run {
-        write_reflowed_epub(input, output, None)
+        write_reflowed_epub(input, output, options, None)
     } else {
         let staged = sibling_work_path(output, "reflow");
-        let result = with_output_writer(input, output, &staged);
+        let result = with_output_writer(input, output, options, &staged);
         match result {
             Ok(report) => {
                 if let Err(error) = commit_staged_output(&staged, output) {
@@ -79,15 +86,21 @@ pub fn reflow_epub(input: &Path, output: &Path, options: &ReflowOptions) -> Resu
     })
 }
 
-fn with_output_writer(input: &Path, output: &Path, staged: &Path) -> Result<ReflowReport> {
+fn with_output_writer(
+    input: &Path,
+    output: &Path,
+    options: &ReflowOptions,
+    staged: &Path,
+) -> Result<ReflowReport> {
     let output_file = File::create(staged)?;
     let writer = ZipWriter::new(output_file);
-    write_reflowed_epub(input, output, Some(writer))
+    write_reflowed_epub(input, output, options, Some(writer))
 }
 
 fn write_reflowed_epub(
     input: &Path,
     output: &Path,
+    options: &ReflowOptions,
     writer: Option<ZipWriter<File>>,
 ) -> Result<ReflowReport> {
     let source = File::open(input)?;
@@ -103,12 +116,12 @@ fn write_reflowed_epub(
     match writer {
         Some(mut writer) => {
             write_mimetype_first(&mut archive, &mut writer)?;
-            write_archive_entries(&mut archive, Some(&mut writer), &mut report)?;
+            write_archive_entries(&mut archive, Some(&mut writer), &mut report, options)?;
             writer.finish()?;
         }
         None => {
             validate_mimetype(&mut archive)?;
-            write_archive_entries(&mut archive, None, &mut report)?;
+            write_archive_entries(&mut archive, None, &mut report, options)?;
         }
     }
 
@@ -119,6 +132,7 @@ fn write_archive_entries(
     archive: &mut ZipArchive<File>,
     mut writer: Option<&mut ZipWriter<File>>,
     report: &mut ReflowReport,
+    options: &ReflowOptions,
 ) -> Result<()> {
     let deflated = SimpleFileOptions::default()
         .compression_method(CompressionMethod::Deflated)
@@ -145,7 +159,7 @@ fn write_archive_entries(
             let xhtml = String::from_utf8(bytes).map_err(|err| {
                 BookforgeError::InvalidInput(format!("XHTML resource '{name}' is not UTF-8: {err}"))
             })?;
-            let outcome = reflow_xhtml_resource(&xhtml, &name)?;
+            let outcome = reflow_xhtml_resource(&xhtml, &name, options)?;
             report.totals.files_checked += 1;
             report.totals.paragraphs_before += outcome.paragraphs_before;
             report.totals.paragraphs_after += outcome.paragraphs_after;
@@ -170,6 +184,10 @@ fn write_archive_entries(
     Ok(())
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug)]
 struct ResourceReflow {
     xhtml: String,
@@ -178,10 +196,14 @@ struct ResourceReflow {
     merges: Vec<ReflowMergeRecord>,
 }
 
-fn reflow_xhtml_resource(xhtml: &str, resource: &str) -> Result<ResourceReflow> {
+fn reflow_xhtml_resource(
+    xhtml: &str,
+    resource: &str,
+    options: &ReflowOptions,
+) -> Result<ResourceReflow> {
     let (mut nodes, paragraphs_before) = parse_xml(xhtml)?;
     let mut merges = Vec::new();
-    reflow_nodes(&mut nodes, resource, &mut merges)?;
+    reflow_nodes(&mut nodes, resource, options, &mut merges)?;
     let paragraphs_after = count_paragraphs(&nodes);
 
     if merges.is_empty() {
@@ -335,11 +357,12 @@ fn write_node(writer: &mut Writer<Vec<u8>>, node: &XmlNode) -> Result<()> {
 fn reflow_nodes(
     nodes: &mut Vec<XmlNode>,
     resource: &str,
+    options: &ReflowOptions,
     merges: &mut Vec<ReflowMergeRecord>,
 ) -> Result<()> {
     for node in nodes.iter_mut() {
         if let XmlNode::Element(element) = node {
-            reflow_nodes(&mut element.children, resource, merges)?;
+            reflow_nodes(&mut element.children, resource, options, merges)?;
         }
     }
 
@@ -356,7 +379,9 @@ fn reflow_nodes(
         };
 
         let decision = match (&nodes[left_index], &nodes[right_index]) {
-            (XmlNode::Element(left), XmlNode::Element(right)) => merge_decision(left, right)?,
+            (XmlNode::Element(left), XmlNode::Element(right)) => {
+                merge_decision(left, right, options)?
+            }
             _ => None,
         };
 
@@ -404,6 +429,9 @@ struct MergeDecision {
     left_preview: String,
     right_preview: String,
     dehyphenated: bool,
+    aggressive: bool,
+    left_class: Option<String>,
+    right_class: Option<String>,
 }
 
 impl MergeDecision {
@@ -415,11 +443,18 @@ impl MergeDecision {
             left_preview: self.left_preview,
             right_preview: self.right_preview,
             dehyphenated: self.dehyphenated,
+            aggressive: self.aggressive,
+            left_class: self.left_class,
+            right_class: self.right_class,
         }
     }
 }
 
-fn merge_decision(left: &XmlElement, right: &XmlElement) -> Result<Option<MergeDecision>> {
+fn merge_decision(
+    left: &XmlElement,
+    right: &XmlElement,
+    options: &ReflowOptions,
+) -> Result<Option<MergeDecision>> {
     let left_text = visible_text(&left.children)?;
     let right_text = visible_text(&right.children)?;
 
@@ -432,11 +467,13 @@ fn merge_decision(left: &XmlElement, right: &XmlElement) -> Result<Option<MergeD
     if ends_with_terminal_punctuation(&left_text) {
         return Ok(None);
     }
-    if !starts_with_unicode_lowercase(&right_text) {
+    let Some(right_start) = right_start_mode(&right_text, options.aggressive) else {
         return Ok(None);
-    }
-    if attr_value_unescaped(&left.start, b"class")? != attr_value_unescaped(&right.start, b"class")?
-    {
+    };
+    let left_class = attr_value_unescaped(&left.start, b"class")?;
+    let right_class = attr_value_unescaped(&right.start, b"class")?;
+    let class_mismatch = left_class != right_class;
+    if class_mismatch && !options.aggressive {
         return Ok(None);
     }
     if attr_value_unescaped(&right.start, b"id")?.is_some() {
@@ -454,6 +491,9 @@ fn merge_decision(left: &XmlElement, right: &XmlElement) -> Result<Option<MergeD
         left_preview: preview(&left_text),
         right_preview: preview(&right_text),
         dehyphenated: should_dehyphenate(&left_text),
+        aggressive: right_start == RightStartMode::Aggressive || class_mismatch,
+        left_class: if class_mismatch { left_class } else { None },
+        right_class: if class_mismatch { right_class } else { None },
     }))
 }
 
@@ -592,11 +632,25 @@ fn is_terminal_closer(ch: char) -> bool {
     matches!(ch, '"' | '”' | '’' | '»' | ')' | ']')
 }
 
-fn starts_with_unicode_lowercase(text: &str) -> bool {
-    text.trim_start()
-        .chars()
-        .next()
-        .is_some_and(char::is_lowercase)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RightStartMode {
+    Conservative,
+    Aggressive,
+}
+
+fn right_start_mode(text: &str, aggressive: bool) -> Option<RightStartMode> {
+    let first = text.trim_start().chars().next()?;
+    if first.is_lowercase() {
+        return Some(RightStartMode::Conservative);
+    }
+    if !aggressive || !text.chars().any(char::is_alphabetic) || !is_aggressive_right_start(first) {
+        return None;
+    }
+    Some(RightStartMode::Aggressive)
+}
+
+fn is_aggressive_right_start(ch: char) -> bool {
+    ch.is_uppercase() || matches!(ch, '“' | '‘' | '"' | '\'' | '«' | '(' | '[' | '—' | '–')
 }
 
 fn should_dehyphenate(text: &str) -> bool {
@@ -985,13 +1039,24 @@ mod tests {
     };
     use zip::{ZipWriter, write::SimpleFileOptions};
 
-    fn reflow_snippet(body: &str) -> ResourceReflow {
+    fn reflow_snippet_with_options(body: &str, options: &ReflowOptions) -> ResourceReflow {
         let xhtml = format!("<html><body>{body}</body></html>");
-        reflow_xhtml_resource(&xhtml, "chapter.xhtml").expect("snippet should reflow")
+        reflow_xhtml_resource(&xhtml, "chapter.xhtml", options).expect("snippet should reflow")
+    }
+
+    fn reflow_snippet(body: &str) -> ResourceReflow {
+        reflow_snippet_with_options(body, &ReflowOptions::default())
     }
 
     fn merge_count(body: &str) -> usize {
         reflow_snippet(body).merges.len()
+    }
+
+    fn aggressive_options() -> ReflowOptions {
+        ReflowOptions {
+            aggressive: true,
+            ..ReflowOptions::default()
+        }
     }
 
     #[test]
@@ -1025,6 +1090,42 @@ mod tests {
     }
 
     #[test]
+    fn aggressive_merges_uppercase_quote_bracket_and_dash_starts() {
+        let cases = [
+            "<p>review of David</p><p>Toop's Rap Attack.</p>",
+            "<p>Hello</p><p>“World.”</p>",
+            "<p>Hello</p><p>[World].</p>",
+            "<p>Hello</p><p>— World.</p>",
+        ];
+        let options = aggressive_options();
+
+        for body in cases {
+            assert_eq!(merge_count(body), 0, "default should not merge {body}");
+            let outcome = reflow_snippet_with_options(body, &options);
+            assert_eq!(outcome.merges.len(), 1, "aggressive should merge {body}");
+            assert!(outcome.merges[0].aggressive);
+        }
+    }
+
+    #[test]
+    fn aggressive_rejects_letterless_right_paragraph() {
+        let options = aggressive_options();
+
+        assert_eq!(
+            reflow_snippet_with_options("<p>Hello</p><p>— 12 —</p>", &options)
+                .merges
+                .len(),
+            0
+        );
+        assert_eq!(
+            reflow_snippet_with_options("<p>Hello</p><p>[123]</p>", &options)
+                .merges
+                .len(),
+            0
+        );
+    }
+
+    #[test]
     fn unicode_lowercase_starts_merge() {
         let outcome = reflow_snippet("<p>Hello</p><p>éclat.</p>");
 
@@ -1038,6 +1139,26 @@ mod tests {
             merge_count(r#"<p class="body">Hello</p><p class="note">world.</p>"#),
             0
         );
+    }
+
+    #[test]
+    fn aggressive_merges_unequal_classes_and_records_audit_fields() {
+        let outcome = reflow_snippet_with_options(
+            r#"<p class="calibre6">review of David</p><p class="calibre1">Toop’s Rap Attack.</p>"#,
+            &aggressive_options(),
+        );
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(
+            outcome
+                .xhtml
+                .contains(r#"<p class="calibre6">review of David Toop’s Rap Attack.</p>"#),
+            "got: {}",
+            outcome.xhtml
+        );
+        assert!(outcome.merges[0].aggressive);
+        assert_eq!(outcome.merges[0].left_class.as_deref(), Some("calibre6"));
+        assert_eq!(outcome.merges[0].right_class.as_deref(), Some("calibre1"));
     }
 
     #[test]
@@ -1141,7 +1262,58 @@ mod tests {
                 left_preview: "Alpha line carries enough text for previ...".to_string(),
                 right_preview: "beta line continues.".to_string(),
                 dehyphenated: false,
+                aggressive: false,
+                left_class: None,
+                right_class: None,
             }
+        );
+    }
+
+    #[test]
+    fn report_marks_only_relaxed_rule_merges_as_aggressive() {
+        let outcome = reflow_snippet_with_options(
+            r#"<p class="body">Hello</p><p class="body">world</p><p class="note">again.</p>"#,
+            &aggressive_options(),
+        );
+
+        assert_eq!(outcome.merges.len(), 2);
+        assert!(!outcome.merges[0].aggressive);
+        assert!(outcome.merges[1].aggressive);
+        assert_eq!(outcome.merges[1].left_class.as_deref(), Some("body"));
+        assert_eq!(outcome.merges[1].right_class.as_deref(), Some("note"));
+        assert!(
+            serde_json::to_string_pretty(&outcome.merges[1])
+                .expect("record should serialize")
+                .contains(r#""aggressive": true"#)
+        );
+        assert!(
+            serde_json::to_string_pretty(&outcome.merges[1])
+                .expect("record should serialize")
+                .contains(r#""left_class": "body""#)
+        );
+        assert!(
+            serde_json::to_string_pretty(&outcome.merges[1])
+                .expect("record should serialize")
+                .contains(r#""right_class": "note""#)
+        );
+    }
+
+    #[test]
+    fn conservative_record_json_omits_aggressive_field() {
+        let outcome = reflow_snippet("<p>Hello</p><p>world.</p>");
+        let json =
+            serde_json::to_string_pretty(&outcome.merges[0]).expect("record should serialize");
+
+        assert_eq!(
+            json,
+            r#"{
+  "resource": "chapter.xhtml",
+  "block_index": 0,
+  "merged_block_index": 1,
+  "left_preview": "Hello",
+  "right_preview": "world.",
+  "dehyphenated": false
+}"#
         );
     }
 
@@ -1151,8 +1323,15 @@ mod tests {
         let output = unique_temp_path("bookforge-reflow-dry-run", "epub");
         let _ = fs::remove_file(&output);
 
-        let outcome = reflow_epub(&input, &output, &ReflowOptions { dry_run: true })
-            .expect("dry run should reflow");
+        let outcome = reflow_epub(
+            &input,
+            &output,
+            &ReflowOptions {
+                dry_run: true,
+                ..ReflowOptions::default()
+            },
+        )
+        .expect("dry run should reflow");
 
         assert!(!outcome.output_written);
         assert!(!output.exists());

--- a/crates/bookforge-epub/src/reflow.rs
+++ b/crates/bookforge-epub/src/reflow.rs
@@ -426,6 +426,9 @@ fn merge_decision(left: &XmlElement, right: &XmlElement) -> Result<Option<MergeD
     if left_text.trim().is_empty() || right_text.trim().is_empty() {
         return Ok(None);
     }
+    if !left_text.chars().any(char::is_alphabetic) {
+        return Ok(None);
+    }
     if ends_with_terminal_punctuation(&left_text) {
         return Ok(None);
     }
@@ -1089,6 +1092,14 @@ mod tests {
         assert_eq!(outcome.merges.len(), 1);
         assert!(outcome.xhtml.contains("<p>translation.</p>"));
         assert!(outcome.merges[0].dehyphenated);
+    }
+
+    #[test]
+    fn letterless_left_paragraph_blocks_merge() {
+        // Bare page/footnote numbers from PDF conversions must not be
+        // glued into prose (§9c.2 condition 7).
+        assert_eq!(merge_count("<p>1</p><p>doubt what attracted.</p>"), 0);
+        assert_eq!(merge_count("<p>— 12 —</p><p>opening up.</p>"), 0);
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reflow.rs
+++ b/crates/bookforge-epub/src/reflow.rs
@@ -1,0 +1,1240 @@
+use std::{
+    fs::{self, File},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use bookforge_core::{BookforgeError, Result};
+use quick_xml::{
+    Reader, Writer,
+    events::{BytesCData, BytesEnd, BytesStart, BytesText, Event},
+};
+use serde::Serialize;
+use zip::{CompressionMethod, DateTime, ZipArchive, ZipWriter, write::SimpleFileOptions};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReflowOptions {
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReflowOutcome {
+    pub report: ReflowReport,
+    pub output_written: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReflowReport {
+    pub schema_version: u32,
+    pub input_path: String,
+    pub output_path: String,
+    pub totals: ReflowTotals,
+    pub merges: Vec<ReflowMergeRecord>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ReflowTotals {
+    pub files_checked: usize,
+    pub files_touched: usize,
+    pub paragraphs_before: usize,
+    pub paragraphs_after: usize,
+    pub merge_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReflowMergeRecord {
+    pub resource: String,
+    pub block_index: usize,
+    pub merged_block_index: usize,
+    pub left_preview: String,
+    pub right_preview: String,
+    pub dehyphenated: bool,
+}
+
+pub fn reflow_epub(input: &Path, output: &Path, options: &ReflowOptions) -> Result<ReflowOutcome> {
+    let result = if options.dry_run {
+        write_reflowed_epub(input, output, None)
+    } else {
+        let staged = sibling_work_path(output, "reflow");
+        let result = with_output_writer(input, output, &staged);
+        match result {
+            Ok(report) => {
+                if let Err(error) = commit_staged_output(&staged, output) {
+                    let _ = fs::remove_file(&staged);
+                    return Err(error);
+                }
+                Ok(report)
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&staged);
+                Err(error)
+            }
+        }
+    }?;
+
+    Ok(ReflowOutcome {
+        report: result,
+        output_written: !options.dry_run,
+    })
+}
+
+fn with_output_writer(input: &Path, output: &Path, staged: &Path) -> Result<ReflowReport> {
+    let output_file = File::create(staged)?;
+    let writer = ZipWriter::new(output_file);
+    write_reflowed_epub(input, output, Some(writer))
+}
+
+fn write_reflowed_epub(
+    input: &Path,
+    output: &Path,
+    writer: Option<ZipWriter<File>>,
+) -> Result<ReflowReport> {
+    let source = File::open(input)?;
+    let mut archive = ZipArchive::new(source)?;
+    let mut report = ReflowReport {
+        schema_version: 1,
+        input_path: input.display().to_string(),
+        output_path: output.display().to_string(),
+        totals: ReflowTotals::default(),
+        merges: Vec::new(),
+    };
+
+    match writer {
+        Some(mut writer) => {
+            write_mimetype_first(&mut archive, &mut writer)?;
+            write_archive_entries(&mut archive, Some(&mut writer), &mut report)?;
+            writer.finish()?;
+        }
+        None => {
+            validate_mimetype(&mut archive)?;
+            write_archive_entries(&mut archive, None, &mut report)?;
+        }
+    }
+
+    Ok(report)
+}
+
+fn write_archive_entries(
+    archive: &mut ZipArchive<File>,
+    mut writer: Option<&mut ZipWriter<File>>,
+    report: &mut ReflowReport,
+) -> Result<()> {
+    let deflated = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .last_modified_time(deterministic_zip_time());
+
+    for index in 0..archive.len() {
+        let mut file = archive.by_index(index)?;
+        let name = file.name().to_string();
+
+        if name == "mimetype" {
+            continue;
+        }
+
+        if file.is_dir() {
+            if let Some(writer) = writer.as_deref_mut() {
+                writer.add_directory(name, deflated)?;
+            }
+            continue;
+        }
+
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        let output_bytes = if is_xhtml_resource_name(&name) {
+            let xhtml = String::from_utf8(bytes).map_err(|err| {
+                BookforgeError::InvalidInput(format!("XHTML resource '{name}' is not UTF-8: {err}"))
+            })?;
+            let outcome = reflow_xhtml_resource(&xhtml, &name)?;
+            report.totals.files_checked += 1;
+            report.totals.paragraphs_before += outcome.paragraphs_before;
+            report.totals.paragraphs_after += outcome.paragraphs_after;
+            report.totals.merge_count += outcome.merges.len();
+            if !outcome.merges.is_empty() {
+                report.totals.files_touched += 1;
+                report.merges.extend(outcome.merges);
+                outcome.xhtml.into_bytes()
+            } else {
+                xhtml.into_bytes()
+            }
+        } else {
+            bytes
+        };
+
+        if let Some(writer) = writer.as_deref_mut() {
+            writer.start_file(name, deflated)?;
+            writer.write_all(&output_bytes)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ResourceReflow {
+    xhtml: String,
+    paragraphs_before: usize,
+    paragraphs_after: usize,
+    merges: Vec<ReflowMergeRecord>,
+}
+
+fn reflow_xhtml_resource(xhtml: &str, resource: &str) -> Result<ResourceReflow> {
+    let (mut nodes, paragraphs_before) = parse_xml(xhtml)?;
+    let mut merges = Vec::new();
+    reflow_nodes(&mut nodes, resource, &mut merges)?;
+    let paragraphs_after = count_paragraphs(&nodes);
+
+    if merges.is_empty() {
+        return Ok(ResourceReflow {
+            xhtml: xhtml.to_string(),
+            paragraphs_before,
+            paragraphs_after,
+            merges,
+        });
+    }
+
+    let reflowed = write_xml(&nodes)?;
+    validate_xml(&reflowed).map_err(|err| {
+        BookforgeError::InvalidInput(format!(
+            "reflowed XHTML '{resource}' failed validation: {err}"
+        ))
+    })?;
+
+    Ok(ResourceReflow {
+        xhtml: reflowed,
+        paragraphs_before,
+        paragraphs_after,
+        merges,
+    })
+}
+
+#[derive(Debug, Clone)]
+enum XmlNode {
+    Element(XmlElement),
+    Empty { start: BytesStart<'static> },
+    Leaf(Event<'static>),
+}
+
+#[derive(Debug, Clone)]
+struct XmlElement {
+    start: BytesStart<'static>,
+    children: Vec<XmlNode>,
+    end: BytesEnd<'static>,
+    paragraph_index: Option<usize>,
+}
+
+#[derive(Debug)]
+struct BuildingElement {
+    start: BytesStart<'static>,
+    children: Vec<XmlNode>,
+    paragraph_index: Option<usize>,
+}
+
+fn parse_xml(xml: &str) -> Result<(Vec<XmlNode>, usize)> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let mut roots = Vec::new();
+    let mut stack = Vec::<BuildingElement>::new();
+    let mut paragraph_count = 0usize;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(element) => {
+                let start = element.into_owned();
+                let paragraph_index = paragraph_index_for(&start, &mut paragraph_count);
+                stack.push(BuildingElement {
+                    start,
+                    children: Vec::new(),
+                    paragraph_index,
+                });
+            }
+            Event::Empty(element) => {
+                let start = element.into_owned();
+                let _ = paragraph_index_for(&start, &mut paragraph_count);
+                push_node(&mut roots, &mut stack, XmlNode::Empty { start });
+            }
+            Event::End(end) => {
+                let Some(frame) = stack.pop() else {
+                    return Err(BookforgeError::InvalidInput(
+                        "unexpected closing tag while parsing XHTML".to_string(),
+                    ));
+                };
+                push_node(
+                    &mut roots,
+                    &mut stack,
+                    XmlNode::Element(XmlElement {
+                        start: frame.start,
+                        children: frame.children,
+                        end: end.into_owned(),
+                        paragraph_index: frame.paragraph_index,
+                    }),
+                );
+            }
+            Event::Eof => break,
+            event => push_node(&mut roots, &mut stack, XmlNode::Leaf(event.into_owned())),
+        }
+    }
+
+    if !stack.is_empty() {
+        return Err(BookforgeError::InvalidInput(
+            "unexpected end of XHTML while parsing element tree".to_string(),
+        ));
+    }
+
+    Ok((roots, paragraph_count))
+}
+
+fn paragraph_index_for(start: &BytesStart<'_>, paragraph_count: &mut usize) -> Option<usize> {
+    if local_name(start.name().as_ref()) == b"p" {
+        let index = *paragraph_count;
+        *paragraph_count += 1;
+        Some(index)
+    } else {
+        None
+    }
+}
+
+fn push_node(roots: &mut Vec<XmlNode>, stack: &mut [BuildingElement], node: XmlNode) {
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(node);
+    } else {
+        roots.push(node);
+    }
+}
+
+fn write_xml(nodes: &[XmlNode]) -> Result<String> {
+    let mut writer = Writer::new(Vec::new());
+    write_nodes(&mut writer, nodes)?;
+    String::from_utf8(writer.into_inner()).map_err(|err| {
+        BookforgeError::InvalidInput(format!("reflowed XHTML is not valid UTF-8: {err}"))
+    })
+}
+
+fn write_nodes(writer: &mut Writer<Vec<u8>>, nodes: &[XmlNode]) -> Result<()> {
+    for node in nodes {
+        write_node(writer, node)?;
+    }
+    Ok(())
+}
+
+fn write_node(writer: &mut Writer<Vec<u8>>, node: &XmlNode) -> Result<()> {
+    match node {
+        XmlNode::Element(element) => {
+            writer.write_event(Event::Start(element.start.borrow()))?;
+            write_nodes(writer, &element.children)?;
+            writer.write_event(Event::End(element.end.borrow()))?;
+        }
+        XmlNode::Empty { start } => {
+            writer.write_event(Event::Empty(start.borrow()))?;
+        }
+        XmlNode::Leaf(event) => writer.write_event(event.borrow())?,
+    }
+    Ok(())
+}
+
+fn reflow_nodes(
+    nodes: &mut Vec<XmlNode>,
+    resource: &str,
+    merges: &mut Vec<ReflowMergeRecord>,
+) -> Result<()> {
+    for node in nodes.iter_mut() {
+        if let XmlNode::Element(element) = node {
+            reflow_nodes(&mut element.children, resource, merges)?;
+        }
+    }
+
+    let mut left_index = 0usize;
+    while left_index < nodes.len() {
+        if !is_paragraph_element(&nodes[left_index]) {
+            left_index += 1;
+            continue;
+        }
+
+        let Some(right_index) = next_paragraph_after_whitespace(nodes, left_index + 1)? else {
+            left_index += 1;
+            continue;
+        };
+
+        let decision = match (&nodes[left_index], &nodes[right_index]) {
+            (XmlNode::Element(left), XmlNode::Element(right)) => merge_decision(left, right)?,
+            _ => None,
+        };
+
+        let Some(decision) = decision else {
+            left_index += 1;
+            continue;
+        };
+
+        let mut drained = nodes
+            .drain(left_index + 1..=right_index)
+            .collect::<Vec<_>>();
+        let right = drained.pop().expect("right paragraph should be drained");
+        let XmlNode::Element(mut right) = right else {
+            unreachable!("merge decision only accepts element paragraphs")
+        };
+        let XmlNode::Element(left) = &mut nodes[left_index] else {
+            unreachable!("merge decision only accepts element paragraphs")
+        };
+
+        append_merged_children(left, &mut right, decision.dehyphenated)?;
+        merges.push(decision.into_record(resource));
+    }
+
+    Ok(())
+}
+
+fn next_paragraph_after_whitespace(nodes: &[XmlNode], start: usize) -> Result<Option<usize>> {
+    let mut index = start;
+    while index < nodes.len() {
+        if is_paragraph_element(&nodes[index]) {
+            return Ok(Some(index));
+        }
+        if !is_whitespace_node(&nodes[index])? {
+            return Ok(None);
+        }
+        index += 1;
+    }
+    Ok(None)
+}
+
+#[derive(Debug)]
+struct MergeDecision {
+    block_index: usize,
+    merged_block_index: usize,
+    left_preview: String,
+    right_preview: String,
+    dehyphenated: bool,
+}
+
+impl MergeDecision {
+    fn into_record(self, resource: &str) -> ReflowMergeRecord {
+        ReflowMergeRecord {
+            resource: resource.to_string(),
+            block_index: self.block_index,
+            merged_block_index: self.merged_block_index,
+            left_preview: self.left_preview,
+            right_preview: self.right_preview,
+            dehyphenated: self.dehyphenated,
+        }
+    }
+}
+
+fn merge_decision(left: &XmlElement, right: &XmlElement) -> Result<Option<MergeDecision>> {
+    let left_text = visible_text(&left.children)?;
+    let right_text = visible_text(&right.children)?;
+
+    if left_text.trim().is_empty() || right_text.trim().is_empty() {
+        return Ok(None);
+    }
+    if ends_with_terminal_punctuation(&left_text) {
+        return Ok(None);
+    }
+    if !starts_with_unicode_lowercase(&right_text) {
+        return Ok(None);
+    }
+    if attr_value_unescaped(&left.start, b"class")? != attr_value_unescaped(&right.start, b"class")?
+    {
+        return Ok(None);
+    }
+    if attr_value_unescaped(&right.start, b"id")?.is_some() {
+        return Ok(None);
+    }
+    if contains_nested_block_or_replaced(&left.children)
+        || contains_nested_block_or_replaced(&right.children)
+    {
+        return Ok(None);
+    }
+
+    Ok(Some(MergeDecision {
+        block_index: left.paragraph_index.unwrap_or_default(),
+        merged_block_index: right.paragraph_index.unwrap_or_default(),
+        left_preview: preview(&left_text),
+        right_preview: preview(&right_text),
+        dehyphenated: should_dehyphenate(&left_text),
+    }))
+}
+
+fn append_merged_children(
+    left: &mut XmlElement,
+    right: &mut XmlElement,
+    dehyphenated: bool,
+) -> Result<()> {
+    if dehyphenated {
+        trim_trailing_whitespace(&mut left.children)?;
+        let _ = remove_trailing_hyphen(&mut left.children)?;
+    } else {
+        trim_trailing_whitespace(&mut left.children)?;
+        trim_leading_whitespace(&mut right.children)?;
+        left.children
+            .push(XmlNode::Leaf(Event::Text(BytesText::new(" ").into_owned())));
+    }
+    left.children.append(&mut right.children);
+    Ok(())
+}
+
+fn is_paragraph_element(node: &XmlNode) -> bool {
+    matches!(node, XmlNode::Element(element) if local_name(element.start.name().as_ref()) == b"p")
+}
+
+fn count_paragraphs(nodes: &[XmlNode]) -> usize {
+    nodes.iter().map(count_paragraphs_in_node).sum()
+}
+
+fn count_paragraphs_in_node(node: &XmlNode) -> usize {
+    match node {
+        XmlNode::Element(element) => {
+            usize::from(local_name(element.start.name().as_ref()) == b"p")
+                + count_paragraphs(&element.children)
+        }
+        XmlNode::Empty { start } => usize::from(local_name(start.name().as_ref()) == b"p"),
+        XmlNode::Leaf(_) => 0,
+    }
+}
+
+fn visible_text(nodes: &[XmlNode]) -> Result<String> {
+    let mut text = String::new();
+    append_visible_text(nodes, &mut text)?;
+    Ok(normalize_space(&text))
+}
+
+fn append_visible_text(nodes: &[XmlNode], text: &mut String) -> Result<()> {
+    for node in nodes {
+        match node {
+            XmlNode::Element(element) => append_visible_text(&element.children, text)?,
+            XmlNode::Empty { .. } => {}
+            XmlNode::Leaf(event) => append_event_text(event, text)?,
+        }
+    }
+    Ok(())
+}
+
+fn append_event_text(event: &Event<'static>, text: &mut String) -> Result<()> {
+    match event {
+        Event::Text(value) => {
+            text.push_str(
+                &value
+                    .html_content()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?,
+            );
+        }
+        Event::CData(value) => {
+            text.push_str(
+                &value
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?,
+            );
+        }
+        Event::GeneralRef(reference) => {
+            if let Some(value) = resolve_general_ref(reference)? {
+                text.push_str(&value);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn is_whitespace_node(node: &XmlNode) -> Result<bool> {
+    match node {
+        XmlNode::Leaf(Event::Text(text)) => Ok(text
+            .html_content()
+            .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?
+            .chars()
+            .all(char::is_whitespace)),
+        XmlNode::Leaf(Event::CData(text)) => Ok(text
+            .decode()
+            .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?
+            .chars()
+            .all(char::is_whitespace)),
+        XmlNode::Leaf(Event::GeneralRef(reference)) => Ok(resolve_general_ref(reference)?
+            .is_some_and(|value| value.chars().all(char::is_whitespace))),
+        _ => Ok(false),
+    }
+}
+
+fn contains_nested_block_or_replaced(nodes: &[XmlNode]) -> bool {
+    nodes.iter().any(|node| match node {
+        XmlNode::Element(element) => {
+            let raw_name = element.start.name();
+            let name = local_name(raw_name.as_ref());
+            is_block_level_name(name)
+                || is_replaced_content_name(name)
+                || contains_nested_block_or_replaced(&element.children)
+        }
+        XmlNode::Empty { start } => {
+            let raw_name = start.name();
+            let name = local_name(raw_name.as_ref());
+            is_block_level_name(name) || is_replaced_content_name(name)
+        }
+        XmlNode::Leaf(_) => false,
+    })
+}
+
+fn ends_with_terminal_punctuation(text: &str) -> bool {
+    for ch in text.trim_end().chars().rev() {
+        if is_terminal_closer(ch) {
+            continue;
+        }
+        return is_terminal_punctuation(ch);
+    }
+    false
+}
+
+fn is_terminal_punctuation(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?' | ':' | ';' | '…')
+}
+
+fn is_terminal_closer(ch: char) -> bool {
+    matches!(ch, '"' | '”' | '’' | '»' | ')' | ']')
+}
+
+fn starts_with_unicode_lowercase(text: &str) -> bool {
+    text.trim_start()
+        .chars()
+        .next()
+        .is_some_and(char::is_lowercase)
+}
+
+fn should_dehyphenate(text: &str) -> bool {
+    let mut chars = text.trim_end().chars().rev();
+    if chars.next() != Some('-') {
+        return false;
+    }
+    chars.next().is_some_and(is_word_char)
+}
+
+fn is_word_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}
+
+fn trim_trailing_whitespace(nodes: &mut Vec<XmlNode>) -> Result<()> {
+    while let Some(last) = nodes.last_mut() {
+        match trim_trailing_whitespace_node(last)? {
+            TrimResult::RemoveNode => {
+                nodes.pop();
+            }
+            TrimResult::Done => return Ok(()),
+        }
+    }
+    Ok(())
+}
+
+fn trim_trailing_whitespace_node(node: &mut XmlNode) -> Result<TrimResult> {
+    match node {
+        XmlNode::Element(element) => {
+            trim_trailing_whitespace(&mut element.children)?;
+            Ok(TrimResult::Done)
+        }
+        XmlNode::Leaf(Event::Text(text)) => {
+            let value = text
+                .html_content()
+                .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+            let trimmed = value.trim_end();
+            if trimmed.is_empty() {
+                Ok(TrimResult::RemoveNode)
+            } else if trimmed.len() == value.len() {
+                Ok(TrimResult::Done)
+            } else {
+                *text = BytesText::new(trimmed).into_owned();
+                Ok(TrimResult::Done)
+            }
+        }
+        XmlNode::Leaf(Event::CData(text)) => {
+            let value = text
+                .decode()
+                .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+            let trimmed = value.trim_end();
+            if trimmed.is_empty() {
+                Ok(TrimResult::RemoveNode)
+            } else if trimmed.len() == value.len() {
+                Ok(TrimResult::Done)
+            } else {
+                *text = BytesCData::new(trimmed).into_owned();
+                Ok(TrimResult::Done)
+            }
+        }
+        _ => Ok(TrimResult::Done),
+    }
+}
+
+fn trim_leading_whitespace(nodes: &mut Vec<XmlNode>) -> Result<()> {
+    loop {
+        let Some(first) = nodes.first_mut() else {
+            return Ok(());
+        };
+        match trim_leading_whitespace_node(first)? {
+            TrimResult::RemoveNode => {
+                nodes.remove(0);
+            }
+            TrimResult::Done => return Ok(()),
+        }
+    }
+}
+
+fn trim_leading_whitespace_node(node: &mut XmlNode) -> Result<TrimResult> {
+    match node {
+        XmlNode::Element(element) => {
+            trim_leading_whitespace(&mut element.children)?;
+            Ok(TrimResult::Done)
+        }
+        XmlNode::Leaf(Event::Text(text)) => {
+            let value = text
+                .html_content()
+                .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+            let trimmed = value.trim_start();
+            if trimmed.is_empty() {
+                Ok(TrimResult::RemoveNode)
+            } else if trimmed.len() == value.len() {
+                Ok(TrimResult::Done)
+            } else {
+                *text = BytesText::new(trimmed).into_owned();
+                Ok(TrimResult::Done)
+            }
+        }
+        XmlNode::Leaf(Event::CData(text)) => {
+            let value = text
+                .decode()
+                .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+            let trimmed = value.trim_start();
+            if trimmed.is_empty() {
+                Ok(TrimResult::RemoveNode)
+            } else if trimmed.len() == value.len() {
+                Ok(TrimResult::Done)
+            } else {
+                *text = BytesCData::new(trimmed).into_owned();
+                Ok(TrimResult::Done)
+            }
+        }
+        _ => Ok(TrimResult::Done),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrimResult {
+    RemoveNode,
+    Done,
+}
+
+fn remove_trailing_hyphen(nodes: &mut [XmlNode]) -> Result<bool> {
+    for node in nodes.iter_mut().rev() {
+        match node {
+            XmlNode::Element(element) => {
+                if remove_trailing_hyphen(&mut element.children)? {
+                    return Ok(true);
+                }
+                if !visible_text(&element.children)?.trim().is_empty() {
+                    return Ok(false);
+                }
+            }
+            XmlNode::Leaf(Event::Text(text)) => {
+                let value = text
+                    .html_content()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                if value.trim().is_empty() {
+                    continue;
+                }
+                if let Some(stripped) = strip_trailing_hyphen(&value) {
+                    *text = BytesText::new(&stripped).into_owned();
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+            XmlNode::Leaf(Event::CData(text)) => {
+                let value = text
+                    .decode()
+                    .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+                if value.trim().is_empty() {
+                    continue;
+                }
+                if let Some(stripped) = strip_trailing_hyphen(&value) {
+                    *text = BytesCData::new(&stripped).into_owned();
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+            XmlNode::Leaf(Event::GeneralRef(reference)) => {
+                if resolve_general_ref(reference)?
+                    .is_some_and(|value| value.chars().all(char::is_whitespace))
+                {
+                    continue;
+                }
+                return Ok(false);
+            }
+            XmlNode::Empty { .. } | XmlNode::Leaf(_) => return Ok(false),
+        }
+    }
+    Ok(false)
+}
+
+fn strip_trailing_hyphen(text: &str) -> Option<String> {
+    let trimmed = text.trim_end();
+    let mut chars = trimmed.char_indices().rev();
+    let (hyphen_index, hyphen) = chars.next()?;
+    if hyphen != '-' {
+        return None;
+    }
+    if !chars.next().is_some_and(|(_, ch)| is_word_char(ch)) {
+        return None;
+    }
+    Some(text[..hyphen_index].to_string())
+}
+
+fn preview(text: &str) -> String {
+    let text = normalize_space(text);
+    let mut preview = text.chars().take(40).collect::<String>();
+    if text.chars().count() > 40 {
+        preview.push_str("...");
+    }
+    preview
+}
+
+fn normalize_space(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_block_level_name(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"p" | b"div"
+            | b"blockquote"
+            | b"li"
+            | b"ul"
+            | b"ol"
+            | b"dl"
+            | b"dt"
+            | b"dd"
+            | b"table"
+            | b"thead"
+            | b"tbody"
+            | b"tfoot"
+            | b"tr"
+            | b"td"
+            | b"th"
+            | b"caption"
+            | b"h1"
+            | b"h2"
+            | b"h3"
+            | b"h4"
+            | b"h5"
+            | b"h6"
+            | b"section"
+            | b"article"
+            | b"aside"
+            | b"figure"
+            | b"figcaption"
+            | b"pre"
+            | b"hr"
+    )
+}
+
+fn is_replaced_content_name(name: &[u8]) -> bool {
+    matches!(
+        name,
+        b"img"
+            | b"image"
+            | b"svg"
+            | b"math"
+            | b"object"
+            | b"embed"
+            | b"iframe"
+            | b"video"
+            | b"audio"
+            | b"canvas"
+            | b"picture"
+            | b"source"
+    )
+}
+
+fn resolve_general_ref(reference: &quick_xml::events::BytesRef<'_>) -> Result<Option<String>> {
+    if let Some(ch) = reference
+        .resolve_char_ref()
+        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?
+    {
+        return Ok(Some(ch.to_string()));
+    }
+    let name = reference
+        .decode()
+        .map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+    let resolved = quick_xml::escape::resolve_html5_entity(&name).map(ToString::to_string);
+    if resolved.is_none() {
+        tracing::warn!(entity = %name, "dropping unresolvable entity reference");
+    }
+    Ok(resolved)
+}
+
+fn validate_xml(xml: &str) -> Result<()> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Eof) => return Ok(()),
+            Ok(_) => continue,
+            Err(error) => return Err(BookforgeError::InvalidInput(error.to_string())),
+        }
+    }
+}
+
+fn validate_mimetype(archive: &mut ZipArchive<File>) -> Result<()> {
+    let mut mimetype = String::new();
+    archive.by_name("mimetype")?.read_to_string(&mut mimetype)?;
+    if mimetype.trim() != "application/epub+zip" {
+        return Err(BookforgeError::InvalidInput(
+            "EPUB mimetype must be application/epub+zip".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn write_mimetype_first(source: &mut ZipArchive<File>, writer: &mut ZipWriter<File>) -> Result<()> {
+    let mut mimetype = String::new();
+    source.by_name("mimetype")?.read_to_string(&mut mimetype)?;
+    if mimetype.trim() != "application/epub+zip" {
+        return Err(BookforgeError::InvalidInput(
+            "EPUB mimetype must be application/epub+zip".to_string(),
+        ));
+    }
+
+    let stored = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .last_modified_time(deterministic_zip_time());
+    writer.start_file("mimetype", stored)?;
+    writer.write_all(b"application/epub+zip")?;
+    Ok(())
+}
+
+fn deterministic_zip_time() -> DateTime {
+    DateTime::from_date_and_time(1980, 1, 1, 0, 0, 0).expect("DOS epoch timestamp should be valid")
+}
+
+fn sibling_work_path(output: &Path, label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let name = output
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("book.epub");
+    output.with_file_name(format!(
+        ".{name}.bookforge-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn commit_staged_output(staged: &Path, output: &Path) -> Result<()> {
+    if !output.exists() {
+        fs::rename(staged, output)?;
+        return Ok(());
+    }
+
+    let backup = sibling_work_path(output, "backup");
+    fs::rename(output, &backup)?;
+    match fs::rename(staged, output) {
+        Ok(()) => {
+            if let Err(error) = fs::remove_file(&backup) {
+                tracing::warn!(
+                    backup = %backup.display(),
+                    error = %error,
+                    "reflowed EPUB is committed but its backup could not be removed"
+                );
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let _ = fs::rename(&backup, output);
+            Err(error.into())
+        }
+    }
+}
+
+fn is_xhtml_resource_name(name: &str) -> bool {
+    name.rsplit_once('.')
+        .map(|(_, extension)| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "xhtml" | "html" | "htm"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn local_name(name: &[u8]) -> &[u8] {
+    name.rsplit(|byte| *byte == b':').next().unwrap_or(name)
+}
+
+fn attr_value_unescaped(element: &BytesStart<'_>, attr_name: &[u8]) -> Result<Option<String>> {
+    for attr in element.attributes() {
+        let attr = attr.map_err(|err| BookforgeError::InvalidInput(err.to_string()))?;
+        if local_name(attr.key.as_ref()) == attr_name {
+            return Ok(Some(attr.unescape_value()?.into_owned()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs::File,
+        io::{Read, Write},
+    };
+    use zip::{ZipWriter, write::SimpleFileOptions};
+
+    fn reflow_snippet(body: &str) -> ResourceReflow {
+        let xhtml = format!("<html><body>{body}</body></html>");
+        reflow_xhtml_resource(&xhtml, "chapter.xhtml").expect("snippet should reflow")
+    }
+
+    fn merge_count(body: &str) -> usize {
+        reflow_snippet(body).merges.len()
+    }
+
+    #[test]
+    fn merges_consecutive_paragraphs() {
+        let outcome = reflow_snippet("<p>Hello</p><p>world.</p>");
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(outcome.xhtml.contains("<p>Hello world.</p>"));
+        assert_eq!(outcome.paragraphs_before, 2);
+        assert_eq!(outcome.paragraphs_after, 1);
+    }
+
+    #[test]
+    fn non_paragraph_blocks_do_not_merge() {
+        assert_eq!(merge_count("<h1>Hello</h1><p>world.</p>"), 0);
+    }
+
+    #[test]
+    fn terminal_punctuation_blocks_merge() {
+        assert_eq!(merge_count("<p>Hello.</p><p>world.</p>"), 0);
+    }
+
+    #[test]
+    fn terminal_punctuation_before_closing_quote_blocks_merge() {
+        assert_eq!(merge_count("<p>Hello.”</p><p>world.</p>"), 0);
+    }
+
+    #[test]
+    fn non_lowercase_second_paragraph_blocks_merge() {
+        assert_eq!(merge_count("<p>Hello</p><p>World.</p>"), 0);
+    }
+
+    #[test]
+    fn unicode_lowercase_starts_merge() {
+        let outcome = reflow_snippet("<p>Hello</p><p>éclat.</p>");
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(outcome.xhtml.contains("<p>Hello éclat.</p>"));
+    }
+
+    #[test]
+    fn unequal_classes_block_merge() {
+        assert_eq!(
+            merge_count(r#"<p class="body">Hello</p><p class="note">world.</p>"#),
+            0
+        );
+    }
+
+    #[test]
+    fn second_paragraph_id_blocks_merge() {
+        assert_eq!(merge_count(r#"<p>Hello</p><p id="anchor">world.</p>"#), 0);
+    }
+
+    #[test]
+    fn empty_paragraph_blocks_merge() {
+        assert_eq!(merge_count("<p>Hello</p><p> </p>"), 0);
+    }
+
+    #[test]
+    fn nested_block_blocks_merge() {
+        assert_eq!(
+            merge_count("<p>Hello</p><p><span>world</span><div>block</div></p>"),
+            0
+        );
+    }
+
+    #[test]
+    fn image_blocks_merge() {
+        assert_eq!(
+            merge_count(r#"<p>Hello</p><p>world <img src="cover.jpg"/></p>"#),
+            0
+        );
+    }
+
+    #[test]
+    fn non_whitespace_between_paragraphs_blocks_merge() {
+        assert_eq!(merge_count("<p>Hello</p><!-- page --><p>world.</p>"), 0);
+    }
+
+    #[test]
+    fn whitespace_between_paragraphs_still_merges() {
+        assert_eq!(merge_count("<p>Hello</p>\n  <p>world.</p>"), 1);
+    }
+
+    #[test]
+    fn chains_successive_merges() {
+        let outcome = reflow_snippet("<p>Alpha</p><p>beta</p><p>gamma.</p>");
+
+        assert_eq!(outcome.merges.len(), 2);
+        assert!(outcome.xhtml.contains("<p>Alpha beta gamma.</p>"));
+        assert_eq!(outcome.paragraphs_after, 1);
+    }
+
+    #[test]
+    fn dehyphenates_word_boundary() {
+        let outcome = reflow_snippet("<p>trans-</p><p>lation.</p>");
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(outcome.xhtml.contains("<p>translation.</p>"));
+        assert!(outcome.merges[0].dehyphenated);
+    }
+
+    #[test]
+    fn appends_inline_children_verbatim() {
+        let outcome = reflow_snippet(r#"<p>Hello <em>dear</em></p><p><strong>world</strong>.</p>"#);
+
+        assert_eq!(outcome.merges.len(), 1);
+        assert!(
+            outcome
+                .xhtml
+                .contains("<p>Hello <em>dear</em> <strong>world</strong>.</p>")
+        );
+    }
+
+    #[test]
+    fn report_records_merge_context() {
+        let outcome = reflow_snippet(
+            "<p>Alpha line carries enough text for preview</p><p>beta line continues.</p>",
+        );
+
+        assert_eq!(
+            outcome.merges[0],
+            ReflowMergeRecord {
+                resource: "chapter.xhtml".to_string(),
+                block_index: 0,
+                merged_block_index: 1,
+                left_preview: "Alpha line carries enough text for previ...".to_string(),
+                right_preview: "beta line continues.".to_string(),
+                dehyphenated: false,
+            }
+        );
+    }
+
+    #[test]
+    fn dry_run_writes_no_epub() {
+        let input = create_minimal_epub("<p>Hello</p><p>world.</p>");
+        let output = unique_temp_path("bookforge-reflow-dry-run", "epub");
+        let _ = fs::remove_file(&output);
+
+        let outcome = reflow_epub(&input, &output, &ReflowOptions { dry_run: true })
+            .expect("dry run should reflow");
+
+        assert!(!outcome.output_written);
+        assert!(!output.exists());
+        assert_eq!(outcome.report.totals.merge_count, 1);
+
+        let _ = fs::remove_file(input);
+    }
+
+    #[test]
+    fn real_run_writes_reflowed_epub() {
+        let input = create_minimal_epub("<p>Hello</p><p>world.</p>");
+        let output = unique_temp_path("bookforge-reflow-real-run", "epub");
+        let _ = fs::remove_file(&output);
+
+        let outcome = reflow_epub(&input, &output, &ReflowOptions::default())
+            .expect("real run should write output");
+
+        assert!(outcome.output_written);
+        assert!(output.exists());
+        assert_eq!(outcome.report.totals.merge_count, 1);
+
+        let mut archive = ZipArchive::new(File::open(&output).expect("output should open"))
+            .expect("output should be a zip");
+        let mut chapter = String::new();
+        archive
+            .by_name("OEBPS/chapter.xhtml")
+            .expect("chapter should exist")
+            .read_to_string(&mut chapter)
+            .expect("chapter should read");
+        assert!(chapter.contains("<p>Hello world.</p>"));
+
+        let _ = fs::remove_file(input);
+        let _ = fs::remove_file(output);
+    }
+
+    fn create_minimal_epub(body: &str) -> PathBuf {
+        let path = unique_temp_path("bookforge-reflow-fixture", "epub");
+        let _ = fs::remove_file(&path);
+        let file = File::create(&path).expect("fixture should create");
+        let mut writer = ZipWriter::new(file);
+        let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+        writer
+            .start_file("mimetype", stored)
+            .expect("mimetype should start");
+        writer
+            .write_all(b"application/epub+zip")
+            .expect("mimetype should write");
+        writer
+            .start_file("META-INF/container.xml", deflated)
+            .expect("container should start");
+        writer
+            .write_all(
+                br#"<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#,
+            )
+            .expect("container should write");
+        writer
+            .start_file("OEBPS/package.opf", deflated)
+            .expect("opf should start");
+        writer
+            .write_all(
+                br#"<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">fixture</dc:identifier>
+    <dc:title>Fixture</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter"/>
+  </spine>
+</package>"#,
+            )
+            .expect("opf should write");
+        writer
+            .start_file("OEBPS/chapter.xhtml", deflated)
+            .expect("chapter should start");
+        writer
+            .write_all(
+                format!(
+                    r#"<?xml version="1.0" encoding="utf-8"?><html xmlns="http://www.w3.org/1999/xhtml"><body>{body}</body></html>"#
+                )
+                .as_bytes(),
+            )
+            .expect("chapter should write");
+        writer.finish().expect("fixture should finish");
+        path
+    }
+
+    fn unique_temp_path(label: &str, extension: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "{label}-{}-{nonce}.{extension}",
+            std::process::id()
+        ))
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2333,12 +2333,22 @@ Merges chain (A+B+C…) as long as each successive pair qualifies.
 B's inline children are appended to A's children verbatim; A's
 attributes win for the merged block.
 
-**`--aggressive` (ruling 2026-07-05, owner-approved).** An opt-in flag
-that relaxes condition 3 only: B may also start with an uppercase
-letter, an opening quote/bracket (`“` `‘` `"` `'` `«` `(` `[`), or a
-dash (`—` `–`). All other conditions hold, plus one extra guard that
-replaces the letterless screen condition 3 gave for free: **B must
-contain at least one alphabetic character** (mirror of condition 7).
+**`--aggressive` (ruling 2026-07-05, owner-approved; amended same day).**
+An opt-in flag that relaxes two conditions:
+
+- Condition 3: B may also start with an uppercase letter, an opening
+  quote/bracket (`“` `‘` `"` `'` `«` `(` `[`), or a dash (`—` `–`).
+- Condition 4 (amended ruling): class equality is **not** required.
+  Calibre-style PDF conversions assign per-line classes (`calibre1`,
+  `calibre6`, …) as typographic artifacts of line position, so the
+  class guard blocks exactly the continuation lines aggressive mode
+  exists for. A's class wins (A's attributes already win); when the
+  two classes differ the merge record carries `left_class`/
+  `right_class` for audit.
+
+All other conditions hold, plus one extra guard that replaces the
+letterless screen condition 3 gave for free: **B must contain at least
+one alphabetic character** (mirror of condition 7).
 Rationale: the conservative rule leaves continuation lines split when
 they begin with a proper noun or bracketed insert (observed on CCRU:
 "…review of David" / "Toop's Rap Attack…"); the cost is a real

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2333,6 +2333,20 @@ Merges chain (A+B+C…) as long as each successive pair qualifies.
 B's inline children are appended to A's children verbatim; A's
 attributes win for the merged block.
 
+**`--aggressive` (ruling 2026-07-05, owner-approved).** An opt-in flag
+that relaxes condition 3 only: B may also start with an uppercase
+letter, an opening quote/bracket (`“` `‘` `"` `'` `«` `(` `[`), or a
+dash (`—` `–`). All other conditions hold, plus one extra guard that
+replaces the letterless screen condition 3 gave for free: **B must
+contain at least one alphabetic character** (mirror of condition 7).
+Rationale: the conservative rule leaves continuation lines split when
+they begin with a proper noun or bracketed insert (observed on CCRU:
+"…review of David" / "Toop's Rap Attack…"); the cost is a real
+false-positive risk on verse and deliberately short lines, which is why
+it is a separate opt-in level, never the default. Every merge that only
+qualified under the relaxed rule is marked `"aggressive": true` in the
+report so audits can focus on them.
+
 ### 9c.3 Report
 
 JSON report: totals plus one record per merge (resource name, block

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2322,6 +2322,10 @@ Consecutive sibling blocks A, B merge when ALL of:
    contains images/replaced content.
 6. Nothing but whitespace sits between them in the parent (no
    intervening elements, comments, or PIs).
+7. A contains at least one alphabetic character (ruling 2026-07-05:
+   bare page/footnote-number paragraphs from PDF conversions — e.g.
+   `<p>1</p>` mid-sentence — must never be glued into prose; observed
+   corrupting 3 merges on Acid Communism).
 
 Join with a single space; **dehyphenation**: if A ends in a hyphen
 attached to a word character, drop the hyphen and join with no space.
@@ -2340,7 +2344,10 @@ count, paragraph count before/after).
 
 1. CCRU Abstract Culture (the motivating book): paragraph count drops
    substantially; spot-checked chapters read as prose; EPUBCheck passes
-   on the output.
+   on the output. (Ruling 2026-07-05: when the *input* already fails
+   EPUBCheck — the CCRU source ships 10 pre-existing errors — the
+   criterion is **error parity**: reflow must introduce no new
+   messages.)
 2. A conventionally-typeset EPUB (e.g. the Fisher sources in `test/`)
    produces **zero or near-zero** merges — the guards must not fire on
    healthy books.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2293,15 +2293,65 @@ language (observed on the CCRU Abstract Culture book, 2026-07-03). This
 is distinct from §9: it is a *source-quality repair* concern for EPUBs
 BookForge did not create.
 
-Sketch: an opt-in `--reflow` preprocessing pass (or `bookforge reflow`
-command) that merges consecutive blocks when the first lacks terminal
-punctuation and the next starts lowercase, with conservative guards
-(same class/style, no intervening headings/images) and a report of every
-merge. Because it deliberately changes structure, it must stay opt-in
-and must never run as part of default translation. Effort guess:
-2–4 days. Priority: high relative to remaining unscheduled work — it
-addresses the most visible reader-facing defect in the owner's actual
-library.
+**Spec (promoted from sketch 2026-07-04, scheduled).**
+
+### 9c.1 Surface
+
+A standalone command only: `bookforge reflow <input.epub> --output
+<out.epub> [--report <path.json>] [--dry-run]`. No `--reflow` flag on
+`translate` in this milestone — the output is a repaired *source* EPUB
+the owner inspects before spending tokens, and keeping the translation
+pipeline untouched means cache keys need no thought (the repaired file
+simply has different source hashes). `--dry-run` writes the report and
+prints the summary without producing an output EPUB. Default report
+path: next to the output with `.reflow-report.json` suffix.
+
+### 9c.2 Merge rule
+
+Consecutive sibling blocks A, B merge when ALL of:
+
+1. Both are `<p>` elements. Only `<p>` — headings, `li`, `blockquote`
+   etc. never participate in this milestone.
+2. A's text ends **without** terminal punctuation. Terminal set:
+   `.` `!` `?` `:` `;` `…`, optionally followed by closing quotes/
+   brackets (`"` `”` `’` `»` `)` `]`), which still count as terminal.
+3. B's text starts with a Unicode lowercase letter.
+4. `class` attributes are equal (or both absent); B carries no `id`
+   (it may be a link target).
+5. Neither block is empty, contains nested block-level elements, or
+   contains images/replaced content.
+6. Nothing but whitespace sits between them in the parent (no
+   intervening elements, comments, or PIs).
+
+Join with a single space; **dehyphenation**: if A ends in a hyphen
+attached to a word character, drop the hyphen and join with no space.
+Merges chain (A+B+C…) as long as each successive pair qualifies.
+B's inline children are appended to A's children verbatim; A's
+attributes win for the merged block.
+
+### 9c.3 Report
+
+JSON report: totals plus one record per merge (resource name, block
+index, first ~40 chars of each side) so every structural change is
+auditable. Human summary printed at the end (files touched, merge
+count, paragraph count before/after).
+
+### 9c.4 Acceptance
+
+1. CCRU Abstract Culture (the motivating book): paragraph count drops
+   substantially; spot-checked chapters read as prose; EPUBCheck passes
+   on the output.
+2. A conventionally-typeset EPUB (e.g. the Fisher sources in `test/`)
+   produces **zero or near-zero** merges — the guards must not fire on
+   healthy books.
+3. `--dry-run` writes no EPUB; the report matches what a real run does.
+4. Un-mockable criterion (§15.6): reflow the real CCRU EPUB and read a
+   chapter of the output.
+
+Because it deliberately changes structure, it stays opt-in forever and
+never runs as part of default translation. Effort: 2–4 days. Priority:
+high relative to remaining unscheduled work — it addresses the most
+visible reader-facing defect in the owner's actual library.
 
 ---
 

--- a/docs/codex-handoff-reflow.md
+++ b/docs/codex-handoff-reflow.md
@@ -1,0 +1,84 @@
+# Handoff to Codex — §9c source-EPUB reflow (2026-07-04)
+
+Written by Claude Code on behalf of the maintainer. First of two
+quality-of-life milestones scheduled after v2.2.0 (the other is §10.1.1
+pause/stop, which will follow on its own branch).
+
+**The authoritative spec is `docs/ROADMAP.md` §9c (freshly promoted from
+sketch to spec — read it in full before writing code).** It defines the
+command surface, the six-condition merge rule, dehyphenation, the report
+format, and acceptance criteria. If a needed detail is missing, stop and
+ask the maintainer rather than inventing it.
+
+## Context — why this exists
+
+Third-party PDF→EPUB conversions (Calibre et al.) emit one `<p>` per
+printed line. BookForge correctly preserves structure, so translations
+inherit English-line-length paragraph breaks and read ragged. This is a
+*source-quality repair* tool for EPUBs BookForge did not create. The
+motivating book is `test/CCRU_Abstract_Culture_2024.epub` (restored to
+the repo working tree; do not commit EPUBs).
+
+## Non-negotiables (ROADMAP §1 + §9c)
+
+- **Reflow is a standalone preprocessing command.** It must NOT touch
+  the translate pipeline, prompts, cache keys, or reassembly. If you
+  find yourself editing translate/resume/reader marker logic, you have
+  gone off-spec.
+- Opt-in forever: no default-on behavior anywhere.
+- Output EPUB must be EPUBCheck-valid and preserve everything the merge
+  rule doesn't explicitly change (metadata, spine, images, CSS, non-`<p>`
+  content byte-preserved as far as the existing writer infra allows).
+- Every merge is auditable via the JSON report (§9c.3).
+- Single-static-binary rule: no new C deps; use the existing
+  quick-xml/zip machinery in `bookforge-epub`.
+
+## Where the work lives
+
+- `crates/bookforge-epub` — new `reflow.rs` module (the merge engine +
+  report types). Reuse the crate's existing EPUB open/rewrite plumbing
+  (see `writer.rs` for how resources are parsed and re-serialized with
+  quick-xml, and `validate.rs` for the validation harness).
+- `crates/bookforge-cli/src/commands/` — new `reflow.rs` command wired
+  into `main.rs`/`mod.rs` alongside `convert`/`validate`. Flags per
+  §9c.1: `--output`, `--report`, `--dry-run`.
+- No serve.rs / dashboard / TUI work in this milestone.
+
+## Merge rule notes (read §9c.2 for the binding text)
+
+- Only consecutive sibling `<p>` pairs, chained A+B+C… while each pair
+  qualifies.
+- Terminal-punctuation test must handle closing quotes/brackets after
+  the terminal mark (`."` `.”` `?»` etc. are terminal).
+- Lowercase test is Unicode-aware (`char::is_lowercase`), not ASCII.
+- Dehyphenation: trailing `-` attached to a word char → join with no
+  space and drop the hyphen.
+- Guards: equal `class` (or both absent), no `id` on B, no nested block
+  elements / images / empty text in either, nothing but whitespace
+  between them.
+- B's inline children append to A's children verbatim; A's attributes
+  win.
+
+## Working agreement
+
+- Branch: `feat/reflow` (already created and checked out; roadmap spec
+  + this handoff are committed on it).
+- Conventional commits, logical units, tests with each commit.
+- Full workspace `cargo check` / `test` / `clippy` / `fmt` clean before
+  each commit.
+- Unit tests: each of the six merge conditions individually blocking a
+  merge; chaining; dehyphenation; terminal-punct-with-closing-quote;
+  Unicode lowercase; report record contents; dry-run writes no EPUB.
+- End-to-end: run `bookforge reflow` on
+  `test/CCRU_Abstract_Culture_2024.epub`, check the paragraph count
+  drops substantially and EPUBCheck passes (if on PATH; also run the
+  BookForge validator). Then run it on `test/AcidCommunism.v16.epub`
+  and confirm zero or near-zero merges (guard sanity).
+- Do not push; leave the branch ready for Claude's review pass.
+
+## Acceptance (from §9c.4, condensed)
+
+CCRU output reads as prose with far fewer `<p>`s and passes
+EPUBCheck/validator; healthy EPUBs are untouched (≈0 merges); dry-run
+report matches a real run; the final un-mockable read-a-chapter check
+is the maintainer's/Claude's job, not yours.

--- a/docs/codex-handoff-reflow.md
+++ b/docs/codex-handoff-reflow.md
@@ -82,3 +82,26 @@ CCRU output reads as prose with far fewer `<p>`s and passes
 EPUBCheck/validator; healthy EPUBs are untouched (≈0 merges); dry-run
 report matches a real run; the final un-mockable read-a-chapter check
 is the maintainer's/Claude's job, not yours.
+
+## Follow-up task: --aggressive level (2026-07-05, owner-approved)
+
+PR #24 is open; add this as new commits on `feat/reflow`. The
+authoritative spec is the new `--aggressive` ruling in ROADMAP §9c.2 —
+read it first. Condensed:
+
+- `--aggressive` flag on `bookforge reflow`, relaxing ONLY condition 3:
+  B may also start with uppercase, opening quote/bracket
+  (`“ ‘ " ' « ( [`), or a dash (`— –`). Everything else unchanged.
+- New guard under aggressive: B must contain at least one alphabetic
+  character (letterless right-side blocks must never merge).
+- Merge records that only qualified under the relaxed rule carry
+  `"aggressive": true` in the JSON report (serde should skip the field
+  when false to keep conservative reports byte-stable).
+- Unit tests: uppercase/bracket/dash starts merge under aggressive and
+  not under default; letterless B never merges; report flag set only on
+  relaxed-rule merges; conservative behavior byte-identical when the
+  flag is absent.
+- E2E: rerun CCRU with and without --aggressive, report both merge
+  counts; the "…review of David" / "Toop's Rap Attack…" pair in
+  index_split_007 must merge under aggressive.
+- Full workspace gates before each commit. Do not push.


### PR DESCRIPTION
## Summary
- New standalone `bookforge reflow <input.epub> --output <out.epub> [--report ...] [--dry-run]` command repairing third-party PDF→EPUB conversions where every printed line is its own `<p>` (ROADMAP §9c, promoted from sketch to binding spec in this PR).
- Merge engine in `bookforge-epub/src/reflow.rs`: seven-condition conservative rule (consecutive sibling `<p>` only, no terminal punctuation on the left, Unicode-lowercase start on the right, equal `class`, no `id` on the right, no nested blocks/replaced content, whitespace-only gaps, left must contain letters), with dehyphenation and chained merges. Every merge is recorded in a JSON audit report.
- Deliberately out of the translate pipeline: no prompt/cache/reassembly changes; opt-in forever.

## Review + verification (Claude)
- Fixed two bugs found in review: dehyphenation left a stray space when the right line began with whitespace (`4a3db56`); bare page-number paragraphs (`<p>1</p>` mid-sentence in Acid Communism) were glued into prose — now blocked by §9c.2 condition 7 (`75196ac`).
- **CCRU Abstract Culture (motivating book):** 1,411 merges, 4,912 → 3,501 paragraphs; worst chapter 513 → 337; spot-read chapters join cleanly. BookForge validators pass; EPUBCheck shows **error parity** (the source ships 10 pre-existing errors; reflow introduces zero new ones — ruling recorded in §9c.4).
- **Acid Communism (guard sanity):** 39 merges, all true positives (it is itself a PDF conversion); dry-run report matches the real run.
- 21 unit tests cover each merge condition, chaining, dehyphenation, reports, dry-run.

## Known limitation (by design)
Continuation lines starting with an uppercase proper noun or bracket stay split (the lowercase-start condition is what keeps false positives at zero). A more aggressive opt-in level is a possible follow-up if the owner wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxQQJA9eB2aeW4vtbqgnoU