### PR TITLE
test: fix flaky Windows CI (collision-proof temp_path)

### DIFF
--- a/crates/bookforge-cli/src/checkpoint.rs
+++ b/crates/bookforge-cli/src/checkpoint.rs
@@ -334,12 +334,18 @@ mod tests {
     }
 
     fn temp_path(name: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let nanos = SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
+        // Counter disambiguates calls that share a timestamp (the clock is
+        // coarse on some platforms), keeping parallel tests off each other's
+        // temp files.
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "bookforge-chk-test-{}-{nanos}-{name}",
+            "bookforge-chk-test-{}-{nanos}-{seq}-{name}",
             std::process::id()
         ))
     }

--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -636,12 +636,17 @@ fn segment(id: &str, ordinal: usize) -> Segment {
 }
 
 fn temp_path(name: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
+    // Counter disambiguates calls that share a timestamp (the clock is coarse
+    // on some platforms), keeping parallel tests off each other's temp files.
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!(
-        "bookforge-cli-test-{}-{nanos}-{name}",
+        "bookforge-cli-test-{}-{nanos}-{seq}-{name}",
         std::process::id()
     ))
 }

--- a/crates/bookforge-cli/src/performance.rs
+++ b/crates/bookforge-cli/src/performance.rs
@@ -415,12 +415,18 @@ mod tests {
     }
 
     fn temp_path(name: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
+        // Counter disambiguates calls that share a timestamp (the clock is
+        // coarse on some platforms), keeping parallel tests off each other's
+        // temp files.
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "bookforge-performance-test-{}-{nanos}-{name}",
+            "bookforge-performance-test-{}-{nanos}-{seq}-{name}",
             std::process::id()
         ))
     }

--- a/crates/bookforge-store/src/db/tests.rs
+++ b/crates/bookforge-store/src/db/tests.rs
@@ -188,10 +188,17 @@ fn segment(id: &str, ordinal: usize) -> Segment {
 }
 
 fn temp_path(name: &str) -> PathBuf {
+    // A per-call counter guarantees a unique path even when two parallel tests
+    // hit the same timestamp — the OS clock is coarse on some platforms
+    // (notably Windows), so pid + nanos alone can collide and let one test's
+    // cleanup race another's setup.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     std::env::temp_dir().join(format!(
-        "bookforge-store-test-{}-{}-{name}",
+        "bookforge-store-test-{}-{}-{}-{name}",
         std::process::id(),
-        unix_timestamp_nanos()
+        unix_timestamp_nanos(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
     ))
 }
 


### PR DESCRIPTION
## Problem
`test (windows-msvc)` intermittently fails on `main` — most recently `db::tests::cached_translation_prefers_repaired_succeeded_rows_over_cached_clones` (`bookforge-store`). It passes on re-run, the signature of a flake.

## Root cause
The four test `temp_path` helpers build names from `process_id + timestamp_nanos + name`. Several tests share fixed names (`input.epub`, `output.epub` via the seeded-store helper). Windows' timestamp clock is coarse, so two parallel tests can land on the **same nanos** and collide on one temp file — then one test's `remove_file` cleanup races another's `create_job`, which fails.

## Fix
Add a per-call `AtomicU64` counter to each helper (`bookforge-store` tests, plus `checkpoint`, `translate/tests`, and `performance` in `bookforge-cli`), so every path is unique within the process regardless of clock resolution — pid + nanos still give cross-process/time uniqueness.

Pure test-infrastructure change; no product code touched. `cargo fmt --check` clean; `bookforge-store` (35) and `bookforge-cli` (171) tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)