### PR TITLE
Release v2.4.1 security and provenance maintenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,10 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
+    permissions:
+      "attestations": "write"
+      "contents": "write"
+      "id-token": "write"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -266,6 +270,11 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Attest
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            artifacts/*
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,9 @@ jobs:
   rustsec:
     name: RustSec advisory audit
     runs-on: ubuntu-22.04
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ BookForge v2.4.1 is a security-gate maintenance release.
 - Granted the RustSec workflow the minimal Checks API permission it needs to
   report audit results without turning dependency warnings into workflow
   failures.
+- Added GitHub/Sigstore provenance attestations for release assets so users
+  can verify that downloads were produced by BookForge's release workflow.
 
 ## v2.4.0 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.4.1 - 2026-07-14
+
+BookForge v2.4.1 is a security-gate maintenance release.
+
+- Replaced the yanked transitive `spin 0.9.8` lockfile entry with the
+  compatible, non-yanked `spin 0.9.9` release.
+- Granted the RustSec workflow the minimal Checks API permission it needs to
+  report audit results without turning dependency warnings into workflow
+  failures.
+
 ## v2.4.0 - 2026-07-13
 
 BookForge v2.4.0 closes the local review loop and makes safe runtime tuning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ BookForge v2.4.1 is a security-gate maintenance release.
   failures.
 - Added GitHub/Sigstore provenance attestations for release assets so users
   can verify that downloads were produced by BookForge's release workflow.
+- Hardened the lifecycle release gate against child-process scheduling delays
+  on loaded Linux CI runners.
 
 ## v2.4.0 - 2026-07-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-core"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "clap",
  "quick-xml",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-epub"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bookforge-core",
  "quick-xml",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-llm"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bookforge-core",
  "reqwest",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-pdf"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bookforge-core",
  "bookforge-epub",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-store"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "bookforge-core",
  "rusqlite",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-cli"
-version = "2.4.0"
+version = "2.4.1"
 description = "CLI-first EPUB translation engine with deterministic structure rebuild and review loop."
 readme = "../../README.md"
 edition.workspace = true
@@ -16,11 +16,11 @@ path = "src/main.rs"
 anyhow.workspace = true
 async-stream = { version = "0.3", optional = true }
 axum = { version = "0.8", optional = true, features = ["multipart"] }
-bookforge-core = { version = "2.4.0", path = "../bookforge-core", features = ["cli"] }
-bookforge-epub = { version = "2.4.0", path = "../bookforge-epub" }
-bookforge-llm = { version = "2.4.0", path = "../bookforge-llm" }
-bookforge-pdf = { version = "2.4.0", path = "../bookforge-pdf" }
-bookforge-store = { version = "2.4.0", path = "../bookforge-store" }
+bookforge-core = { version = "2.4.1", path = "../bookforge-core", features = ["cli"] }
+bookforge-epub = { version = "2.4.1", path = "../bookforge-epub" }
+bookforge-llm = { version = "2.4.1", path = "../bookforge-llm" }
+bookforge-pdf = { version = "2.4.1", path = "../bookforge-pdf" }
+bookforge-store = { version = "2.4.1", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true
 futures-core = { version = "0.3", optional = true }

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -3201,11 +3201,11 @@ fn job_id_from_events(path: &Path) -> String {
 fn wait_for_job_id_in_store(temp: &TempDir) -> String {
     let db = temp.path().join(".bookforge/jobs.sqlite");
     // The lifecycle suite runs many child CLI processes in parallel. A loaded
-    // shared CI runner can take more than ten seconds to schedule a newly
-    // spawned worker even though the store appears immediately once it runs.
-    // Keep the success path unchanged while giving process startup enough
-    // headroom to avoid a scheduler-induced release-gate flake.
-    let deadline = Instant::now() + Duration::from_secs(30);
+    // shared CI runner has taken slightly more than thirty seconds to schedule
+    // a newly spawned worker even though the store appears immediately once it
+    // runs. Keep the success path unchanged while giving process startup enough
+    // headroom, and avoid adding pressure with a tight disk/SQLite polling loop.
+    let deadline = Instant::now() + Duration::from_secs(60);
     loop {
         if db.exists()
             && let Ok(store) = JobStore::open(&db)
@@ -3219,7 +3219,7 @@ fn wait_for_job_id_in_store(temp: &TempDir) -> String {
             "timed out waiting for a job id in {}",
             db.display()
         );
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(25));
     }
 }
 

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-core"
-version = "2.4.0"
+version = "2.4.1"
 description = "Core IR, segmentation, configuration, and progress types for BookForge."
 edition.workspace = true
 license.workspace = true

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-epub"
-version = "2.4.0"
+version = "2.4.1"
 description = "EPUB reading, validation, and deterministic rebuild support for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.4.1", path = "../bookforge-core" }
 quick-xml.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/crates/bookforge-llm/Cargo.toml
+++ b/crates/bookforge-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-llm"
-version = "2.4.0"
+version = "2.4.1"
 description = "Prompting, providers, batching, and validation for BookForge translation runs."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.4.1", path = "../bookforge-core" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-pdf"
-version = "2.4.0"
+version = "2.4.1"
 description = "PDF ingestion for BookForge: poppler-based layout extraction and deterministic reconstruction into a translatable EPUB."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.4.1", path = "../bookforge-core" }
 quick-xml.workspace = true
 crc32fast = "1.5.0"
 flate2 = "1.1.9"
@@ -19,5 +19,5 @@ tracing.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-bookforge-epub = { version = "2.4.0", path = "../bookforge-epub" }
+bookforge-epub = { version = "2.4.1", path = "../bookforge-epub" }
 tempfile = "3"

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-store"
-version = "2.4.0"
+version = "2.4.1"
 description = "SQLite checkpoint and job store for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.4.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.4.1", path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,6 +15,9 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-da
 install-path = "CARGO_HOME"
 # Where to host releases
 hosting = "github"
+# Publish Sigstore-backed provenance for every release asset.
+github-attestations = true
+github-attestations-phase = "host"
 # Whether to install an updater program
 install-updater = false
 # Archive formats (locked per ROADMAP §7.4)


### PR DESCRIPTION
## What changed

- bump all BookForge workspace crates from 2.4.0 to 2.4.1
- replace the yanked transitive `spin 0.9.8` lockfile entry with compatible, non-yanked `spin 0.9.9`
- grant the RustSec job the minimal `checks: write` permission required to publish its result
- enable cargo-dist’s GitHub/Sigstore provenance attestations for every release asset and regenerate the release workflow with cargo-dist 0.32.0
- harden lifecycle child-process startup waits against loaded Linux CI runners
- add v2.4.1 release notes

## Root cause

The v2.4.0 post-merge Security workflow found no vulnerabilities, but reported the newly yanked `spin 0.9.8` lockfile entry. `rustsec/audit-check` then attempted to create a check run while the job had only `contents: read`, so GitHub rejected the write with `Resource not accessible by integration` and marked the workflow red.

The release assets had checksums but no cryptographic build-provenance attestation. During this PR, Linux CI also demonstrated that the lifecycle suite’s 30-second child-process startup ceiling was still too tight under shared-runner contention; the helper now allows 60 seconds and polls SQLite less aggressively.

## Impact

This patch removes the supply-chain warning, makes the security gate report findings without a permissions failure, lets users verify release-asset provenance with `gh attestation verify`, and removes a demonstrated release-gate flake. There are no application behavior changes.

## Local validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings`
- `cargo test --workspace --locked`
- failing lifecycle test repeated three times with `--exact`
- Rust 1.88.0: `cargo check --workspace --all-targets --locked`
- `cargo audit` — 335 dependencies, zero vulnerabilities, zero warnings
- cargo-dist 0.32.0: `dist generate --mode ci --check`
- cargo-dist 0.32.0: `dist plan --tag v2.4.1 --allow-dirty`
