### PR TITLE
Audiobook hardening: model auto-selection, chapter fixes, and OCR endpoint foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 - ElevenLabs audiobook requests now enforce each model's documented character
   limit consistently in the CLI, dashboard, server, and provider layer: 40,000
   for Flash/Turbo v2.5, 10,000 for Multilingual v2, and 5,000 for Eleven v3.
+- ElevenLabs live audiobook runs now auto-select the first available compatible
+  model in the preference order Eleven v3, Flash v2.5, Turbo v2.5, then
+  Multilingual v2, with a warning and Multilingual v2 fallback if preflight
+  fails. Explicit models still bypass preflight, and dry runs stay offline.
+- ElevenLabs requests now omit `voice_settings` at the default speed, reject
+  speed changes with Eleven v3, and list dashboard models in preference order
+  while retaining Multilingual v2 as the dashboard default.
 
 ## v2.5.1 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added optional OCR recovery for low-confidence PDF pages through
+  OpenAI-compatible endpoints, including the SGLang-specific Unlimited-OCR
+  dialect, retrying blocking HTTP client, `action=ocr` reporting, and a
+  loopback-friendly endpoint doctor.
+- Added an Unlimited-OCR deployment guide and helper script for serializing
+  SGLang's custom no-repeat n-gram logit processor.
 - Audiobook chapter extraction now recognizes canonical Toki Pona headings
   such as `lipu nanpa VI` and can recover chapter boundaries from legacy
   BookForge translations that used the old `KAPITELO` label.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Audiobook chapter extraction now recognizes canonical Toki Pona headings
+  such as `lipu nanpa VI` and can recover chapter boundaries from legacy
+  BookForge translations that used the old `KAPITELO` label.
+- ElevenLabs audiobook requests now enforce each model's documented character
+  limit consistently in the CLI, dashboard, server, and provider layer: 40,000
+  for Flash/Turbo v2.5, 10,000 for Multilingual v2, and 5,000 for Eleven v3.
+
 ## v2.5.1 - 2026-07-16
 
 - Fixed drag-and-drop uploads in the dashboard. The translation and audiobook

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,11 +347,13 @@ dependencies = [
 name = "bookforge-pdf"
 version = "2.5.1"
 dependencies = [
+ "base64",
  "bookforge-core",
  "bookforge-epub",
  "crc32fast",
  "flate2",
  "quick-xml",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -894,6 +896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -901,6 +904,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -921,7 +930,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1921,7 +1933,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/README.md
+++ b/README.md
@@ -202,14 +202,26 @@ directory; on Windows use the poppler-windows release zip):
 cargo run -p bookforge-cli -- convert paper.pdf --out paper.epub
 ```
 
+For scanned or otherwise low-confidence pages, add an OpenAI-compatible OCR
+server. Successful pages are reported with `action=ocr`; local loopback
+servers do not require an API key:
+
+```bash
+cargo run -p bookforge-cli -- convert scan.pdf --out scan.epub \
+  --ocr-endpoint http://127.0.0.1:10000/v1
+```
+
+See [docs/pdf-ocr.md](docs/pdf-ocr.md) for the recommended Unlimited-OCR
+SGLang setup and the vLLM alternative.
+
 The converter detects two-column layouts per page (scientific papers),
 repairs hyphenated line breaks, joins paragraphs across pages, and maps
 oversized fonts to headings. It prints a fidelity report comparing the
 reconstructed text against the raw `pdftotext` baseline — check that
 coverage number (and `inspect` on the result) before spending tokens.
-Figures, tables-as-images, and low-confidence page fallbacks are
-roadmap items (ROADMAP §9b, phases P2–P4); for image-heavy PDFs expect
-text-only output for now.
+Figures, tables, equations, and low-confidence page fallbacks are preserved or
+reported according to the conversion options; complex layouts still require
+review.
 
 Inspect an EPUB:
 

--- a/crates/bookforge-audio/src/lib.rs
+++ b/crates/bookforge-audio/src/lib.rs
@@ -27,9 +27,10 @@ pub use builder::{
 };
 pub use cleanup::{StaleChunk, find_stale_chunks, remove_stale_chunks};
 pub use provider::{
-    AudioClip, AudioFormat, ELEVENLABS_MAX_INPUT_CHARS, ElevenLabsTtsConfig, ElevenLabsTtsProvider,
-    GeminiTtsConfig, GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider,
-    SpeechRequest, TtsError, TtsProvider, elevenlabs_model_max_input_chars,
+    AudioClip, AudioFormat, ELEVENLABS_MAX_INPUT_CHARS, ELEVENLABS_PREFERRED_MODELS,
+    ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig, GeminiTtsProvider,
+    MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, SpeechRequest, TtsError, TtsProvider,
+    elevenlabs_model_max_input_chars, resolve_preferred_elevenlabs_model,
 };
 pub use stitch::{StitchOptions, StitchReport, ffmpeg_available, stitch};
 pub use text::{Chapter, chapters_from_book, chunk_text};

--- a/crates/bookforge-audio/src/lib.rs
+++ b/crates/bookforge-audio/src/lib.rs
@@ -27,9 +27,9 @@ pub use builder::{
 };
 pub use cleanup::{StaleChunk, find_stale_chunks, remove_stale_chunks};
 pub use provider::{
-    AudioClip, AudioFormat, ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig,
-    GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, SpeechRequest,
-    TtsError, TtsProvider,
+    AudioClip, AudioFormat, ELEVENLABS_MAX_INPUT_CHARS, ElevenLabsTtsConfig, ElevenLabsTtsProvider,
+    GeminiTtsConfig, GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider,
+    SpeechRequest, TtsError, TtsProvider, elevenlabs_model_max_input_chars,
 };
 pub use stitch::{StitchOptions, StitchReport, ffmpeg_available, stitch};
 pub use text::{Chapter, chapters_from_book, chunk_text};

--- a/crates/bookforge-audio/src/provider.rs
+++ b/crates/bookforge-audio/src/provider.rs
@@ -13,8 +13,8 @@ mod elevenlabs;
 mod gemini;
 
 pub use elevenlabs::{
-    ELEVENLABS_MAX_INPUT_CHARS, ElevenLabsTtsConfig, ElevenLabsTtsProvider,
-    elevenlabs_model_max_input_chars,
+    ELEVENLABS_MAX_INPUT_CHARS, ELEVENLABS_PREFERRED_MODELS, ElevenLabsTtsConfig,
+    ElevenLabsTtsProvider, elevenlabs_model_max_input_chars, resolve_preferred_elevenlabs_model,
 };
 pub use gemini::{GeminiTtsConfig, GeminiTtsProvider};
 
@@ -468,7 +468,7 @@ fn local_api_key_is_optional(name: &str) -> bool {
     )
 }
 
-fn base_url_is_loopback(base_url: &str) -> bool {
+pub(super) fn base_url_is_loopback(base_url: &str) -> bool {
     reqwest::Url::parse(base_url)
         .ok()
         .and_then(|url| url.host_str().map(str::to_owned))

--- a/crates/bookforge-audio/src/provider.rs
+++ b/crates/bookforge-audio/src/provider.rs
@@ -12,7 +12,10 @@ use tokio_util::sync::CancellationToken;
 mod elevenlabs;
 mod gemini;
 
-pub use elevenlabs::{ElevenLabsTtsConfig, ElevenLabsTtsProvider};
+pub use elevenlabs::{
+    ELEVENLABS_MAX_INPUT_CHARS, ElevenLabsTtsConfig, ElevenLabsTtsProvider,
+    elevenlabs_model_max_input_chars,
+};
 pub use gemini::{GeminiTtsConfig, GeminiTtsProvider};
 
 /// Output container/codec requested from the provider. The string form is

--- a/crates/bookforge-audio/src/provider/elevenlabs.rs
+++ b/crates/bookforge-audio/src/provider/elevenlabs.rs
@@ -223,7 +223,7 @@ fn elevenlabs_request_body(model: &str, request: &SpeechRequest) -> serde_json::
         "text": request.text,
         "model_id": model,
     });
-    if !((request.speed - 1.0).abs() < f32::EPSILON) {
+    if (request.speed - 1.0).abs() >= f32::EPSILON {
         body["voice_settings"] = serde_json::json!({"speed": request.speed});
     }
     body

--- a/crates/bookforge-audio/src/provider/elevenlabs.rs
+++ b/crates/bookforge-audio/src/provider/elevenlabs.rs
@@ -5,6 +5,25 @@ use super::{
     required_api_key, send_with_retry, validate_audio_payload, validate_path_component,
 };
 
+/// Absolute maximum Unicode characters accepted by an ElevenLabs TTS model.
+pub const ELEVENLABS_MAX_INPUT_CHARS: usize = 40_000;
+
+/// Return the documented per-request character limit for an ElevenLabs model.
+///
+/// Unknown models use the conservative long-form default rather than the
+/// absolute Flash/Turbo ceiling. ElevenLabs can add models without BookForge
+/// knowing their contract yet, and rejecting locally is safer than spending a
+/// provider request that cannot succeed.
+pub fn elevenlabs_model_max_input_chars(model: &str) -> usize {
+    match model {
+        "eleven_flash_v2_5" | "eleven_turbo_v2_5" => 40_000,
+        "eleven_flash_v2" | "eleven_turbo_v2" => 30_000,
+        "eleven_v3" => 5_000,
+        "eleven_multilingual_v1" | "eleven_multilingual_v2" => 10_000,
+        _ => 10_000,
+    }
+}
+
 /// Configuration for ElevenLabs' native text-to-speech endpoint.
 #[derive(Debug, Clone)]
 pub struct ElevenLabsTtsConfig {
@@ -68,6 +87,14 @@ impl ElevenLabsTtsProvider {
 
 impl TtsProvider for ElevenLabsTtsProvider {
     async fn synthesize(&self, request: SpeechRequest) -> Result<AudioClip> {
+        let input_chars = request.text.chars().count();
+        let model_limit = elevenlabs_model_max_input_chars(&self.config.model);
+        if input_chars > model_limit {
+            return Err(TtsError::Provider(format!(
+                "ElevenLabs model {} is limited to {model_limit} characters; received {input_chars}",
+                self.config.model
+            )));
+        }
         let endpoint = self.endpoint(&request.voice, request.format)?;
         let api_key = required_api_key(&self.config.api_key_env)?;
         let body = elevenlabs_request_body(&self.config.model, &request);
@@ -159,6 +186,34 @@ mod tests {
             elevenlabs_output_format(AudioFormat::Aac),
             Err(TtsError::UnsupportedFormat("aac"))
         ));
+    }
+
+    #[tokio::test]
+    async fn rejects_input_above_provider_character_limit_before_network() {
+        let provider = ElevenLabsTtsProvider::new(ElevenLabsTtsConfig::hosted(None)).unwrap();
+        let mut oversized = request(AudioFormat::Mp3);
+        oversized.text = "a".repeat(10_001);
+
+        let error = provider.synthesize(oversized).await.unwrap_err();
+        assert!(error.to_string().contains("limited to 10000 characters"));
+    }
+
+    #[test]
+    fn model_character_limits_match_elevenlabs_contracts() {
+        assert_eq!(elevenlabs_model_max_input_chars("eleven_v3"), 5_000);
+        assert_eq!(
+            elevenlabs_model_max_input_chars("eleven_multilingual_v2"),
+            10_000
+        );
+        assert_eq!(
+            elevenlabs_model_max_input_chars("eleven_flash_v2_5"),
+            40_000
+        );
+        assert_eq!(
+            elevenlabs_model_max_input_chars("eleven_turbo_v2_5"),
+            40_000
+        );
+        assert_eq!(elevenlabs_model_max_input_chars("future-model"), 10_000);
     }
 
     #[tokio::test]

--- a/crates/bookforge-audio/src/provider/elevenlabs.rs
+++ b/crates/bookforge-audio/src/provider/elevenlabs.rs
@@ -1,12 +1,21 @@
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    AudioClip, AudioFormat, Result, SpeechRequest, TtsError, TtsProvider, build_http_client,
-    required_api_key, send_with_retry, validate_audio_payload, validate_path_component,
+    AudioClip, AudioFormat, Result, SpeechRequest, TtsError, TtsProvider, base_url_is_loopback,
+    build_http_client, required_api_key, send_with_retry, validate_audio_payload,
+    validate_path_component,
 };
 
 /// Absolute maximum Unicode characters accepted by an ElevenLabs TTS model.
 pub const ELEVENLABS_MAX_INPUT_CHARS: usize = 40_000;
+
+/// ElevenLabs models in BookForge's preferred auto-selection order.
+pub const ELEVENLABS_PREFERRED_MODELS: &[&str] = &[
+    "eleven_v3",
+    "eleven_flash_v2_5",
+    "eleven_turbo_v2_5",
+    "eleven_multilingual_v2",
+];
 
 /// Return the documented per-request character limit for an ElevenLabs model.
 ///
@@ -22,6 +31,86 @@ pub fn elevenlabs_model_max_input_chars(model: &str) -> usize {
         "eleven_multilingual_v1" | "eleven_multilingual_v2" => 10_000,
         _ => 10_000,
     }
+}
+
+/// Select the best available ElevenLabs model for the requested contract.
+pub async fn resolve_preferred_elevenlabs_model(
+    config: &ElevenLabsTtsConfig,
+    max_chars: usize,
+    needs_speed_control: bool,
+) -> Result<String> {
+    let endpoint = format!("{}/models", config.base_url.trim_end_matches('/'));
+    let api_key = if base_url_is_loopback(&config.base_url) {
+        std::env::var(&config.api_key_env)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    } else {
+        Some(required_api_key(&config.api_key_env)?)
+    };
+    let client = build_http_client(config.timeout_seconds)?;
+    let cancel_token = CancellationToken::new();
+    let payload = send_with_retry(&cancel_token, config.max_attempts.min(2), || {
+        let mut request = client.get(&endpoint);
+        if let Some(api_key) = api_key.as_deref() {
+            request = request.header("xi-api-key", api_key);
+        }
+        request
+    })
+    .await?;
+    let value: serde_json::Value = serde_json::from_slice(&payload.bytes).map_err(|error| {
+        TtsError::Provider(format!(
+            "could not parse ElevenLabs models response as JSON: {error}"
+        ))
+    })?;
+    let models = match &value {
+        serde_json::Value::Array(models) => models,
+        serde_json::Value::Object(object) => object
+            .get("models")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| {
+                TtsError::Provider(
+                    "ElevenLabs models response did not contain a models array".to_string(),
+                )
+            })?,
+        _ => {
+            return Err(TtsError::Provider(
+                "ElevenLabs models response was not an array or object".to_string(),
+            ));
+        }
+    };
+
+    let available_models = models
+        .iter()
+        .filter_map(|entry| {
+            let model_id = entry.get("model_id")?.as_str()?;
+            let supports_tts = match entry.get("can_do_text_to_speech") {
+                Some(serde_json::Value::Bool(value)) => *value,
+                None => true,
+                Some(_) => false,
+            };
+            supports_tts.then_some(model_id)
+        })
+        .collect::<std::collections::HashSet<_>>();
+
+    ELEVENLABS_PREFERRED_MODELS
+        .iter()
+        .copied()
+        .find(|model| {
+            available_models.contains(model)
+                && elevenlabs_model_max_input_chars(model) >= max_chars
+                && !(needs_speed_control && *model == "eleven_v3")
+        })
+        .map(str::to_string)
+        .ok_or_else(|| {
+            TtsError::Provider(format!(
+                "no available preferred ElevenLabs model supports max_chars={max_chars}{}",
+                if needs_speed_control {
+                    " with speed control"
+                } else {
+                    ""
+                }
+            ))
+        })
 }
 
 /// Configuration for ElevenLabs' native text-to-speech endpoint.
@@ -130,11 +219,14 @@ fn elevenlabs_output_format(format: AudioFormat) -> Result<&'static str> {
 }
 
 fn elevenlabs_request_body(model: &str, request: &SpeechRequest) -> serde_json::Value {
-    serde_json::json!({
+    let mut body = serde_json::json!({
         "text": request.text,
         "model_id": model,
-        "voice_settings": {"speed": request.speed}
-    })
+    });
+    if !((request.speed - 1.0).abs() < f32::EPSILON) {
+        body["voice_settings"] = serde_json::json!({"speed": request.speed});
+    }
+    body
 }
 
 #[cfg(test)]
@@ -186,6 +278,146 @@ mod tests {
             elevenlabs_output_format(AudioFormat::Aac),
             Err(TtsError::UnsupportedFormat("aac"))
         ));
+    }
+
+    #[test]
+    fn native_contract_omits_voice_settings_at_default_speed() {
+        let mut speech = request(AudioFormat::Mp3);
+        speech.speed = 1.0;
+        let body = elevenlabs_request_body("eleven_multilingual_v2", &speech);
+        assert!(body.get("voice_settings").is_none());
+    }
+
+    fn resolver_config(base_url: String, api_key_env: &str) -> ElevenLabsTtsConfig {
+        ElevenLabsTtsConfig {
+            base_url,
+            api_key_env: api_key_env.to_string(),
+            model: "unused-by-preflight".to_string(),
+            timeout_seconds: 5,
+            max_attempts: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolver_picks_v3_when_all_preferred_models_are_available() {
+        let body = serde_json::json!({"models": [
+            {"model_id": "eleven_multilingual_v2"},
+            {"model_id": "eleven_turbo_v2_5"},
+            {"model_id": "eleven_flash_v2_5"},
+            {"model_id": "eleven_v3"}
+        ]});
+        let (base_url, _) = one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_V3_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-v3-key") };
+        let resolved =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, false)
+                .await
+                .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+        assert_eq!(resolved, "eleven_v3");
+    }
+
+    #[tokio::test]
+    async fn resolver_picks_flash_when_v3_character_limit_is_too_small() {
+        let body = serde_json::json!([
+            {"model_id": "eleven_v3"},
+            {"model_id": "eleven_flash_v2_5"},
+            {"model_id": "eleven_turbo_v2_5"},
+            {"model_id": "eleven_multilingual_v2"}
+        ]);
+        let (base_url, _) = one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_LIMIT_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-limit-key") };
+        let resolved =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 8_000, false)
+                .await
+                .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+        assert_eq!(resolved, "eleven_flash_v2_5");
+    }
+
+    #[tokio::test]
+    async fn resolver_skips_models_without_text_to_speech() {
+        let body = serde_json::json!([
+            {"model_id": "eleven_v3", "can_do_text_to_speech": false},
+            {"model_id": "eleven_flash_v2_5", "can_do_text_to_speech": true}
+        ]);
+        let (base_url, _) = one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_TTS_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-tts-key") };
+        let resolved =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, false)
+                .await
+                .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+        assert_eq!(resolved, "eleven_flash_v2_5");
+    }
+
+    #[tokio::test]
+    async fn resolver_skips_v3_when_speed_control_is_needed() {
+        let body = serde_json::json!([
+            {"model_id": "eleven_v3"},
+            {"model_id": "eleven_flash_v2_5"}
+        ]);
+        let (base_url, _) = one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_SPEED_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-speed-key") };
+        let resolved =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, true)
+                .await
+                .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+        assert_eq!(resolved, "eleven_flash_v2_5");
+    }
+
+    #[tokio::test]
+    async fn resolver_sends_models_get_and_api_key_header() {
+        let body = serde_json::json!([{"model_id": "eleven_multilingual_v2"}]);
+        let (base_url, captured) =
+            one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_REQUEST_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-request-key") };
+        let resolved =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, false)
+                .await
+                .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+
+        assert_eq!(resolved, "eleven_multilingual_v2");
+        let raw = captured.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(raw.starts_with("GET /v1/models HTTP/1.1"));
+        assert!(
+            raw.to_ascii_lowercase()
+                .contains("xi-api-key: resolver-request-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolver_errors_on_unparseable_body() {
+        let (base_url, _) = one_request_server(b"not json".to_vec(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_GARBAGE_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-garbage-key") };
+        let error =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, false)
+                .await
+                .unwrap_err();
+        unsafe { std::env::remove_var(key_env) };
+        assert!(matches!(error, TtsError::Provider(_)));
+        assert!(error.to_string().contains("parse ElevenLabs models"));
+    }
+
+    #[tokio::test]
+    async fn resolver_errors_on_empty_body() {
+        let (base_url, _) = one_request_server(Vec::new(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_RESOLVER_EMPTY_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "resolver-empty-key") };
+        let error =
+            resolve_preferred_elevenlabs_model(&resolver_config(base_url, key_env), 5_000, false)
+                .await
+                .unwrap_err();
+        unsafe { std::env::remove_var(key_env) };
+        assert!(matches!(error, TtsError::Provider(_)));
+        assert!(error.to_string().contains("empty response body"));
     }
 
     #[tokio::test]

--- a/crates/bookforge-audio/src/text.rs
+++ b/crates/bookforge-audio/src/text.rs
@@ -59,7 +59,10 @@ pub fn chapters_from_book_with_options(book: &Book, pdf_page_grouping: bool) -> 
     let sections = book
         .sections
         .iter()
-        .filter(|section| is_narratable_section(&section.href, &navigation_hrefs))
+        .filter(|section| {
+            !section.id.0.starts_with("sec_nav_")
+                && is_narratable_section(&section.href, &navigation_hrefs)
+        })
         .collect::<Vec<_>>();
 
     // Some PDF converters emit one XHTML spine item per physical page. In
@@ -291,18 +294,55 @@ fn chapter_label_key(text: &str) -> Option<String> {
         "capítulo",
         "capitulo",
     ];
-    let mut words = text.split_whitespace();
-    let label = words.next()?.trim_matches(|ch: char| !ch.is_alphabetic());
+    let normalized_words = text
+        .split_whitespace()
+        .map(|word| word.trim_matches(|ch: char| !ch.is_alphanumeric()))
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>();
+    let label = *normalized_words.first()?;
+
+    // Canonical Toki Pona chapter headings keep the protected Roman numeral:
+    // `lipu nanpa VI`. Requiring a Roman numeral prevents ordinary phrases
+    // such as `lipu nanpa 17 ...` from becoming accidental chapter breaks.
+    if normalized_words.len() >= 3
+        && label.eq_ignore_ascii_case("lipu")
+        && normalized_words[1].eq_ignore_ascii_case("nanpa")
+        && is_roman_number(normalized_words[2])
+    {
+        return Some(format!(
+            "lipu nanpa {}",
+            normalized_words[2].to_ascii_uppercase()
+        ));
+    }
+
+    // Early BookForge Toki Pona output used the non-standard KAPITELO label.
+    // Recognize it when narrating existing files, but translation prompts and
+    // validation continue to require ordinary `lipu nanpa <Roman>`.
+    if label.eq_ignore_ascii_case("kapitelo")
+        && normalized_words.len() >= 2
+        && normalized_words.len() <= 5
+        && normalized_words[1..].iter().all(|word| {
+            is_roman_number(word)
+                || matches!(
+                    word.to_ascii_lowercase().as_str(),
+                    "wan" | "tu" | "luka" | "mute" | "ale"
+                )
+        })
+    {
+        return Some(
+            normalized_words
+                .iter()
+                .map(|word| word.to_ascii_uppercase())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+    }
+
     if !LABELS.iter().any(|known| label.eq_ignore_ascii_case(known)) {
         return None;
     }
-    let number = words
-        .next()?
-        .trim_matches(|ch: char| !ch.is_ascii_alphanumeric());
-    let roman = !number.is_empty()
-        && number
-            .chars()
-            .all(|ch| matches!(ch.to_ascii_uppercase(), 'I' | 'V' | 'X' | 'L' | 'C'));
+    let number = *normalized_words.get(1)?;
+    let roman = is_roman_number(number);
     if !number.chars().all(|ch| ch.is_ascii_digit()) && !roman {
         return None;
     }
@@ -311,6 +351,13 @@ fn chapter_label_key(text: &str) -> Option<String> {
         label.to_ascii_lowercase(),
         number.to_ascii_uppercase()
     ))
+}
+
+fn is_roman_number(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| matches!(ch.to_ascii_uppercase(), 'I' | 'V' | 'X' | 'L' | 'C'))
 }
 
 fn embedded_chapter_label_offset(text: &str) -> Option<usize> {
@@ -349,7 +396,13 @@ fn should_join_across_page(left: &str, right: &str) -> bool {
 /// extensions alone would incorrectly read the table of contents aloud.
 fn is_narratable_section(href: &str, navigation_hrefs: &std::collections::HashSet<String>) -> bool {
     let path = normalized_href(href);
-    !(path.ends_with(".opf") || path.ends_with(".ncx") || navigation_hrefs.contains(&path))
+    let is_navigation = navigation_hrefs.iter().any(|navigation| {
+        path == *navigation
+            || path
+                .strip_suffix(navigation)
+                .is_some_and(|prefix| prefix.ends_with('/'))
+    });
+    !(path.ends_with(".opf") || path.ends_with(".ncx") || is_navigation)
 }
 
 fn normalized_href(href: &str) -> String {
@@ -599,6 +652,7 @@ mod tests {
         assert!(!is_narratable_section("OEBPS/package.OPF", &nav));
         assert!(!is_narratable_section("toc.ncx", &nav));
         assert!(!is_narratable_section("TEXT/navigation.xhtml#toc", &nav));
+        assert!(!is_narratable_section("OEBPS/Text/navigation.xhtml", &nav));
         assert!(is_narratable_section("text/chapter-1.xhtml", &nav));
         assert!(is_narratable_section("chapter.html#frag", &nav));
         assert!(is_printed_toc_heading("INDICE"));
@@ -609,6 +663,15 @@ mod tests {
             "Cap. I / Il Buonsenso Pag. 1 Cap. II / La natura Pag. 8"
         ));
         assert!(is_front_matter_heading("Nota dell’autore"));
+        assert_eq!(
+            chapter_label_key("lipu nanpa VI"),
+            Some("lipu nanpa VI".to_string())
+        );
+        assert!(chapter_label_key("lipu nanpa 17 li toki e ni").is_none());
+        assert_eq!(
+            chapter_label_key("KAPITELO LUKA WAN"),
+            Some("KAPITELO LUKA WAN".to_string())
+        );
     }
 
     #[test]

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -7,7 +7,8 @@ use anyhow::{Context, Result};
 use bookforge_audio::{
     AudioFormat, AudiobookOptions, ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig,
     GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, Progress,
-    StitchOptions, build_audiobook, plan_chunks, stitch, validate_options,
+    StitchOptions, build_audiobook, elevenlabs_model_max_input_chars, plan_chunks, stitch,
+    validate_options,
 };
 use bookforge_epub::{ReflowOptions, read_epub, reflow_epub};
 use clap::{Args, ValueEnum};
@@ -243,6 +244,12 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 .model
                 .clone()
                 .unwrap_or_else(|| "eleven_multilingual_v2".to_string());
+            let model_limit = elevenlabs_model_max_input_chars(&model);
+            if args.max_chars > model_limit {
+                anyhow::bail!(
+                    "ElevenLabs model {model} is limited to {model_limit} characters; set --max-chars to {model_limit} or less"
+                );
+            }
             let base_url = args
                 .base_url
                 .as_deref()

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use bookforge_audio::{
     AudioFormat, AudiobookOptions, ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig,
     GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, Progress,
-    StitchOptions, build_audiobook, elevenlabs_model_max_input_chars, plan_chunks, stitch,
-    validate_options,
+    StitchOptions, build_audiobook, elevenlabs_model_max_input_chars, plan_chunks,
+    resolve_preferred_elevenlabs_model, stitch, validate_options,
 };
 use bookforge_epub::{ReflowOptions, read_epub, reflow_epub};
 use clap::{Args, ValueEnum};
@@ -195,6 +195,8 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         anyhow::bail!("--timeout-seconds must be greater than zero");
     }
 
+    let elevenlabs_dry_run_default =
+        args.provider == AudioProviderKind::Elevenlabs && args.model.is_none() && args.dry_run;
     let (model, synthesis_id) = match args.provider {
         AudioProviderKind::Mock => {
             let model = args
@@ -240,10 +242,35 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             (model.clone(), format!("gemini:{base_url}:{model}"))
         }
         AudioProviderKind::Elevenlabs => {
-            let model = args
-                .model
-                .clone()
-                .unwrap_or_else(|| "eleven_multilingual_v2".to_string());
+            let model = if let Some(model) = args.model.clone() {
+                model
+            } else if args.dry_run {
+                "eleven_multilingual_v2".to_string()
+            } else {
+                let mut config = ElevenLabsTtsConfig::hosted(None);
+                if let Some(base_url) = args.base_url.clone() {
+                    config.base_url = base_url;
+                }
+                if let Some(api_key_env) = args.api_key_env.clone() {
+                    config.api_key_env = api_key_env;
+                }
+                config.timeout_seconds = args.timeout_seconds.min(15);
+                match resolve_preferred_elevenlabs_model(
+                    &config,
+                    args.max_chars,
+                    (args.speed - 1.0).abs() > f32::EPSILON,
+                )
+                .await
+                {
+                    Ok(model) => model,
+                    Err(error) => {
+                        eprintln!(
+                            "warning: ElevenLabs model preflight failed ({error}); using default eleven_multilingual_v2"
+                        );
+                        "eleven_multilingual_v2".to_string()
+                    }
+                }
+            };
             let model_limit = elevenlabs_model_max_input_chars(&model);
             if args.max_chars > model_limit {
                 anyhow::bail!(
@@ -258,6 +285,14 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             (model.clone(), format!("elevenlabs:{base_url}:{model}"))
         }
     };
+    if args.provider == AudioProviderKind::Elevenlabs
+        && model == "eleven_v3"
+        && (args.speed - 1.0).abs() > f32::EPSILON
+    {
+        anyhow::bail!(
+            "eleven_v3 has no speed control on the ElevenLabs TTS endpoint; use --speed 1.0 or pick another model"
+        );
+    }
     let options = AudiobookOptions {
         out_dir: out_dir.clone(),
         voice: voice.clone(),
@@ -294,7 +329,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         );
         println!("Output: {}", out_dir.display());
         println!("Voice: {voice} | Format: {}", format.extension());
-        println!("Model: {model}");
+        if elevenlabs_dry_run_default {
+            println!(
+                "Model: {model} (default; a live run auto-selects the best available ElevenLabs model)"
+            );
+        } else {
+            println!("Model: {model}");
+        }
         println!(
             "Plan: {chapter_count} chapters, {} chunks, {total_chars} characters",
             plan.len()

--- a/crates/bookforge-cli/src/commands/convert.rs
+++ b/crates/bookforge-cli/src/commands/convert.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use bookforge_pdf::{ColumnMode, ConvertOptions, LowConfidenceMode, convert_pdf};
+use bookforge_pdf::{
+    ColumnMode, ConvertOptions, HttpOcrClient, LowConfidenceMode, OcrConfig, OcrDialect, OcrEngine,
+    convert_pdf_with_ocr,
+};
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -33,6 +36,34 @@ pub struct ConvertArgs {
     /// `<out>.convert.json`.
     #[arg(long)]
     pub report: Option<PathBuf>,
+
+    /// OpenAI-compatible base URL used to OCR low-confidence pages.
+    #[arg(long)]
+    pub ocr_endpoint: Option<String>,
+
+    /// OCR server request dialect.
+    #[arg(long, value_enum, default_value_t = OcrDialectArg::Openai)]
+    pub ocr_dialect: OcrDialectArg,
+
+    /// OCR model name.
+    #[arg(long)]
+    pub ocr_model: Option<String>,
+
+    /// Environment variable containing the OCR API key.
+    #[arg(long)]
+    pub ocr_api_key_env: Option<String>,
+
+    /// Prompt sent with each rendered page.
+    #[arg(long)]
+    pub ocr_prompt: Option<String>,
+
+    /// Unlimited-OCR image processing mode.
+    #[arg(long, value_enum, default_value_t = OcrImageModeArg::Gundam)]
+    pub ocr_image_mode: OcrImageModeArg,
+
+    /// File containing a serialized Unlimited-OCR custom logit processor.
+    #[arg(long)]
+    pub ocr_logit_processor: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -48,6 +79,37 @@ pub enum ColumnsArg {
 pub enum LowConfidenceArg {
     Preserve,
     Linearize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum OcrDialectArg {
+    Openai,
+    #[value(name = "unlimited-ocr")]
+    UnlimitedOcr,
+}
+
+impl OcrDialectArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Openai => "openai",
+            Self::UnlimitedOcr => "unlimited-ocr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum OcrImageModeArg {
+    Gundam,
+    Base,
+}
+
+impl OcrImageModeArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Gundam => "gundam",
+            Self::Base => "base",
+        }
+    }
 }
 
 impl From<ColumnsArg> for ColumnMode {
@@ -89,15 +151,65 @@ pub async fn run(args: ConvertArgs) -> Result<()> {
         title: args.title.clone().unwrap_or_default(),
     };
 
-    let outcome = convert_pdf(&args.input, &output, &options)
-        .with_context(|| format!("converting {}", args.input.display()))?;
+    let mut ocr_config = args.ocr_endpoint.as_ref().map(|endpoint| {
+        let mut config = OcrConfig::new(endpoint);
+        config.dialect = match args.ocr_dialect {
+            OcrDialectArg::Openai => OcrDialect::OpenAiCompatible,
+            OcrDialectArg::UnlimitedOcr => OcrDialect::UnlimitedOcr,
+        };
+        if let Some(model) = &args.ocr_model {
+            config.model.clone_from(model);
+        }
+        if let Some(api_key_env) = &args.ocr_api_key_env {
+            config.api_key_env.clone_from(api_key_env);
+        }
+        if let Some(prompt) = &args.ocr_prompt {
+            config.prompt.clone_from(prompt);
+        }
+        config.image_mode = args.ocr_image_mode.as_str().to_string();
+        config
+    });
+    if let Some(path) = &args.ocr_logit_processor {
+        let processor = tokio::fs::read_to_string(path)
+            .await
+            .with_context(|| format!("reading OCR logit processor {}", path.display()))?;
+        let config = ocr_config
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("--ocr-logit-processor requires --ocr-endpoint"))?;
+        config.logit_processor = Some(processor.trim().to_string());
+    }
+    let ocr_summary = ocr_config.as_ref().map(|config| {
+        (
+            config.base_url.clone(),
+            config.model.clone(),
+            args.ocr_dialect.as_str(),
+        )
+    });
+
+    let input = args.input.clone();
+    let conversion_input = input.clone();
+    let conversion_output = output.clone();
+    let outcome = tokio::task::spawn_blocking(move || -> Result<_> {
+        let ocr_client = ocr_config
+            .map(HttpOcrClient::new)
+            .transpose()
+            .context("initializing OCR client")?;
+        let engine = ocr_client.as_ref().map(|client| client as &dyn OcrEngine);
+        convert_pdf_with_ocr(&conversion_input, &conversion_output, &options, engine)
+            .with_context(|| format!("converting {}", conversion_input.display()))
+    })
+    .await
+    .context("PDF conversion worker failed")??;
 
     let json = serde_json::to_string_pretty(&outcome.report)?;
     std::fs::write(&report_path, json)
         .with_context(|| format!("writing report {}", report_path.display()))?;
 
-    println!("Input: {}", args.input.display());
+    println!("Input: {}", input.display());
     println!("Output: {}", outcome.output.display());
+    if let Some((endpoint, model, dialect)) = ocr_summary {
+        println!("OCR: {endpoint} ({model}, {dialect})");
+    }
     print!("{}", outcome.report.summary());
     println!("Report: {}", report_path.display());
     println!();

--- a/crates/bookforge-cli/src/commands/doctor.rs
+++ b/crates/bookforge-cli/src/commands/doctor.rs
@@ -5,7 +5,7 @@ use bookforge_llm::{
     CompletionRequest, LlmProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
     RequestMetadata, ResponseFormat,
 };
-use bookforge_pdf::PopplerTools;
+use bookforge_pdf::{HttpOcrClient, OcrConfig, PopplerTools};
 use bookforge_store::run_doctor;
 
 #[derive(Debug, Args)]
@@ -21,6 +21,10 @@ pub struct DoctorArgs {
     /// Check provider health
     #[arg(long)]
     pub provider: Option<String>,
+
+    /// Check an OpenAI-compatible OCR endpoint.
+    #[arg(long)]
+    pub ocr_endpoint: Option<String>,
 
     /// Model to test with
     #[arg(long)]
@@ -64,10 +68,68 @@ pub async fn run(args: DoctorArgs) -> anyhow::Result<()> {
         .await?;
     }
 
+    if let Some(endpoint) = &args.ocr_endpoint {
+        ran = true;
+        run_ocr_doctor(
+            endpoint,
+            args.model.as_deref(),
+            args.api_key_env.as_deref(),
+            args.timeout_seconds,
+        )
+        .await?;
+    }
+
     if !ran {
         run_storage_doctor().await?;
     }
 
+    Ok(())
+}
+
+async fn run_ocr_doctor(
+    endpoint: &str,
+    model: Option<&str>,
+    api_key_env: Option<&str>,
+    timeout_seconds: u64,
+) -> anyhow::Result<()> {
+    let mut config = OcrConfig::new(endpoint);
+    if let Some(model) = model {
+        config.model = model.to_string();
+    }
+    if let Some(api_key_env) = api_key_env {
+        config.api_key_env = api_key_env.to_string();
+    }
+    config.timeout_seconds = timeout_seconds;
+    let display_endpoint = config.base_url.clone();
+    let display_model = config.model.clone();
+
+    println!("OCR endpoint:");
+    println!("  Base URL: {display_endpoint}");
+    println!("  Model: {display_model}");
+
+    let result = tokio::task::spawn_blocking(move || {
+        HttpOcrClient::new(config).and_then(|client| client.health_check())
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("OCR health-check worker failed: {error}"))?;
+
+    match result {
+        Ok(models) => {
+            println!("  Reachable: yes");
+            if models.is_empty() {
+                println!("  Models: (none reported)");
+            } else {
+                println!("  Models: {}", models.join(", "));
+            }
+        }
+        Err(error) => {
+            println!("  Reachable: no");
+            println!("  Error: {error}");
+            println!(
+                "  Hint: OCR_API_KEY is only needed for non-loopback endpoints (or set --api-key-env to another variable)."
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -70,10 +70,10 @@ const AUDIO_PROVIDER_KEY_ENVS: &[(&str, &str)] = &[
 const AUDIO_OPENAI_MODELS: &[&str] = &["gpt-4o-mini-tts", "tts-1", "tts-1-hd"];
 const AUDIO_GEMINI_MODELS: &[&str] = &["gemini-3.1-flash-tts-preview"];
 const AUDIO_ELEVENLABS_MODELS: &[&str] = &[
-    "eleven_multilingual_v2",
     "eleven_v3",
     "eleven_flash_v2_5",
     "eleven_turbo_v2_5",
+    "eleven_multilingual_v2",
 ];
 const AUDIO_MOCK_MODELS: &[&str] = &["mock-silence"];
 
@@ -1184,6 +1184,11 @@ async fn launch_audiobook(
     }
     if provider == "gemini" && (speed - 1.0).abs() > f32::EPSILON {
         return Ok(bad_request("Gemini does not expose playback-speed control"));
+    }
+    if provider == "elevenlabs" && model == "eleven_v3" && (speed - 1.0).abs() > f32::EPSILON {
+        return Ok(bad_request(
+            "eleven_v3 does not support speed control; use speed 1.0",
+        ));
     }
     let instructions = field_value(&fields, "instructions");
     if provider == "elevenlabs" && instructions.is_some() {
@@ -2619,6 +2624,8 @@ mod tests {
             .expect("ElevenLabs provider option should exist");
         assert!(elevenlabs.requires_voice);
         assert!(!elevenlabs.supports_instructions);
+        assert_eq!(elevenlabs.models.first(), Some(&"eleven_v3"));
+        assert_eq!(elevenlabs.default_model, "eleven_multilingual_v2");
         assert_eq!(elevenlabs.max_chars, 10_000);
         assert_eq!(audio_provider_max_chars("openai", "anything"), 4_096);
         assert_eq!(audio_provider_max_chars("elevenlabs", "eleven_v3"), 5_000);

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -69,7 +69,12 @@ const AUDIO_PROVIDER_KEY_ENVS: &[(&str, &str)] = &[
 ];
 const AUDIO_OPENAI_MODELS: &[&str] = &["gpt-4o-mini-tts", "tts-1", "tts-1-hd"];
 const AUDIO_GEMINI_MODELS: &[&str] = &["gemini-3.1-flash-tts-preview"];
-const AUDIO_ELEVENLABS_MODELS: &[&str] = &["eleven_multilingual_v2", "eleven_flash_v2_5"];
+const AUDIO_ELEVENLABS_MODELS: &[&str] = &[
+    "eleven_multilingual_v2",
+    "eleven_v3",
+    "eleven_flash_v2_5",
+    "eleven_turbo_v2_5",
+];
 const AUDIO_MOCK_MODELS: &[&str] = &["mock-silence"];
 
 const LANGUAGE_OPTIONS: &[&str] = &[
@@ -1186,6 +1191,19 @@ async fn launch_audiobook(
             "ElevenLabs does not accept free-form instructions",
         ));
     }
+    let max_chars = field_value(&fields, "max_chars")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2_000);
+    let provider_max_chars = audio_provider_max_chars(&provider, &model);
+    if max_chars == 0 || max_chars > provider_max_chars {
+        return Ok(bad_request(&format!(
+            "{provider} accepts between 1 and {provider_max_chars} characters per request"
+        )));
+    }
+    let concurrency = field_value(&fields, "concurrency")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(4)
+        .clamp(1, 16);
     let make_m4b = truthy_field(&fields, "m4b");
     let stitch_audio = truthy_field(&fields, "stitch") || make_m4b;
     if stitch_audio && format == "pcm" {
@@ -1241,15 +1259,6 @@ async fn launch_audiobook(
     }
     std::fs::create_dir_all(&out_dir)?;
     write_audio_process_state(&out_dir, "starting", None, None)?;
-
-    let max_chars = field_value(&fields, "max_chars")
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(2_000)
-        .clamp(1, 4_096);
-    let concurrency = field_value(&fields, "concurrency")
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(4)
-        .clamp(1, 16);
 
     let exe = std::env::current_exe()?;
     let mut command = tokio::process::Command::new(exe);
@@ -1915,6 +1924,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 requires_key: false,
                 supports_instructions: false,
                 supports_speed: true,
+                max_chars: 40_000,
             },
             AudioProviderOption {
                 id: "openai",
@@ -1928,6 +1938,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 requires_key: true,
                 supports_instructions: true,
                 supports_speed: true,
+                max_chars: 4_096,
             },
             AudioProviderOption {
                 id: "gemini",
@@ -1941,6 +1952,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 requires_key: true,
                 supports_instructions: true,
                 supports_speed: false,
+                max_chars: 4_096,
             },
             AudioProviderOption {
                 id: "elevenlabs",
@@ -1954,6 +1966,9 @@ fn dashboard_options_payload() -> DashboardOptions {
                 requires_key: true,
                 supports_instructions: false,
                 supports_speed: true,
+                max_chars: bookforge_audio::elevenlabs_model_max_input_chars(
+                    "eleven_multilingual_v2",
+                ),
             },
         ],
         ffmpeg_available: bookforge_audio::ffmpeg_available(),
@@ -1965,6 +1980,15 @@ fn field_value(fields: &HashMap<String, String>, key: &str) -> Option<String> {
         .get(key)
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn audio_provider_max_chars(provider: &str, model: &str) -> usize {
+    match provider {
+        "mock" => 40_000,
+        "elevenlabs" => bookforge_audio::elevenlabs_model_max_input_chars(model),
+        "openai" | "gemini" => 4_096,
+        _ => 4_096,
+    }
 }
 
 fn truthy_field(fields: &HashMap<String, String>, key: &str) -> bool {
@@ -2351,6 +2375,7 @@ struct AudioProviderOption {
     requires_key: bool,
     supports_instructions: bool,
     supports_speed: bool,
+    max_chars: usize,
 }
 
 impl JobDetail {
@@ -2594,6 +2619,13 @@ mod tests {
             .expect("ElevenLabs provider option should exist");
         assert!(elevenlabs.requires_voice);
         assert!(!elevenlabs.supports_instructions);
+        assert_eq!(elevenlabs.max_chars, 10_000);
+        assert_eq!(audio_provider_max_chars("openai", "anything"), 4_096);
+        assert_eq!(audio_provider_max_chars("elevenlabs", "eleven_v3"), 5_000);
+        assert_eq!(
+            audio_provider_max_chars("elevenlabs", "eleven_flash_v2_5"),
+            40_000
+        );
     }
 
     #[test]
@@ -2921,14 +2953,14 @@ mod tests {
     fn dashboard_assets_reassemble_byte_stably() {
         use sha2::{Digest, Sha256};
 
-        assert_eq!(DASHBOARD_HTML.len(), 96_386);
+        assert_eq!(DASHBOARD_HTML.len(), 97_182);
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_CSS}}"));
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_JS}}"));
         let digest = Sha256::digest(DASHBOARD_HTML.as_bytes());
         let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
         assert_eq!(
             digest_hex,
-            "c8a0125fd9096f1a0fbf8b61c3907378dce1c5692bc0f592a3f05526bbb07c34"
+            "6a7999e04b3714c0669b72387e4834ba6620b42585d3ca963797f8258da61440"
         );
 
         let crlf = |asset: &str| asset.replace("\r\n", "\n").replace('\n', "\r\n");

--- a/crates/bookforge-cli/src/commands/serve/dashboard.js
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.js
@@ -382,16 +382,26 @@ function audioProviderOption(id) {
   return (App.options.audio_providers || []).find(p => p.id === id)
     || { id:"mock", label:"mock", models:["mock-silence"], default_model:"mock-silence",
       default_voice:"mock", formats:["wav"], default_format:"wav", requires_key:false,
-      requires_voice:false, supports_instructions:false, supports_speed:true };
+      requires_voice:false, supports_instructions:false, supports_speed:true, max_chars:40000 };
+}
+function audioProviderMaxChars(provider, model) {
+  if (provider.id === "elevenlabs") {
+    const limits = { eleven_v3:5000, eleven_multilingual_v1:10000, eleven_multilingual_v2:10000,
+      eleven_flash_v2:30000, eleven_turbo_v2:30000, eleven_flash_v2_5:40000, eleven_turbo_v2_5:40000 };
+    return limits[model] || 10000;
+  }
+  return Math.max(1, Number(provider.max_chars) || 4096);
 }
 function bfAudioProvider(id) {
   syncAudioInputs();
   const w = App.audioWizard, p = audioProviderOption(id);
   w.provider = id; w.model = p.default_model; w.voice = p.default_voice;
+  w.maxChars = Math.min(w.maxChars, audioProviderMaxChars(p, w.model));
   w.format = p.default_format; w.speed = 1; w.instructions = ""; w.status = "";
   renderAudiobook($("#stage"));
 }
 function bfAudioFormat(format) { syncAudioInputs(); App.audioWizard.format = format; renderAudiobook($("#stage")); }
+function bfAudioModel() { syncAudioInputs(); const w=App.audioWizard, p=audioProviderOption(w.provider); w.maxChars=Math.min(w.maxChars,audioProviderMaxChars(p,w.model)); renderAudiobook($("#stage")); }
 function bfAudioPickFile(input) {
   const file = input.files && input.files[0]; if (!file) return;
   App.audioWizard.file = file; App.audioWizard.fileName = file.name; renderAudiobook($("#stage"));
@@ -406,7 +416,7 @@ function syncAudioInputs() {
   const model = $("#a_model"); if (model) w.model = model.value.trim();
   const voice = $("#a_voice"); if (voice) w.voice = voice.value.trim();
   const speed = $("#a_speed"); if (speed) w.speed = Number(speed.value) || 1;
-  const maxChars = $("#a_chars"); if (maxChars) w.maxChars = Math.max(1, Math.min(4096, parseInt(maxChars.value,10)||2000));
+  const maxChars = $("#a_chars"); if (maxChars) w.maxChars = Math.max(1, Math.min(audioProviderMaxChars(audioProviderOption(w.provider), w.model), parseInt(maxChars.value,10)||2000));
   const concurrency = $("#a_conc"); if (concurrency) w.concurrency = Math.max(1, Math.min(16, parseInt(concurrency.value,10)||4));
   const instructions = $("#a_instructions"); if (instructions) w.instructions = instructions.value.trim();
   const baseUrl = $("#a_base"); if (baseUrl) w.baseUrl = baseUrl.value.trim();
@@ -436,10 +446,10 @@ function renderAudiobook(stage) {
       </div><input type="file" id="audio-file" accept=".epub" hidden onchange="bfAudioPickFile(this)">
       <div class="field-label" style="margin-top:20px">Speech provider</div><div class="chips">${providerChips}</div>
       <div class="adv-grid" style="margin-top:18px">
-        <div><div class="field-label">Model</div><input class="inp" id="a_model" value="${esc(w.model)}" list="audio-models"></div>
+        <div><div class="field-label">Model</div><input class="inp" id="a_model" value="${esc(w.model)}" list="audio-models" onchange="bfAudioModel()"></div>
         <div><div class="field-label">${p.requires_voice?"Voice ID":"Voice"}</div><input class="inp" id="a_voice" value="${esc(w.voice)}" placeholder="${p.requires_voice?"Required ElevenLabs voice ID":"Voice name"}"></div>
         <div><div class="field-label">Speed</div><input class="inp" id="a_speed" type="number" min="0.25" max="4" step="0.05" value="${w.speed}" ${p.supports_speed?"":"disabled"}></div>
-        <div><div class="field-label">Characters per request</div><input class="inp" id="a_chars" type="number" min="1" max="4096" value="${w.maxChars}"></div>
+        <div><div class="field-label">Characters per request</div><input class="inp" id="a_chars" type="number" min="1" max="${audioProviderMaxChars(p,w.model)}" value="${w.maxChars}"></div>
         <div><div class="field-label">Concurrency</div><input class="inp" id="a_conc" type="number" min="1" max="16" value="${w.concurrency}"></div>
         <div><div class="field-label">Format</div><div class="chips">${formatChips}</div></div>
       </div>

--- a/crates/bookforge-cli/tests/audiobook.rs
+++ b/crates/bookforge-cli/tests/audiobook.rs
@@ -189,6 +189,86 @@ fn audiobook_elevenlabs_enforces_model_character_limits() {
 }
 
 #[test]
+fn elevenlabs_dry_run_without_model_uses_static_default_offline() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "elevenlabs",
+            "--voice",
+            "v",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("eleven_multilingual_v2"))
+        .stdout(predicates::str::contains("auto-selects"));
+}
+
+#[test]
+fn elevenlabs_preflight_failure_warns_and_falls_back() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+    let key_env = "BOOKFORGE_ELEVENLABS_PREFLIGHT_FALLBACK_TEST_KEY";
+
+    bookforge()
+        .current_dir(temp.path())
+        .env(key_env, "dummy-test-key")
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "elevenlabs",
+            "--voice",
+            "v",
+            "--base-url",
+            "http://127.0.0.1:9",
+            "--api-key-env",
+            key_env,
+            "--timeout-seconds",
+            "1",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "warning: ElevenLabs model preflight failed",
+        ))
+        .stderr(predicates::str::contains(
+            "using default eleven_multilingual_v2",
+        ));
+}
+
+#[test]
+fn elevenlabs_v3_rejects_speed() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "elevenlabs",
+            "--model",
+            "eleven_v3",
+            "--speed",
+            "1.2",
+            "--voice",
+            "v",
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("speed control"));
+}
+
+#[test]
 fn audiobook_resume_skips_existing_files() {
     let temp = tempfile::tempdir().expect("temp dir");
     let input = fixture(temp.path());

--- a/crates/bookforge-cli/tests/audiobook.rs
+++ b/crates/bookforge-cli/tests/audiobook.rs
@@ -162,6 +162,33 @@ fn audiobook_dry_run_writes_nothing() {
 }
 
 #[test]
+fn audiobook_elevenlabs_enforces_model_character_limits() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "elevenlabs",
+            "--voice",
+            "test-voice-id",
+            "--model",
+            "eleven_v3",
+            "--max-chars",
+            "5001",
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "eleven_v3 is limited to 5000 characters",
+        ));
+}
+
+#[test]
 fn audiobook_resume_skips_existing_files() {
     let temp = tempfile::tempdir().expect("temp dir");
     let input = fixture(temp.path());
@@ -331,13 +358,17 @@ fn audiobook_elevenlabs_dry_run_accepts_native_provider_options() {
             "elevenlabs",
             "--voice",
             "JBFqnCBsd6RMkjVDRZzb",
+            "--model",
+            "eleven_flash_v2_5",
+            "--max-chars",
+            "40000",
             "--dry-run",
         ])
         .assert()
         .success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(stdout.contains("Voice: JBFqnCBsd6RMkjVDRZzb | Format: mp3"));
-    assert!(stdout.contains("Model: eleven_multilingual_v2"));
+    assert!(stdout.contains("Model: eleven_flash_v2_5"));
 }
 
 #[test]

--- a/crates/bookforge-cli/tests/doctor_ocr.rs
+++ b/crates/bookforge-cli/tests/doctor_ocr.rs
@@ -1,0 +1,60 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    time::Duration,
+};
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn bookforge() -> Command {
+    Command::cargo_bin("bookforge").expect("bookforge binary should be built")
+}
+
+#[test]
+fn doctor_lists_models_from_loopback_ocr_endpoint() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("mock OCR listener");
+    let address = listener.local_addr().expect("mock OCR address");
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("mock OCR accept");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("read timeout");
+        let mut request = Vec::new();
+        let mut scratch = [0u8; 2048];
+        loop {
+            let read = stream.read(&mut scratch).expect("read request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&scratch[..read]);
+            if request.windows(4).any(|part| part == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let body = br#"{"data":[{"id":"baidu/Unlimited-OCR"}]}"#;
+        let headers = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(headers.as_bytes()).expect("write headers");
+        stream.write_all(body).expect("write body");
+        sender
+            .send(String::from_utf8_lossy(&request).into_owned())
+            .expect("send request");
+    });
+
+    bookforge()
+        .args(["doctor", "--ocr-endpoint", &format!("http://{address}/v1")])
+        .assert()
+        .success()
+        .stdout(contains("Reachable: yes"))
+        .stdout(contains("baidu/Unlimited-OCR"));
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("doctor request captured");
+    assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+}

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -12,6 +12,8 @@ bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
 quick-xml.workspace = true
 crc32fast = "1.5.0"
 flate2 = "1.1.9"
+base64.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -17,6 +17,7 @@ use crate::{
         ColumnMode, DocBlock, Fragment, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span,
         normalize_text_key, spans_text,
     },
+    ocr::OcrEngine,
     parse::parse_pdf2xml,
     reconstruct::{AnchoredBlock, BlockAnchor, PageStats, reconstruct},
     report::{ConversionReport, LOW_CONFIDENCE_COVERAGE_RATIO, ReportMetrics},
@@ -39,7 +40,7 @@ use detection::{
 #[cfg(test)]
 use rendering::remove_blocks_in_region;
 use rendering::{
-    PageCropRenderer, image_asset, insert_figure_blocks, media_asset,
+    PageCropRenderer, image_asset, insert_figure_blocks, media_asset, ocr_low_confidence_pages,
     preserve_low_confidence_pages, render_figure_crop,
 };
 use reporting::{baseline_page_char_counts, mark_low_confidence_pages, media_layout_warnings};
@@ -78,8 +79,17 @@ pub fn convert_pdf(
     output: &Path,
     options: &ConvertOptions,
 ) -> Result<ConvertOutcome> {
+    convert_pdf_with_ocr(input, output, options, None)
+}
+
+pub fn convert_pdf_with_ocr(
+    input: &Path,
+    output: &Path,
+    options: &ConvertOptions,
+    ocr: Option<&dyn OcrEngine>,
+) -> Result<ConvertOutcome> {
     let tools = PopplerTools::discover()?;
-    convert_pdf_with_tools(input, output, options, &tools)
+    convert_pdf_with_tools(input, output, options, &tools, ocr)
 }
 
 fn convert_pdf_with_tools(
@@ -87,6 +97,7 @@ fn convert_pdf_with_tools(
     output: &Path,
     options: &ConvertOptions,
     tools: &PopplerTools,
+    ocr: Option<&dyn OcrEngine>,
 ) -> Result<ConvertOutcome> {
     let xml = tools.pdf_to_xml(input)?;
     let pages = parse_pdf2xml(&xml)?;
@@ -98,7 +109,8 @@ fn convert_pdf_with_tools(
     for (stats, chars) in page_stats.iter_mut().zip(baseline_page_chars) {
         stats.baseline_chars = chars;
     }
-    let low_confidence_pages = mark_low_confidence_pages(&mut page_stats, options.low_confidence);
+    let mut low_confidence_pages =
+        mark_low_confidence_pages(&mut page_stats, options.low_confidence);
 
     let media_dir = scoped_temp_dir("bookforge-pdf-media")?;
     let image_dir = scoped_temp_dir("bookforge-pdf-images")?;
@@ -134,6 +146,23 @@ fn convert_pdf_with_tools(
     let mut blocks = reconstruction.blocks;
     let media_preserved_chars =
         insert_figure_blocks(&mut blocks, figure_blocks, &mut layout_warnings);
+    if let Some(engine) = ocr {
+        let ocr_page_dir = scoped_temp_dir("bookforge-pdf-ocr-pages")?;
+        let mut render = |page_number| {
+            let path = tools.render_page_png(input, page_number, &ocr_page_dir)?;
+            Ok(fs::read(path)?)
+        };
+        let ocr_outcome =
+            ocr_low_confidence_pages(engine, &mut render, &mut blocks, &low_confidence_pages);
+        let _ = fs::remove_dir_all(&ocr_page_dir);
+        for stats in &mut page_stats {
+            if ocr_outcome.recovered.contains(&stats.page) {
+                stats.low_confidence_action = Some("ocr".to_string());
+            }
+        }
+        low_confidence_pages.retain(|page| !ocr_outcome.recovered.contains(page));
+        layout_warnings.extend(ocr_outcome.warnings);
+    }
     if options.low_confidence == LowConfidenceMode::Preserve {
         layout_warnings.extend(preserve_low_confidence_pages(
             input,

--- a/crates/bookforge-pdf/src/convert/rendering.rs
+++ b/crates/bookforge-pdf/src/convert/rendering.rs
@@ -1,5 +1,95 @@
 use super::*;
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct OcrPagesOutcome {
+    pub recovered: Vec<u32>,
+    pub warnings: Vec<String>,
+}
+
+pub(super) fn ocr_low_confidence_pages(
+    engine: &dyn OcrEngine,
+    render: &mut dyn FnMut(u32) -> Result<Vec<u8>>,
+    blocks: &mut Vec<AnchoredBlock>,
+    low_confidence_pages: &[u32],
+) -> OcrPagesOutcome {
+    let mut outcome = OcrPagesOutcome::default();
+    for page_number in low_confidence_pages {
+        let image = match render(*page_number) {
+            Ok(image) => image,
+            Err(error) => {
+                outcome.warnings.push(format!(
+                    "page {page_number}: OCR skipped because raster rendering failed: {error}"
+                ));
+                continue;
+            }
+        };
+        match engine.ocr_page(&image, *page_number) {
+            Ok(text) => {
+                replace_page_with_ocr_text(blocks, *page_number, &text);
+                outcome.recovered.push(*page_number);
+            }
+            Err(error) => outcome
+                .warnings
+                .push(format!("page {page_number}: OCR failed: {error}")),
+        }
+    }
+    outcome
+}
+
+fn replace_page_with_ocr_text(blocks: &mut Vec<AnchoredBlock>, page_number: u32, text: &str) {
+    let old_blocks = std::mem::take(blocks);
+    let mut insert_at = None;
+
+    for anchored in old_blocks {
+        if anchored.anchor.page == page_number {
+            insert_at.get_or_insert(blocks.len());
+            continue;
+        }
+        if anchored.anchor.page > page_number {
+            insert_at.get_or_insert(blocks.len());
+        }
+        blocks.push(anchored);
+    }
+
+    let insert_at = insert_at.unwrap_or(blocks.len());
+    let mut paragraphs = Vec::new();
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            if !lines.is_empty() {
+                paragraphs.push(lines.join("\n"));
+                lines.clear();
+            }
+        } else {
+            lines.push(line);
+        }
+    }
+    if !lines.is_empty() {
+        paragraphs.push(lines.join("\n"));
+    }
+
+    for (offset, paragraph) in paragraphs.into_iter().enumerate() {
+        blocks.insert(
+            insert_at + offset,
+            AnchoredBlock {
+                block: DocBlock::Paragraph {
+                    spans: vec![Span {
+                        text: paragraph,
+                        bold: false,
+                        italic: false,
+                    }],
+                },
+                anchor: BlockAnchor {
+                    page: page_number,
+                    top: i32::try_from(offset).unwrap_or(i32::MAX),
+                    left: 0,
+                    width: 1,
+                },
+            },
+        );
+    }
+}
+
 pub(super) fn preserve_low_confidence_pages(
     input: &Path,
     pages: &[Page],
@@ -342,4 +432,103 @@ fn audit_snippet(text: &str) -> String {
     let mut snippet = normalized.chars().take(LIMIT).collect::<String>();
     snippet.push_str("...");
     snippet
+}
+
+#[cfg(test)]
+mod ocr_tests {
+    use crate::ocr::MockOcrEngine;
+
+    use super::*;
+
+    fn paragraph(page: u32, text: &str) -> AnchoredBlock {
+        AnchoredBlock {
+            block: DocBlock::Paragraph {
+                spans: vec![Span {
+                    text: text.to_string(),
+                    bold: false,
+                    italic: false,
+                }],
+            },
+            anchor: BlockAnchor {
+                page,
+                top: 10,
+                left: 10,
+                width: 100,
+            },
+        }
+    }
+
+    #[test]
+    fn successful_ocr_replaces_page_with_paragraphs() {
+        let engine = MockOcrEngine::success("First OCR paragraph.\n\nSecond OCR paragraph.");
+        let mut blocks = vec![paragraph(1, "garbage"), paragraph(2, "keep")];
+        let mut rendered = Vec::new();
+        let outcome = ocr_low_confidence_pages(
+            &engine,
+            &mut |page| {
+                rendered.push(page);
+                Ok(vec![1, 2, 3])
+            },
+            &mut blocks,
+            &[1],
+        );
+
+        assert_eq!(rendered, vec![1]);
+        assert_eq!(outcome.recovered, vec![1]);
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(
+            blocks
+                .iter()
+                .map(|block| block.block.text())
+                .collect::<Vec<_>>(),
+            vec!["First OCR paragraph.", "Second OCR paragraph.", "keep"]
+        );
+        assert_eq!(blocks[0].anchor.top, 0);
+        assert_eq!(blocks[1].anchor.top, 1);
+    }
+
+    #[test]
+    fn failed_ocr_leaves_page_blocks_intact_and_warns() {
+        let engine = MockOcrEngine::failure("offline");
+        let mut blocks = vec![paragraph(3, "original")];
+        let outcome =
+            ocr_low_confidence_pages(&engine, &mut |_page| Ok(vec![1, 2, 3]), &mut blocks, &[3]);
+
+        assert!(outcome.recovered.is_empty());
+        assert_eq!(blocks[0].block.text(), "original");
+        assert!(outcome.warnings[0].contains("page 3: OCR failed"));
+        assert!(outcome.warnings[0].contains("offline"));
+    }
+
+    #[test]
+    fn recovered_pages_are_excluded_from_later_preservation() {
+        let engine = MockOcrEngine::success("Recovered");
+        let mut blocks = vec![paragraph(1, "bad one"), paragraph(2, "bad two")];
+        let outcome =
+            ocr_low_confidence_pages(&engine, &mut |_page| Ok(vec![1, 2, 3]), &mut blocks, &[1]);
+        let mut preserve_pages = vec![1, 2];
+        preserve_pages.retain(|page| !outcome.recovered.contains(page));
+
+        for page in preserve_pages {
+            replace_page_with_preserved_image(
+                &mut blocks,
+                page,
+                ImageAsset {
+                    id: "preserved".to_string(),
+                    href: "images/preserved.png".to_string(),
+                    media_type: "image/png".to_string(),
+                    bytes: vec![1],
+                    page,
+                    top: Some(0),
+                    left: Some(0),
+                    width: Some(1),
+                    height: Some(1),
+                },
+            );
+        }
+
+        assert!(matches!(blocks[0].block, DocBlock::Paragraph { .. }));
+        assert_eq!(blocks[0].block.text(), "Recovered");
+        assert!(matches!(blocks[1].block, DocBlock::Figure { .. }));
+    }
 }

--- a/crates/bookforge-pdf/src/convert/tests.rs
+++ b/crates/bookforge-pdf/src/convert/tests.rs
@@ -860,7 +860,7 @@ exit 9
         pdftoppm: Some(pdftoppm),
     };
 
-    let result = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools);
+    let result = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None);
 
     assert!(result.is_err());
     assert!(
@@ -903,7 +903,7 @@ XML
         pdftoppm: None,
     };
 
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed without optional image tools");
 
     assert!(output.exists());
@@ -974,7 +974,7 @@ printf 'Paper Title\nFigure 1. A test image.\nBody text after the figure.\n'
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.images, 1);
@@ -1039,7 +1039,7 @@ fn convert_pdf_snaps_figure_crop_above_caption_boundary_fixture() {
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.images, 2);
@@ -1108,7 +1108,7 @@ fn convert_pdf_groups_multipanel_figure_fixture_as_one_captioned_crop() {
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.images, 2);
@@ -1164,7 +1164,7 @@ fn convert_pdf_preserves_vector_chart_fixture_as_captioned_crop() {
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.images, 0);
@@ -1238,7 +1238,7 @@ printf 'This paragraph\ncontinues after the figure.\n'
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert!(
@@ -1308,7 +1308,7 @@ printf 'Body before table.\nTable 1. Scores.\nMetric 2019 2020\nA 0.91 0.93\nB 0
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.tables, 1);
@@ -1403,7 +1403,7 @@ printf 'Body before equation.\nE = mc^2\nBody after equation.\n'
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.tables, 0);
@@ -1477,7 +1477,7 @@ printf 'The energy term E = mc^2 appears inline.\n'
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     let book = bookforge_epub::read_epub(&output).expect("converted EPUB should be readable");
@@ -1522,7 +1522,7 @@ fn convert_pdf_does_not_crop_model_parameter_prose_as_equation() {
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.tables, 0);
@@ -1586,7 +1586,7 @@ printf 'Tiny plus many baseline characters that the XML reconstruction did not r
         pdfimages: Some(pdfimages),
         pdftoppm: Some(pdftoppm),
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &ConvertOptions::default(), &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.low_confidence_pages, 1);
@@ -1666,7 +1666,7 @@ printf 'Tiny plus many baseline characters that the XML reconstruction did not r
         low_confidence: LowConfidenceMode::Preserve,
         ..ConvertOptions::default()
     };
-    let outcome = convert_pdf_with_tools(&input, &output, &options, &tools)
+    let outcome = convert_pdf_with_tools(&input, &output, &options, &tools, None)
         .expect("conversion should succeed");
 
     assert_eq!(outcome.report.low_confidence_pages, 1);

--- a/crates/bookforge-pdf/src/lib.rs
+++ b/crates/bookforge-pdf/src/lib.rs
@@ -10,15 +10,17 @@
 pub mod convert;
 pub mod epub;
 pub mod model;
+pub mod ocr;
 pub mod parse;
 pub mod reconstruct;
 pub mod report;
 pub mod tools;
 
-pub use convert::{ConvertOptions, ConvertOutcome, convert_pdf};
+pub use convert::{ConvertOptions, ConvertOutcome, convert_pdf, convert_pdf_with_ocr};
 pub use model::{
     ColumnMode, DocBlock, ImageAsset, ImageRegion, Line, LowConfidenceMode, Page, Span,
 };
+pub use ocr::{HttpOcrClient, OcrConfig, OcrDialect, OcrEngine, OcrError};
 pub use parse::parse_pdf2xml;
 pub use reconstruct::reconstruct;
 pub use report::ConversionReport;
@@ -40,6 +42,9 @@ pub enum PdfError {
 
     #[error("zip: {0}")]
     Zip(#[from] zip::result::ZipError),
+
+    #[error("OCR: {0}")]
+    Ocr(#[from] ocr::OcrError),
 }
 
 pub type Result<T> = std::result::Result<T, PdfError>;

--- a/crates/bookforge-pdf/src/ocr.rs
+++ b/crates/bookforge-pdf/src/ocr.rs
@@ -1,0 +1,500 @@
+//! OCR engines used to recover PDF pages whose text reconstruction is weak.
+
+use std::{sync::Once, thread, time::Duration};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use reqwest::{
+    Url,
+    blocking::{Client, RequestBuilder},
+    header::{HeaderMap, RETRY_AFTER},
+};
+use serde_json::{Value, json};
+
+static UNLIMITED_OCR_NO_PROCESSOR_WARNING: Once = Once::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OcrDialect {
+    OpenAiCompatible,
+    UnlimitedOcr,
+}
+
+#[derive(Debug, Clone)]
+pub struct OcrConfig {
+    pub base_url: String,
+    pub dialect: OcrDialect,
+    pub api_key_env: String,
+    pub model: String,
+    pub prompt: String,
+    pub image_mode: String,
+    pub ngram_size: u32,
+    pub window_size: u32,
+    pub logit_processor: Option<String>,
+    pub timeout_seconds: u64,
+    pub max_attempts: usize,
+}
+
+impl OcrConfig {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            dialect: OcrDialect::OpenAiCompatible,
+            api_key_env: "OCR_API_KEY".to_string(),
+            model: "baidu/Unlimited-OCR".to_string(),
+            prompt: "document parsing.".to_string(),
+            image_mode: "gundam".to_string(),
+            ngram_size: 35,
+            window_size: 90,
+            logit_processor: None,
+            timeout_seconds: 120,
+            max_attempts: 3,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OcrError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("OCR provider error: {0}")]
+    Provider(String),
+
+    #[error("OCR API key environment variable '{0}' is not set")]
+    MissingKey(String),
+
+    #[error("invalid OCR response: {0}")]
+    InvalidResponse(String),
+}
+
+pub trait OcrEngine: Send + Sync {
+    fn ocr_page(&self, image_png: &[u8], page_number: u32) -> Result<String, OcrError>;
+}
+
+/// Blocking HTTP OCR client.
+///
+/// This client MUST NOT run on an async runtime thread because
+/// `reqwest::blocking` can panic there. Async callers should use
+/// `tokio::task::spawn_blocking`.
+#[derive(Clone)]
+pub struct HttpOcrClient {
+    config: OcrConfig,
+    client: Client,
+}
+
+impl HttpOcrClient {
+    pub fn new(config: OcrConfig) -> Result<Self, OcrError> {
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(config.timeout_seconds))
+            .pool_idle_timeout(Duration::from_secs(90))
+            .tcp_keepalive(Duration::from_secs(60))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        Ok(Self { config, client })
+    }
+
+    pub fn health_check(&self) -> Result<Vec<String>, OcrError> {
+        let endpoint = endpoint(&self.config.base_url, "models");
+        let api_key = api_key_for_request(&self.config)?;
+        let payload = send_with_retry_blocking(self.config.max_attempts, || {
+            let request = self.client.get(&endpoint);
+            with_api_key(request, api_key.as_deref())
+        })?;
+        parse_models_response(&payload)
+    }
+}
+
+impl OcrEngine for HttpOcrClient {
+    fn ocr_page(&self, image_png: &[u8], _page_number: u32) -> Result<String, OcrError> {
+        let endpoint = endpoint(&self.config.base_url, "chat/completions");
+        let body = ocr_request_body(&self.config, image_png);
+        let api_key = api_key_for_request(&self.config)?;
+        let payload = send_with_retry_blocking(self.config.max_attempts, || {
+            let request = self.client.post(&endpoint).json(&body);
+            with_api_key(request, api_key.as_deref())
+        })?;
+        parse_ocr_response(&payload)
+    }
+}
+
+fn endpoint(base_url: &str, suffix: &str) -> String {
+    format!("{}/{}", base_url.trim_end_matches('/'), suffix)
+}
+
+fn with_api_key(request: RequestBuilder, api_key: Option<&str>) -> RequestBuilder {
+    match api_key {
+        Some(key) => request.bearer_auth(key),
+        None => request,
+    }
+}
+
+fn api_key_for_request(config: &OcrConfig) -> Result<Option<String>, OcrError> {
+    match std::env::var(&config.api_key_env) {
+        Ok(value) if !value.trim().is_empty() => Ok(Some(value)),
+        _ if base_url_is_loopback(&config.base_url) => Ok(None),
+        _ => Err(OcrError::MissingKey(config.api_key_env.clone())),
+    }
+}
+
+fn base_url_is_loopback(base_url: &str) -> bool {
+    Url::parse(base_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
+}
+
+fn ocr_request_body(config: &OcrConfig, image_png: &[u8]) -> Value {
+    let encoded = STANDARD.encode(image_png);
+    let mut body = json!({
+        "model": config.model,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": format!("data:image/png;base64,{encoded}")}
+                },
+                {"type": "text", "text": config.prompt}
+            ]
+        }]
+    });
+
+    if config.dialect == OcrDialect::UnlimitedOcr {
+        body["images_config"] = json!({"image_mode": config.image_mode});
+        body["custom_params"] = json!({
+            "ngram_size": config.ngram_size,
+            "window_size": config.window_size,
+        });
+        if let Some(processor) = &config.logit_processor {
+            body["custom_logit_processor"] = Value::String(processor.clone());
+        } else {
+            UNLIMITED_OCR_NO_PROCESSOR_WARNING.call_once(|| {
+                tracing::warn!(
+                    "Unlimited-OCR is configured without a custom logit processor; dense pages may hit repetition loops"
+                );
+            });
+        }
+    }
+
+    body
+}
+
+fn parse_ocr_response(bytes: &[u8]) -> Result<String, OcrError> {
+    let value: Value = serde_json::from_slice(bytes).map_err(|error| {
+        OcrError::InvalidResponse(format!("response body is not valid JSON: {error}"))
+    })?;
+    if let Some(error) = value.get("error") {
+        let detail = error
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| error.to_string());
+        return Err(OcrError::Provider(detail));
+    }
+
+    let content = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .ok_or_else(|| {
+            OcrError::InvalidResponse("missing choices[0].message.content".to_string())
+        })?;
+
+    let text = if let Some(text) = content.as_str() {
+        text.to_string()
+    } else if let Some(parts) = content.as_array() {
+        parts
+            .iter()
+            .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("")
+    } else {
+        return Err(OcrError::InvalidResponse(
+            "choices[0].message.content must be a string or an array of text parts".to_string(),
+        ));
+    };
+    if text.trim().is_empty() {
+        return Err(OcrError::InvalidResponse(
+            "choices[0].message.content contains no text".to_string(),
+        ));
+    }
+    Ok(text)
+}
+
+fn parse_models_response(bytes: &[u8]) -> Result<Vec<String>, OcrError> {
+    let value: Value = serde_json::from_slice(bytes).map_err(|error| {
+        OcrError::InvalidResponse(format!("models response is not valid JSON: {error}"))
+    })?;
+    if let Some(error) = value.get("error") {
+        return Err(OcrError::Provider(
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown provider error")
+                .to_string(),
+        ));
+    }
+    let entries = value
+        .get("data")
+        .and_then(Value::as_array)
+        .or_else(|| value.as_array())
+        .ok_or_else(|| {
+            OcrError::InvalidResponse(
+                "models response must be an array or contain a 'data' array".to_string(),
+            )
+        })?;
+    Ok(entries
+        .iter()
+        .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect())
+}
+
+fn send_with_retry_blocking<F>(max_attempts: usize, build_request: F) -> Result<Vec<u8>, OcrError>
+where
+    F: Fn() -> RequestBuilder,
+{
+    let max_attempts = max_attempts.max(1);
+    let mut last_error = None;
+    for attempt in 0..max_attempts {
+        match build_request().send() {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    let bytes = response.bytes()?;
+                    if !bytes.is_empty() {
+                        return Ok(bytes.to_vec());
+                    }
+                    last_error = Some(OcrError::Provider(
+                        "provider returned an empty response body".to_string(),
+                    ));
+                } else {
+                    let retryable = status.is_server_error() || status.as_u16() == 429;
+                    let retry_after = retry_after_delay(response.headers());
+                    let detail = response.text().unwrap_or_default();
+                    let detail = detail.chars().take(300).collect::<String>();
+                    last_error = Some(OcrError::Provider(format!("HTTP {status}: {detail}")));
+                    if !retryable {
+                        break;
+                    }
+                    if attempt + 1 < max_attempts
+                        && let Some(delay) = retry_after
+                    {
+                        thread::sleep(delay);
+                        continue;
+                    }
+                }
+            }
+            Err(error) => {
+                let retryable = error.is_timeout() || error.is_connect();
+                last_error = Some(OcrError::Http(error));
+                if !retryable {
+                    break;
+                }
+            }
+        }
+
+        if attempt + 1 < max_attempts {
+            let exponential = 500u64.saturating_mul(1u64 << attempt.min(6));
+            let jitter = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |duration| u64::from(duration.subsec_millis()) % 251);
+            thread::sleep(Duration::from_millis(exponential.saturating_add(jitter)));
+        }
+    }
+    Err(last_error.unwrap_or_else(|| OcrError::Provider("no attempts were made".to_string())))
+}
+
+fn retry_after_delay(headers: &HeaderMap) -> Option<Duration> {
+    headers
+        .get(RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(|seconds| Duration::from_secs(seconds.min(300)))
+}
+
+#[cfg(test)]
+pub(crate) struct MockOcrEngine {
+    result: Result<String, String>,
+}
+
+#[cfg(test)]
+impl MockOcrEngine {
+    pub(crate) fn success(text: impl Into<String>) -> Self {
+        Self {
+            result: Ok(text.into()),
+        }
+    }
+
+    pub(crate) fn failure(message: impl Into<String>) -> Self {
+        Self {
+            result: Err(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl OcrEngine for MockOcrEngine {
+    fn ocr_page(&self, _image_png: &[u8], _page_number: u32) -> Result<String, OcrError> {
+        self.result.clone().map_err(OcrError::Provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+        time::Duration,
+    };
+
+    use super::*;
+
+    fn one_request_server(response_body: &str) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("mock listener");
+        let address = listener.local_addr().expect("mock address");
+        let response_body = response_body.as_bytes().to_vec();
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("mock accept");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("read timeout");
+            let mut request = Vec::new();
+            let mut scratch = [0u8; 4096];
+            loop {
+                let read = stream.read(&mut scratch).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&scratch[..read]);
+                let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]).to_ascii_lowercase();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length:"))
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response_body.len()
+            );
+            stream.write_all(response.as_bytes()).expect("headers");
+            stream.write_all(&response_body).expect("body");
+            sender
+                .send(String::from_utf8_lossy(&request).into_owned())
+                .expect("captured request");
+        });
+        (format!("http://{address}/v1"), receiver)
+    }
+
+    #[test]
+    fn openai_body_has_only_standard_fields() {
+        let config = OcrConfig::new("http://localhost:10000/v1");
+        let body = ocr_request_body(&config, b"png");
+        assert_eq!(body["model"], "baidu/Unlimited-OCR");
+        assert_eq!(
+            body["messages"][0]["content"][1]["text"],
+            "document parsing."
+        );
+        assert!(
+            body["messages"][0]["content"][0]["image_url"]["url"]
+                .as_str()
+                .unwrap()
+                .starts_with("data:image/png;base64,")
+        );
+        assert!(body.get("images_config").is_none());
+        assert!(body.get("custom_params").is_none());
+        assert!(body.get("custom_logit_processor").is_none());
+    }
+
+    #[test]
+    fn unlimited_body_adds_dialect_fields_and_optional_processor() {
+        let mut config = OcrConfig::new("http://localhost:10000/v1");
+        config.dialect = OcrDialect::UnlimitedOcr;
+        let without = ocr_request_body(&config, b"png");
+        assert_eq!(without["images_config"]["image_mode"], "gundam");
+        assert_eq!(without["custom_params"]["ngram_size"], 35);
+        assert_eq!(without["custom_params"]["window_size"], 90);
+        assert!(without.get("custom_logit_processor").is_none());
+
+        config.logit_processor = Some("processor-blob".to_string());
+        let with = ocr_request_body(&config, b"png");
+        assert_eq!(with["custom_logit_processor"], "processor-blob");
+    }
+
+    #[test]
+    fn parses_string_and_text_part_content() {
+        assert_eq!(
+            parse_ocr_response(br#"{"choices":[{"message":{"content":"hello"}}]}"#).unwrap(),
+            "hello"
+        );
+        assert_eq!(
+            parse_ocr_response(
+                br#"{"choices":[{"message":{"content":[{"type":"text","text":"hello "},{"type":"image_url","url":"ignored"},{"type":"text","text":"world"}]}}]}"#
+            )
+            .unwrap(),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn reports_error_bodies_and_missing_choices() {
+        let error = parse_ocr_response(br#"{"error":{"message":"bad image"}}"#).unwrap_err();
+        assert!(error.to_string().contains("bad image"));
+        let missing = parse_ocr_response(br#"{"id":"response"}"#).unwrap_err();
+        assert!(missing.to_string().contains("choices[0].message.content"));
+    }
+
+    #[test]
+    fn tcp_round_trip_uses_path_and_authorization() {
+        let (base_url, captured) =
+            one_request_server(r#"{"choices":[{"message":{"content":"OCR text"}}]}"#);
+        let key_env = "BOOKFORGE_OCR_TEST_ROUND_TRIP_KEY";
+        unsafe { std::env::set_var(key_env, "secret") };
+        let mut config = OcrConfig::new(base_url);
+        config.api_key_env = key_env.to_string();
+        config.max_attempts = 1;
+        let client = HttpOcrClient::new(config).unwrap();
+        assert_eq!(client.ocr_page(b"png", 1).unwrap(), "OCR text");
+        unsafe { std::env::remove_var(key_env) };
+
+        let request = captured.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(request.starts_with("POST /v1/chat/completions HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer secret")
+        );
+    }
+
+    #[test]
+    fn loopback_succeeds_without_api_key() {
+        let (base_url, captured) =
+            one_request_server(r#"{"choices":[{"message":{"content":"local OCR"}}]}"#);
+        let key_env = "BOOKFORGE_OCR_TEST_UNSET_LOOPBACK_KEY";
+        unsafe { std::env::remove_var(key_env) };
+        let mut config = OcrConfig::new(base_url);
+        config.api_key_env = key_env.to_string();
+        config.max_attempts = 1;
+        let client = HttpOcrClient::new(config).unwrap();
+        assert_eq!(client.ocr_page(b"png", 9).unwrap(), "local OCR");
+
+        let request = captured.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(!request.to_ascii_lowercase().contains("authorization:"));
+    }
+}

--- a/crates/bookforge-pdf/src/report.rs
+++ b/crates/bookforge-pdf/src/report.rs
@@ -31,6 +31,7 @@ pub struct ConversionReport {
     pub tables: usize,
     pub equations: usize,
     pub low_confidence_pages: usize,
+    pub ocr_pages: usize,
     pub page_stats: Vec<PageStats>,
     pub warnings: Vec<String>,
 }
@@ -100,6 +101,10 @@ impl ConversionReport {
             tables: metrics.tables,
             equations: metrics.equations,
             low_confidence_pages: page_stats.iter().filter(|page| page.low_confidence).count(),
+            ocr_pages: page_stats
+                .iter()
+                .filter(|page| page.low_confidence_action.as_deref() == Some("ocr"))
+                .count(),
             page_stats,
             warnings,
         }
@@ -107,7 +112,7 @@ impl ConversionReport {
 
     pub fn summary(&self) -> String {
         let mut out = format!(
-            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nTables: {} crop(s)\nEquations: {} crop(s)\nLow-confidence pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed + {} preserved as images / {} baseline characters)\n",
+            "Pages: {}\nBlocks: {}\nTwo-column pages: {}\nImages: {} extracted, {} figure block(s)\nTables: {} crop(s)\nEquations: {} crop(s)\nLow-confidence pages: {}\nOCR-recovered pages: {}\nText coverage vs pdftotext: {:.1}% ({} reconstructed + {} preserved as images / {} baseline characters)\n",
             self.pages,
             self.blocks,
             self.two_column_pages,
@@ -116,6 +121,7 @@ impl ConversionReport {
             self.tables,
             self.equations,
             self.low_confidence_pages,
+            self.ocr_pages,
             self.coverage_percent,
             self.reconstructed_chars,
             self.media_preserved_chars,
@@ -273,6 +279,37 @@ mod tests {
                     && warning.contains("action=preserve"))
         );
         assert!(report.summary().contains("Low-confidence pages: 1"));
+    }
+
+    #[test]
+    fn ocr_recovered_pages_are_counted_and_summarized() {
+        let report = ConversionReport::build(
+            "in.pdf",
+            "out.epub",
+            vec![PageStats {
+                page: 4,
+                lines: 1,
+                chars: 4,
+                baseline_chars: 100,
+                two_column: false,
+                low_confidence: true,
+                low_confidence_action: Some("ocr".to_string()),
+            }],
+            ReportMetrics {
+                blocks: 1,
+                reconstructed_chars: 4,
+                media_preserved_chars: 0,
+                baseline_chars: 100,
+                images: 0,
+                figures: 0,
+                tables: 0,
+                equations: 0,
+                layout_warnings: Vec::new(),
+            },
+        );
+
+        assert_eq!(report.ocr_pages, 1);
+        assert!(report.summary().contains("OCR-recovered pages: 1"));
     }
 
     #[test]

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -78,8 +78,13 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
 
 - **`elevenlabs`** - ElevenLabs' native text-to-speech API, authenticated with
   `ELEVENLABS_API_KEY` by default. Pass an ElevenLabs voice ID with `--voice`;
-  voice names are not interchangeable with IDs. The default model is
-  `eleven_multilingual_v2`. Supported outputs are MP3, Opus, WAV, and PCM.
+  voice names are not interchangeable with IDs. When `--model` is omitted on
+  a live run, BookForge checks the account's available TTS models and selects
+  the first compatible model in this order: `eleven_v3`,
+  `eleven_flash_v2_5`, `eleven_turbo_v2_5`, then
+  `eleven_multilingual_v2`. An explicit `--model` bypasses auto-selection. A
+  dry run stays offline and reports the static `eleven_multilingual_v2`
+  default instead. Supported outputs are MP3, Opus, WAV, and PCM.
 
   ```bash
   bookforge audiobook book.epub --provider elevenlabs \
@@ -89,8 +94,9 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
 
   ElevenLabs does not expose a free-form instructions field on this endpoint.
   Configure the selected voice in ElevenLabs, use `--speed`, or place
-  model-supported audio tags directly in the source text. BookForge enforces
-  the selected model's per-request character limit.
+  model-supported audio tags directly in the source text. `eleven_v3` does not
+  support speed control on the TTS endpoint, so it requires `--speed 1.0`.
+  BookForge enforces the selected model's per-request character limit.
 
 - **`mock`** — a deterministic, offline provider that emits valid silent WAV
   clips scaled to the text length. Its format is always `wav`; BookForge uses

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -18,8 +18,8 @@ the local browser dashboard started by `bookforge serve`.
    skipped — you do not want a table of contents read aloud. Inline markers
    are stripped so the narrator hears clean prose.
 3. **Chunk** each chapter on sentence boundaries into pieces under
-   `--max-chars` (default 2000; OpenAI's hard limit is 4096). Chunking is a
-   pure function of the text, so a resumed run re-derives the exact same
+   `--max-chars` (default 2000; the maximum is provider-specific). Chunking is
+   a pure function of the text, so a resumed run re-derives the exact same
    chunks.
 4. **Synthesize** each chunk through the TTS provider, `--concurrency` at a
    time, writing `chapter-NNN-part-NNN-<hash>.<ext>` atomically (temp file then
@@ -89,7 +89,8 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
 
   ElevenLabs does not expose a free-form instructions field on this endpoint.
   Configure the selected voice in ElevenLabs, use `--speed`, or place
-  model-supported audio tags directly in the source text.
+  model-supported audio tags directly in the source text. BookForge enforces
+  the selected model's per-request character limit.
 
 - **`mock`** — a deterministic, offline provider that emits valid silent WAV
   clips scaled to the text length. Its format is always `wav`; BookForge uses
@@ -135,6 +136,10 @@ completed chunk files remain available for a resumed stitch.
 
 - Hosted OpenAI speech requests are capped at 4096 input characters; BookForge
   rejects a larger `--max-chars` value for that endpoint.
+- ElevenLabs limits are model-specific: 40,000 input characters for Flash and
+  Turbo v2.5, 10,000 for Multilingual v2, and 5,000 for Eleven v3. The CLI and
+  dashboard reject larger values, and the provider checks the final request as
+  a last line of defense.
 - Gemini TTS supports WAV and raw PCM in BookForge. ElevenLabs supports MP3,
   Opus, WAV, and raw PCM; some high-sample-rate formats require a qualifying
   ElevenLabs plan.

--- a/docs/pdf-ocr.md
+++ b/docs/pdf-ocr.md
@@ -1,0 +1,85 @@
+# OCR recovery for PDF conversion
+
+`bookforge convert --ocr-endpoint <BASE_URL>` sends only low-confidence PDF
+pages to an OpenAI-compatible vision endpoint. BookForge first renders each
+page as PNG, then replaces that page's weak reconstructed blocks with the OCR
+response. The conversion report keeps the page marked low-confidence but
+records `action=ocr` and includes it in `OCR-recovered pages`. If OCR fails,
+the configured `--low-confidence` behavior still applies.
+
+OCR output is inserted as plain paragraphs split at blank lines. A model may
+return Markdown; BookForge currently preserves it as raw text. Markdown-aware
+post-processing is deferred.
+
+Loopback endpoints (`localhost`, `127.0.0.1`, or `::1`) do not need an API key.
+For remote endpoints, set `OCR_API_KEY`, or name another environment variable
+with `--ocr-api-key-env`.
+
+## Recommended SGLang setup for Unlimited-OCR
+
+The model card's tested SGLang path uses its development wheel and the matching
+kernels release. From the Unlimited-OCR checkout or release bundle:
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install wheel/sglang-0.0.0.dev11416+g92e8bb79e-py3-none-any.whl
+uv pip install kernels==0.11.7
+```
+
+Launch the server with custom logit processors enabled:
+
+```bash
+python -m sglang.launch_server \
+  --model baidu/Unlimited-OCR \
+  --served-model-name Unlimited-OCR \
+  --attention-backend fa3 \
+  --page-size 1 \
+  --mem-fraction-static 0.8 \
+  --context-length 32768 \
+  --enable-custom-logit-processor \
+  --disable-overlap-schedule \
+  --skip-server-warmup \
+  --host 0.0.0.0 \
+  --port 10000
+```
+
+Generate the serialized Python-side processor value in the same environment:
+
+```bash
+python scripts/unlimited-ocr-logit-processor.py > unlimited-ocr-processor.txt
+```
+
+Then convert with the Unlimited-OCR dialect:
+
+```bash
+bookforge convert scan.pdf --out scan.epub \
+  --ocr-endpoint http://127.0.0.1:10000/v1 \
+  --ocr-dialect unlimited-ocr \
+  --ocr-model Unlimited-OCR \
+  --ocr-image-mode gundam \
+  --ocr-logit-processor unlimited-ocr-processor.txt
+```
+
+The dialect always sends `images_config` and the default custom parameters
+`ngram_size=35` and `window_size=90`. The serialized processor blob is passed
+through verbatim. Omitting it is supported, but dense pages may enter
+repetition loops.
+
+## vLLM alternative
+
+Unlimited-OCR also has a plain OpenAI-compatible vLLM recipe. Point BookForge
+at its `/v1` base URL and keep the default `openai` dialect:
+
+```bash
+bookforge convert scan.pdf --out scan.epub \
+  --ocr-endpoint http://127.0.0.1:8000/v1 \
+  --ocr-dialect openai \
+  --ocr-model baidu/Unlimited-OCR
+```
+
+This path works without SGLang's custom fields, but dense pages have a greater
+risk of repetition loops because n-gram suppression is unavailable.
+
+Use `bookforge doctor --ocr-endpoint http://127.0.0.1:10000/v1` to verify that
+the endpoint is reachable and list its reported model IDs.

--- a/scripts/unlimited-ocr-logit-processor.py
+++ b/scripts/unlimited-ocr-logit-processor.py
@@ -1,0 +1,26 @@
+"""Print Unlimited-OCR's serialized SGLang logit processor.
+
+Usage:
+    python scripts/unlimited-ocr-logit-processor.py > unlimited-ocr-processor.txt
+"""
+
+try:
+    from sglang.srt.sampling.custom_logit_processor import (
+        DeepseekOCRNoRepeatNGramLogitProcessor,
+    )
+except ModuleNotFoundError as error:
+    if error.name == "sglang" or (error.name and error.name.startswith("sglang.")):
+        raise SystemExit(
+            "sglang is not installed; activate the Unlimited-OCR SGLang environment "
+            "and install the model-card development wheel first"
+        ) from error
+    raise
+except ImportError as error:
+    raise SystemExit(
+        "the installed sglang build does not provide "
+        "DeepseekOCRNoRepeatNGramLogitProcessor; install the development wheel "
+        "recommended by baidu/Unlimited-OCR"
+    ) from error
+
+
+print(DeepseekOCRNoRepeatNGramLogitProcessor.to_str())


### PR DESCRIPTION
## Summary

Three work streams:

### 1. Chapter extraction + provider limit hardening (`ceb84b53`)
Per-model ElevenLabs character limits enforced CLI/dashboard/provider-side; Toki Pona and PDF-derived chapter labeling fixes.

### 2. ElevenLabs model auto-selection (`cae960d3`)
- Live `audiobook` runs without `--model` now query `GET /v1/models` and pick the first available TTS-capable model in the preference order **eleven_v3 → eleven_flash_v2_5 → eleven_turbo_v2_5 → eleven_multilingual_v2**, filtered by `--max-chars` compatibility and speed-control needs.
- Preflight failure degrades gracefully: warning + the old `eleven_multilingual_v2` default, so offline/CI behavior is unchanged. Explicit `--model` bypasses preflight; `--dry-run` stays offline.
- `voice_settings` is omitted at the default speed; `eleven_v3` + non-default `--speed` is rejected early in both CLI and dashboard. Dashboard model list reordered (default unchanged).

### 3. OCR endpoint foundations for `convert` (`afcfe988`)
- New dialect-aware OCR client in `bookforge-pdf::ocr`: `openai` (plain OpenAI-compatible) and `unlimited-ocr` (adds the SGLang `images_config`/`custom_params` fields and passes through a serialized `custom_logit_processor` blob, per the baidu/Unlimited-OCR model card).
- Low-confidence pages are rendered and OCR'd; recovered pages replace their garbled blocks, skip preserve/linearize, and are reported as `action=ocr` + `ocr_pages`.
- New flags: `convert --ocr-endpoint/--ocr-dialect/--ocr-model/--ocr-api-key-env/--ocr-prompt/--ocr-image-mode/--ocr-logit-processor`; `doctor --ocr-endpoint` health check; `docs/pdf-ocr.md`; `scripts/unlimited-ocr-logit-processor.py`.

## Live end-to-end validation
Full pipeline exercised for real: marxists.org HTML → EPUB3 (Lenin, *What Is To Be Done?*, 447k chars) → DeepSeek EN→IT translation (50/50 requests OK, validated output) → ElevenLabs audiobook of the trimmed *Che fare* edition. **Auto-selection picked `eleven_v3` live**; 11/11 chunks synthesized, 4-chapter m4b (18.2 min) with correct markers; resume re-run was a full cache hit (0 re-synthesized). Live `/v1/models` response shape matches the resolver's parsing.

## Test plan
- `cargo test --workspace`: 700 tests, all green (includes new resolver unit tests, CLI integration tests, OCR unit/pipeline/report tests, and `doctor_ocr` integration test — all offline and Windows-friendly).
- Live E2E as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)