### PR TITLE
feat: live reconfigure + truncation fail-fast alerts (ROADMAP §10.1.3, §10.1.4)

### DIFF
--- a/crates/bookforge-cli/src/commands/mod.rs
+++ b/crates/bookforge-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod estimate;
 pub mod glossary;
 pub mod ingest_flags;
 pub mod inspect;
+pub mod reconfigure;
 pub mod reflow;
 pub mod resume;
 pub mod retry;

--- a/crates/bookforge-cli/src/commands/reconfigure.rs
+++ b/crates/bookforge-cli/src/commands/reconfigure.rs
@@ -1,0 +1,467 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use bookforge_core::{
+    GlossaryFormat, ProviderPreset, ResolvedRunSettings,
+    config::{ContextScope, DoubleCheckMode, TranslationProfile},
+    run_dir_for_job,
+};
+use bookforge_store::JobStore;
+use clap::Args;
+
+use crate::QaMode;
+
+#[derive(Debug, Args)]
+pub struct ReconfigureArgs {
+    pub job_id: String,
+
+    #[arg(long)]
+    pub batch_max_output_tokens: Option<u32>,
+
+    #[arg(long)]
+    pub batch_max_items: Option<usize>,
+
+    #[arg(long)]
+    pub batch_target_tokens: Option<usize>,
+
+    #[arg(long)]
+    pub concurrency: Option<usize>,
+
+    #[arg(long, value_enum)]
+    pub qa: Option<QaMode>,
+
+    #[arg(long, value_enum)]
+    pub double_check: Option<DoubleCheckMode>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub validate_output: Option<bool>,
+
+    #[arg(long)]
+    pub provider_max_attempts: Option<usize>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub adaptive_concurrency: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub adaptive_batch_sizing: Option<bool>,
+
+    #[arg(long)]
+    provider: Option<String>,
+
+    #[arg(long)]
+    model: Option<String>,
+
+    #[arg(long)]
+    source: Option<String>,
+
+    #[arg(long)]
+    target: Option<String>,
+
+    #[arg(long, value_enum)]
+    profile: Option<TranslationProfile>,
+
+    #[arg(long)]
+    max_segment_tokens: Option<usize>,
+
+    #[arg(long)]
+    context_tokens: Option<usize>,
+
+    #[arg(long)]
+    context_window: Option<usize>,
+
+    #[arg(long)]
+    context_budget_tokens: Option<usize>,
+
+    #[arg(long, value_enum)]
+    context_scope: Option<ContextScope>,
+
+    #[arg(long)]
+    prompt_version: Option<String>,
+
+    #[arg(long = "glossary")]
+    glossary: Vec<PathBuf>,
+
+    #[arg(long)]
+    glossary_budget_tokens: Option<usize>,
+
+    #[arg(long, value_enum)]
+    glossary_format: Option<GlossaryFormat>,
+
+    #[arg(long)]
+    prompt_extra: Option<String>,
+
+    #[arg(long = "style")]
+    style: Vec<PathBuf>,
+
+    #[arg(long = "entities")]
+    entities: Vec<PathBuf>,
+
+    #[arg(long, value_enum)]
+    provider_preset: Option<ProviderPreset>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub(crate) struct RunConfigOverrides {
+    pub batch_max_output_tokens: Option<u32>,
+    pub batch_max_items: Option<usize>,
+    pub batch_target_tokens: Option<usize>,
+    pub concurrency: Option<usize>,
+    pub qa: Option<QaMode>,
+    pub double_check: Option<DoubleCheckMode>,
+    pub validate_output: Option<bool>,
+    pub provider_max_attempts: Option<usize>,
+    pub adaptive_concurrency: Option<bool>,
+    pub adaptive_batch_sizing: Option<bool>,
+}
+
+impl RunConfigOverrides {
+    fn from_args(args: &ReconfigureArgs) -> Self {
+        Self {
+            batch_max_output_tokens: args.batch_max_output_tokens,
+            batch_max_items: args.batch_max_items,
+            batch_target_tokens: args.batch_target_tokens,
+            concurrency: args.concurrency,
+            qa: args.qa,
+            double_check: args.double_check,
+            validate_output: args.validate_output,
+            provider_max_attempts: args.provider_max_attempts,
+            adaptive_concurrency: args.adaptive_concurrency,
+            adaptive_batch_sizing: args.adaptive_batch_sizing,
+        }
+    }
+
+    fn merge(self, existing: Self) -> Self {
+        Self {
+            batch_max_output_tokens: self
+                .batch_max_output_tokens
+                .or(existing.batch_max_output_tokens),
+            batch_max_items: self.batch_max_items.or(existing.batch_max_items),
+            batch_target_tokens: self.batch_target_tokens.or(existing.batch_target_tokens),
+            concurrency: self.concurrency.or(existing.concurrency),
+            qa: self.qa.or(existing.qa),
+            double_check: self.double_check.or(existing.double_check),
+            validate_output: self.validate_output.or(existing.validate_output),
+            provider_max_attempts: self
+                .provider_max_attempts
+                .or(existing.provider_max_attempts),
+            adaptive_concurrency: self.adaptive_concurrency.or(existing.adaptive_concurrency),
+            adaptive_batch_sizing: self
+                .adaptive_batch_sizing
+                .or(existing.adaptive_batch_sizing),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.batch_max_output_tokens.is_none()
+            && self.batch_max_items.is_none()
+            && self.batch_target_tokens.is_none()
+            && self.concurrency.is_none()
+            && self.qa.is_none()
+            && self.double_check.is_none()
+            && self.validate_output.is_none()
+            && self.provider_max_attempts.is_none()
+            && self.adaptive_concurrency.is_none()
+            && self.adaptive_batch_sizing.is_none()
+    }
+}
+
+pub async fn run(args: ReconfigureArgs) -> Result<()> {
+    reject_immutable_changes(&args)?;
+    let incoming = RunConfigOverrides::from_args(&args);
+    if incoming.is_empty() {
+        anyhow::bail!(
+            "no mutable settings provided; reconfigure accepts cache-safe scheduling, budget, QA, double-check, validation, provider-attempt, and adaptive flags"
+        );
+    }
+
+    let store = JobStore::open_default()?;
+    let Some(job) = store.get_job(&args.job_id)? else {
+        anyhow::bail!("job '{}' was not found", args.job_id);
+    };
+    if job.status != "paused" {
+        anyhow::bail!(
+            "job '{}' is '{}'; reconfigure only applies to paused jobs. Run `bookforge pause {}` first, or start a fresh run for immutable settings.",
+            args.job_id,
+            job.status,
+            args.job_id
+        );
+    }
+    if store.load_job_config_snapshot(&args.job_id)?.is_none() {
+        anyhow::bail!(
+            "job '{}' does not have a run configuration snapshot; it cannot be reconfigured safely",
+            args.job_id
+        );
+    }
+
+    let existing = load_overrides_for_job(&args.job_id)?;
+    let merged = incoming.merge(existing.unwrap_or_default());
+    let path = write_overrides_for_job(&args.job_id, &merged)?;
+    println!("Reconfigured: {}", args.job_id);
+    println!("Overrides: {}", path.display());
+    for line in describe_overrides(&merged) {
+        println!("  {line}");
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_overrides_to_settings(
+    settings: &mut ResolvedRunSettings,
+    overrides: &RunConfigOverrides,
+) {
+    if let Some(value) = overrides.batch_max_output_tokens {
+        settings.provider.batch_max_output_tokens = Some(value);
+    }
+    if let Some(value) = overrides.batch_max_items {
+        settings.batch.max_items = value.max(1);
+    }
+    if let Some(value) = overrides.batch_target_tokens {
+        settings.batch.target_tokens = value.max(1);
+    }
+    if let Some(value) = overrides.concurrency {
+        settings.scheduler.concurrency = value.max(1);
+    }
+    if let Some(value) = overrides.double_check {
+        settings.double_check.mode = value;
+    }
+    if let Some(value) = overrides.provider_max_attempts {
+        settings.provider.provider_max_attempts = value.max(1);
+    }
+    if let Some(value) = overrides.adaptive_concurrency {
+        settings.adaptive_concurrency = value;
+    }
+    if let Some(value) = overrides.adaptive_batch_sizing {
+        settings.batch.adaptive_sizing = value;
+    }
+}
+
+pub(crate) fn load_overrides_for_job(job_id: &str) -> Result<Option<RunConfigOverrides>> {
+    load_overrides_from_path(&overrides_path_for_job(job_id))
+}
+
+pub(crate) fn overrides_path_for_job(job_id: &str) -> PathBuf {
+    run_dir_for_job(job_id).join("overrides.json")
+}
+
+pub(crate) fn describe_overrides(overrides: &RunConfigOverrides) -> Vec<String> {
+    let mut lines = Vec::new();
+    push_opt(
+        &mut lines,
+        "batch-max-output-tokens",
+        overrides.batch_max_output_tokens,
+    );
+    push_opt(&mut lines, "batch-max-items", overrides.batch_max_items);
+    push_opt(
+        &mut lines,
+        "batch-target-tokens",
+        overrides.batch_target_tokens,
+    );
+    push_opt(&mut lines, "concurrency", overrides.concurrency);
+    push_opt(
+        &mut lines,
+        "qa",
+        overrides.qa.map(|value| format!("{value:?}")),
+    );
+    push_opt(
+        &mut lines,
+        "double-check",
+        overrides.double_check.map(|value| format!("{value:?}")),
+    );
+    push_opt(&mut lines, "validate-output", overrides.validate_output);
+    push_opt(
+        &mut lines,
+        "provider-max-attempts",
+        overrides.provider_max_attempts,
+    );
+    push_opt(
+        &mut lines,
+        "adaptive-concurrency",
+        overrides.adaptive_concurrency,
+    );
+    push_opt(
+        &mut lines,
+        "adaptive-batch-sizing",
+        overrides.adaptive_batch_sizing,
+    );
+    lines
+}
+
+fn push_opt<T: ToString>(lines: &mut Vec<String>, name: &str, value: Option<T>) {
+    if let Some(value) = value {
+        lines.push(format!("{name}: {}", value.to_string()));
+    }
+}
+
+fn load_overrides_from_path(path: &Path) -> Result<Option<RunConfigOverrides>> {
+    match fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents)
+            .map(Some)
+            .with_context(|| format!("failed to parse {}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn write_overrides_for_job(job_id: &str, overrides: &RunConfigOverrides) -> Result<PathBuf> {
+    let path = overrides_path_for_job(job_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(overrides)?;
+    fs::write(&path, format!("{json}\n"))
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+fn reject_immutable_changes(args: &ReconfigureArgs) -> Result<()> {
+    let mut rejected = Vec::new();
+    if args.provider.is_some() {
+        rejected.push("provider");
+    }
+    if args.model.is_some() {
+        rejected.push("model");
+    }
+    if args.source.is_some() {
+        rejected.push("source language");
+    }
+    if args.target.is_some() {
+        rejected.push("target language");
+    }
+    if args.profile.is_some() {
+        rejected.push("profile");
+    }
+    if args.max_segment_tokens.is_some() {
+        rejected.push("max segment tokens");
+    }
+    if args.context_tokens.is_some()
+        || args.context_window.is_some()
+        || args.context_budget_tokens.is_some()
+        || args.context_scope.is_some()
+    {
+        rejected.push("context settings");
+    }
+    if args.prompt_version.is_some() {
+        rejected.push("prompt version");
+    }
+    if !args.glossary.is_empty()
+        || args.glossary_budget_tokens.is_some()
+        || args.glossary_format.is_some()
+        || args.prompt_extra.is_some()
+    {
+        rejected.push("glossary inputs");
+    }
+    if !args.style.is_empty() {
+        rejected.push("style inputs");
+    }
+    if !args.entities.is_empty() {
+        rejected.push("entity inputs");
+    }
+    if args.provider_preset.is_some() {
+        rejected.push("provider preset");
+    }
+    if rejected.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "cannot reconfigure {} for an existing job; these settings affect cache identity or prompt inputs, so start a fresh run instead",
+        rejected.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn immutable_provider_is_rejected_with_fresh_run_message() {
+        let args = ReconfigureArgs {
+            job_id: "job".to_string(),
+            batch_max_output_tokens: None,
+            batch_max_items: None,
+            batch_target_tokens: None,
+            concurrency: None,
+            qa: None,
+            double_check: None,
+            validate_output: None,
+            provider_max_attempts: None,
+            adaptive_concurrency: None,
+            adaptive_batch_sizing: None,
+            provider: Some("deepseek".to_string()),
+            model: None,
+            source: None,
+            target: None,
+            profile: None,
+            max_segment_tokens: None,
+            context_tokens: None,
+            context_window: None,
+            context_budget_tokens: None,
+            context_scope: None,
+            prompt_version: None,
+            glossary: Vec::new(),
+            glossary_budget_tokens: None,
+            glossary_format: None,
+            prompt_extra: None,
+            style: Vec::new(),
+            entities: Vec::new(),
+            provider_preset: None,
+        };
+
+        let err = reject_immutable_changes(&args).expect_err("provider must be rejected");
+
+        assert!(err.to_string().contains("provider"));
+        assert!(err.to_string().contains("fresh run"));
+    }
+
+    #[test]
+    fn describes_only_present_overrides() {
+        let overrides = RunConfigOverrides {
+            batch_max_output_tokens: Some(12_000),
+            batch_max_items: Some(3),
+            validate_output: Some(true),
+            ..RunConfigOverrides::default()
+        };
+
+        let lines = describe_overrides(&overrides);
+
+        assert_eq!(
+            lines,
+            vec![
+                "batch-max-output-tokens: 12000",
+                "batch-max-items: 3",
+                "validate-output: true"
+            ]
+        );
+    }
+
+    #[test]
+    fn applies_runtime_overrides_without_touching_cache_fields() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        let overrides = RunConfigOverrides {
+            batch_max_output_tokens: Some(12_000),
+            batch_max_items: Some(2),
+            batch_target_tokens: Some(4_000),
+            concurrency: Some(3),
+            provider_max_attempts: Some(5),
+            adaptive_concurrency: Some(true),
+            adaptive_batch_sizing: Some(false),
+            double_check: Some(DoubleCheckMode::Semantic),
+            ..RunConfigOverrides::default()
+        };
+
+        apply_overrides_to_settings(&mut settings, &overrides);
+
+        assert_eq!(settings.provider.batch_max_output_tokens, Some(12_000));
+        assert_eq!(settings.batch.max_items, 2);
+        assert_eq!(settings.batch.target_tokens, 4_000);
+        assert_eq!(settings.scheduler.concurrency, 3);
+        assert_eq!(settings.provider.provider_max_attempts, 5);
+        assert!(settings.adaptive_concurrency);
+        assert!(!settings.batch.adaptive_sizing);
+        assert_eq!(settings.double_check.mode, DoubleCheckMode::Semantic);
+    }
+}

--- a/crates/bookforge-cli/src/commands/reconfigure.rs
+++ b/crates/bookforge-cli/src/commands/reconfigure.rs
@@ -205,6 +205,7 @@ pub async fn run(args: ReconfigureArgs) -> Result<()> {
     for line in describe_overrides(&merged) {
         println!("  {line}");
     }
+    println!("Apply: {}", apply_instructions(&args.job_id));
     Ok(())
 }
 
@@ -242,8 +243,23 @@ pub(crate) fn load_overrides_for_job(job_id: &str) -> Result<Option<RunConfigOve
     load_overrides_from_path(&overrides_path_for_job(job_id))
 }
 
+pub(crate) fn clear_overrides_for_job(job_id: &str) -> Result<PathBuf> {
+    let path = overrides_path_for_job(job_id);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(path),
+        Err(err) => Err(err).with_context(|| format!("failed to remove {}", path.display())),
+    }
+}
+
 pub(crate) fn overrides_path_for_job(job_id: &str) -> PathBuf {
     run_dir_for_job(job_id).join("overrides.json")
+}
+
+pub(crate) fn apply_instructions(job_id: &str) -> String {
+    format!(
+        "Stop the paused run first: `bookforge stop {job_id}`, then `bookforge resume {job_id}` to apply overrides. If the paused process is already gone, use `bookforge resume {job_id} --force`."
+    )
 }
 
 pub(crate) fn describe_overrides(overrides: &RunConfigOverrides) -> Vec<String> {

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -94,29 +94,14 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         anyhow::bail!("job '{}' was not found", args.job_id);
     };
     if job.status == "paused" && !args.force {
-        let path = crate::control::request_job_control(&args.job_id, ControlCommand::Resume)?;
-        if human_stdout_enabled(args.ui) {
-            println!("resume requested for {} ({})", args.job_id, path.display());
-        }
-        if wait_for_paused_job_to_leave_paused(
-            &store,
-            &args.job_id,
-            PAUSED_RESUME_WAIT,
-            PAUSED_RESUME_POLL,
-        )
-        .await?
-        {
-            return Ok(());
-        }
-        eprintln!("{}", dead_paused_resume_hint(&args.job_id));
-        return Ok(());
+        return live_fast_resume_paused_job(&store, &args).await;
     }
     crate::control::clear_job_control(&args.job_id)?;
     if (job.status == "paused" && args.force) || job.status == "stopped" {
         store.mark_job_running_for_resume(&args.job_id)?;
     }
     let mut snapshot = load_resume_snapshot(&store, &args.job_id)?;
-    let overrides = reconfigure::load_overrides_for_job(&args.job_id)?;
+    let overrides = load_resume_overrides_for_status(&args.job_id, &job.status)?;
 
     let progress_jsonl = args
         .progress_jsonl
@@ -131,6 +116,42 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
 
     let run_result = run_inner(args, store, job, &mut snapshot, overrides, progress).await;
     finalize_reporter(run_result, reporter).await
+}
+
+async fn live_fast_resume_paused_job(store: &JobStore, args: &ResumeArgs) -> Result<()> {
+    if reconfigure::load_overrides_for_job(&args.job_id)?.is_some() {
+        anyhow::bail!(
+            "job '{}' has pending reconfigure overrides that a live fast-resume cannot apply. {}",
+            args.job_id,
+            reconfigure::apply_instructions(&args.job_id)
+        );
+    }
+    let path = crate::control::request_job_control(&args.job_id, ControlCommand::Resume)?;
+    if human_stdout_enabled(args.ui) {
+        println!("resume requested for {} ({})", args.job_id, path.display());
+    }
+    if wait_for_paused_job_to_leave_paused(
+        store,
+        &args.job_id,
+        PAUSED_RESUME_WAIT,
+        PAUSED_RESUME_POLL,
+    )
+    .await?
+    {
+        return Ok(());
+    }
+    eprintln!("{}", dead_paused_resume_hint(&args.job_id));
+    Ok(())
+}
+
+fn load_resume_overrides_for_status(
+    job_id: &str,
+    job_status: &str,
+) -> Result<Option<reconfigure::RunConfigOverrides>> {
+    match job_status {
+        "paused" | "stopped" => reconfigure::load_overrides_for_job(job_id),
+        _ => Ok(None),
+    }
 }
 
 async fn wait_for_paused_job_to_leave_paused(
@@ -647,6 +668,7 @@ async fn run_inner(
     snapshot.report_json_path = Some(report.json.clone());
     snapshot.report_markdown_path = Some(report.markdown.clone());
     store.update_job_config_snapshot(&job.id, snapshot)?;
+    reconfigure::clear_overrides_for_job(&job.id)?;
     progress.emit(ProgressEvent::ArtifactWritten {
         path: output.display().to_string(),
         timestamp_ms: now_ms(),
@@ -1152,7 +1174,7 @@ mod tests {
     use bookforge_store::{CreateJob, SaveNeedsReview, SaveTranslation};
     use std::{
         io::Write,
-        path::Path,
+        path::{Path, PathBuf},
         sync::Mutex,
         time::{Duration, SystemTime, UNIX_EPOCH},
     };
@@ -1229,6 +1251,41 @@ mod tests {
         .expect("paused wait should not error");
 
         assert!(resumed, "live paused job should be observed leaving paused");
+    }
+
+    #[tokio::test]
+    async fn paused_fast_resume_with_overrides_errors_with_apply_guidance() {
+        let fixture = resume_fixture(TranslationProfile::V1Fast.resolve(), 1);
+        fixture
+            .store
+            .mark_job_paused(&fixture.job.id)
+            .expect("job should mark paused");
+        let _path = write_overrides_sidecar(
+            &fixture.job.id,
+            &reconfigure::RunConfigOverrides {
+                batch_max_output_tokens: Some(12_000),
+                ..reconfigure::RunConfigOverrides::default()
+            },
+        );
+        let args = resume_args(&fixture.job.id);
+
+        let error = live_fast_resume_paused_job(&fixture.store, &args)
+            .await
+            .expect_err("pending overrides must block live fast-resume");
+        let message = error.to_string();
+
+        assert!(message.contains("live fast-resume cannot apply"));
+        assert!(message.contains(&format!("bookforge stop {}", fixture.job.id)));
+        assert!(message.contains(&format!("bookforge resume {}", fixture.job.id)));
+        assert!(message.contains("--force"));
+        assert_eq!(
+            bookforge_core::read_control_file(&bookforge_core::control_path_for_job(
+                &fixture.job.id
+            ))
+            .expect("control file should read"),
+            ControlCommand::Run
+        );
+        reconfigure::clear_overrides_for_job(&fixture.job.id).expect("sidecar should clear");
     }
 
     #[tokio::test]
@@ -1354,6 +1411,45 @@ mod tests {
                     && block.text.starts_with("stored")),
             "succeeded segment should keep its original checkpointed translation"
         );
+    }
+
+    #[tokio::test]
+    async fn resume_clears_overrides_after_success_and_terminal_status_ignores_stale_sidecar() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = false;
+        settings.provider.batch_max_output_tokens = Some(2_000);
+        let mut fixture = resume_fixture(settings, 1);
+        let overrides = reconfigure::RunConfigOverrides {
+            batch_max_output_tokens: Some(12_000),
+            ..reconfigure::RunConfigOverrides::default()
+        };
+        let path = write_overrides_sidecar(&fixture.job.id, &overrides);
+
+        let events = run_fixture_with_overrides(&mut fixture, Some(overrides))
+            .await
+            .expect("resume should apply overrides and finish");
+        let runtime = runtime_config_event(&events);
+
+        assert_eq!(runtime.batch_max_output_tokens, Some(12_000));
+        assert!(
+            !path.exists(),
+            "successful terminal resume should remove overrides sidecar"
+        );
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("sidecar parent should exist");
+        }
+        std::fs::write(&path, "{not valid json").expect("stale malformed sidecar should write");
+        let overrides = load_resume_overrides_for_status(&fixture.job.id, "succeeded")
+            .expect("terminal job should not read stale sidecar");
+
+        assert!(overrides.is_none());
+        assert!(
+            path.exists(),
+            "terminal status guard should not consume the stale sidecar"
+        );
+        reconfigure::clear_overrides_for_job(&fixture.job.id)
+            .expect("stale sidecar should clean up");
     }
 
     #[tokio::test]
@@ -1740,21 +1836,7 @@ mod tests {
             events: events.clone(),
         });
         let run_store = JobStore::open(fixture.store.path()).expect("store should reopen");
-        let args = ResumeArgs {
-            job_id: fixture.job.id.clone(),
-            concurrency: None,
-            max_attempts: None,
-            provider_max_attempts: None,
-            validation_max_attempts: None,
-            qa: None,
-            timeout_seconds: None,
-            max_output_tokens: None,
-            ui: None,
-            progress_jsonl: None,
-            output: None,
-            no_thinking: false,
-            force: false,
-        };
+        let args = resume_args(&fixture.job.id);
 
         run_inner(
             args,
@@ -1767,6 +1849,37 @@ mod tests {
         .await?;
 
         Ok(events.lock().expect("events lock").clone())
+    }
+
+    fn resume_args(job_id: &str) -> ResumeArgs {
+        ResumeArgs {
+            job_id: job_id.to_string(),
+            concurrency: None,
+            max_attempts: None,
+            provider_max_attempts: None,
+            validation_max_attempts: None,
+            qa: None,
+            timeout_seconds: None,
+            max_output_tokens: None,
+            ui: None,
+            progress_jsonl: None,
+            output: None,
+            no_thinking: false,
+            force: false,
+        }
+    }
+
+    fn write_overrides_sidecar(
+        job_id: &str,
+        overrides: &reconfigure::RunConfigOverrides,
+    ) -> PathBuf {
+        let path = reconfigure::overrides_path_for_job(job_id);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("sidecar parent should exist");
+        }
+        let json = serde_json::to_string_pretty(overrides).expect("overrides should serialize");
+        std::fs::write(&path, format!("{json}\n")).expect("overrides sidecar should write");
+        path
     }
 
     fn runtime_config_event(events: &[ProgressEvent]) -> RuntimeConfigEvent<'_> {

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -31,6 +31,7 @@ const PAUSED_RESUME_POLL: Duration = Duration::from_millis(250);
 
 use crate::{
     QaMode,
+    commands::{reconfigure, validate},
     performance::performance_summary_from_events,
     report::{ReportInput, write_report},
 };
@@ -58,8 +59,8 @@ pub struct ResumeArgs {
     #[arg(long)]
     pub validation_max_attempts: Option<usize>,
 
-    #[arg(long, value_enum, default_value_t = QaMode::Off)]
-    pub qa: QaMode,
+    #[arg(long, value_enum)]
+    pub qa: Option<QaMode>,
 
     #[arg(long)]
     pub timeout_seconds: Option<u64>,
@@ -115,6 +116,7 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
         store.mark_job_running_for_resume(&args.job_id)?;
     }
     let mut snapshot = load_resume_snapshot(&store, &args.job_id)?;
+    let overrides = reconfigure::load_overrides_for_job(&args.job_id)?;
 
     let progress_jsonl = args
         .progress_jsonl
@@ -127,7 +129,7 @@ pub async fn run(args: ResumeArgs) -> Result<()> {
     );
     let progress = reporter.sink();
 
-    let run_result = run_inner(args, store, job, &mut snapshot, progress).await;
+    let run_result = run_inner(args, store, job, &mut snapshot, overrides, progress).await;
     finalize_reporter(run_result, reporter).await
 }
 
@@ -188,6 +190,7 @@ async fn run_inner(
     store: JobStore,
     job: JobRecord,
     snapshot: &mut RunConfigSnapshot,
+    overrides: Option<reconfigure::RunConfigOverrides>,
     progress: Arc<dyn ProgressSink>,
 ) -> Result<()> {
     let started = std::time::Instant::now();
@@ -216,6 +219,17 @@ async fn run_inner(
     });
     let book = read_epub(&input)?;
     let mut settings = snapshot.settings.to_settings();
+    let qa_mode = args
+        .qa
+        .or_else(|| overrides.as_ref().and_then(|overrides| overrides.qa))
+        .unwrap_or(QaMode::Off);
+    let validate_output = overrides
+        .as_ref()
+        .and_then(|overrides| overrides.validate_output)
+        .unwrap_or(false);
+    if let Some(overrides) = overrides.as_ref() {
+        reconfigure::apply_overrides_to_settings(&mut settings, overrides);
+    }
     if let Some(value) = args.concurrency {
         settings.scheduler.concurrency = value.max(1);
     }
@@ -492,7 +506,7 @@ async fn run_inner(
         &run_config,
         snapshot,
         &settings,
-        args.qa,
+        qa_mode,
         progress.clone(),
         stop_cancel_token.clone(),
     )
@@ -576,6 +590,20 @@ async fn run_inner(
     let block_translations = rebuild_block_translations(&segments, &stored_blocks, &translations);
     let rebuild_options = super::translate::rebuild_options_from_snapshot(snapshot);
     rebuild_epub_with_options(&book, &block_translations, &output, &rebuild_options)?;
+    if validate_output {
+        let validation_path = validate::default_report_path(&output);
+        let validation = validate::validate_and_write(&output, &validation_path, false)?;
+        if print_stdout {
+            println!("Validation report: {}", validation_path.display());
+        }
+        if validation.failed {
+            store.mark_job_failed(&job.id)?;
+            anyhow::bail!(
+                "rebuilt EPUB failed validation; see {}",
+                validation_path.display()
+            );
+        }
+    }
     loop {
         if matches!(
             control_poller
@@ -1269,6 +1297,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resume_applies_reconfigure_overrides_without_retranslating_succeeded_segments() {
+        let mut settings = TranslationProfile::V1Fast.resolve();
+        settings.batch.enabled = true;
+        settings.batch.target_tokens = 8_000;
+        settings.batch.max_items = 8;
+        settings.batch.adaptive_sizing = true;
+        settings.provider.batch_max_output_tokens = Some(2_000);
+        settings.provider.provider_max_attempts = 2;
+        let mut fixture = resume_fixture(settings, 2);
+        save_succeeded(
+            &fixture.store,
+            &fixture.job.id,
+            &fixture.segments[0],
+            "stored",
+        );
+        fixture
+            .store
+            .mark_segment_failed(&fixture.job.id, &fixture.segments[1].id.0, "retry")
+            .expect("second segment should be retryable");
+
+        let events = run_fixture_with_overrides(
+            &mut fixture,
+            Some(reconfigure::RunConfigOverrides {
+                batch_max_output_tokens: Some(12_000),
+                batch_max_items: Some(1),
+                batch_target_tokens: Some(4_000),
+                provider_max_attempts: Some(5),
+                adaptive_concurrency: Some(true),
+                adaptive_batch_sizing: Some(false),
+                ..reconfigure::RunConfigOverrides::default()
+            }),
+        )
+        .await
+        .expect("resume should apply reconfigure overrides");
+        let runtime = runtime_config_event(&events);
+
+        assert_eq!(runtime.batch_max_output_tokens, Some(12_000));
+        assert_eq!(runtime.batch_max_items, 1);
+        assert_eq!(runtime.batch_target_tokens, 4_000);
+        assert_eq!(runtime.provider_max_attempts, 5);
+        assert!(runtime.adaptive_concurrency);
+        assert!(!runtime.adaptive_batch_sizing);
+        assert_eq!(
+            segment_finished_ids(&events),
+            vec![fixture.segments[1].id.0.clone()]
+        );
+        let stored = fixture
+            .store
+            .load_block_translations(&fixture.job.id)
+            .expect("stored translations should load");
+        assert!(
+            stored
+                .iter()
+                .any(|block| block.segment_id == fixture.segments[0].id.0
+                    && block.text.starts_with("stored")),
+            "succeeded segment should keep its original checkpointed translation"
+        );
+    }
+
+    #[tokio::test]
     async fn resume_missing_config_snapshot_fails_clearly() {
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         let input = fixture_input();
@@ -1640,6 +1728,13 @@ mod tests {
     }
 
     async fn run_fixture(fixture: &mut ResumeFixture) -> Result<Vec<ProgressEvent>> {
+        run_fixture_with_overrides(fixture, None).await
+    }
+
+    async fn run_fixture_with_overrides(
+        fixture: &mut ResumeFixture,
+        overrides: Option<reconfigure::RunConfigOverrides>,
+    ) -> Result<Vec<ProgressEvent>> {
         let events = Arc::new(Mutex::new(Vec::new()));
         let sink = Arc::new(RecordingSink {
             events: events.clone(),
@@ -1651,7 +1746,7 @@ mod tests {
             max_attempts: None,
             provider_max_attempts: None,
             validation_max_attempts: None,
-            qa: QaMode::Off,
+            qa: None,
             timeout_seconds: None,
             max_output_tokens: None,
             ui: None,
@@ -1666,6 +1761,7 @@ mod tests {
             run_store,
             fixture.job.clone(),
             &mut fixture.snapshot,
+            overrides,
             sink,
         )
         .await?;
@@ -1680,6 +1776,11 @@ mod tests {
                 if let ProgressEvent::RuntimeConfigResolved {
                     profile,
                     provider_max_attempts,
+                    batch_target_tokens,
+                    batch_max_items,
+                    adaptive_batch_sizing,
+                    adaptive_concurrency,
+                    batch_max_output_tokens,
                     compact_prompts,
                     json_mode,
                     ..
@@ -1688,6 +1789,11 @@ mod tests {
                     Some(RuntimeConfigEvent {
                         profile,
                         provider_max_attempts: *provider_max_attempts,
+                        batch_target_tokens: *batch_target_tokens,
+                        batch_max_items: *batch_max_items,
+                        adaptive_batch_sizing: *adaptive_batch_sizing,
+                        adaptive_concurrency: *adaptive_concurrency,
+                        batch_max_output_tokens: *batch_max_output_tokens,
                         compact_prompts: *compact_prompts,
                         json_mode,
                     })
@@ -1701,6 +1807,11 @@ mod tests {
     struct RuntimeConfigEvent<'a> {
         profile: &'a str,
         provider_max_attempts: usize,
+        batch_target_tokens: usize,
+        batch_max_items: usize,
+        adaptive_batch_sizing: bool,
+        adaptive_concurrency: bool,
+        batch_max_output_tokens: Option<u32>,
         compact_prompts: bool,
         json_mode: &'a str,
     }

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -6,6 +6,7 @@ use bookforge_core::RunConfigSnapshot;
 use bookforge_store::{JobRecord, JobStore, JobSummary};
 
 use crate::{
+    commands::reconfigure,
     performance::{RunPerformanceSummary, performance_summary_from_events},
     report::report_paths,
 };
@@ -41,6 +42,16 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     }
     if let Some(ref api_key_env) = job.api_key_env {
         println!("API key env: {api_key_env}");
+    }
+    if let Some(overrides) = reconfigure::load_overrides_for_job(&args.job_id)? {
+        println!();
+        println!(
+            "Overrides: {}",
+            reconfigure::overrides_path_for_job(&args.job_id).display()
+        );
+        for line in reconfigure::describe_overrides(&overrides) {
+            println!("  {line}");
+        }
     }
     println!();
     println!("Segments:");

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -20,7 +20,7 @@ use commands::serve;
 use commands::watch;
 use commands::{
     control as control_commands, convert, doctor, entity, estimate, glossary, ingest_flags,
-    inspect, reflow, resume, retry, review, status, style, tail, translate, validate,
+    inspect, reconfigure, reflow, resume, retry, review, status, style, tail, translate, validate,
 };
 #[cfg(any(test, not(feature = "serve")))]
 use std::io::Write;
@@ -58,6 +58,7 @@ enum Command {
     Estimate(estimate::EstimateArgs),
     Translate(Box<translate::TranslateArgs>),
     Pause(control_commands::PauseArgs),
+    Reconfigure(reconfigure::ReconfigureArgs),
     Resume(resume::ResumeArgs),
     Stop(control_commands::StopArgs),
     Review(review::ReviewArgs),
@@ -118,6 +119,7 @@ async fn run_command(command: Command, cancel_token: CancellationToken) -> Resul
         Command::Estimate(args) => estimate::run(args).await,
         Command::Translate(args) => translate::run(*args, cancel_token).await,
         Command::Pause(args) => control_commands::pause(args).await,
+        Command::Reconfigure(args) => reconfigure::run(args).await,
         Command::Resume(args) => resume::run(args).await,
         Command::Stop(args) => control_commands::stop(args).await,
         Command::Review(args) => review::run(args).await,
@@ -217,7 +219,8 @@ pub(crate) struct ProviderArgs {
     pub(crate) timeout_seconds: Option<u64>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum QaMode {
     Off,
     Suspicious,

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -31,6 +31,8 @@ struct BatchWorkerOutput {
     request_status: RequestStatus,
     latency_ms: u64,
     max_output_tokens: u32,
+    output_escalated: bool,
+    next_max_output_tokens: Option<u32>,
     request_permit: Option<OwnedSemaphorePermit>,
 }
 
@@ -157,6 +159,33 @@ const BATCH_SIZER_STABLE_SUCCESS_THRESHOLD: f64 = 0.98;
 const BATCH_SIZER_INCREASE_INTERVAL: Duration = Duration::from_secs(5);
 const BATCH_SIZER_DECREASE_INTERVAL: Duration = Duration::from_secs(1);
 const BATCH_SIZER_TARGET_P95_LATENCY_MS: u64 = 30_000;
+const SYSTEMIC_TRUNCATION_ALERT_AFTER: usize = 3;
+
+#[derive(Default)]
+struct TruncationAlertState {
+    unresolved_after_escalation: usize,
+    alert_emitted: bool,
+}
+
+impl TruncationAlertState {
+    fn observe_resolved(&mut self) {
+        self.unresolved_after_escalation = 0;
+    }
+
+    fn observe_unresolved(&mut self, progress: &Arc<dyn bookforge_core::ProgressSink>) {
+        self.unresolved_after_escalation = self.unresolved_after_escalation.saturating_add(1);
+        if self.alert_emitted || self.unresolved_after_escalation < SYSTEMIC_TRUNCATION_ALERT_AFTER
+        {
+            return;
+        }
+        self.alert_emitted = true;
+        progress.emit(bookforge_core::ProgressEvent::Warning {
+            kind: "systemic_truncation".to_string(),
+            message: "output budget repeatedly exhausted after escalation; raise --batch-max-output-tokens, lower --batch-max-items, or try a different model".to_string(),
+            timestamp_ms: bookforge_core::progress::now_ms(),
+        });
+    }
+}
 
 impl BatchSizer {
     pub fn new(target_tokens: usize, max_items: usize) -> Self {
@@ -1466,6 +1495,8 @@ where
     let max_rounds = 3usize;
     let mut single_invalid_attempts: HashMap<String, usize> = HashMap::new();
     let mut transient_attempts: HashMap<String, usize> = HashMap::new();
+    let mut escalated_output_tokens: HashMap<String, u32> = HashMap::new();
+    let mut truncation_alert = TruncationAlertState::default();
     let mut stop_dispatch = false;
 
     for _round in 0..max_rounds {
@@ -1499,6 +1530,7 @@ where
                     Some(config.as_ref()),
                 );
                 let batch = normalized.remove(0);
+                let output_override = escalated_output_tokens.remove(&batch.id);
                 for extra in normalized.into_iter().rev() {
                     pending_queue.push_front(extra);
                 }
@@ -1518,6 +1550,7 @@ where
                 let pause_signal = pause_signal.clone();
 
                 tasks.spawn(async move {
+                    let output_escalated = output_override.is_some();
                     // Strict context must be awaited before any permit is
                     // held (waiters would starve prerequisite batches);
                     // best-effort context is snapshotted after permits so
@@ -1536,6 +1569,8 @@ where
                             request_status: RequestStatus::OtherError,
                             latency_ms: 0,
                             max_output_tokens: 0,
+                            output_escalated,
+                            next_max_output_tokens: None,
                             request_permit: None,
                         };
                     }
@@ -1549,6 +1584,8 @@ where
                                 request_status: RequestStatus::OtherError,
                                 latency_ms: 0,
                                 max_output_tokens: 0,
+                                output_escalated,
+                                next_max_output_tokens: None,
                                 request_permit: None,
                             };
                         }
@@ -1566,6 +1603,8 @@ where
                                     request_status: RequestStatus::OtherError,
                                     latency_ms: 0,
                                     max_output_tokens: 0,
+                                    output_escalated,
+                                    next_max_output_tokens: None,
                                     request_permit: None,
                                 };
                             }
@@ -1584,6 +1623,8 @@ where
                                     request_status: RequestStatus::OtherError,
                                     latency_ms: 0,
                                     max_output_tokens: 0,
+                                    output_escalated,
+                                    next_max_output_tokens: None,
                                     request_permit: Some(request_permit),
                                 };
                             }
@@ -1598,6 +1639,19 @@ where
 
                     let started = std::time::Instant::now();
                     let is_reasoning = provider.is_reasoning();
+                    let default_max_output_tokens =
+                        capped_batch_max_output_tokens(&batch, &config, is_reasoning);
+                    let max_output_tokens = output_override.unwrap_or(default_max_output_tokens);
+                    let next_max_output_tokens = (!output_escalated)
+                        .then(|| {
+                            next_escalated_batch_max_output_tokens(
+                                max_output_tokens,
+                                &batch,
+                                &config,
+                                is_reasoning,
+                            )
+                        })
+                        .flatten();
 
                     let request_id = format!("batch_{}", batch.id);
                     progress.emit(bookforge_core::ProgressEvent::RequestStarted {
@@ -1609,23 +1663,18 @@ where
                         prompt_template: None,
                         items: batch.items.len(),
                         estimated_input_tokens: batch.token_estimate,
-                        max_output_tokens: Some(capped_batch_max_output_tokens(
-                            &batch,
-                            &config,
-                            is_reasoning,
-                        )),
+                        max_output_tokens: Some(max_output_tokens),
                         active_requests: 0,
                         target_concurrency: config.scheduler.concurrency,
                         timestamp_ms: bookforge_core::progress::now_ms(),
                     });
 
-                    let max_output_tokens =
-                        capped_batch_max_output_tokens(&batch, &config, is_reasoning);
                     let result = translate_one_batch(
                         provider.clone(),
                         library.clone(),
                         batch.clone(),
                         &config,
+                        Some(max_output_tokens),
                         context_pairs,
                         validate_source_copy,
                         &section_titles,
@@ -1642,6 +1691,8 @@ where
                         request_status,
                         latency_ms,
                         max_output_tokens,
+                        output_escalated,
+                        next_max_output_tokens,
                         request_permit: Some(request_permit),
                     }
                 });
@@ -1670,6 +1721,8 @@ where
                 request_status,
                 latency_ms,
                 max_output_tokens,
+                output_escalated,
+                next_max_output_tokens,
                 request_permit,
             } = joined
                 .map_err(|err| LlmError::Provider(format!("batch worker task failed: {err}")))?;
@@ -1743,6 +1796,7 @@ where
 
             match result {
                 Ok(batch_result) => {
+                    truncation_alert.observe_resolved();
                     if let Some(ref mut sizer) = batch_sizer {
                         sizer.on_success_for_mode(batch.mode, latency_ms);
                     }
@@ -1800,7 +1854,27 @@ where
                     }
                     all_results.push(batch_result);
                 }
+                Err(LlmError::InvalidResponse(_))
+                    if batch.kind == BatchKind::Translation
+                        && request_status == RequestStatus::Truncated
+                        && !output_escalated
+                        && next_max_output_tokens.is_some() =>
+                {
+                    let next_max_output_tokens =
+                        next_max_output_tokens.expect("checked Some above");
+                    progress.emit(bookforge_core::ProgressEvent::Warning {
+                        kind: "batch_truncation_escalated_retry".to_string(),
+                        message: format!(
+                            "batch {} exhausted max_output_tokens {}; retrying once with {} before splitting",
+                            batch.id, max_output_tokens, next_max_output_tokens
+                        ),
+                        timestamp_ms: bookforge_core::progress::now_ms(),
+                    });
+                    escalated_output_tokens.insert(batch.id.clone(), next_max_output_tokens);
+                    pending_queue.push_back(batch);
+                }
                 Err(LlmError::InvalidResponse(_)) if batch.kind == BatchKind::Repair => {
+                    truncation_alert.observe_resolved();
                     progress.emit(bookforge_core::ProgressEvent::Warning {
                         kind: "repair_batch_invalid_response".to_string(),
                         message: format!(
@@ -1839,7 +1913,49 @@ where
                         output_tokens: None,
                     });
                 }
+                Err(error @ LlmError::InvalidResponse(_))
+                    if request_status == RequestStatus::Truncated && batch.items.len() == 1 =>
+                {
+                    if let Some(ref mut sizer) = batch_sizer {
+                        sizer.on_truncation_for_mode(batch.mode);
+                    }
+                    truncation_alert.observe_unresolved(&progress);
+                    progress.emit(bookforge_core::ProgressEvent::Warning {
+                        kind: "single_item_batch_truncated".to_string(),
+                        message: format!(
+                            "single-item batch {} still exhausted max_output_tokens {}; not splitting further",
+                            batch.id, max_output_tokens
+                        ),
+                        timestamp_ms: bookforge_core::progress::now_ms(),
+                    });
+                    unblock_fence_for_batch_failure(
+                        config.context_registry.as_deref(),
+                        &segments_by_id,
+                        &batch.items,
+                    );
+                    all_results.push(BatchTranslationResult {
+                        batch_id: batch.id.clone(),
+                        translations: Vec::new(),
+                        failures: batch
+                            .items
+                            .iter()
+                            .map(|item| BatchItemFailure {
+                                item_id: item.item_id.clone(),
+                                segment_id: item.segment_id.clone(),
+                                error: format!("single-item batch truncated: {error}"),
+                                input_tokens: None,
+                                input_cached_tokens: None,
+                                output_tokens: None,
+                                tokens_estimated: false,
+                            })
+                            .collect(),
+                        input_tokens: None,
+                        input_cached_tokens: None,
+                        output_tokens: None,
+                    });
+                }
                 Err(error @ LlmError::InvalidResponse(_)) if batch.items.len() == 1 => {
+                    truncation_alert.observe_resolved();
                     let attempts = single_invalid_attempts
                         .entry(batch.id.clone())
                         .and_modify(|count| *count += 1)
@@ -1898,6 +2014,11 @@ where
                             sizer.on_invalid_json_for_mode(batch.mode);
                         }
                     }
+                    if request_status == RequestStatus::Truncated {
+                        truncation_alert.observe_unresolved(&progress);
+                    } else {
+                        truncation_alert.observe_resolved();
+                    }
                     let split = split_batch_with_config(&batch, Some(config.as_ref()));
                     if split.len() == 2 {
                         progress.emit(bookforge_core::ProgressEvent::BatchSplit {
@@ -1908,16 +2029,27 @@ where
                         });
                     }
                     progress.emit(bookforge_core::ProgressEvent::Warning {
-                        kind: "batch_invalid_response_split".to_string(),
+                        kind: if request_status == RequestStatus::Truncated {
+                            "batch_truncated_split"
+                        } else {
+                            "batch_invalid_response_split"
+                        }
+                        .to_string(),
                         message: format!(
-                            "batch {} failed with invalid response, splitting",
-                            batch.id
+                            "batch {} failed with {}, splitting",
+                            batch.id,
+                            if request_status == RequestStatus::Truncated {
+                                "truncated output"
+                            } else {
+                                "invalid response"
+                            }
                         ),
                         timestamp_ms: bookforge_core::progress::now_ms(),
                     });
                     pending_queue.extend(split);
                 }
                 Err(ref error) if is_transient(error) && batch.kind == BatchKind::Translation => {
+                    truncation_alert.observe_resolved();
                     let attempts = transient_attempts
                         .entry(batch.id.clone())
                         .and_modify(|count| *count += 1)
@@ -1969,6 +2101,7 @@ where
                     }
                 }
                 Err(error) => {
+                    truncation_alert.observe_resolved();
                     progress.emit(bookforge_core::ProgressEvent::Warning {
                         kind: "batch_failed".to_string(),
                         message: format!("batch {} failed: {error}", batch.id),
@@ -2521,11 +2654,45 @@ fn capped_batch_max_output_tokens(
     )
 }
 
+fn next_escalated_batch_max_output_tokens(
+    current: u32,
+    batch: &TranslationBatch,
+    config: &TranslationRunConfig,
+    reasoning: bool,
+) -> Option<u32> {
+    let ceiling = batch_output_token_ceiling(batch, config, reasoning);
+    let bumped = current.saturating_mul(2).max(current.saturating_add(2_048));
+    let next = bumped.min(ceiling);
+    (next > current).then_some(next)
+}
+
+fn batch_output_token_ceiling(
+    batch: &TranslationBatch,
+    config: &TranslationRunConfig,
+    reasoning: bool,
+) -> u32 {
+    let extended_output = config.provider.eq_ignore_ascii_case("deepseek");
+    let ceiling = if config.profile == TranslationProfile::FreeTier {
+        if reasoning { 8_192 } else { 4_096 }
+    } else if extended_output || reasoning {
+        32_768
+    } else {
+        16_384
+    };
+    bookforge_core::config::cap_output_tokens(
+        ceiling,
+        batch.token_estimate,
+        config.model_context_tokens,
+        None,
+    )
+}
+
 async fn translate_one_batch(
     provider: Arc<impl LlmProvider>,
     library: Arc<PromptLibrary>,
     batch: TranslationBatch,
     config: &TranslationRunConfig,
+    max_output_tokens_override: Option<u32>,
     context_pairs: Vec<crate::scheduler::CompletedContext>,
     validate_source_copy: bool,
     section_titles: &HashMap<String, String>,
@@ -2582,7 +2749,8 @@ async fn translate_one_batch(
         .render(&vars)
         .map_err(|e| LlmError::Provider(e.to_string()))?;
 
-    let max_tokens = capped_batch_max_output_tokens(&batch, config, provider.is_reasoning());
+    let max_tokens = max_output_tokens_override
+        .unwrap_or_else(|| capped_batch_max_output_tokens(&batch, config, provider.is_reasoning()));
 
     let response = provider
         .complete(CompletionRequest {
@@ -3830,6 +3998,88 @@ mod tests {
         }
     }
 
+    enum RecordedResponse {
+        FinishLength,
+        ItemsFromBatch(Vec<(String, String)>),
+    }
+
+    struct RecordingSequenceProvider {
+        responses: Mutex<Vec<RecordedResponse>>,
+        max_output_tokens: Arc<Mutex<Vec<Option<u32>>>>,
+    }
+
+    impl RecordingSequenceProvider {
+        fn new(
+            responses: Vec<RecordedResponse>,
+            max_output_tokens: Arc<Mutex<Vec<Option<u32>>>>,
+        ) -> Self {
+            Self {
+                responses: Mutex::new(responses.into_iter().rev().collect()),
+                max_output_tokens,
+            }
+        }
+    }
+
+    impl LlmProviderTrait for RecordingSequenceProvider {
+        async fn complete(&self, request: CompletionRequest) -> ProviderResult<CompletionResponse> {
+            self.max_output_tokens
+                .lock()
+                .unwrap()
+                .push(request.max_output_tokens);
+            let response = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or(RecordedResponse::FinishLength);
+            match response {
+                RecordedResponse::FinishLength => Ok(CompletionResponse {
+                    content: "{\"items\":[]}".to_string(),
+                    input_tokens: Some(1),
+                    input_cached_tokens: Some(0),
+                    output_tokens: Some(1),
+                    finish_reason: FinishReason::Length,
+                    provider_latency_ms: 0,
+                    raw: serde_json::json!({}),
+                }),
+                RecordedResponse::ItemsFromBatch(items) => {
+                    let json = serde_json::json!({
+                        "items": items
+                            .into_iter()
+                            .map(|(id, t)| serde_json::json!({"id": id, "translation": t}))
+                            .collect::<Vec<_>>(),
+                    });
+                    Ok(CompletionResponse {
+                        content: json.to_string(),
+                        input_tokens: Some(1),
+                        input_cached_tokens: Some(0),
+                        output_tokens: Some(1),
+                        finish_reason: FinishReason::Stop,
+                        provider_latency_ms: 0,
+                        raw: serde_json::json!({}),
+                    })
+                }
+            }
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
+            }
+        }
+    }
+
+    struct RecordingProgress {
+        events: Arc<Mutex<Vec<bookforge_core::ProgressEvent>>>,
+    }
+
+    impl bookforge_core::ProgressSink for RecordingProgress {
+        fn emit(&self, event: bookforge_core::ProgressEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
     impl LlmProviderTrait for StubProvider {
         async fn complete(
             &self,
@@ -3995,6 +4245,7 @@ mod tests {
             library,
             batch,
             &config,
+            None,
             Vec::new(),
             false,
             &HashMap::new(),
@@ -4022,6 +4273,7 @@ mod tests {
             library,
             batch,
             &config,
+            None,
             Vec::new(),
             false,
             &HashMap::new(),
@@ -4034,6 +4286,140 @@ mod tests {
             Ok(_) => panic!("truncated error must not be swallowed into Ok"),
             other => panic!("expected InvalidResponse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn batch_truncation_retries_same_batch_with_escalated_budget() {
+        let seg1 = make_segment("seg1", vec![plain_block("Hello")], vec![]);
+        let seg2 = make_segment("seg2", vec![plain_block("Goodbye")], vec![]);
+        let segments = vec![seg1, seg2];
+        let cfg = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 64,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+        let item_ids = batches[0]
+            .items
+            .iter()
+            .map(|item| {
+                (
+                    item.item_id.clone(),
+                    format!("Tradotto {}", item.source_text),
+                )
+            })
+            .collect::<Vec<_>>();
+        let max_tokens = Arc::new(Mutex::new(Vec::new()));
+        let provider = RecordingSequenceProvider::new(
+            vec![
+                RecordedResponse::FinishLength,
+                RecordedResponse::ItemsFromBatch(item_ids),
+            ],
+            max_tokens.clone(),
+        );
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let progress = Arc::new(RecordingProgress {
+            events: events.clone(),
+        });
+
+        let translations = translate_batches_with_callback(
+            provider,
+            batches,
+            &segments,
+            &test_run_config(),
+            Arc::new(TelemetryLog::new()),
+            None,
+            None,
+            progress,
+            None,
+            |_| Ok(()),
+        )
+        .await
+        .expect("escalated retry should succeed");
+
+        assert_eq!(translations.len(), 2);
+        let budgets = max_tokens.lock().unwrap().clone();
+        assert_eq!(budgets.len(), 2);
+        assert!(
+            budgets[1].unwrap() > budgets[0].unwrap(),
+            "second request should use escalated output budget: {budgets:?}"
+        );
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                bookforge_core::ProgressEvent::Warning { kind, .. }
+                    if kind == "batch_truncation_escalated_retry"
+            )
+        }));
+        assert!(
+            !events
+                .iter()
+                .any(|event| { matches!(event, bookforge_core::ProgressEvent::BatchSplit { .. }) })
+        );
+    }
+
+    #[tokio::test]
+    async fn systemic_truncation_emits_alert_after_escalated_failures() {
+        let segments = (0..6)
+            .map(|idx| make_segment(&format!("seg{idx}"), vec![plain_block("Hello")], vec![]))
+            .collect::<Vec<_>>();
+        let cfg = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 2,
+            adaptive_sizing: false,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+        assert!(
+            batches.len() >= 3,
+            "fixture should build at least 3 batches"
+        );
+        let max_tokens = Arc::new(Mutex::new(Vec::new()));
+        let provider = RecordingSequenceProvider::new(
+            std::iter::repeat_with(|| RecordedResponse::FinishLength)
+                .take(64)
+                .collect(),
+            max_tokens,
+        );
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let progress = Arc::new(RecordingProgress {
+            events: events.clone(),
+        });
+
+        let _translations = translate_batches_with_callback(
+            provider,
+            batches,
+            &segments,
+            &test_run_config(),
+            Arc::new(TelemetryLog::new()),
+            None,
+            None,
+            progress,
+            None,
+            |_| Ok(()),
+        )
+        .await
+        .expect("systemic truncation should become bounded failures");
+
+        let events = events.lock().unwrap();
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    bookforge_core::ProgressEvent::Warning { kind, message, .. }
+                        if kind == "systemic_truncation"
+                            && message.contains("--batch-max-output-tokens")
+                            && message.contains("--batch-max-items")
+                )
+            }),
+            "systemic truncation alert should be emitted"
+        );
     }
 
     #[tokio::test]

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1524,13 +1524,13 @@ where
                 let Some(batch) = pending_queue.pop_front() else {
                     break;
                 };
+                let output_override = escalated_output_tokens.remove(&batch.id);
                 let mut normalized = normalize_batch_for_current_sizer(
                     batch,
                     batch_sizer.as_deref(),
                     Some(config.as_ref()),
                 );
                 let batch = normalized.remove(0);
-                let output_override = escalated_output_tokens.remove(&batch.id);
                 for extra in normalized.into_iter().rev() {
                     pending_queue.push_front(extra);
                 }
@@ -4359,6 +4359,76 @@ mod tests {
             !events
                 .iter()
                 .any(|event| { matches!(event, bookforge_core::ProgressEvent::BatchSplit { .. }) })
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_truncation_escalated_retry_survives_adaptive_renaming() {
+        let long_source = "long ".repeat(3_600);
+        let seg = make_segment("seg1", vec![plain_block(&long_source)], vec![]);
+        let segments = vec![seg];
+        let cfg = BatchConfig {
+            enabled: true,
+            target_tokens: 1000,
+            max_items: 64,
+            adaptive_sizing: true,
+            split_on_json_failure: true,
+            repair_invalid_items: true,
+        };
+        let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+        assert_eq!(batches.len(), 1);
+        assert!(
+            batches[0].token_estimate
+                > BatchSizer::new(cfg.target_tokens, cfg.max_items).target_tokens(),
+            "fixture must force adaptive normalization to rename the single-item batch"
+        );
+        let item_ids = batches[0]
+            .items
+            .iter()
+            .map(|item| (item.item_id.clone(), "Tradotto lungo".to_string()))
+            .collect::<Vec<_>>();
+        let max_tokens = Arc::new(Mutex::new(Vec::new()));
+        let provider = RecordingSequenceProvider::new(
+            vec![
+                RecordedResponse::FinishLength,
+                RecordedResponse::ItemsFromBatch(item_ids),
+            ],
+            max_tokens.clone(),
+        );
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let progress = Arc::new(RecordingProgress {
+            events: events.clone(),
+        });
+        let mut sizer = BatchSizer::new(cfg.target_tokens, cfg.max_items);
+
+        let translations = translate_batches_with_callback(
+            provider,
+            batches,
+            &segments,
+            &test_run_config(),
+            Arc::new(TelemetryLog::new()),
+            None,
+            Some(&mut sizer),
+            progress,
+            None,
+            |_| Ok(()),
+        )
+        .await
+        .expect("escalated retry should survive adaptive renaming");
+
+        assert_eq!(translations.len(), 1);
+        let budgets = max_tokens.lock().unwrap().clone();
+        assert_eq!(budgets.len(), 2);
+        assert!(
+            budgets[1].unwrap() > budgets[0].unwrap(),
+            "second request should keep the escalated output budget after adaptive renaming: {budgets:?}"
+        );
+        let events = events.lock().unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|event| { matches!(event, bookforge_core::ProgressEvent::BatchSplit { .. }) }),
+            "batch should not split before the escalated retry"
         );
     }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2561,6 +2561,10 @@ seam to amend them.
    the control-file architecture from §10.1.1). On `resume` (and on a live
    run's next batch boundary, if feasible later), merge the overrides over the
    loaded `RunConfigSnapshot`.
+   For v1, live fast-resume of an already-paused process cannot apply pending
+   overrides because that process keeps its in-memory scheduler settings. Stop
+   the paused run first and then `resume`, or use `resume --force` only when the
+   paused process is already gone; full live application remains deferred.
 3. **Guardrails — reject cache-affecting settings.** Only settings that change
    *how remaining work is scheduled/budgeted* are mutable. Immutable
    (would make partial output inconsistent or invalidate the cache):

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2474,6 +2474,161 @@ across machine reboots beyond what the control file naturally provides.
 **Effort:** 1–2 days engine + 1 day surfaces. **Priority:** after v1.7
 ships; pairs naturally with §9c in a quality-of-life release.
 
+> **Shipped 2026-07-05 in v2.3.0**, alongside §9c reflow (+`--aggressive`).
+> The finalize-stage pause path required a fix pass (threading the shared
+> PauseSignal into QA/double-check, a run-long control-file watcher, and
+> resumable stop) caught by a pre-merge review; see
+> `docs/codex-fix-pause-review.md`.
+
+#### 10.1.2 Mini-spec: In-dashboard review & correction loop (added 2026-07-06, owner-approved)
+
+**Goal.** Make the `serve` dashboard's Review screen *editable* so a
+non-developer translator can fix a flagged / `needs_review` segment in
+place — edit the translation, save it, and rebuild — without touching the
+CLI. Today Review is read-only (`GET /api/jobs/{id}/review`); the only
+correction path is the CLI `ingest-flags` JSON workflow + `retry`, which the
+dashboard's intended audience (translator friends dogfooding real books)
+cannot use. Every real-provider run to date has produced `needs_review`
+segments — recurring case: quote-heavy blocks the model leaves partly
+untranslated — whose remediation is currently developer-only. Closing this
+loop is what turns BookForge from "automated translator you monitor" into
+"the translator's cockpit."
+
+**Design — reuse existing seams, no new deps (§1.6):**
+
+1. **Store: human-override provenance.** Persist a corrected translation
+   with an explicit manual-source marker (provider/model recorded as
+   `manual`, a `human_corrected` flag) so re-runs / QA / double-check never
+   overwrite a human edit and reports can distinguish it. Additive
+   column(s) only (§1.5 events / §11.2 forward migration).
+2. **Engine/CLI: a correction is just a translation write + rebuild.**
+   Reuse `save_translation` and the existing rebuild path
+   (`persist_corrected_translations` / `rebuild_epub_with_options`). Add
+   `bookforge correct <job-id> --segment <id> (--text … | --from-file …)`
+   as the CLI twin so the loop is scriptable and mock-testable.
+3. **Serve: editable Review + save.** New
+   `POST /api/jobs/{id}/segments/{segment-id}/translation` (CSRF-protected,
+   localhost-only, same pattern as the §10.1.1 pause/stop POSTs). The
+   Review screen renders each segment's source + current translation;
+   flagged / `needs_review` ones get an inline editable field with **Save**
+   and **re-translate with a hint** (feeds `ingest-flags`-style guidance
+   into a single-segment retry). Saving persists the override and triggers a
+   rebuild; the events stream reflects it.
+4. **Idempotency + status.** A manual override marks the segment terminal,
+   clears its review flag, and recomputes job status (mirrors the
+   finalize-status handling added in §10.1.1). Resume / QA / double-check
+   must treat `human_corrected` segments as frozen.
+
+**Acceptance.**
+1. In the dashboard, a `needs_review` segment can be edited, saved, and the
+   rebuilt EPUB reflects the change — no CLI, no restart.
+2. A human-corrected segment is never overwritten by a later resume, QA, or
+   double-check pass.
+3. The correction is auditable (report shows it as `manual`) and the output
+   stays EPUBCheck-clean.
+4. CLI `bookforge correct` and the dashboard path produce equivalent results
+   (mock-provider e2e; assert on rebuilt-EPUB SHA where applicable).
+5. A pre-feature job with no overrides behaves exactly as today.
+
+**Out of scope:** full side-by-side/WYSIWYG diff editor, multi-user editing
+or locking, translation-memory suggestions while editing (that's the
+fuzzy-TM sketch in §10.1), batch bulk-edit. Keep it one-segment-at-a-time.
+
+**Effort:** ~1 day store+engine+CLI, ~1–2 days dashboard. **Priority:**
+high — completes the review loop the v2 dashboard started and is the top
+blocker for the non-developer audience.
+
+#### 10.1.3 Mini-spec: On-the-fly settings reconfiguration (added 2026-07-06, owner-approved)
+
+**Goal.** Adjust *cache-safe* run settings on an existing (initially: paused)
+job and have `resume` apply them — without starting a fresh run and losing
+progress. Motivated directly by real use: a run hit repeated output
+truncation on an extreme target (Italian → Toki Pona), and the only way to
+raise `--batch-max-output-tokens` / lower `--batch-max-items` was to abandon
+the job and re-launch from zero. Run settings are baked into the
+`RunConfigSnapshot` at launch and replayed verbatim on resume; there is no
+seam to amend them.
+
+**Design — CLI-first, reuse existing seams, no new deps (§1.6):**
+
+1. **CLI command.** `bookforge reconfigure <job-id> [flags…]` writing only the
+   allowed knobs, e.g. `--batch-max-output-tokens`, `--batch-max-items`,
+   `--batch-target-tokens`, `--concurrency`, `--qa`, `--double-check`,
+   `--validate-output`, `--provider-max-attempts`, adaptive-concurrency
+   toggles.
+2. **Persistence: an overrides sidecar.** Write
+   `.bookforge/runs/<job-id>/overrides.json` (additive, no migration — matches
+   the control-file architecture from §10.1.1). On `resume` (and on a live
+   run's next batch boundary, if feasible later), merge the overrides over the
+   loaded `RunConfigSnapshot`.
+3. **Guardrails — reject cache-affecting settings.** Only settings that change
+   *how remaining work is scheduled/budgeted* are mutable. Immutable
+   (would make partial output inconsistent or invalidate the cache):
+   provider, model, source/target language, profile, context window/scope,
+   prompt version, glossary/style/entity inputs. Attempting to change these
+   fails with a clear message explaining a fresh run is required and why.
+4. **Surfaces.** CLI now. Dashboard later: the Advanced panel, editable on a
+   paused job's Progress screen (pairs with §10.1.2).
+
+**Acceptance.**
+1. Reconfigure a paused job's `--batch-max-output-tokens` + `--batch-max-items`,
+   resume, and the remaining batches use the new budget; already-succeeded
+   segments are not re-translated (cache/checkpoint identical).
+2. Attempting to change provider/model/language is rejected with a clear,
+   actionable message.
+3. Overrides are auditable (visible in `status`), additive, and a job with no
+   overrides resumes exactly as today.
+
+**Out of scope (for v1):** live reconfiguration of a *running* (non-paused)
+job mid-batch; changing the model/provider mid-job; reconfiguring completed
+jobs.
+
+**Effort:** ~1 day CLI + snapshot-merge. **Priority:** high — small, and it
+removes a real "lost all my progress to change one number" cliff.
+
+#### 10.1.4 Mini-spec: Truncation handling + fail-fast alert (added 2026-07-06, owner-approved)
+
+**Goal.** Handle `max_output_tokens` truncation intelligently, and surface a
+prominent, actionable **alert** when truncation is *systemic* instead of
+spiraling silently. Surfaced by the Toki Pona limit test: a minimal-vocabulary
+target forces long circumlocutions, and its words fragment into many subword
+tokens, so output token count vastly exceeds the input-proportional budget
+(`input × 3–5`, capped 32k). Every batch truncated mid-JSON; the scheduler's
+reflex is to *split* (`batch_invalid_response_split`), but the per-batch budget
+is proportional to item count, so each split gets a *smaller* ceiling and
+truncates again — recursing to single items that also fail. Result: ~5 minutes
+of churn, mostly failures, with no clear signal to the operator.
+
+**Design (in `bookforge-llm` batch scheduler, `batch.rs`):**
+
+1. **Distinguish truncation from invalid JSON.** The failure branch already
+   knows `RequestStatus::Truncated` vs invalid JSON — act on it differently.
+2. **Escalate-then-split.** On truncation, first **retry the same batch with an
+   escalated `max_output_tokens`** (e.g. toward the model cap / a bounded
+   multiple of the last budget) before falling back to splitting. Splitting is
+   correct for isolating a few pathological items; it is backwards for a budget
+   that was simply too small.
+3. **Fail-fast alert on systemic truncation.** Track the truncation rate; when
+   it crosses a threshold (e.g. N consecutive batches, or >X% still truncating
+   after escalation), emit a prominent additive alert event (new
+   `ProgressEvent` variant or a distinct `Warning` kind, §1.5) surfaced in CLI
+   `--ui`, `watch`, and the dashboard — with an actionable message ("output
+   budget repeatedly exhausted; the target/model may be producing runaway
+   output — raise `--batch-max-output-tokens`, lower `--batch-max-items`, or try
+   a different model"). Optionally auto-park (pause) rather than burn tokens.
+
+**Acceptance.**
+1. A single legitimately-long segment that fits under the model cap succeeds
+   after escalation instead of being marked failed.
+2. On systemic truncation, a clear alert appears within a bounded number of
+   failures (not a multi-minute silent spiral), and spend is bounded.
+3. Events are additive (§1.5); no new dependencies (§1.6); normal runs (no
+   truncation) are unaffected and byte-stable.
+
+**Effort:** ~1 day. **Priority:** medium-high — bounds cost and confusion on
+hard targets; pairs naturally with §10.1.3 (the alert tells you what to
+reconfigure).
+
 ### 10.2 Explicit non-goals (still)
 
 - LLM-driven DOM repair. Architectural invariant violation.

--- a/docs/codex-handoff-live-reconfig.md
+++ b/docs/codex-handoff-live-reconfig.md
@@ -1,0 +1,81 @@
+# Handoff to Codex — on-the-fly settings reconfiguration + truncation fail-alert (2026-07-06)
+
+Two related tasks, both surfaced by a real run (Italian → Toki Pona) that hit
+repeated output truncation and could not be re-tuned without abandoning
+progress. **The authoritative specs are `docs/ROADMAP.md` §10.1.3 and §10.1.4 —
+read them in full before writing code.** If a detail is missing or a spec looks
+self-contradictory, stop and ask the maintainer rather than inventing it (you
+have correctly flagged spec contradictions before — keep doing that).
+
+## Non-negotiables (ROADMAP §1)
+
+- Additive only: new JSONL events are new variants / optional fields (§1.5);
+  SQLite changes are forward-only migrations (§11.2). Prefer a sidecar file
+  over a schema change where noted.
+- No new dependencies; single static binary (§1.6). Reuse quick-xml/zip/rusqlite
+  and the existing control-file + snapshot machinery.
+- Never invalidate the cache or re-translate already-succeeded segments.
+- Don't touch reassembly/prompt/marker logic.
+- Conventional commits, logical units, full workspace gates before EACH commit:
+  `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings`, `cargo test --workspace --locked`.
+- Do NOT push. Leave the branch ready for the maintainer's review + live verify.
+
+## Task 1 — `bookforge reconfigure <job-id>` (ROADMAP §10.1.3)
+
+Let a **paused** job's cache-safe settings be amended so `resume` uses the new
+values, without a fresh run.
+
+- **New CLI command** `crates/bookforge-cli/src/commands/reconfigure.rs`, wired
+  into `main.rs` (Subcommand enum + dispatch) and `commands/mod.rs` alongside
+  `resume`/`status`. Flags = the cache-safe knobs only: `--batch-max-output-tokens`,
+  `--batch-max-items`, `--batch-target-tokens`, `--concurrency`, `--qa`,
+  `--double-check`, `--validate-output`, `--provider-max-attempts`, adaptive
+  toggles. (Match the exact flag names/types used by `translate`.)
+- **Persistence: sidecar, not migration.** Write
+  `.bookforge/runs/<job-id>/overrides.json` next to `control` (see
+  `bookforge-core` `run_dir_for_job` / `control.rs`). On resume, merge overrides
+  over the loaded `RunConfigSnapshot` (`bookforge-core/src/run_snapshot.rs`;
+  loaded via `store.load_job_config_snapshot`, consumed in
+  `commands/resume.rs`). Merge = override-if-present, else snapshot value.
+- **Guardrails.** Reject cache-affecting settings (provider, model, source/target
+  language, profile, context window/scope, prompt version, glossary/style/entity
+  inputs) with a clear message that a fresh run is required and why. These must
+  never be silently accepted.
+- **Surface it in `status`** so overrides are auditable. Dashboard is out of
+  scope here (later, per §10.1.2/§10.1.3).
+- **Tests:** reconfigure a paused mock job's batch budget + max-items → resume →
+  remaining batches use new values, succeeded segments untouched (assert no
+  re-translation / identical checkpoint); rejecting an immutable flag errors
+  clearly; a job with no overrides resumes byte-identically to today.
+
+## Task 2 — truncation handling + fail-fast alert (ROADMAP §10.1.4)
+
+In the batch scheduler (`crates/bookforge-llm/src/batch.rs`). Today the
+`Err(LlmError::InvalidResponse(_))` branch (~line 1893) splits on BOTH truncation
+and malformed JSON; splitting shrinks the per-batch output budget
+(`capped_batch_max_output_tokens` ~2508 / `batch_max_output_tokens` ~2473 are
+proportional to item count), so truncation-driven splits spiral.
+
+- **Distinguish** `RequestStatus::Truncated` from invalid JSON (the status is
+  already known at the branch).
+- **Escalate-then-split:** on truncation, first retry the *same* batch once with
+  an escalated `max_output_tokens` (bounded multiple of the last budget, capped
+  at the model/context limit) before falling back to the existing split path.
+- **Fail-fast alert:** track truncation rate; when systemic (e.g. N consecutive
+  batches or >X% still truncating after escalation), emit a prominent **additive**
+  alert (new `ProgressEvent` variant or a distinct `Warning` kind) surfaced in
+  CLI/`watch`/dashboard with an actionable message (raise
+  `--batch-max-output-tokens`, lower `--batch-max-items`, or change model).
+  Optionally auto-park instead of burning tokens — propose before implementing.
+- **Tests (mock):** a single over-budget item succeeds after escalation instead
+  of failing; a forced systemic-truncation scenario emits the alert within a
+  bounded number of failures rather than spiraling; normal runs are byte-stable
+  and emit no alert.
+
+## Working agreement
+
+- Branch: create `feat/live-reconfig` off latest `main` (v2.3.0 is released).
+- Task 1 and Task 2 are independent — separate commits (or separate PRs) are fine.
+- The un-mockable acceptance (maintainer's job, not yours): a real provider run
+  that (1) reconfigures a paused job's output budget and resumes to completion,
+  and (2) triggers the systemic-truncation alert on a hard target.

--- a/docs/codex-handoff-live-reconfig.md
+++ b/docs/codex-handoff-live-reconfig.md
@@ -79,3 +79,86 @@ proportional to item count), so truncation-driven splits spiral.
 - The un-mockable acceptance (maintainer's job, not yours): a real provider run
   that (1) reconfigures a paused job's output budget and resumes to completion,
   and (2) triggers the systemic-truncation alert on a hard target.
+
+## Fix pass — review of PR #26 (Claude, 2026-07-06)
+
+The initial commit `6a98137` is correct on the truncation state machine
+(terminates, additive alert, no dep/schema/prompt changes) and on the reconfigure
+guardrails. An independent review found **three real defects**. Rulings below are
+binding — implement all three with tests, run the full gate before committing, do
+not push.
+
+### Fix 1 (BLOCKER) — live fast-resume silently ignores overrides
+
+`resume.rs` (`run`, the `job.status == "paused" && !args.force` branch): this path
+signals the already-running parked process via a Resume control file and returns.
+That live process keeps its **old in-memory settings** and never reads
+`overrides.json`, so the natural `pause → reconfigure → resume` silently drops the
+new budget — defeating §10.1.3 acceptance #1.
+
+Full live re-application (resizing a running scheduler/semaphore mid-flight) stays
+**deferred** per the §10.1.3 "if feasible later" note — do NOT attempt it here.
+Instead make the gap **loud and give a working path**:
+
+- In that branch, before signalling, check `reconfigure::load_overrides_for_job`.
+  If overrides exist, do **not** silently fast-resume — `bail!` with an actionable
+  message, e.g.: *"job '<id>' has pending reconfigure overrides that a live
+  fast-resume cannot apply. Stop the paused run first: `bookforge stop <id>`, then
+  `bookforge resume <id>` to apply them. If the paused process is already gone, use
+  `bookforge resume <id> --force`."* (Both `stop`→`resume` and `resume --force`
+  route through `run_inner`, which already reads and applies overrides — verify
+  the stopped-job path in `run` at the `job.status == "stopped"` branch.)
+- With no overrides present, behaviour is unchanged.
+- Add the apply-instructions to `reconfigure::run`'s success stdout (one line:
+  how to make the overrides take effect, matching the message above).
+- Add a short note to ROADMAP §10.1.3 documenting this application model
+  (live fast-resume cannot apply overrides; use `stop`+`resume` or `resume
+  --force`; full live application deferred).
+- Test: a paused job with an overrides sidecar + `resume` (no `--force`) errors
+  with the guidance instead of returning Ok and skipping overrides.
+
+### Fix 2 (SHOULD-FIX) — escalation override lost when adaptive sizing renames the batch
+
+`batch.rs` ~line 1533: `escalated_output_tokens.remove(&batch.id)` runs **after**
+`normalize_batch_for_current_sizer`, which (`repack_batch_with_config`) renames the
+batch to `{base_id}_adaptive_{part}` whenever it exceeds the current sizer
+thresholds. The escalation arm inserted the override under the *as-queued* id, so
+if adaptive sizing shrinks between re-queue and re-pop the lookup misses and the
+escalated retry is dropped (falls back to split at the smaller budget — the spiral
+we were preventing).
+
+- Fix: capture the override from the **popped batch's id, before** calling
+  `normalize_batch_for_current_sizer` (that id equals the key the escalation arm
+  inserted under). Carry the captured `output_override` onto the primary
+  normalized batch (`normalized.remove(0)`); extras re-queue without it.
+- Keep the existing single-escalation invariant (escalated batches don't
+  re-escalate).
+- Test (mock, `adaptive_sizing: true`): a batch scheduled for an escalated retry
+  still runs its retry at the escalated budget even after a sizer change — assert
+  the retried request uses the escalated `max_output_tokens` and no premature
+  `BatchSplit` is emitted before the escalated retry.
+
+### Fix 3 (SHOULD-FIX) — stale overrides sidecar reused / never cleaned up
+
+`resume.rs`: `overrides.json` is loaded for **any** resume with no terminal-job
+guard and is never removed after success. Resuming an already-succeeded job
+re-applies stale overrides; a stale `validate-output: true` can rerun finalization
+and even `mark_job_failed` a previously-succeeded job.
+
+- Fix: **clear `overrides.json` on successful terminal completion** of a resume
+  (next to where the run finishes / control file is cleared — add a
+  `reconfigure::clear_overrides_for_job` helper mirroring the control-file clear;
+  removal must be idempotent / NotFound-tolerant).
+- Also guard application: do not apply overrides when the job entering `resume` is
+  already terminal (e.g. `succeeded`); only resumable states (`paused`/`stopped`)
+  should consume them.
+- Test: after a successful override-applied resume the sidecar is gone; a second
+  resume of the now-succeeded job neither reads nor re-applies it.
+
+### Gate + commit
+
+- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -A
+  clippy::too_many_arguments -D warnings`, `cargo test --workspace --locked` must
+  all pass before committing.
+- Conventional-commit each logical fix (or one `fix:` commit covering all three is
+  fine). Do NOT push — leave for maintainer verify + merge.


### PR DESCRIPTION
Implements two related roadmap milestones surfaced by a real Italian→Toki Pona run that hit repeated output truncation and could not be re-tuned without abandoning progress.

## Task 1 — `bookforge reconfigure <job-id>` (§10.1.3)
Amend a **paused** job's cache-safe settings so `resume` applies them, without a fresh run.
- New CLI command; cache-safe knobs only (`--batch-max-output-tokens`, `--batch-max-items`, `--batch-target-tokens`, `--concurrency`, `--qa`, `--double-check`, `--validate-output`, `--provider-max-attempts`, adaptive toggles).
- **Persistence via sidecar** `.bookforge/runs/<job-id>/overrides.json` (additive, no migration). Merged over the loaded `RunConfigSnapshot` on resume.
- **Guardrails**: cache-affecting settings (provider/model/language/profile/context/prompt/glossary/style/entities) are rejected with a fresh-run message.
- Overrides surfaced in `status` for auditability.

## Task 2 — truncation handling + fail-fast alert (§10.1.4)
In the batch scheduler.
- **Distinguish** `RequestStatus::Truncated` from invalid JSON at the failure branch.
- **Escalate-then-split**: on truncation, retry the same batch once with an escalated `max_output_tokens` (bounded, capped at model ceiling) before falling back to the split path.
- **Fail-fast alert**: track truncation rate; emit a prominent additive `Warning { kind: "systemic_truncation", .. }` with an actionable message after N consecutive unresolved truncations, instead of spiraling silently. Single-item truncated batches terminate instead of splitting forever.

## Invariants
- Additive only (reuses existing `ProgressEvent::Warning`; sidecar, not a schema migration). No new dependencies. Succeeded segments never re-translated.
- Full workspace gate green: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --workspace --locked`.

## Not yet verified (maintainer, un-mockable)
A real provider run that (1) reconfigures a paused job's output budget and resumes to completion, and (2) triggers the systemic-truncation alert on a hard target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)