### PR TITLE
release: v2.5.1 — dashboard drag-and-drop + read-only launch dir fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## v2.5.1 - 2026-07-16
+
+- Fixed drag-and-drop uploads in the dashboard. The translation and audiobook
+  "drop" zones looked droppable but only responded to clicks — dragging an
+  EPUB onto them did nothing. They now handle drag-and-drop, validate the
+  `.epub` extension, and highlight while a file is dragged over them.
+- Fixed "Access is denied. (os error 5)" when starting a translation from the
+  dashboard. The server and the runs it spawns persist state under a
+  `.bookforge` directory resolved relative to the process working directory.
+  Launched from the desktop shell (a Start Menu shortcut, an installer, or a
+  URL/protocol handler), that directory is often read-only (for example
+  `System32` or `Program Files`), so the first upload write failed. `bookforge
+  serve` now relocates to a per-user data directory (`%LOCALAPPDATA%\BookForge`
+  on Windows, `$XDG_DATA_HOME`/`$HOME` elsewhere) when the working directory
+  is not writable, and leaves a writable working directory untouched.
+
 ## v2.5.0 - 2026-07-15
 
 - Added audiobook generation: `bookforge audiobook <book.epub>` narrates an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-audio"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "base64",
  "bookforge-core",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-cli"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "clap",
  "quick-xml",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-epub"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bookforge-core",
  "quick-xml",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-llm"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bookforge-core",
  "reqwest",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-pdf"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bookforge-core",
  "bookforge-epub",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-store"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bookforge-core",
  "rusqlite",

--- a/crates/bookforge-audio/Cargo.toml
+++ b/crates/bookforge-audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-audio"
-version = "2.5.0"
+version = "2.5.1"
 description = "Audiobook generation for BookForge with OpenAI, Gemini, ElevenLabs, and local TTS providers."
 edition.workspace = true
 license.workspace = true
@@ -9,8 +9,8 @@ rust-version.workspace = true
 
 [dependencies]
 base64.workspace = true
-bookforge-core = { version = "2.5.0", path = "../bookforge-core" }
-bookforge-epub = { version = "2.5.0", path = "../bookforge-epub" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
+bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-cli"
-version = "2.5.0"
+version = "2.5.1"
 description = "CLI-first EPUB translation engine with deterministic structure rebuild and review loop."
 readme = "../../README.md"
 edition.workspace = true
@@ -16,12 +16,12 @@ path = "src/main.rs"
 anyhow.workspace = true
 async-stream = { version = "0.3", optional = true }
 axum = { version = "0.8", optional = true, features = ["multipart"] }
-bookforge-audio = { version = "2.5.0", path = "../bookforge-audio" }
-bookforge-core = { version = "2.5.0", path = "../bookforge-core", features = ["cli"] }
-bookforge-epub = { version = "2.5.0", path = "../bookforge-epub" }
-bookforge-llm = { version = "2.5.0", path = "../bookforge-llm" }
-bookforge-pdf = { version = "2.5.0", path = "../bookforge-pdf" }
-bookforge-store = { version = "2.5.0", path = "../bookforge-store" }
+bookforge-audio = { version = "2.5.1", path = "../bookforge-audio" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core", features = ["cli"] }
+bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
+bookforge-llm = { version = "2.5.1", path = "../bookforge-llm" }
+bookforge-pdf = { version = "2.5.1", path = "../bookforge-pdf" }
+bookforge-store = { version = "2.5.1", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true
 futures-core = { version = "0.3", optional = true }

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -171,7 +171,98 @@ fn default_store_path() -> PathBuf {
     PathBuf::from(".bookforge/jobs.sqlite")
 }
 
+/// Ensure the process working directory can hold the `.bookforge` data root.
+///
+/// If the current directory already accepts a `.bookforge` write we keep it
+/// (preserving the CLI convention of storing runs alongside the project). If it
+/// doesn't — the typical outcome when the app is launched from the desktop
+/// shell with a read-only working directory — we move to a per-user data
+/// directory and switch the process there, so every CWD-relative `.bookforge`
+/// path (uploads, the job store, run outputs, and any child the dashboard
+/// spawns, which inherits this directory) resolves to a writable location.
+fn ensure_writable_workdir() -> Result<()> {
+    if data_root_is_writable(std::path::Path::new(".")) {
+        return Ok(());
+    }
+
+    let fallback =
+        stable_data_dir().context("could not determine a writable data directory for BookForge")?;
+    std::fs::create_dir_all(&fallback)
+        .with_context(|| format!("failed to create data directory {}", fallback.display()))?;
+    if !data_root_is_writable(&fallback) {
+        return Err(anyhow::anyhow!(
+            "data directory {} is not writable",
+            fallback.display()
+        ));
+    }
+    std::env::set_current_dir(&fallback)
+        .with_context(|| format!("failed to switch to data directory {}", fallback.display()))?;
+    println!(
+        "  working directory was not writable; storing data in {}",
+        fallback.display()
+    );
+    Ok(())
+}
+
+/// Return true when a `.bookforge` directory can be created and written under
+/// `base`. A directory that merely exists isn't enough — it may be read-only —
+/// so this probes with an actual file write and cleans up after itself.
+fn data_root_is_writable(base: &std::path::Path) -> bool {
+    let root = base.join(".bookforge");
+    if std::fs::create_dir_all(&root).is_err() {
+        return false;
+    }
+    let probe = root.join(".write-probe");
+    match std::fs::write(&probe, b"ok") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// A stable, per-user directory to fall back to when the working directory is
+/// read-only. Prefers the platform's local application-data location and falls
+/// back to the user's home directory.
+fn stable_data_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(local) = std::env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(local).join("BookForge"));
+        }
+        if let Some(profile) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(profile).join("BookForge"));
+        }
+        None
+    }
+    #[cfg(not(windows))]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(xdg).join("bookforge"));
+        }
+        if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(home).join(".local/share/bookforge"));
+        }
+        None
+    }
+}
+
 pub async fn run(args: ServeArgs) -> Result<()> {
+    // The dashboard and every run it spawns write their state under a
+    // `.bookforge` directory resolved relative to the process working
+    // directory. When BookForge is launched from the desktop shell — a Start
+    // Menu shortcut, an installer, or a URL/protocol handler — that working
+    // directory is often a location the user cannot write to (e.g.
+    // `C:\Windows\System32` or `C:\Program Files\…`), which surfaced as
+    // "Access is denied. (os error 5)" the moment a translation tried to
+    // persist its upload. Relocate to a stable, per-user data directory when
+    // the current one isn't writable so the web flow works regardless of how
+    // the process was started. A writable CWD (the usual CLI case) is left
+    // untouched, so `bookforge serve` from a project folder still keeps its
+    // `.bookforge` there.
+    ensure_writable_workdir()?;
+
     let addr: SocketAddr = args
         .bind
         .parse()
@@ -2830,14 +2921,14 @@ mod tests {
     fn dashboard_assets_reassemble_byte_stably() {
         use sha2::{Digest, Sha256};
 
-        assert_eq!(DASHBOARD_HTML.len(), 94_924);
+        assert_eq!(DASHBOARD_HTML.len(), 96_386);
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_CSS}}"));
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_JS}}"));
         let digest = Sha256::digest(DASHBOARD_HTML.as_bytes());
         let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
         assert_eq!(
             digest_hex,
-            "f16c434797d2768c46271e5a262da64713f8dfb45646ee06437fcf6a39795d5b"
+            "c8a0125fd9096f1a0fbf8b61c3907378dce1c5692bc0f592a3f05526bbb07c34"
         );
 
         let crlf = |asset: &str| asset.replace("\r\n", "\n").replace('\n', "\r\n");

--- a/crates/bookforge-cli/src/commands/serve/dashboard.css
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.css
@@ -98,6 +98,7 @@ main{min-height:calc(100vh - 60px)}
 .field-label{font:600 11px var(--sans);text-transform:uppercase;letter-spacing:.06em;color:var(--faint);margin-bottom:7px}
 .drop{margin-top:6px;padding:26px 20px;border:1.5px dashed var(--line);border-radius:14px;background:var(--soft);text-align:center;cursor:pointer}
 .drop.has{border-style:solid;border-color:var(--accentline);background:var(--card)}
+.drop.dragging{border-style:solid;border-color:var(--accent);background:var(--card)}
 .drop b{color:var(--accent)}
 .drop .fname{font:600 14px var(--serif);color:var(--ink)}
 .inp{width:100%;border-radius:10px;padding:12px 14px;background:var(--card);border:1px solid var(--line);font:500 14px var(--sans);color:var(--ink)}

--- a/crates/bookforge-cli/src/commands/serve/dashboard.js
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.js
@@ -181,7 +181,8 @@ function bfWizBack() { syncWizInputs(); if (App.wizard.step > 0) { App.wizard.st
 function renderWizBody() {
   const w = App.wizard, body = $("#wizbody"); if (!body) return;
   if (w.step === 0) {
-    body.innerHTML = `<div class="drop ${w.file?"has":""}" onclick="$('#fileinput').click()">
+    body.innerHTML = `<div class="drop ${w.file?"has":""}" onclick="$('#fileinput').click()"
+        ondragover="bfDragOver(event)" ondragenter="bfDragOver(event)" ondragleave="bfDragLeave(event)" ondrop="bfDropFile(event)">
       ${w.file ? `<div class="fname">${esc(w.fileName)}</div><div style="color:var(--muted);font-size:12px;margin-top:6px">Click to choose a different file</div>`
                : `<div>Drop an <b>EPUB</b> here or click to browse.</div>`}
       </div><input type="file" id="fileinput" accept=".epub" hidden onchange="bfPickFile(this)">`;
@@ -221,6 +222,24 @@ function syncWizInputs() {
 function bfPickFile(input) {
   const f = input.files && input.files[0];
   if (!f) return;
+  App.wizard.file = f; App.wizard.fileName = f.name; App.wizard.estimate = null;
+  renderWizard($("#stage"));
+}
+/* Drag-and-drop onto a .drop zone. dragover/dragenter must preventDefault or the
+   browser navigates to the dropped file instead of firing our drop handler. */
+function bfDragOver(e) { e.preventDefault(); if (e.dataTransfer) e.dataTransfer.dropEffect = "copy"; e.currentTarget.classList.add("dragging"); }
+function bfDragLeave(e) { e.currentTarget.classList.remove("dragging"); }
+function bfDroppedEpub(e) {
+  e.preventDefault();
+  if (e.currentTarget) e.currentTarget.classList.remove("dragging");
+  const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+  if (!f) return null;
+  if (!/\.epub$/i.test(f.name)) return null;
+  return f;
+}
+function bfDropFile(e) {
+  const f = bfDroppedEpub(e);
+  if (!f) { toastWiz("drop an EPUB (.epub) file"); return; }
   App.wizard.file = f; App.wizard.fileName = f.name; App.wizard.estimate = null;
   renderWizard($("#stage"));
 }
@@ -377,6 +396,11 @@ function bfAudioPickFile(input) {
   const file = input.files && input.files[0]; if (!file) return;
   App.audioWizard.file = file; App.audioWizard.fileName = file.name; renderAudiobook($("#stage"));
 }
+function bfAudioDropFile(e) {
+  const f = bfDroppedEpub(e);
+  if (!f) { audioToast("drop an EPUB (.epub) file"); return; }
+  App.audioWizard.file = f; App.audioWizard.fileName = f.name; renderAudiobook($("#stage"));
+}
 function syncAudioInputs() {
   const w = App.audioWizard; if (!w) return;
   const model = $("#a_model"); if (model) w.model = model.value.trim();
@@ -406,7 +430,8 @@ function renderAudiobook(stage) {
       <button class="btn btn-ghost" onclick="bfGo('library')">Back to library</button></div>
     <div class="wizpanel" style="max-width:920px;margin:0 auto">
       <div class="kicker">Source EPUB</div>
-      <div class="drop ${w.file?"has":""}" onclick="$('#audio-file').click()">
+      <div class="drop ${w.file?"has":""}" onclick="$('#audio-file').click()"
+          ondragover="bfDragOver(event)" ondragenter="bfDragOver(event)" ondragleave="bfDragLeave(event)" ondrop="bfAudioDropFile(event)">
         ${w.file ? `<div class="fname">${esc(w.fileName)}</div><div style="color:var(--muted);font-size:12px;margin-top:6px">Click to choose another EPUB</div>` : `<div>Drop an <b>EPUB</b> here or click to browse.</div>`}
       </div><input type="file" id="audio-file" accept=".epub" hidden onchange="bfAudioPickFile(this)">
       <div class="field-label" style="margin-top:20px">Speech provider</div><div class="chips">${providerChips}</div>

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-core"
-version = "2.5.0"
+version = "2.5.1"
 description = "Core IR, segmentation, configuration, and progress types for BookForge."
 edition.workspace = true
 license.workspace = true

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-epub"
-version = "2.5.0"
+version = "2.5.1"
 description = "EPUB reading, validation, and deterministic rebuild support for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
 quick-xml.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/crates/bookforge-llm/Cargo.toml
+++ b/crates/bookforge-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-llm"
-version = "2.5.0"
+version = "2.5.1"
 description = "Prompting, providers, batching, and validation for BookForge translation runs."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-pdf"
-version = "2.5.0"
+version = "2.5.1"
 description = "PDF ingestion for BookForge: poppler-based layout extraction and deterministic reconstruction into a translatable EPUB."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
 quick-xml.workspace = true
 crc32fast = "1.5.0"
 flate2 = "1.1.9"
@@ -19,5 +19,5 @@ tracing.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-bookforge-epub = { version = "2.5.0", path = "../bookforge-epub" }
+bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
 tempfile = "3"

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-store"
-version = "2.5.0"
+version = "2.5.1"
 description = "SQLite checkpoint and job store for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.0", path = "../bookforge-core" }
+bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Patch release **v2.5.1**.

## Fixes
1. **Drag-and-drop uploads** in the dashboard now work. The translation and audiobook "drop" zones were styled to look droppable but only had an `onclick` handler — no drag listeners — so dragging an EPUB did nothing. They now handle `dragover`/`dragenter`/`dragleave`/`drop`, validate the `.epub` extension, and highlight while a file is dragged over.
2. **"Access is denied. (os error 5)"** when starting a translation from the dashboard is fixed. `serve` and the runs it spawns persist state under a `.bookforge` directory resolved relative to the process working directory. Launched from the desktop shell (shortcut, installer, protocol handler), that directory is often read-only (`System32`, `Program Files`), so the first upload write failed. `serve` now relocates to a per-user data dir (`%LOCALAPPDATA%\BookForge` on Windows, `$XDG_DATA_HOME`/`$HOME` elsewhere) when the working directory isn't writable, and leaves a writable one untouched.

## Verification
- Reproduced os error 5 by launching `serve` from `System32`; confirmed the relocated instance accepts uploads and spawns runs.
- Verified drag-and-drop (accept + non-EPUB rejection) in-browser against a live dashboard.
- Full suite green (171/171). Dashboard asset snapshot test updated for the intentional JS/CSS edits.

Version bumped across all workspace crates; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)