### PR TITLE
v3.0: audiobook narration quality + WebUI parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+- **Breaking:** existing audio chunk caches are invalidated by the
+  `bookforge-audio-v2` synthesis hash and manifest schema 3. The manifest adds
+  narration kind, seed, language, text-normalization, gaps, and author data
+  while retaining serde-defaulted backward reads. Rerun audiobook jobs with
+  `--prune` to remove superseded chunk files (`--prune --dry-run` previews the
+  cleanup).
+- Audiobook narration now preserves document hierarchy: chapter titles and
+  in-section headings are emitted as separate typed chunks instead of being
+  packed into body prose. Stitching adds configurable chapter, title/heading,
+  and paragraph silence (1200/800/0 ms by default), with automatic ElevenLabs
+  `<break>` tags on supported v2 models.
+- ElevenLabs synthesis now supplies up to 300 characters of same-chapter
+  `previous_text` and `next_text` for smoother joins, plus optional `--seed`,
+  `--language`, and `--text-normalization` controls. Language codes are sent
+  only to Flash/Turbo v2.5 and are warned-and-dropped for Multilingual v2 and
+  Eleven v3, whose APIs reject them.
+- A chaptered `audiobook.m4b` with chapter markers and title/author metadata is
+  now the default deliverable when ffmpeg is available; `--no-book-file` opts
+  out and `--single` adds a flat audio file for on-the-go listening. Added
+  configurable whole-book `--loudnorm` while leaving per-chapter files
+  unnormalized.
+- Added schema-1 per-character TTS pricing in
+  `pricing/audio-providers.json`, estimated dollar/credit cost in audiobook
+  plan and dry-run output, and a non-fatal ElevenLabs subscription-quota
+  preflight. Added one-based chapter subset selection with `--chapters` and
+  ElevenLabs account voice discovery with `--list-voices`.
+- Brought the browser audiobook workflow to CLI parity: ElevenLabs now offers
+  `Auto (recommended)` model selection and a server-side voice-list proxy at
+  `GET /api/audio/voices`; pre-launch estimates from
+  `POST /api/audiobook/estimate` include cost and quota; progress is grouped by
+  chapter; and completed `.m4b` files can be played in-page. An Advanced
+  section exposes chapter pause, flat-file output, loudness normalization,
+  seed, and language.
 - Added optional OCR recovery for low-confidence PDF pages through
   OpenAI-compatible endpoints, including the SGLang-specific Unlimited-OCR
   dialect, retrying blocking HTTP client, `action=ocr` reporting, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.6.0 - 2026-07-21
+
 - **Breaking:** existing audio chunk caches are invalidated by the
   `bookforge-audio-v2` synthesis hash and manifest schema 3. The manifest adds
   narration kind, seed, language, text-normalization, gaps, and author data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,18 @@
 - ElevenLabs synthesis now supplies up to 300 characters of same-chapter
   `previous_text` and `next_text` for smoother joins, plus optional `--seed`,
   `--language`, and `--text-normalization` controls. Language codes are sent
-  only to Flash/Turbo v2.5 and are warned-and-dropped for Multilingual v2 and
-  Eleven v3, whose APIs reject them.
-- A chaptered `audiobook.m4b` with chapter markers and title/author metadata is
+  only to Flash/Turbo v2.5 and are warned-and-dropped for every other model or
+  provider.
+- A chaptered `audiobook.m4b` with chapter markers and title/artist metadata is
   now the default deliverable when ffmpeg is available; `--no-book-file` opts
   out and `--single` adds a flat audio file for on-the-go listening. Added
   configurable whole-book `--loudnorm` while leaving per-chapter files
   unnormalized.
 - Added schema-1 per-character TTS pricing in
-  `pricing/audio-providers.json`, estimated dollar/credit cost in audiobook
-  plan and dry-run output, and a non-fatal ElevenLabs subscription-quota
-  preflight. Added one-based chapter subset selection with `--chapters` and
+  `crates/bookforge-cli/pricing/audio-providers.json`, estimated dollar/credit
+  cost in audiobook plan and dry-run output, and a non-fatal ElevenLabs
+  subscription-quota preflight. Pricing figures are estimates; provider billing
+  is authoritative. Added one-based chapter subset selection with `--chapters` and
   ElevenLabs account voice discovery with `--list-voices`.
 - Brought the browser audiobook workflow to CLI parity: ElevenLabs now offers
   `Auto (recommended)` model selection and a server-side voice-list proxy at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-audio"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "base64",
  "bookforge-core",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-cli"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-core"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "clap",
  "quick-xml",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-epub"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "bookforge-core",
  "quick-xml",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-llm"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "bookforge-core",
  "reqwest",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-pdf"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "base64",
  "bookforge-core",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "bookforge-store"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "bookforge-core",
  "rusqlite",

--- a/README.md
+++ b/README.md
@@ -444,17 +444,38 @@ cargo run -p bookforge-cli -- audiobook book.epub --provider gemini --voice Kore
 cargo run -p bookforge-cli -- audiobook book.epub --provider elevenlabs --voice <VOICE_ID> --format mp3
 ```
 
-BookForge owns the structure here the same way it does for translation: it
-extracts chapter prose (skipping the OPF metadata and table of contents),
-splits it into sentence-boundary chunks under the provider's character limit,
-and writes one content-and-settings-hashed audio file per chunk plus a
-`manifest.json`. Re-running resumes matching chunks, while a changed model,
-voice, speed, instructions, or source text gets a new hash. Point `--base-url`
-at a local server (for example kokoro-fastapi) to synthesize offline, and pass
-`--stitch` (or `--m4b`) to join the chunks with ffmpeg when it is installed.
-Use `--provider mock --dry-run` to preview the chapter and chunk counts without
-spending anything. See [docs/audiobooks.md](docs/audiobooks.md) for the full
-option list.
+BookForge owns the structure here the same way it does for translation. Chapter
+titles and in-section headings are separate narration chunks, and stitching
+supports configurable chapter, title/heading, and paragraph pauses through
+`--gap-chapter-ms` (1200 by default), `--gap-title-ms` (800), and
+`--gap-paragraph-ms` (0). ElevenLabs `--break-tags auto|off` adds `<break>`
+tags only for Flash v2.5, Turbo v2.5, and Multilingual v2, never Eleven v3.
+
+ElevenLabs requests carry same-chapter `previous_text`/`next_text` context and
+support `--seed`, `--text-normalization auto|on|off`, and `--language`.
+Language defaults from the EPUB metadata, is sent only to Flash/Turbo v2.5,
+and is warned-and-dropped elsewhere. Use `--chapters 1-3,7` for a one-based
+subset or `--list-voices` to inspect the account's voices.
+
+With ffmpeg available, a normal run creates a chaptered `audiobook.m4b` with
+chapter markers and title/artist metadata. `--no-book-file` opts out,
+`--single` additionally creates a flat audio file, and `--loudnorm` normalizes
+only whole-book assembly; per-chapter files remain unnormalized. Point
+`--base-url` at a local server such as kokoro-fastapi to synthesize offline.
+
+Plans and dry runs use `crates/bookforge-cli/pricing/audio-providers.json` for
+cost estimates, and ElevenLabs performs a non-fatal quota preflight. The
+estimates are planning figures only; provider billing is authoritative. The
+browser dashboard adds ElevenLabs Auto model selection and a voice picker, a
+pre-launch cost/quota estimate, per-chapter progress, in-page playback, and
+Advanced controls for chapter pause, flat output, loudness, seed, and language.
+
+Runs write content-and-settings-hashed chunks plus a `manifest.json` and reuse
+matching chunks when resumed. The v2.6.0 cache tag `bookforge-audio-v2` and
+manifest schema 3 invalidate earlier audio chunk caches; rerun with `--prune`
+(`--prune --dry-run` previews cleanup). Use `--provider mock --dry-run` to
+preview a plan without spending. See [docs/audiobooks.md](docs/audiobooks.md)
+for the complete option and behavior reference.
 
 ## QA Modes
 

--- a/crates/bookforge-audio/Cargo.toml
+++ b/crates/bookforge-audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-audio"
-version = "2.5.1"
+version = "2.6.0"
 description = "Audiobook generation for BookForge with OpenAI, Gemini, ElevenLabs, and local TTS providers."
 edition.workspace = true
 license.workspace = true
@@ -9,8 +9,8 @@ rust-version.workspace = true
 
 [dependencies]
 base64.workspace = true
-bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
-bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core" }
+bookforge-epub = { version = "2.6.0", path = "../bookforge-epub" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-audio/src/builder.rs
+++ b/crates/bookforge-audio/src/builder.rs
@@ -15,8 +15,8 @@ use sha2::{Digest, Sha256};
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
-use crate::provider::{AudioFormat, SpeechRequest, TtsProvider};
-use crate::text::{chapters_from_book_with_options, chunk_text};
+use crate::provider::{AudioFormat, SpeechRequest, TextNormalization, TtsProvider};
+use crate::text::{ChunkKind, chapters_from_book_with_options, chunk_blocks};
 
 /// Knobs for a single audiobook build.
 #[derive(Debug, Clone)]
@@ -34,6 +34,14 @@ pub struct AudiobookOptions {
     pub synthesis_id: String,
     /// Optional voice delivery/pronunciation guidance.
     pub instructions: Option<String>,
+    /// Neighboring chunk context sent to providers that support continuity.
+    /// Zero disables context entirely.
+    pub context_chars: usize,
+    pub seed: Option<u32>,
+    pub language_code: Option<String>,
+    pub text_normalization: Option<TextNormalization>,
+    pub heading_break_tag: Option<String>,
+    pub chapter_filter: Option<std::collections::BTreeSet<usize>>,
     /// Group physical pdftohtml pages around explicit chapter headings.
     /// This must only be enabled from a positive source-format signal.
     pub pdf_page_grouping: bool,
@@ -50,6 +58,12 @@ impl Default for AudiobookOptions {
             concurrency: 4,
             synthesis_id: "default".to_string(),
             instructions: None,
+            context_chars: 300,
+            seed: None,
+            language_code: None,
+            text_normalization: None,
+            heading_break_tag: None,
+            chapter_filter: None,
             pdf_page_grouping: false,
         }
     }
@@ -61,6 +75,8 @@ pub struct ChunkRecord {
     pub chapter_index: usize,
     pub chapter_title: String,
     pub part: usize,
+    #[serde(default)]
+    pub kind: ChunkKind,
     pub file: String,
     pub chars: usize,
     /// Hash of text plus every synthesis setting that can alter the audio.
@@ -108,6 +124,16 @@ pub struct AudiobookManifest {
     pub max_chars: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text_normalization: Option<TextNormalization>,
+    #[serde(default)]
+    pub gaps: GapSettings,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
     pub chapters: usize,
     pub chunks: Vec<ChunkRecord>,
     #[serde(default)]
@@ -118,6 +144,13 @@ pub struct AudiobookManifest {
     pub updated_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GapSettings {
+    pub chapter_ms: u32,
+    pub title_ms: u32,
+    pub paragraph_ms: u32,
 }
 
 /// Summary returned to the caller after a build.
@@ -176,7 +209,10 @@ struct PlannedChunk {
     chapter_index: usize,
     chapter_title: String,
     part: usize,
+    kind: ChunkKind,
     text: String,
+    previous_text: Option<String>,
+    next_text: Option<String>,
     synthesis_sha256: String,
     path: PathBuf,
 }
@@ -190,6 +226,7 @@ pub fn plan_chunks(book: &Book, options: &AudiobookOptions) -> Vec<ChunkRecord> 
             chapter_index: chunk.chapter_index,
             chapter_title: chunk.chapter_title,
             part: chunk.part,
+            kind: chunk.kind,
             file: chunk
                 .path
                 .file_name()
@@ -212,26 +249,79 @@ fn build_plan(book: &Book, options: &AudiobookOptions) -> Vec<PlannedChunk> {
         if chapter.is_empty() {
             continue;
         }
-        let chunks = chunk_text(&chapter.text, options.max_chars);
-        for (part_idx, text) in chunks.into_iter().enumerate() {
-            let synthesis_sha256 = synthesis_hash(&text, options);
-            let file_name = format!(
-                "chapter-{:03}-part-{:03}-{}.{ext}",
-                chapter.index + 1,
-                part_idx + 1,
-                &synthesis_sha256[..16]
-            );
+        if options
+            .chapter_filter
+            .as_ref()
+            .is_some_and(|filter| !filter.contains(&(chapter.index + 1)))
+        {
+            continue;
+        }
+        let chunks = chunk_blocks(&chapter.blocks, options.max_chars);
+        for (part_idx, mut chunk) in chunks.into_iter().enumerate() {
+            if matches!(chunk.kind, ChunkKind::Title | ChunkKind::Heading)
+                && let Some(tag) = options.heading_break_tag.as_deref()
+                && !tag.is_empty()
+            {
+                chunk.text.push(' ');
+                chunk.text.push_str(tag);
+            }
             planned.push(PlannedChunk {
                 chapter_index: chapter.index,
                 chapter_title: chapter.title.clone(),
                 part: part_idx + 1,
-                text,
-                synthesis_sha256,
-                path: options.out_dir.join(file_name),
+                kind: chunk.kind,
+                text: chunk.text,
+                previous_text: None,
+                next_text: None,
+                synthesis_sha256: String::new(),
+                path: PathBuf::new(),
             });
         }
     }
+
+    for index in 0..planned.len() {
+        let previous_text = index.checked_sub(1).and_then(|previous| {
+            (planned[previous].chapter_index == planned[index].chapter_index)
+                .then(|| context_slice(&planned[previous].text, options.context_chars, true))
+                .flatten()
+        });
+        let next_text = planned.get(index + 1).and_then(|next| {
+            (next.chapter_index == planned[index].chapter_index)
+                .then(|| context_slice(&next.text, options.context_chars, false))
+                .flatten()
+        });
+        let synthesis_sha256 = synthesis_hash(
+            &planned[index].text,
+            planned[index].kind,
+            previous_text.as_deref(),
+            next_text.as_deref(),
+            options,
+        );
+        let file_name = format!(
+            "chapter-{:03}-part-{:03}-{}.{ext}",
+            planned[index].chapter_index + 1,
+            planned[index].part,
+            &synthesis_sha256[..16]
+        );
+        planned[index].previous_text = previous_text;
+        planned[index].next_text = next_text;
+        planned[index].synthesis_sha256 = synthesis_sha256;
+        planned[index].path = options.out_dir.join(file_name);
+    }
     planned
+}
+
+fn context_slice(text: &str, chars: usize, from_end: bool) -> Option<String> {
+    if chars == 0 || text.is_empty() {
+        return None;
+    }
+    if from_end {
+        let mut slice = text.chars().rev().take(chars).collect::<Vec<_>>();
+        slice.reverse();
+        Some(slice.into_iter().collect())
+    } else {
+        Some(text.chars().take(chars).collect())
+    }
 }
 
 /// Synthesize an audiobook. Existing non-empty files are treated as already
@@ -273,6 +363,7 @@ where
             chapter_index: chunk.chapter_index,
             chapter_title: chunk.chapter_title.clone(),
             part: chunk.part,
+            kind: chunk.kind,
             file: file_name_of(&chunk.path),
             chars: chunk.text.chars().count(),
             synthesis_sha256: chunk.synthesis_sha256.clone(),
@@ -290,7 +381,7 @@ where
         .len();
     let manifest_path = options.out_dir.join("manifest.json");
     let manifest = Arc::new(Mutex::new(AudiobookManifest {
-        schema_version: 2,
+        schema_version: 3,
         title: book.metadata.title.clone(),
         synthesis_id: options.synthesis_id.clone(),
         voice: options.voice.clone(),
@@ -298,6 +389,15 @@ where
         speed: options.speed,
         max_chars: options.max_chars,
         instructions: options.instructions.clone(),
+        seed: options.seed,
+        language: options.language_code.clone(),
+        text_normalization: options.text_normalization,
+        gaps: GapSettings {
+            chapter_ms: 1_200,
+            title_ms: 800,
+            paragraph_ms: 0,
+        },
+        author: (!book.metadata.creators.is_empty()).then(|| book.metadata.creators.join(", ")),
         chapters,
         chunks: records,
         completed_chunks: 0,
@@ -316,6 +416,9 @@ where
         let format = options.format;
         let speed = options.speed;
         let instructions = options.instructions.clone();
+        let seed = options.seed;
+        let language_code = options.language_code.clone();
+        let text_normalization = options.text_normalization;
         let done = Arc::clone(&done);
         let synthesized = Arc::clone(&synthesized);
         let skipped = Arc::clone(&skipped);
@@ -344,6 +447,11 @@ where
                         format,
                         speed,
                         instructions,
+                        previous_text: chunk.previous_text.clone(),
+                        next_text: chunk.next_text.clone(),
+                        seed,
+                        language_code,
+                        text_normalization,
                     })
                     .await?;
                 if clip.format != format {
@@ -567,20 +675,62 @@ pub fn validate_options(options: &AudiobookOptions) -> Result<()> {
     Ok(())
 }
 
-fn synthesis_hash(text: &str, options: &AudiobookOptions) -> String {
+fn synthesis_hash(
+    text: &str,
+    kind: ChunkKind,
+    previous_text: Option<&str>,
+    next_text: Option<&str>,
+    options: &AudiobookOptions,
+) -> String {
+    synthesis_hash_with_version(
+        "bookforge-audio-v2",
+        text,
+        kind,
+        previous_text,
+        next_text,
+        options,
+    )
+}
+
+fn synthesis_hash_with_version(
+    version: &str,
+    text: &str,
+    kind: ChunkKind,
+    previous_text: Option<&str>,
+    next_text: Option<&str>,
+    options: &AudiobookOptions,
+) -> String {
     let mut hasher = Sha256::new();
+    let seed = options
+        .seed
+        .map(|seed| seed.to_string())
+        .unwrap_or_default();
     for value in [
-        "bookforge-audio-v1",
+        version,
         &options.synthesis_id,
         &options.voice,
         options.format.as_api_str(),
         &options.speed.to_bits().to_string(),
         options.instructions.as_deref().unwrap_or(""),
         text,
+        seed.as_str(),
+        options.language_code.as_deref().unwrap_or(""),
+        options
+            .text_normalization
+            .map(TextNormalization::as_str)
+            .unwrap_or(""),
+        previous_text.unwrap_or(""),
+        next_text.unwrap_or(""),
+        match kind {
+            ChunkKind::Title => "title",
+            ChunkKind::Heading => "heading",
+            ChunkKind::Body => "body",
+        },
     ] {
         hasher.update((value.len() as u64).to_le_bytes());
         hasher.update(value.as_bytes());
     }
+    // Neighbor context deliberately means editing chunk N invalidates N±1.
     let digest = hasher.finalize();
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -638,7 +788,11 @@ mod tests {
         let make_block = |id: &str, section: &str, text: &str| Block {
             id: BlockId(id.to_string()),
             section_id: SectionId(section.to_string()),
-            kind: BlockKind::Paragraph,
+            kind: if matches!(id, "b1" | "b3") {
+                BlockKind::Heading(1)
+            } else {
+                BlockKind::Paragraph
+            },
             dom_path: DomPath(vec![0]),
             text_runs: vec![TextRun {
                 id: format!("{id}_r0"),
@@ -705,6 +859,153 @@ mod tests {
         // File names are zero-padded and format-suffixed.
         assert!(plan[0].file.starts_with("chapter-001-part-001"));
         assert_eq!(plan[0].synthesis_sha256.len(), 64);
+        for chapter_index in [0, 1] {
+            assert_eq!(
+                plan.iter()
+                    .find(|chunk| chunk.chapter_index == chapter_index)
+                    .unwrap()
+                    .kind,
+                ChunkKind::Title
+            );
+        }
+    }
+
+    #[test]
+    fn context_slices_are_unicode_safe_and_zero_disables_them() {
+        assert_eq!(context_slice("aé日z", 2, false).as_deref(), Some("aé"));
+        assert_eq!(context_slice("aé日z", 2, true).as_deref(), Some("日z"));
+        assert_eq!(context_slice("aé日z", 99, false).as_deref(), Some("aé日z"));
+        assert_eq!(context_slice("aé日z", 0, false), None);
+    }
+
+    #[test]
+    fn planned_context_stops_at_chapter_boundaries() {
+        let options = AudiobookOptions {
+            max_chars: 40,
+            context_chars: 8,
+            ..AudiobookOptions::default()
+        };
+        let plan = build_plan(&book_with_sections(), &options);
+        for pair in plan.windows(2) {
+            if pair[0].chapter_index != pair[1].chapter_index {
+                assert_eq!(pair[0].next_text, None);
+                assert_eq!(pair[1].previous_text, None);
+            }
+        }
+        assert!(plan.iter().any(|chunk| chunk.next_text.is_some()));
+    }
+
+    #[test]
+    fn heading_break_tag_is_appended_only_to_structural_chunks() {
+        let options = AudiobookOptions {
+            heading_break_tag: Some("<break time=\"0.6s\" />".to_string()),
+            ..AudiobookOptions::default()
+        };
+        let plan = build_plan(&book_with_sections(), &options);
+        assert!(plan[0].text.ends_with(" <break time=\"0.6s\" />"));
+        assert!(
+            plan.iter()
+                .filter(|chunk| chunk.kind == ChunkKind::Body)
+                .all(|chunk| !chunk.text.contains("<break"))
+        );
+    }
+
+    #[test]
+    fn synthesis_hash_changes_for_every_new_consistency_input_and_kind() {
+        let options = AudiobookOptions::default();
+        let base = synthesis_hash("text", ChunkKind::Body, None, None, &options);
+
+        let mut changed = options.clone();
+        changed.seed = Some(7);
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Body, None, None, &changed)
+        );
+
+        let mut changed = options.clone();
+        changed.language_code = Some("it".to_string());
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Body, None, None, &changed)
+        );
+
+        let mut changed = options.clone();
+        changed.text_normalization = Some(TextNormalization::Auto);
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Body, None, None, &changed)
+        );
+
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Body, Some("before"), None, &options)
+        );
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Body, None, Some("after"), &options)
+        );
+        assert_ne!(
+            base,
+            synthesis_hash("text", ChunkKind::Title, None, None, &options)
+        );
+    }
+
+    #[test]
+    fn synthesis_hash_uses_v2_cache_tag() {
+        let options = AudiobookOptions::default();
+        let actual = synthesis_hash("text", ChunkKind::Body, None, None, &options);
+        assert_eq!(
+            actual,
+            synthesis_hash_with_version(
+                "bookforge-audio-v2",
+                "text",
+                ChunkKind::Body,
+                None,
+                None,
+                &options,
+            )
+        );
+        assert_ne!(
+            actual,
+            synthesis_hash_with_version(
+                "bookforge-audio-v1",
+                "text",
+                ChunkKind::Body,
+                None,
+                None,
+                &options,
+            )
+        );
+    }
+
+    #[test]
+    fn v2_manifest_without_new_fields_still_deserializes() {
+        let json = serde_json::json!({
+            "schema_version": 2,
+            "title": "Old Book",
+            "synthesis_id": "mock:model",
+            "voice": "voice",
+            "format": "wav",
+            "speed": 1.0,
+            "max_chars": 2000,
+            "chapters": 1,
+            "chunks": [{
+                "chapter_index": 0,
+                "chapter_title": "One",
+                "part": 1,
+                "file": "chapter-001-part-001-old.wav",
+                "chars": 10,
+                "synthesis_sha256": "0"
+            }]
+        });
+        let manifest: AudiobookManifest = serde_json::from_value(json).unwrap();
+        assert_eq!(manifest.schema_version, 2);
+        assert_eq!(manifest.chunks[0].kind, ChunkKind::Body);
+        assert_eq!(manifest.seed, None);
+        assert_eq!(manifest.language, None);
+        assert_eq!(manifest.text_normalization, None);
+        assert_eq!(manifest.gaps, GapSettings::default());
+        assert_eq!(manifest.author, None);
     }
 
     #[tokio::test]

--- a/crates/bookforge-audio/src/cleanup.rs
+++ b/crates/bookforge-audio/src/cleanup.rs
@@ -121,6 +121,7 @@ mod tests {
             chapter_index: 0,
             chapter_title: "Ch".to_string(),
             part: 1,
+            kind: crate::text::ChunkKind::Body,
             file: file.to_string(),
             chars: 10,
             synthesis_sha256: "0".repeat(64),

--- a/crates/bookforge-audio/src/lib.rs
+++ b/crates/bookforge-audio/src/lib.rs
@@ -23,14 +23,18 @@ pub mod text;
 
 pub use builder::{
     AudiobookManifest, AudiobookOptions, AudiobookReport, AudiobookStatus, BuildError, ChunkRecord,
-    ChunkStatus, Progress, build_audiobook, plan_chunks, validate_options,
+    ChunkStatus, GapSettings, Progress, build_audiobook, plan_chunks, validate_options,
 };
 pub use cleanup::{StaleChunk, find_stale_chunks, remove_stale_chunks};
 pub use provider::{
     AudioClip, AudioFormat, ELEVENLABS_MAX_INPUT_CHARS, ELEVENLABS_PREFERRED_MODELS,
-    ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig, GeminiTtsProvider,
-    MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, SpeechRequest, TtsError, TtsProvider,
-    elevenlabs_model_max_input_chars, resolve_preferred_elevenlabs_model,
+    ElevenLabsSubscription, ElevenLabsTtsConfig, ElevenLabsTtsProvider, ElevenLabsVoice,
+    GeminiTtsConfig, GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider,
+    SpeechRequest, TextNormalization, TtsError, TtsProvider, elevenlabs_model_max_input_chars,
+    fetch_elevenlabs_subscription, list_elevenlabs_voices, resolve_preferred_elevenlabs_model,
 };
-pub use stitch::{StitchOptions, StitchReport, ffmpeg_available, stitch};
-pub use text::{Chapter, chapters_from_book, chunk_text};
+pub use stitch::{StitchOptions, StitchReport, ffmpeg_available, single_file_ffmpeg_args, stitch};
+pub use text::{
+    Chapter, ChunkKind, NarrationBlock, NarrationBlockKind, NarrationChunk, chapters_from_book,
+    chunk_blocks, chunk_text,
+};

--- a/crates/bookforge-audio/src/provider.rs
+++ b/crates/bookforge-audio/src/provider.rs
@@ -13,20 +13,22 @@ mod elevenlabs;
 mod gemini;
 
 pub use elevenlabs::{
-    ELEVENLABS_MAX_INPUT_CHARS, ELEVENLABS_PREFERRED_MODELS, ElevenLabsTtsConfig,
-    ElevenLabsTtsProvider, elevenlabs_model_max_input_chars, resolve_preferred_elevenlabs_model,
+    ELEVENLABS_MAX_INPUT_CHARS, ELEVENLABS_PREFERRED_MODELS, ElevenLabsSubscription,
+    ElevenLabsTtsConfig, ElevenLabsTtsProvider, ElevenLabsVoice, elevenlabs_model_max_input_chars,
+    fetch_elevenlabs_subscription, list_elevenlabs_voices, resolve_preferred_elevenlabs_model,
 };
 pub use gemini::{GeminiTtsConfig, GeminiTtsProvider};
 
 /// Output container/codec requested from the provider. The string form is
 /// what OpenAI-compatible endpoints expect in `response_format`, and the
 /// extension is used for the files BookForge writes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AudioFormat {
     Mp3,
     Opus,
     Aac,
     Flac,
+    #[default]
     Wav,
     Pcm,
 }
@@ -86,7 +88,25 @@ pub type Result<T> = std::result::Result<T, TtsError>;
 
 /// A single unit of text to narrate, plus the voice and format it should be
 /// rendered in.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TextNormalization {
+    Auto,
+    On,
+    Off,
+}
+
+impl TextNormalization {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::On => "on",
+            Self::Off => "off",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct SpeechRequest {
     pub text: String,
     pub voice: String,
@@ -98,6 +118,11 @@ pub struct SpeechRequest {
     /// `gpt-4o-mini-tts` model supports this; compatible providers may ignore
     /// it.
     pub instructions: Option<String>,
+    pub previous_text: Option<String>,
+    pub next_text: Option<String>,
+    pub seed: Option<u32>,
+    pub language_code: Option<String>,
+    pub text_normalization: Option<TextNormalization>,
 }
 
 /// Rendered audio bytes for one [`SpeechRequest`].
@@ -584,6 +609,7 @@ mod tests {
                 format: AudioFormat::Mp3,
                 speed: 1.0,
                 instructions: None,
+                ..SpeechRequest::default()
             })
             .await
             .expect_err("mock should reject mislabeled output");
@@ -600,6 +626,7 @@ mod tests {
                 format: AudioFormat::Wav,
                 speed: 1.0,
                 instructions: None,
+                ..SpeechRequest::default()
             })
             .await
             .expect("mock synthesis should succeed");
@@ -618,6 +645,7 @@ mod tests {
             format: AudioFormat::Wav,
             speed: 1.0,
             instructions: None,
+            ..SpeechRequest::default()
         };
         let a = provider.synthesize(request.clone()).await.unwrap();
         let b = provider.synthesize(request).await.unwrap();
@@ -632,6 +660,7 @@ mod tests {
             format: AudioFormat::Mp3,
             speed: 0.9,
             instructions: Some("Pronounce Toki Pona clearly.".to_string()),
+            ..SpeechRequest::default()
         };
         let body = speech_request_body("gpt-4o-mini-tts", &request);
         assert_eq!(body["model"], "gpt-4o-mini-tts");

--- a/crates/bookforge-audio/src/provider/elevenlabs.rs
+++ b/crates/bookforge-audio/src/provider/elevenlabs.rs
@@ -1,5 +1,7 @@
 use tokio_util::sync::CancellationToken;
 
+use std::collections::BTreeMap;
+
 use super::{
     AudioClip, AudioFormat, Result, SpeechRequest, TtsError, TtsProvider, base_url_is_loopback,
     build_http_client, required_api_key, send_with_retry, validate_audio_payload,
@@ -16,6 +18,78 @@ pub const ELEVENLABS_PREFERRED_MODELS: &[&str] = &[
     "eleven_turbo_v2_5",
     "eleven_multilingual_v2",
 ];
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ElevenLabsVoice {
+    pub voice_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub category: String,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ElevenLabsSubscription {
+    pub character_count: u64,
+    pub character_limit: u64,
+}
+
+pub async fn fetch_elevenlabs_subscription(
+    config: &ElevenLabsTtsConfig,
+) -> Result<ElevenLabsSubscription> {
+    let endpoint = format!(
+        "{}/user/subscription",
+        config.base_url.trim_end_matches('/')
+    );
+    let api_key = if base_url_is_loopback(&config.base_url) {
+        std::env::var(&config.api_key_env)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    } else {
+        Some(required_api_key(&config.api_key_env)?)
+    };
+    let client = build_http_client(config.timeout_seconds)?;
+    let cancel_token = CancellationToken::new();
+    let payload = send_with_retry(&cancel_token, config.max_attempts, || {
+        let mut request = client.get(&endpoint);
+        if let Some(api_key) = api_key.as_deref() {
+            request = request.header("xi-api-key", api_key);
+        }
+        request
+    })
+    .await?;
+    serde_json::from_slice(&payload.bytes).map_err(|error| {
+        TtsError::Provider(format!(
+            "could not parse ElevenLabs subscription response as JSON: {error}"
+        ))
+    })
+}
+
+pub async fn list_elevenlabs_voices(
+    base_url: &str,
+    api_key: &str,
+    timeout_seconds: u64,
+) -> Result<Vec<ElevenLabsVoice>> {
+    #[derive(serde::Deserialize)]
+    struct VoicesResponse {
+        voices: Vec<ElevenLabsVoice>,
+    }
+
+    let endpoint = format!("{}/voices", base_url.trim_end_matches('/'));
+    let client = build_http_client(timeout_seconds)?;
+    let cancel_token = CancellationToken::new();
+    let payload = send_with_retry(&cancel_token, 2, || {
+        client.get(&endpoint).header("xi-api-key", api_key)
+    })
+    .await?;
+    let response: VoicesResponse = serde_json::from_slice(&payload.bytes).map_err(|error| {
+        TtsError::Provider(format!(
+            "could not parse ElevenLabs voices response as JSON: {error}"
+        ))
+    })?;
+    Ok(response.voices)
+}
 
 /// Return the documented per-request character limit for an ElevenLabs model.
 ///
@@ -226,6 +300,21 @@ fn elevenlabs_request_body(model: &str, request: &SpeechRequest) -> serde_json::
     if !((request.speed - 1.0).abs() < f32::EPSILON) {
         body["voice_settings"] = serde_json::json!({"speed": request.speed});
     }
+    if let Some(previous_text) = &request.previous_text {
+        body["previous_text"] = serde_json::json!(previous_text);
+    }
+    if let Some(next_text) = &request.next_text {
+        body["next_text"] = serde_json::json!(next_text);
+    }
+    if let Some(seed) = request.seed {
+        body["seed"] = serde_json::json!(seed);
+    }
+    if let Some(language_code) = &request.language_code {
+        body["language_code"] = serde_json::json!(language_code);
+    }
+    if let Some(text_normalization) = request.text_normalization {
+        body["apply_text_normalization"] = serde_json::json!(text_normalization.as_str());
+    }
     body
 }
 
@@ -242,6 +331,7 @@ mod tests {
             format,
             speed: 0.9,
             instructions: None,
+            ..SpeechRequest::default()
         }
     }
 
@@ -286,6 +376,47 @@ mod tests {
         speech.speed = 1.0;
         let body = elevenlabs_request_body("eleven_multilingual_v2", &speech);
         assert!(body.get("voice_settings").is_none());
+        for field in [
+            "previous_text",
+            "next_text",
+            "seed",
+            "language_code",
+            "apply_text_normalization",
+        ] {
+            assert!(body.get(field).is_none(), "unexpected field {field}");
+        }
+    }
+
+    #[tokio::test]
+    async fn synthesis_sends_context_consistency_fields() {
+        let (base_url, captured) = one_request_server(b"ID3mock-audio".to_vec(), "audio/mpeg");
+        let key_env = "BOOKFORGE_ELEVENLABS_CONTEXT_BODY_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "context-key") };
+        let provider = ElevenLabsTtsProvider::new(ElevenLabsTtsConfig {
+            base_url,
+            api_key_env: key_env.to_string(),
+            model: "eleven_flash_v2_5".to_string(),
+            timeout_seconds: 5,
+            max_attempts: 1,
+        })
+        .unwrap();
+        let mut speech = request(AudioFormat::Mp3);
+        speech.previous_text = Some("before".to_string());
+        speech.next_text = Some("after".to_string());
+        speech.seed = Some(42);
+        speech.language_code = Some("it".to_string());
+        speech.text_normalization = Some(crate::provider::TextNormalization::On);
+        provider.synthesize(speech).await.unwrap();
+        unsafe { std::env::remove_var(key_env) };
+
+        let raw = captured.recv_timeout(Duration::from_secs(2)).unwrap();
+        let body: serde_json::Value =
+            serde_json::from_str(raw.split_once("\r\n\r\n").unwrap().1).unwrap();
+        assert_eq!(body["previous_text"], "before");
+        assert_eq!(body["next_text"], "after");
+        assert_eq!(body["seed"], 42);
+        assert_eq!(body["language_code"], "it");
+        assert_eq!(body["apply_text_normalization"], "on");
     }
 
     fn resolver_config(base_url: String, api_key_env: &str) -> ElevenLabsTtsConfig {
@@ -421,6 +552,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn subscription_get_parses_counts_and_sends_key() {
+        let body = serde_json::json!({"character_count": 123, "character_limit": 456});
+        let (base_url, captured) =
+            one_request_server(body.to_string().into_bytes(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_SUBSCRIPTION_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "subscription-key") };
+        let subscription = fetch_elevenlabs_subscription(&resolver_config(base_url, key_env))
+            .await
+            .unwrap();
+        unsafe { std::env::remove_var(key_env) };
+        assert_eq!(subscription.character_count, 123);
+        assert_eq!(subscription.character_limit, 456);
+        let raw = captured.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(raw.starts_with("GET /v1/user/subscription HTTP/1.1"));
+        assert!(
+            raw.to_ascii_lowercase()
+                .contains("xi-api-key: subscription-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_errors_on_garbage_body() {
+        let (base_url, _) = one_request_server(b"garbage".to_vec(), "application/json");
+        let key_env = "BOOKFORGE_ELEVENLABS_SUBSCRIPTION_GARBAGE_TEST_KEY";
+        unsafe { std::env::set_var(key_env, "subscription-garbage-key") };
+        let error = fetch_elevenlabs_subscription(&resolver_config(base_url, key_env))
+            .await
+            .unwrap_err();
+        unsafe { std::env::remove_var(key_env) };
+        assert!(error.to_string().contains("parse ElevenLabs subscription"));
+    }
+
+    #[tokio::test]
+    async fn voices_get_parses_contract_and_sends_explicit_key() {
+        let body = serde_json::json!({"voices": [{
+            "voice_id": "voice-1",
+            "name": "Narrator",
+            "category": "premade",
+            "labels": {"accent": "italian"}
+        }]});
+        let (base_url, captured) =
+            one_request_server(body.to_string().into_bytes(), "application/json");
+        let voices = list_elevenlabs_voices(&base_url, "voices-key", 5)
+            .await
+            .unwrap();
+        assert_eq!(voices.len(), 1);
+        assert_eq!(voices[0].voice_id, "voice-1");
+        assert_eq!(voices[0].name, "Narrator");
+        assert_eq!(voices[0].category, "premade");
+        assert_eq!(voices[0].labels["accent"], "italian");
+        let raw = captured.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(raw.starts_with("GET /v1/voices HTTP/1.1"));
+        assert!(raw.to_ascii_lowercase().contains("xi-api-key: voices-key"));
+    }
+
+    #[tokio::test]
+    async fn voices_errors_on_garbage_body() {
+        let (base_url, _) = one_request_server(b"garbage".to_vec(), "application/json");
+        let error = list_elevenlabs_voices(&base_url, "voices-garbage-key", 5)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("parse ElevenLabs voices"));
+    }
+
+    #[tokio::test]
     async fn rejects_input_above_provider_character_limit_before_network() {
         let provider = ElevenLabsTtsProvider::new(ElevenLabsTtsConfig::hosted(None)).unwrap();
         let mut oversized = request(AudioFormat::Mp3);
@@ -481,5 +677,14 @@ mod tests {
             serde_json::from_str(raw.split_once("\r\n\r\n").unwrap().1).unwrap();
         assert_eq!(body["model_id"], "eleven_multilingual_v2");
         assert_eq!(body["text"], "toki pona");
+        for field in [
+            "previous_text",
+            "next_text",
+            "seed",
+            "language_code",
+            "apply_text_normalization",
+        ] {
+            assert!(body.get(field).is_none(), "unexpected field {field}");
+        }
     }
 }

--- a/crates/bookforge-audio/src/provider/gemini.rs
+++ b/crates/bookforge-audio/src/provider/gemini.rs
@@ -180,6 +180,7 @@ mod tests {
             format,
             speed: 1.0,
             instructions: Some("Speak clearly.".to_string()),
+            ..SpeechRequest::default()
         }
     }
 

--- a/crates/bookforge-audio/src/stitch.rs
+++ b/crates/bookforge-audio/src/stitch.rs
@@ -1,33 +1,59 @@
-//! Optional post-processing that joins the many per-chunk files into one
-//! file per chapter, and (when possible) a single `.m4b` with chapter
-//! markers. Everything here shells out to `ffmpeg`/`ffprobe`; if those
-//! tools are absent the functions return warnings instead of failing, so a
-//! build that produced per-chunk files is never lost to a missing binary.
+//! Optional ffmpeg-based audiobook post-processing.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::builder::{AudiobookManifest, ChunkRecord};
+use crate::text::ChunkKind;
 
 #[derive(Debug, Clone)]
 pub struct StitchOptions {
     pub out_dir: PathBuf,
     /// File extension of the per-chunk files (e.g. "mp3", "wav").
     pub extension: String,
-    /// Also assemble a single `.m4b` with chapter markers.
     pub make_m4b: bool,
     pub title: Option<String>,
+    pub gap_chapter_ms: u32,
+    pub gap_title_ms: u32,
+    pub gap_paragraph_ms: u32,
+    pub loudnorm: bool,
+    pub make_single: bool,
+    pub author: Option<String>,
+}
+
+impl Default for StitchOptions {
+    fn default() -> Self {
+        Self {
+            out_dir: PathBuf::from("audiobook"),
+            extension: "wav".to_string(),
+            make_m4b: false,
+            title: None,
+            gap_chapter_ms: 1_200,
+            gap_title_ms: 800,
+            gap_paragraph_ms: 0,
+            loudnorm: false,
+            make_single: false,
+            author: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct StitchReport {
     pub chapter_files: Vec<PathBuf>,
     pub book_file: Option<PathBuf>,
+    pub single_file: Option<PathBuf>,
     pub warnings: Vec<String>,
 }
 
-/// True if `ffmpeg` answers `-version`.
+#[derive(Debug, Clone, Default)]
+struct ConcatGaps {
+    chapter: Option<String>,
+    title: Option<String>,
+    paragraph: Option<String>,
+}
+
 pub fn ffmpeg_available() -> bool {
     tool_available("ffmpeg")
 }
@@ -46,11 +72,8 @@ fn tool_available(tool: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Concatenate per-chunk files into one file per chapter, then optionally a
-/// single `.m4b`. Requires `ffmpeg` to be on PATH.
 pub fn stitch(manifest: &AudiobookManifest, options: &StitchOptions) -> StitchReport {
     let mut report = StitchReport::default();
-
     if !ffmpeg_available() {
         report.warnings.push(
             "ffmpeg not found on PATH; skipped stitching (per-chunk files are intact)".into(),
@@ -59,42 +82,102 @@ pub fn stitch(manifest: &AudiobookManifest, options: &StitchOptions) -> StitchRe
     }
 
     let chapters = group_by_chapter(&manifest.chunks);
+    let requested_gaps =
+        options.gap_chapter_ms > 0 || options.gap_title_ms > 0 || options.gap_paragraph_ms > 0;
+    let mut gaps = ConcatGaps::default();
+    let mut silence_files = Vec::new();
+    if requested_gaps {
+        let first_chunk = chapters
+            .iter()
+            .flat_map(|(_, parts)| parts)
+            .next()
+            .map(|part| options.out_dir.join(&part.file));
+        match first_chunk
+            .as_deref()
+            .and_then(probe_audio_params)
+            .and_then(|(rate, channels)| {
+                prepare_silence_files(options, rate, channels, &mut silence_files).ok()
+            }) {
+            Some(prepared) => gaps = prepared,
+            None => report.warnings.push(
+                "ffprobe could not determine audio parameters or silence generation failed; stitching without gaps"
+                    .to_string(),
+            ),
+        }
+    }
+
     for (chapter_index, parts) in &chapters {
         let title = parts
             .first()
             .map(|part| part.chapter_title.clone())
             .unwrap_or_else(|| format!("Chapter {}", chapter_index + 1));
-        let file_names: Vec<String> = parts.iter().map(|part| part.file.clone()).collect();
+        let entries = build_chapter_concat_entries(parts, &gaps);
         let output_name = format!(
             "chapter-{:03}-{}.{}",
             chapter_index + 1,
             sanitize_filename(&title),
             options.extension
         );
-        match concat_copy(&options.out_dir, &file_names, &output_name) {
-            Ok(()) => report
-                .chapter_files
-                .push(options.out_dir.join(&output_name)),
+        match concat_copy(&options.out_dir, &entries, &output_name) {
+            Ok(()) => report.chapter_files.push(options.out_dir.join(output_name)),
             Err(error) => report
                 .warnings
                 .push(format!("chapter {}: {error}", chapter_index + 1)),
         }
     }
 
-    if options.make_m4b && report.chapter_files.len() != chapters.len() {
+    let all_chapters = report.chapter_files.len() == chapters.len();
+    if (options.make_m4b || options.make_single) && !all_chapters {
         report.warnings.push(format!(
-            "only {}/{} chapters stitched successfully; skipped m4b assembly to avoid an incomplete audiobook",
+            "only {}/{} chapters stitched successfully; skipped book assembly to avoid an incomplete audiobook",
             report.chapter_files.len(),
             chapters.len()
         ));
-    } else if options.make_m4b {
-        match assemble_m4b(options, &chapters, &report.chapter_files) {
-            Ok(path) => report.book_file = Some(path),
-            Err(error) => report.warnings.push(error),
+    } else {
+        if options.make_m4b {
+            match assemble_m4b(options, &chapters, &report.chapter_files, &gaps) {
+                Ok(path) => report.book_file = Some(path),
+                Err(error) => report.warnings.push(error),
+            }
+        }
+        if options.make_single {
+            match assemble_single_file(options, &report.chapter_files, &gaps) {
+                Ok(path) => report.single_file = Some(path),
+                Err(error) => report.warnings.push(error),
+            }
         }
     }
 
+    for path in silence_files {
+        let _ = std::fs::remove_file(path);
+    }
     report
+}
+
+fn prepare_silence_files(
+    options: &StitchOptions,
+    rate: u32,
+    channels: u16,
+    generated: &mut Vec<PathBuf>,
+) -> std::result::Result<ConcatGaps, String> {
+    let mut cache = BTreeMap::<u32, String>::new();
+    for ms in [
+        options.gap_chapter_ms,
+        options.gap_title_ms,
+        options.gap_paragraph_ms,
+    ] {
+        if ms == 0 || cache.contains_key(&ms) {
+            continue;
+        }
+        let path = ensure_silence_file(&options.out_dir, ms, &options.extension, rate, channels)?;
+        generated.push(path.clone());
+        cache.insert(ms, file_name_of(&path));
+    }
+    Ok(ConcatGaps {
+        chapter: cache.get(&options.gap_chapter_ms).cloned(),
+        title: cache.get(&options.gap_title_ms).cloned(),
+        paragraph: cache.get(&options.gap_paragraph_ms).cloned(),
+    })
 }
 
 fn group_by_chapter(chunks: &[ChunkRecord]) -> Vec<(usize, Vec<ChunkRecord>)> {
@@ -114,15 +197,49 @@ fn group_by_chapter(chunks: &[ChunkRecord]) -> Vec<(usize, Vec<ChunkRecord>)> {
         .collect()
 }
 
-/// Run the ffmpeg concat demuxer with stream copy. `cwd` is set to the
-/// output dir so the list file can use bare relative names.
+fn build_chapter_concat_entries(parts: &[ChunkRecord], gaps: &ConcatGaps) -> Vec<String> {
+    let mut entries = Vec::new();
+    for (index, part) in parts.iter().enumerate() {
+        entries.push(part.file.clone());
+        match part.kind {
+            ChunkKind::Title | ChunkKind::Heading => {
+                if let Some(gap) = &gaps.title {
+                    entries.push(gap.clone());
+                }
+            }
+            ChunkKind::Body
+                if parts
+                    .get(index + 1)
+                    .is_some_and(|next| next.kind == ChunkKind::Body) =>
+            {
+                if let Some(gap) = &gaps.paragraph {
+                    entries.push(gap.clone());
+                }
+            }
+            ChunkKind::Body => {}
+        }
+    }
+    entries
+}
+
+fn build_book_concat_entries(chapter_files: &[PathBuf], gap: Option<&str>) -> Vec<String> {
+    let mut entries = Vec::new();
+    for (index, path) in chapter_files.iter().enumerate() {
+        entries.push(file_name_of(path));
+        if index + 1 < chapter_files.len()
+            && let Some(gap) = gap
+        {
+            entries.push(gap.to_string());
+        }
+    }
+    entries
+}
+
 fn concat_copy(dir: &Path, inputs: &[String], output: &str) -> std::result::Result<(), String> {
     let list_name = format!("{output}.concat.txt");
-    let list_content = concat_list_content(inputs);
     let list_path = dir.join(&list_name);
-    std::fs::write(&list_path, list_content)
+    std::fs::write(&list_path, concat_list_content(inputs))
         .map_err(|error| format!("writing concat list: {error}"))?;
-
     let status = Command::new("ffmpeg")
         .current_dir(dir)
         .args(["-y", "-f", "concat", "-safe", "0", "-i"])
@@ -133,28 +250,22 @@ fn concat_copy(dir: &Path, inputs: &[String], output: &str) -> std::result::Resu
         .stderr(std::process::Stdio::null())
         .status()
         .map_err(|error| format!("launching ffmpeg: {error}"))?;
-
     let _ = std::fs::remove_file(&list_path);
-
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!("ffmpeg concat exited with {status}"))
-    }
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| format!("ffmpeg concat exited with {status}"))
 }
 
-/// Assemble a single `.m4b` from the per-chapter files, adding chapter
-/// markers when `ffprobe` can measure durations. Falls back to a
-/// marker-less m4b if `ffprobe` is missing.
 fn assemble_m4b(
     options: &StitchOptions,
     chapters: &[(usize, Vec<ChunkRecord>)],
     chapter_files: &[PathBuf],
+    gaps: &ConcatGaps,
 ) -> std::result::Result<PathBuf, String> {
     if chapter_files.is_empty() {
         return Err("no chapter files were produced; cannot assemble m4b".into());
     }
-
     let chapter_names: Vec<String> = chapters
         .iter()
         .map(|(index, parts)| {
@@ -164,70 +275,248 @@ fn assemble_m4b(
                 .unwrap_or_else(|| format!("Chapter {}", index + 1))
         })
         .collect();
-
-    let file_names: Vec<String> = chapter_files
-        .iter()
-        .map(|path| {
-            path.file_name()
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_default()
-        })
-        .collect();
-
-    // Durations power the chapter markers. Without ffprobe we still emit a
-    // playable m4b, just without a chapter list.
-    let mut ffmeta_arg: Vec<String> = Vec::new();
-    if ffprobe_available() {
-        let mut durations_ms = Vec::with_capacity(chapter_files.len());
-        for path in chapter_files {
-            match ffprobe_duration_ms(path) {
-                Some(ms) => durations_ms.push(ms),
-                None => {
-                    durations_ms.clear();
-                    break;
-                }
-            }
-        }
-        if durations_ms.len() == chapter_names.len() {
-            let meta = build_ffmetadata(options.title.as_deref(), &chapter_names, &durations_ms);
-            let meta_name = "chapters.ffmeta.txt";
-            std::fs::write(options.out_dir.join(meta_name), meta)
-                .map_err(|error| format!("writing chapter metadata: {error}"))?;
-            ffmeta_arg = vec![meta_name.to_string()];
-        }
-    }
-
-    let list_content = concat_list_content(&file_names);
+    let entries = build_book_concat_entries(chapter_files, gaps.chapter.as_deref());
     let list_name = "book.concat.txt";
-    std::fs::write(options.out_dir.join(list_name), list_content)
-        .map_err(|error| format!("writing book concat list: {error}"))?;
+    std::fs::write(
+        options.out_dir.join(list_name),
+        concat_list_content(&entries),
+    )
+    .map_err(|error| format!("writing book concat list: {error}"))?;
 
-    let output = "audiobook.m4b";
-    let mut command = Command::new("ffmpeg");
-    command
-        .current_dir(&options.out_dir)
-        .args(["-y", "-f", "concat", "-safe", "0", "-i"])
-        .arg(list_name);
-    if let Some(meta_name) = ffmeta_arg.first() {
-        command.args(["-i", meta_name, "-map_metadata", "1"]);
+    let mut ffmeta_name = None;
+    let durations = chapter_files
+        .iter()
+        .map(|path| ffprobe_duration_ms(path))
+        .collect::<Option<Vec<_>>>();
+    if let Some(durations) = durations {
+        let meta_name = "chapters.ffmeta.txt";
+        let chapter_gap_ms = gaps.chapter.as_ref().map_or(0, |_| options.gap_chapter_ms);
+        let metadata = build_ffmetadata(
+            options.title.as_deref(),
+            &chapter_names,
+            &durations,
+            chapter_gap_ms,
+        );
+        std::fs::write(options.out_dir.join(meta_name), metadata)
+            .map_err(|error| format!("writing chapter metadata: {error}"))?;
+        ffmeta_name = Some(meta_name);
     }
-    command
-        .args(["-c:a", "aac", "-b:a", "128k"])
-        .arg(output)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
 
-    let status = command
+    let mut args = vec![
+        "-y".to_string(),
+        "-f".to_string(),
+        "concat".to_string(),
+        "-safe".to_string(),
+        "0".to_string(),
+        "-i".to_string(),
+        list_name.to_string(),
+    ];
+    if let Some(meta_name) = ffmeta_name {
+        args.extend([
+            "-i".to_string(),
+            meta_name.to_string(),
+            "-map_metadata".to_string(),
+            "1".to_string(),
+        ]);
+    }
+    if options.loudnorm {
+        args.extend(["-af".to_string(), "loudnorm=I=-18:TP=-2:LRA=11".to_string()]);
+    }
+    args.extend([
+        "-c:a".to_string(),
+        "aac".to_string(),
+        "-b:a".to_string(),
+        "128k".to_string(),
+    ]);
+    append_metadata_args(
+        &mut args,
+        options.title.as_deref(),
+        options.author.as_deref(),
+    );
+    args.push("audiobook.m4b".to_string());
+    let status = Command::new("ffmpeg")
+        .current_dir(&options.out_dir)
+        .args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .map_err(|error| format!("launching ffmpeg for m4b: {error}"))?;
-
     let _ = std::fs::remove_file(options.out_dir.join(list_name));
     let _ = std::fs::remove_file(options.out_dir.join("chapters.ffmeta.txt"));
+    if status.success() {
+        Ok(options.out_dir.join("audiobook.m4b"))
+    } else {
+        Err(format!("ffmpeg m4b assembly exited with {status}"))
+    }
+}
 
+fn assemble_single_file(
+    options: &StitchOptions,
+    chapter_files: &[PathBuf],
+    gaps: &ConcatGaps,
+) -> std::result::Result<PathBuf, String> {
+    if options.extension.eq_ignore_ascii_case("pcm") {
+        return Err("cannot assemble a single pcm file; choose a container format".to_string());
+    }
+    if chapter_files.is_empty() {
+        return Err("no chapter files were produced; cannot assemble single file".to_string());
+    }
+    let entries = build_book_concat_entries(chapter_files, gaps.chapter.as_deref());
+    let list_name = "single.concat.txt";
+    std::fs::write(
+        options.out_dir.join(list_name),
+        concat_list_content(&entries),
+    )
+    .map_err(|error| format!("writing single-file concat list: {error}"))?;
+    let output = format!("audiobook.{}", options.extension);
+    let args = single_file_ffmpeg_args(
+        list_name,
+        &options.extension,
+        options.loudnorm,
+        options.title.as_deref(),
+        options.author.as_deref(),
+        &output,
+    );
+    let status = Command::new("ffmpeg")
+        .current_dir(&options.out_dir)
+        .args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|error| format!("launching ffmpeg for single file: {error}"))?;
+    let _ = std::fs::remove_file(options.out_dir.join(list_name));
     if status.success() {
         Ok(options.out_dir.join(output))
     } else {
-        Err(format!("ffmpeg m4b assembly exited with {status}"))
+        Err(format!("ffmpeg single-file assembly exited with {status}"))
+    }
+}
+
+pub fn single_file_ffmpeg_args(
+    list_name: &str,
+    extension: &str,
+    loudnorm: bool,
+    title: Option<&str>,
+    author: Option<&str>,
+    output: &str,
+) -> Vec<String> {
+    let mut args = vec![
+        "-y".to_string(),
+        "-f".to_string(),
+        "concat".to_string(),
+        "-safe".to_string(),
+        "0".to_string(),
+        "-i".to_string(),
+        list_name.to_string(),
+    ];
+    if loudnorm {
+        args.extend([
+            "-af".to_string(),
+            "loudnorm=I=-18:TP=-2:LRA=11".to_string(),
+            "-c:a".to_string(),
+            encoder_for_extension(extension)
+                .unwrap_or(extension)
+                .to_string(),
+        ]);
+    } else {
+        args.extend(["-c".to_string(), "copy".to_string()]);
+    }
+    append_metadata_args(&mut args, title, author);
+    args.push(output.to_string());
+    args
+}
+
+fn append_metadata_args(args: &mut Vec<String>, title: Option<&str>, author: Option<&str>) {
+    if let Some(title) = title {
+        args.extend(["-metadata".to_string(), format!("title={title}")]);
+    }
+    if let Some(author) = author {
+        args.extend(["-metadata".to_string(), format!("artist={author}")]);
+    }
+}
+
+fn encoder_for_extension(extension: &str) -> Option<&'static str> {
+    match extension.to_ascii_lowercase().as_str() {
+        "mp3" => Some("libmp3lame"),
+        "wav" => Some("pcm_s16le"),
+        "opus" => Some("libopus"),
+        "aac" => Some("aac"),
+        "flac" => Some("flac"),
+        _ => None,
+    }
+}
+
+fn probe_audio_params(path: &Path) -> Option<(u32, u16)> {
+    let output = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=sample_rate,channels",
+            "-of",
+            "json",
+        ])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let stream = value.get("streams")?.as_array()?.first()?;
+    let rate = stream.get("sample_rate")?.as_str()?.parse().ok()?;
+    let channels = u16::try_from(stream.get("channels")?.as_u64()?).ok()?;
+    Some((rate, channels))
+}
+
+fn ensure_silence_file(
+    out_dir: &Path,
+    ms: u32,
+    extension: &str,
+    rate: u32,
+    channels: u16,
+) -> std::result::Result<PathBuf, String> {
+    let encoder = match extension.to_ascii_lowercase().as_str() {
+        "mp3" => "libmp3lame",
+        "wav" => "pcm_s16le",
+        "opus" => "libopus",
+        _ => return Err(format!("silence gaps are unsupported for .{extension}")),
+    };
+    // Rate and channels belong in the cache key: a stitch killed before the
+    // cleanup pass leaves this file behind, and a later run with a different
+    // voice or format probes different parameters. Reusing that stale file
+    // would feed mismatched silence into a `-c copy` concat.
+    let output_name = format!("silence-{ms}-{rate}-{channels}.{extension}");
+    let output_path = out_dir.join(&output_name);
+    if output_path.is_file() {
+        return Ok(output_path);
+    }
+    let channel_layout = if channels == 1 { "mono" } else { "stereo" };
+    let duration = format!("{:.3}", f64::from(ms) / 1_000.0);
+    let status = Command::new("ffmpeg")
+        .current_dir(out_dir)
+        .args([
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("anullsrc=r={rate}:cl={channel_layout}"),
+            "-t",
+            &duration,
+            "-c:a",
+            encoder,
+            &output_name,
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|error| format!("launching ffmpeg for silence: {error}"))?;
+    if status.success() {
+        Ok(output_path)
+    } else {
+        Err(format!("ffmpeg silence generation exited with {status}"))
     }
 }
 
@@ -247,13 +536,19 @@ fn ffprobe_duration_ms(path: &Path) -> Option<u64> {
     if !output.status.success() {
         return None;
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    let seconds: f64 = text.trim().parse().ok()?;
-    Some((seconds * 1000.0).round() as u64)
+    let seconds: f64 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .ok()?;
+    Some((seconds * 1_000.0).round() as u64)
 }
 
-/// Build the content of an ffmpeg concat-demuxer list. Single quotes in
-/// names are escaped per ffmpeg's rules (`'` becomes `'\''`).
+fn file_name_of(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
 pub fn concat_list_content(files: &[String]) -> String {
     let mut out = String::new();
     for file in files {
@@ -263,28 +558,31 @@ pub fn concat_list_content(files: &[String]) -> String {
     out
 }
 
-/// Build an FFMETADATA1 document with one `[CHAPTER]` per entry. `durations`
-/// are per-chapter lengths in milliseconds; chapter start/end times are the
-/// running cumulative sum.
-pub fn build_ffmetadata(title: Option<&str>, names: &[String], durations: &[u64]) -> String {
+pub fn build_ffmetadata(
+    title: Option<&str>,
+    names: &[String],
+    durations: &[u64],
+    inter_chapter_gap_ms: u32,
+) -> String {
     let mut out = String::from(";FFMETADATA1\n");
     if let Some(title) = title {
         out.push_str(&format!("title={}\n", escape_ffmeta(title)));
     }
     let mut start = 0u64;
-    for (name, duration) in names.iter().zip(durations.iter()) {
+    for (index, (name, duration)) in names.iter().zip(durations.iter()).enumerate() {
         let end = start + duration;
         out.push_str("\n[CHAPTER]\nTIMEBASE=1/1000\n");
-        out.push_str(&format!("START={start}\n"));
-        out.push_str(&format!("END={end}\n"));
+        out.push_str(&format!("START={start}\nEND={end}\n"));
         out.push_str(&format!("title={}\n", escape_ffmeta(name)));
         start = end;
+        if index + 1 < names.len() {
+            start += u64::from(inter_chapter_gap_ms);
+        }
     }
     out
 }
 
 fn escape_ffmeta(value: &str) -> String {
-    // ffmetadata treats =, ;, #, \, and newlines as special; escape with \.
     let mut out = String::with_capacity(value.len());
     for ch in value.chars() {
         match ch {
@@ -299,7 +597,6 @@ fn escape_ffmeta(value: &str) -> String {
     out
 }
 
-/// Make a title safe for use as a filename component.
 pub fn sanitize_filename(title: &str) -> String {
     let mut out: String = title
         .chars()
@@ -324,20 +621,71 @@ pub fn sanitize_filename(title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder::ChunkStatus;
 
-    fn chunk(chapter_index: usize, part: usize) -> ChunkRecord {
+    fn chunk(chapter_index: usize, part: usize, kind: ChunkKind) -> ChunkRecord {
         ChunkRecord {
             chapter_index,
             chapter_title: format!("Chapter {}", chapter_index + 1),
             part,
+            kind,
             file: format!("c{chapter_index}-p{part}.wav"),
             chars: 10,
             synthesis_sha256: "0".repeat(64),
-            status: crate::ChunkStatus::Synthesized,
+            status: ChunkStatus::Synthesized,
             audio_sha256: Some("1".repeat(64)),
             bytes: Some(44),
             error: None,
         }
+    }
+
+    #[test]
+    fn chapter_concat_entries_insert_requested_gaps() {
+        let parts = vec![
+            chunk(0, 1, ChunkKind::Title),
+            chunk(0, 2, ChunkKind::Body),
+            chunk(0, 3, ChunkKind::Body),
+            chunk(0, 4, ChunkKind::Heading),
+            chunk(0, 5, ChunkKind::Body),
+        ];
+        let gaps = ConcatGaps {
+            title: Some("title.wav".to_string()),
+            paragraph: Some("paragraph.wav".to_string()),
+            chapter: None,
+        };
+        assert_eq!(
+            build_chapter_concat_entries(&parts, &gaps),
+            vec![
+                "c0-p1.wav",
+                "title.wav",
+                "c0-p2.wav",
+                "paragraph.wav",
+                "c0-p3.wav",
+                "c0-p4.wav",
+                "title.wav",
+                "c0-p5.wav",
+            ]
+        );
+        assert_eq!(
+            build_chapter_concat_entries(&parts, &ConcatGaps::default()),
+            parts
+                .iter()
+                .map(|part| part.file.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn book_concat_entries_insert_gaps_only_between_chapters() {
+        let files = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
+        assert_eq!(
+            build_book_concat_entries(&files, Some("chapter.wav")),
+            vec!["one.wav", "chapter.wav", "two.wav"]
+        );
+        assert_eq!(
+            build_book_concat_entries(&files, None),
+            vec!["one.wav", "two.wav"]
+        );
     }
 
     #[test]
@@ -348,27 +696,63 @@ mod tests {
 
     #[test]
     fn chapter_parts_are_sorted_before_stitching() {
-        let grouped = group_by_chapter(&[chunk(0, 2), chunk(1, 1), chunk(0, 1)]);
+        let grouped = group_by_chapter(&[
+            chunk(0, 2, ChunkKind::Body),
+            chunk(1, 1, ChunkKind::Title),
+            chunk(0, 1, ChunkKind::Title),
+        ]);
         assert_eq!(grouped[0].1[0].part, 1);
         assert_eq!(grouped[0].1[1].part, 2);
     }
 
     #[test]
-    fn ffmetadata_has_cumulative_chapter_times() {
+    fn ffmetadata_has_cumulative_chapter_times_including_gaps() {
         let meta = build_ffmetadata(
             Some("My Book"),
             &["Intro".to_string(), "One".to_string()],
             &[1_000, 2_500],
+            1_200,
         );
         assert!(meta.starts_with(";FFMETADATA1\n"));
         assert!(meta.contains("title=My Book"));
         assert!(meta.contains("START=0\nEND=1000\ntitle=Intro"));
-        assert!(meta.contains("START=1000\nEND=3500\ntitle=One"));
+        assert!(meta.contains("START=2200\nEND=4700\ntitle=One"));
+    }
+
+    #[test]
+    fn single_file_args_select_copy_or_loudnorm_and_include_metadata() {
+        let copy = single_file_ffmpeg_args(
+            "book.txt",
+            "mp3",
+            false,
+            Some("Title"),
+            Some("Author"),
+            "audiobook.mp3",
+        );
+        assert!(copy.windows(2).any(|pair| pair == ["-c", "copy"]));
+        assert!(copy.contains(&"title=Title".to_string()));
+        assert!(copy.contains(&"artist=Author".to_string()));
+
+        let normalized = single_file_ffmpeg_args(
+            "book.txt",
+            "mp3",
+            true,
+            Some("Title"),
+            Some("Author"),
+            "audiobook.mp3",
+        );
+        assert!(normalized.contains(&"loudnorm=I=-18:TP=-2:LRA=11".to_string()));
+        assert!(
+            normalized
+                .windows(2)
+                .any(|pair| pair == ["-c:a", "libmp3lame"])
+        );
+        assert!(!normalized.windows(2).any(|pair| pair == ["-c", "copy"]));
     }
 
     #[test]
     fn ffmetadata_escapes_special_characters() {
-        let meta = build_ffmetadata(None, &["A = B; C".to_string()], &[10]);
+        let meta = build_ffmetadata(None, &["A = B; C".to_string()], &[10], 0);
         assert!(meta.contains(r"title=A \= B\; C"));
     }
 

--- a/crates/bookforge-audio/src/text.rs
+++ b/crates/bookforge-audio/src/text.rs
@@ -11,6 +11,34 @@
 use bookforge_core::ir::{Block, BlockId, BlockKind, Book};
 use bookforge_core::marker::strip_marker_tokens;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NarrationBlockKind {
+    Title,
+    Heading(u8),
+    Paragraph,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NarrationBlock {
+    pub kind: NarrationBlockKind,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChunkKind {
+    Title,
+    Heading,
+    #[default]
+    Body,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NarrationChunk {
+    pub kind: ChunkKind,
+    pub text: String,
+}
+
 /// One narratable chapter: the visible prose of a single spine section,
 /// with a display title used for filenames and (when stitched) chapter
 /// markers.
@@ -19,15 +47,22 @@ pub struct Chapter {
     /// Zero-based position in reading order.
     pub index: usize,
     pub title: String,
-    /// Clean prose with inline markers removed and blocks joined by blank
-    /// lines. Empty for sections that carry no readable text (cover images,
-    /// nav documents).
-    pub text: String,
+    /// Clean narratable blocks with inline markers removed. Empty for
+    /// sections that carry no readable text (cover images, nav documents).
+    pub blocks: Vec<NarrationBlock>,
 }
 
 impl Chapter {
+    pub fn text(&self) -> String {
+        self.blocks
+            .iter()
+            .map(|block| block.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.text.trim().is_empty()
+        self.blocks.iter().all(|block| block.text.trim().is_empty())
     }
 }
 
@@ -84,7 +119,8 @@ pub fn chapters_from_book_with_options(book: &Book, pdf_page_grouping: bool) -> 
         .into_iter()
         .enumerate()
         .map(|(index, section)| {
-            let mut paragraphs: Vec<String> = Vec::new();
+            let mut blocks = Vec::new();
+            let mut first_heading = true;
             for block_id in &section.block_ids {
                 let Some(block) = block_index.get(block_id) else {
                     continue;
@@ -94,7 +130,15 @@ pub fn chapters_from_book_with_options(book: &Book, pdf_page_grouping: bool) -> 
                 }
                 let text = clean_block_text(block);
                 if !text.is_empty() {
-                    paragraphs.push(text);
+                    let kind = match block.kind {
+                        BlockKind::Heading(_) if first_heading => {
+                            first_heading = false;
+                            NarrationBlockKind::Title
+                        }
+                        BlockKind::Heading(level) => NarrationBlockKind::Heading(level),
+                        _ => NarrationBlockKind::Paragraph,
+                    };
+                    blocks.push(NarrationBlock { kind, text });
                 }
             }
             let title = section
@@ -106,7 +150,7 @@ pub fn chapters_from_book_with_options(book: &Book, pdf_page_grouping: bool) -> 
             Chapter {
                 index,
                 title,
-                text: paragraphs.join("\n\n"),
+                blocks,
             }
         })
         .collect()
@@ -141,12 +185,12 @@ fn chapters_from_pdf_pages(
         .clone()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "Front matter".to_string());
-    let mut paragraphs = Vec::<String>::new();
+    let mut blocks = Vec::<NarrationBlock>::new();
     let mut printed_toc = false;
     let mut printed_toc_roman_folio = false;
 
     for section in sections {
-        let mut page_start = paragraphs.len();
+        let mut page_start = blocks.len();
         for block_id in &section.block_ids {
             let Some(block) = block_index.get(block_id) else {
                 continue;
@@ -175,13 +219,13 @@ fn chapters_from_pdf_pages(
             if chapter_label_key(&text).is_some() {
                 printed_toc = false;
                 printed_toc_roman_folio = false;
-                if !paragraphs.is_empty() {
+                if !blocks.is_empty() {
                     chapters.push(Chapter {
                         index: chapters.len(),
                         title,
-                        text: paragraphs.join("\n\n"),
+                        blocks,
                     });
-                    paragraphs.clear();
+                    blocks = Vec::new();
                     page_start = 0;
                 }
                 title = text.clone();
@@ -201,26 +245,36 @@ fn chapters_from_pdf_pages(
             {
                 continue;
             }
-            paragraphs.push(text);
+            let kind = if chapter_label_key(&text).is_some() {
+                NarrationBlockKind::Title
+            } else {
+                match block.kind {
+                    BlockKind::Heading(level) => NarrationBlockKind::Heading(level),
+                    _ => NarrationBlockKind::Paragraph,
+                }
+            };
+            blocks.push(NarrationBlock { kind, text });
         }
 
         // Join only a paragraph that actually crosses a physical page. Do
         // not flatten ordinary paragraph boundaries within the page.
         if page_start > 0
-            && paragraphs.len() > page_start
-            && should_join_across_page(&paragraphs[page_start - 1], &paragraphs[page_start])
+            && blocks.len() > page_start
+            && blocks[page_start - 1].kind == NarrationBlockKind::Paragraph
+            && blocks[page_start].kind == NarrationBlockKind::Paragraph
+            && should_join_across_page(&blocks[page_start - 1].text, &blocks[page_start].text)
         {
-            let right = paragraphs.remove(page_start);
-            paragraphs[page_start - 1].push(' ');
-            paragraphs[page_start - 1].push_str(&right);
+            let right = blocks.remove(page_start).text;
+            blocks[page_start - 1].text.push(' ');
+            blocks[page_start - 1].text.push_str(&right);
         }
     }
 
-    if !paragraphs.is_empty() {
+    if !blocks.is_empty() {
         chapters.push(Chapter {
             index: chapters.len(),
             title,
-            text: paragraphs.join("\n\n"),
+            blocks,
         });
     }
     chapters
@@ -450,7 +504,67 @@ fn collapse_whitespace(text: &str) -> String {
 /// `max_chars` counts Unicode scalar values, not bytes; every returned
 /// chunk is a valid string and non-empty. Returns an empty vector for
 /// blank input.
+pub fn chunk_blocks(blocks: &[NarrationBlock], max_chars: usize) -> Vec<NarrationChunk> {
+    let max_chars = max_chars.max(1);
+    let mut chunks = Vec::new();
+    let mut paragraphs = Vec::new();
+
+    let flush_paragraphs =
+        |paragraphs: &mut Vec<&str>, chunks: &mut Vec<NarrationChunk>| {
+            if paragraphs.is_empty() {
+                return;
+            }
+            let text = paragraphs.join("\n\n");
+            chunks.extend(chunk_body_text(&text, max_chars).into_iter().map(|text| {
+                NarrationChunk {
+                    kind: ChunkKind::Body,
+                    text,
+                }
+            }));
+            paragraphs.clear();
+        };
+
+    for block in blocks {
+        match block.kind {
+            NarrationBlockKind::Paragraph => paragraphs.push(block.text.as_str()),
+            NarrationBlockKind::Title | NarrationBlockKind::Heading(_) => {
+                flush_paragraphs(&mut paragraphs, &mut chunks);
+                let kind = match block.kind {
+                    NarrationBlockKind::Title => ChunkKind::Title,
+                    NarrationBlockKind::Heading(_) => ChunkKind::Heading,
+                    NarrationBlockKind::Paragraph => unreachable!(),
+                };
+                let text = block.text.trim();
+                if !text.is_empty() {
+                    let pieces = if text.chars().count() > max_chars {
+                        split_long_unit(text, max_chars)
+                    } else {
+                        vec![text.to_string()]
+                    };
+                    chunks.extend(pieces.into_iter().map(|text| NarrationChunk { kind, text }));
+                }
+            }
+        }
+    }
+    flush_paragraphs(&mut paragraphs, &mut chunks);
+    chunks
+}
+
+/// Compatibility wrapper for callers that have unstructured prose.
 pub fn chunk_text(text: &str, max_chars: usize) -> Vec<String> {
+    chunk_blocks(
+        &[NarrationBlock {
+            kind: NarrationBlockKind::Paragraph,
+            text: text.to_string(),
+        }],
+        max_chars,
+    )
+    .into_iter()
+    .map(|chunk| chunk.text)
+    .collect()
+}
+
+fn chunk_body_text(text: &str, max_chars: usize) -> Vec<String> {
     let max_chars = max_chars.max(1);
     let mut chunks: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -746,18 +860,112 @@ mod tests {
         assert_eq!(chapters[0].title, "Test Book");
         assert_eq!(chapters[1].title, "CAPITOLO I:");
         assert_eq!(chapters[2].title, "CAPITOLO II");
+        assert_eq!(chapters[1].blocks[0].kind, NarrationBlockKind::Title);
+        assert_eq!(chapters[1].blocks[0].text, "CAPITOLO I:");
+        assert_eq!(chapters[2].blocks[0].kind, NarrationBlockKind::Title);
         assert!(
             chapters
                 .iter()
-                .all(|chapter| !chapter.text.contains("Repeated Book Title"))
+                .all(|chapter| !chapter.text().contains("Repeated Book Title"))
         );
         assert!(
             chapters
                 .iter()
-                .all(|chapter| chapter.text.lines().all(|line| {
+                .all(|chapter| chapter.text().lines().all(|line| {
                     let line = line.trim();
                     line.is_empty() || !line.chars().all(|ch| ch.is_ascii_digit())
                 }))
         );
+    }
+
+    #[test]
+    fn headings_are_typed_and_section_title_appears_once() {
+        use bookforge_core::ir::{
+            Block, BlockId, BookFormat, BookId, DomPath, Metadata, Section, SectionId, TextRun,
+        };
+
+        let section_id = SectionId("section".to_string());
+        let make_block = |id: &str, kind, text: &str| Block {
+            id: BlockId(id.to_string()),
+            section_id: section_id.clone(),
+            kind,
+            dom_path: DomPath(vec![0]),
+            text_runs: vec![TextRun {
+                id: format!("{id}-run"),
+                text: text.to_string(),
+            }],
+            inline_marks: Vec::new(),
+            protected_spans: Vec::new(),
+            token_estimate: 1,
+        };
+        let book = Book {
+            source_path: None,
+            id: BookId("headings".to_string()),
+            format: BookFormat::Epub,
+            metadata: Metadata::default(),
+            manifest: Vec::new(),
+            spine: Vec::new(),
+            sections: vec![Section {
+                id: section_id.clone(),
+                href: "chapter.xhtml".to_string(),
+                spine_index: 0,
+                title: Some("The Title".to_string()),
+                heading_level: Some(1),
+                block_ids: vec![
+                    BlockId("title".to_string()),
+                    BlockId("body".to_string()),
+                    BlockId("heading".to_string()),
+                ],
+                prev: None,
+                next: None,
+            }],
+            blocks: vec![
+                make_block("title", BlockKind::Heading(1), "The Title"),
+                make_block("body", BlockKind::Paragraph, "Body text."),
+                make_block("heading", BlockKind::Heading(2), "A Subheading"),
+            ],
+        };
+
+        let chapters = chapters_from_book(&book);
+        assert_eq!(chapters[0].blocks[0].kind, NarrationBlockKind::Title);
+        assert_eq!(chapters[0].blocks[2].kind, NarrationBlockKind::Heading(2));
+        assert_eq!(
+            chapters[0]
+                .blocks
+                .iter()
+                .filter(|block| block.text == "The Title")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn chunk_blocks_keeps_titles_and_headings_separate_from_body() {
+        let blocks = vec![
+            NarrationBlock {
+                kind: NarrationBlockKind::Title,
+                text: "The Title".to_string(),
+            },
+            NarrationBlock {
+                kind: NarrationBlockKind::Paragraph,
+                text: "First body sentence.".to_string(),
+            },
+            NarrationBlock {
+                kind: NarrationBlockKind::Heading(2),
+                text: "A Heading".to_string(),
+            },
+            NarrationBlock {
+                kind: NarrationBlockKind::Paragraph,
+                text: "Second body sentence.".to_string(),
+            },
+        ];
+
+        let chunks = chunk_blocks(&blocks, 100);
+        assert_eq!(chunks[0].kind, ChunkKind::Title);
+        assert_eq!(chunks[0].text, "The Title");
+        assert_eq!(chunks[1].kind, ChunkKind::Body);
+        assert_eq!(chunks[2].kind, ChunkKind::Heading);
+        assert_eq!(chunks[2].text, "A Heading");
+        assert_eq!(chunks[3].kind, ChunkKind::Body);
     }
 }

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-cli"
-version = "2.5.1"
+version = "2.6.0"
 description = "CLI-first EPUB translation engine with deterministic structure rebuild and review loop."
 readme = "../../README.md"
 edition.workspace = true
@@ -16,12 +16,12 @@ path = "src/main.rs"
 anyhow.workspace = true
 async-stream = { version = "0.3", optional = true }
 axum = { version = "0.8", optional = true, features = ["multipart"] }
-bookforge-audio = { version = "2.5.1", path = "../bookforge-audio" }
-bookforge-core = { version = "2.5.1", path = "../bookforge-core", features = ["cli"] }
-bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
-bookforge-llm = { version = "2.5.1", path = "../bookforge-llm" }
-bookforge-pdf = { version = "2.5.1", path = "../bookforge-pdf" }
-bookforge-store = { version = "2.5.1", path = "../bookforge-store" }
+bookforge-audio = { version = "2.6.0", path = "../bookforge-audio" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core", features = ["cli"] }
+bookforge-epub = { version = "2.6.0", path = "../bookforge-epub" }
+bookforge-llm = { version = "2.6.0", path = "../bookforge-llm" }
+bookforge-pdf = { version = "2.6.0", path = "../bookforge-pdf" }
+bookforge-store = { version = "2.6.0", path = "../bookforge-store" }
 clap.workspace = true
 console.workspace = true
 futures-core = { version = "0.3", optional = true }

--- a/crates/bookforge-cli/pricing/audio-providers.json
+++ b/crates/bookforge-cli/pricing/audio-providers.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-07-20",
+  "providers": {
+    "elevenlabs": {
+      "eleven_v3": {
+        "usd_per_million_chars": null,
+        "credits_per_char": 0.27,
+        "note": "Estimate from a measured pay-as-you-go charge of about 0.27 credits per character."
+      },
+      "eleven_flash_v2_5": {
+        "usd_per_million_chars": null,
+        "credits_per_char": 0.14,
+        "note": "Estimate using the typical half-weight credit multiplier relative to v3-class models."
+      },
+      "eleven_turbo_v2_5": {
+        "usd_per_million_chars": null,
+        "credits_per_char": 0.14,
+        "note": "Estimate using the typical half-weight credit multiplier relative to v3-class models."
+      },
+      "eleven_multilingual_v2": {
+        "usd_per_million_chars": null,
+        "credits_per_char": 0.27,
+        "note": "Estimate using the measured v3-class pay-as-you-go credit weight."
+      }
+    },
+    "openai": {
+      "gpt-4o-mini-tts": {
+        "usd_per_million_chars": 15.0,
+        "credits_per_char": null,
+        "note": "Approximate character-equivalent estimate; this model is billed from text and generated-audio tokens."
+      },
+      "tts-1": {
+        "usd_per_million_chars": 15.0,
+        "credits_per_char": null,
+        "note": "Published character rate; actual provider billing is authoritative."
+      },
+      "tts-1-hd": {
+        "usd_per_million_chars": 30.0,
+        "credits_per_char": null,
+        "note": "Published character rate; actual provider billing is authoritative."
+      }
+    }
+  }
+}

--- a/crates/bookforge-cli/src/audio_cost.rs
+++ b/crates/bookforge-cli/src/audio_cost.rs
@@ -1,0 +1,162 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+const BUNDLED_PRICING: &str = include_str!("../pricing/audio-providers.json");
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct AudioCost {
+    pub usd: Option<f64>,
+    pub credits: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AudioPricingCatalog {
+    data: AudioPricingFile,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AudioPricingFile {
+    schema_version: u32,
+    #[allow(dead_code)]
+    updated_at: String,
+    providers: BTreeMap<String, BTreeMap<String, AudioModelPricing>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AudioModelPricing {
+    usd_per_million_chars: Option<f64>,
+    credits_per_char: Option<f64>,
+    #[allow(dead_code)]
+    note: String,
+}
+
+impl AudioPricingCatalog {
+    pub(crate) fn estimate(&self, provider: &str, model: &str, chars: usize) -> Option<AudioCost> {
+        let provider = self
+            .data
+            .providers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(provider))?
+            .1;
+        let pricing = provider
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(model))?
+            .1;
+        Some(AudioCost {
+            usd: pricing
+                .usd_per_million_chars
+                .map(|rate| chars as f64 / 1_000_000.0 * rate),
+            credits: pricing.credits_per_char.map(|rate| chars as f64 * rate),
+        })
+    }
+}
+
+pub(crate) fn load_audio_pricing() -> Result<AudioPricingCatalog> {
+    let override_path = std::env::var_os("BOOKFORGE_AUDIO_PRICING_PATH").map(PathBuf::from);
+    match override_path {
+        Some(path) => {
+            let content = fs::read_to_string(&path)
+                .with_context(|| format!("reading audio pricing file {}", path.display()))?;
+            parse_audio_pricing(&content, Some(&path))
+        }
+        None => parse_audio_pricing(BUNDLED_PRICING, None),
+    }
+}
+
+pub(crate) fn estimate_audio_cost(provider: &str, model: &str, chars: usize) -> Option<AudioCost> {
+    load_audio_pricing().ok()?.estimate(provider, model, chars)
+}
+
+fn parse_audio_pricing(content: &str, source: Option<&Path>) -> Result<AudioPricingCatalog> {
+    let data: AudioPricingFile = serde_json::from_str(content).with_context(|| match source {
+        Some(path) => format!("parsing audio pricing JSON from {}", path.display()),
+        None => "parsing bundled audio pricing JSON".to_string(),
+    })?;
+    if data.schema_version != 1 {
+        bail!(
+            "unsupported audio pricing schema_version {}; expected 1",
+            data.schema_version
+        );
+    }
+    if data.providers.is_empty() {
+        bail!("audio pricing catalog contains no providers");
+    }
+    for (provider, models) in &data.providers {
+        for (model, pricing) in models {
+            if pricing.usd_per_million_chars.is_none() && pricing.credits_per_char.is_none() {
+                bail!(
+                    "audio pricing entry {provider}/{model} must define usd_per_million_chars or credits_per_char"
+                );
+            }
+            for (label, value) in [
+                ("usd_per_million_chars", pricing.usd_per_million_chars),
+                ("credits_per_char", pricing.credits_per_char),
+            ] {
+                if value.is_some_and(|value| !value.is_finite() || value < 0.0) {
+                    bail!("audio pricing entry {provider}/{model} has invalid {label}");
+                }
+            }
+        }
+    }
+    Ok(AudioPricingCatalog { data })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_PRICING: &str = r#"{
+      "schema_version": 1,
+      "updated_at": "2026-07-20",
+      "providers": {
+        "test": {
+          "voice-model": {
+            "usd_per_million_chars": 20.0,
+            "credits_per_char": 0.25,
+            "note": "test estimate"
+          }
+        }
+      }
+    }"#;
+
+    #[test]
+    fn parses_and_estimates_audio_pricing() {
+        let pricing = parse_audio_pricing(TEST_PRICING, None).expect("pricing should parse");
+        let cost = pricing
+            .estimate("TEST", "VOICE-MODEL", 2_000_000)
+            .expect("model should be found case-insensitively");
+        assert_eq!(cost.usd, Some(40.0));
+        assert_eq!(cost.credits, Some(500_000.0));
+    }
+
+    #[test]
+    fn rejects_wrong_audio_pricing_schema() {
+        let error = parse_audio_pricing(
+            r#"{"schema_version":2,"updated_at":"x","providers":{"x":{}}}"#,
+            None,
+        )
+        .expect_err("schema 2 should be rejected");
+        assert!(error.to_string().contains("schema_version 2"));
+    }
+
+    #[test]
+    fn audio_pricing_lookup_misses_unknown_entries() {
+        let pricing = parse_audio_pricing(TEST_PRICING, None).expect("pricing should parse");
+        assert_eq!(pricing.estimate("test", "missing", 10), None);
+        assert_eq!(pricing.estimate("missing", "voice-model", 10), None);
+    }
+
+    #[test]
+    fn bundled_audio_pricing_parses_and_public_lookup_hits() {
+        let pricing =
+            parse_audio_pricing(BUNDLED_PRICING, None).expect("bundled pricing should parse");
+        assert!(pricing.estimate("elevenlabs", "eleven_v3", 100).is_some());
+        assert!(estimate_audio_cost("openai", "tts-1", 100).is_some());
+    }
+}

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 #[cfg(feature = "tui")]
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -7,7 +8,8 @@ use anyhow::{Context, Result};
 use bookforge_audio::{
     AudioFormat, AudiobookOptions, ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig,
     GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, Progress,
-    StitchOptions, build_audiobook, elevenlabs_model_max_input_chars, plan_chunks,
+    StitchOptions, TextNormalization, build_audiobook, elevenlabs_model_max_input_chars,
+    fetch_elevenlabs_subscription, list_elevenlabs_voices, plan_chunks,
     resolve_preferred_elevenlabs_model, stitch, validate_options,
 };
 use bookforge_epub::{ReflowOptions, read_epub, reflow_epub};
@@ -15,7 +17,7 @@ use clap::{Args, ValueEnum};
 use indicatif::{ProgressBar, ProgressStyle};
 use tokio_util::sync::CancellationToken;
 
-use crate::progress::UiMode;
+use crate::{audio_cost::AudioCost, progress::UiMode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -56,10 +58,35 @@ impl AudioFormatArg {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum BreakTagsArg {
+    Auto,
+    Off,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum TextNormalizationArg {
+    Auto,
+    On,
+    Off,
+}
+
+impl TextNormalizationArg {
+    fn into_audio(self) -> TextNormalization {
+        match self {
+            Self::Auto => TextNormalization::Auto,
+            Self::On => TextNormalization::On,
+            Self::Off => TextNormalization::Off,
+        }
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct AudiobookArgs {
     /// Source EPUB to narrate.
-    pub input: PathBuf,
+    pub input: Option<PathBuf>,
 
     /// Output directory for the audio files and manifest. Defaults to
     /// `<input-stem>.audiobook`.
@@ -112,14 +139,62 @@ pub struct AudiobookArgs {
     #[arg(long)]
     pub instructions: Option<String>,
 
+    /// Pause between chapters in milliseconds when stitching.
+    #[arg(long, default_value_t = 1_200)]
+    pub gap_chapter_ms: u32,
+
+    /// Pause after chapter titles and headings in milliseconds.
+    #[arg(long, default_value_t = 800)]
+    pub gap_title_ms: u32,
+
+    /// Pause between body chunks in milliseconds.
+    #[arg(long, default_value_t = 0)]
+    pub gap_paragraph_ms: u32,
+
+    /// Add supported ElevenLabs SSML-like breaks after headings.
+    #[arg(long, value_enum, default_value_t = BreakTagsArg::Auto)]
+    pub break_tags: BreakTagsArg,
+
+    /// Deterministic ElevenLabs synthesis seed.
+    #[arg(long)]
+    pub seed: Option<u32>,
+
+    /// Narration language code. Defaults to the EPUB language.
+    #[arg(long)]
+    pub language: Option<String>,
+
+    /// ElevenLabs text-normalization policy.
+    #[arg(long, value_enum, default_value_t = TextNormalizationArg::Auto)]
+    pub text_normalization: TextNormalizationArg,
+
+    /// Normalize loudness while assembling whole-book files.
+    #[arg(long, default_value_t = false)]
+    pub loudnorm: bool,
+
+    /// Also assemble a flat whole-book file in the selected audio format.
+    #[arg(long, default_value_t = false)]
+    pub single: bool,
+
+    /// Narrate only these 1-based chapters (for example `1-3,7`).
+    #[arg(long, value_parser = parse_chapter_ranges)]
+    pub chapters: Option<BTreeSet<usize>>,
+
+    /// List the voices on an ElevenLabs account and exit.
+    #[arg(long, default_value_t = false)]
+    pub list_voices: bool,
+
     /// After synthesis, join each chapter's parts into one file with ffmpeg.
     #[arg(long, default_value_t = false)]
     pub stitch: bool,
 
-    /// Also assemble a single `.m4b` with chapter markers. Implies
-    /// `--stitch` and requires ffmpeg (and ffprobe for the markers).
+    /// Explicitly assemble a chapter-marked `.m4b`. This is already the
+    /// default when ffmpeg is available; the flag remains a strict override.
     #[arg(long, default_value_t = false)]
     pub m4b: bool,
+
+    /// Do not automatically create the default chapter-marked `.m4b`.
+    #[arg(long, default_value_t = false)]
+    pub no_book_file: bool,
 
     /// Print the chapter/chunk plan and exit without synthesizing.
     #[arg(long, default_value_t = false)]
@@ -138,13 +213,30 @@ pub struct AudiobookArgs {
     pub ui: UiMode,
 }
 
-pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
-    let (book, pdf_page_grouping) = read_epub_for_audio(&args.input)?;
+#[derive(Debug, Clone, Copy)]
+struct QuotaInfo {
+    remaining: u64,
+    limit: u64,
+}
 
-    let out_dir = args
-        .out
-        .clone()
-        .unwrap_or_else(|| default_out_dir(&args.input));
+pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
+    if args.list_voices {
+        return list_voices_and_exit(&args).await;
+    }
+    let input = args
+        .input
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("INPUT is required unless --list-voices is passed"))?;
+    if args.seed.is_some() && args.provider != AudioProviderKind::Elevenlabs {
+        anyhow::bail!("--seed is supported only with --provider elevenlabs");
+    }
+    if args.timeout_seconds == 0 {
+        anyhow::bail!("--timeout-seconds must be greater than zero");
+    }
+
+    let (book, pdf_page_grouping) = read_epub_for_audio(input)?;
+
+    let out_dir = args.out.clone().unwrap_or_else(|| default_out_dir(input));
     let format = args
         .format
         .map(AudioFormatArg::into_format)
@@ -158,7 +250,9 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         AudioProviderKind::Openai => args.voice.clone().unwrap_or_else(|| "alloy".to_string()),
         AudioProviderKind::Gemini => args.voice.clone().unwrap_or_else(|| "Kore".to_string()),
         AudioProviderKind::Elevenlabs => args.voice.clone().ok_or_else(|| {
-            anyhow::anyhow!("ElevenLabs requires --voice with an ElevenLabs voice ID")
+            anyhow::anyhow!(
+                "ElevenLabs requires --voice with an ElevenLabs voice ID; run `bookforge audiobook --list-voices --provider elevenlabs` to see the voices on your account"
+            )
         })?,
     };
     if args.provider == AudioProviderKind::Mock && format != AudioFormat::Wav {
@@ -186,13 +280,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             "ElevenLabs has no free-form instructions field; use --speed, voice settings stored in ElevenLabs, or inline model-supported audio tags"
         );
     }
-    if (args.stitch || args.m4b) && format == AudioFormat::Pcm {
+    let ffmpeg_available = bookforge_audio::ffmpeg_available();
+    let make_m4b = args.m4b || (!args.no_book_file && ffmpeg_available);
+    let postprocess = args.stitch || make_m4b || args.single;
+    if postprocess && format == AudioFormat::Pcm {
         anyhow::bail!(
-            "raw PCM does not carry the sample metadata needed for stitching; choose wav, mp3, opus, aac, or flac"
+            "raw PCM does not carry the sample metadata needed for stitching, --m4b, or --single; choose wav, mp3, opus, aac, or flac (or pass --no-book-file for per-chunk PCM output)"
         );
-    }
-    if args.timeout_seconds == 0 {
-        anyhow::bail!("--timeout-seconds must be greater than zero");
     }
 
     let elevenlabs_dry_run_default =
@@ -293,6 +387,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             "eleven_v3 has no speed control on the ElevenLabs TTS endpoint; use --speed 1.0 or pick another model"
         );
     }
+    let language_code = resolve_language_code(
+        args.provider,
+        &model,
+        args.language.as_deref(),
+        book.metadata.language.as_deref(),
+    );
+    let heading_break_tag = resolve_heading_break_tag(args.provider, &model, args.break_tags);
     let options = AudiobookOptions {
         out_dir: out_dir.clone(),
         voice: voice.clone(),
@@ -302,6 +403,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         concurrency: args.concurrency,
         synthesis_id,
         instructions: args.instructions.clone(),
+        context_chars: 300,
+        seed: args.seed,
+        language_code,
+        text_normalization: (args.provider == AudioProviderKind::Elevenlabs)
+            .then(|| args.text_normalization.into_audio()),
+        heading_break_tag,
+        chapter_filter: args.chapters.clone(),
         pdf_page_grouping,
     };
     validate_options(&options)?;
@@ -310,7 +418,7 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     if plan.is_empty() {
         anyhow::bail!(
             "no narratable text found in {} (cover-only or empty book?)",
-            args.input.display()
+            input.display()
         );
     }
     let chapter_count = plan
@@ -319,10 +427,15 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         .collect::<std::collections::BTreeSet<_>>()
         .len();
     let total_chars: usize = plan.iter().map(|chunk| chunk.chars).sum();
+    let provider_name = audio_provider_name(args.provider);
+    crate::audio_cost::load_audio_pricing()?;
+    let estimated_cost = crate::audio_cost::estimate_audio_cost(provider_name, &model, total_chars);
+    let cost_line = format_audio_cost_line(estimated_cost);
+    let quota = elevenlabs_quota_preflight(&args, &model, total_chars).await;
 
     let human_output = !matches!(args.ui, UiMode::Quiet | UiMode::Json | UiMode::Tui);
     if human_output {
-        println!("Input: {}", args.input.display());
+        println!("Input: {}", input.display());
         println!(
             "Title: {}",
             book.metadata.title.as_deref().unwrap_or("(untitled)")
@@ -340,6 +453,18 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             "Plan: {chapter_count} chapters, {} chunks, {total_chars} characters",
             plan.len()
         );
+        println!("{cost_line}");
+        if let Some(quota) = quota {
+            println!(
+                "ElevenLabs quota: {} remaining of {}",
+                quota.remaining, quota.limit
+            );
+        }
+        if !ffmpeg_available && !args.no_book_file && !args.m4b {
+            eprintln!(
+                "warning: ffmpeg not found on PATH; only per-chunk audio files will be produced"
+            );
+        }
     }
 
     if args.dry_run {
@@ -357,6 +482,14 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                     "chapters": chapter_count,
                     "chunks": plan.len(),
                     "characters": total_chars,
+                    "provider": provider_name,
+                    "model": model,
+                    "estimated_cost_usd": estimated_cost.and_then(|cost| cost.usd),
+                    "estimated_credits": estimated_cost.and_then(|cost| cost.credits),
+                    "quota_remaining": quota.map(|quota| quota.remaining),
+                    "quota_limit": quota.map(|quota| quota.limit),
+                    "book_file": make_m4b,
+                    "single_file": args.single,
                     "dry_run": true,
                     "stale_chunks": stale.len(),
                     "stale_bytes": stale.iter().map(|chunk| chunk.bytes).sum::<u64>(),
@@ -369,6 +502,27 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             }
         }
         return Ok(());
+    }
+
+    if args.ui == UiMode::Json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "event": "audiobook_plan",
+                "chapters": chapter_count,
+                "chunks": plan.len(),
+                "characters": total_chars,
+                "provider": provider_name,
+                "model": model,
+                "estimated_cost_usd": estimated_cost.and_then(|cost| cost.usd),
+                "estimated_credits": estimated_cost.and_then(|cost| cost.credits),
+                "quota_remaining": quota.map(|quota| quota.remaining),
+                "quota_limit": quota.map(|quota| quota.limit),
+                "book_file": make_m4b,
+                "single_file": args.single,
+                "dry_run": false,
+            })
+        );
     }
 
     #[cfg(feature = "tui")]
@@ -388,11 +542,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 .title
                 .clone()
                 .unwrap_or_else(|| "(untitled)".to_string()),
-            input: args.input.display().to_string(),
+            input: input.display().to_string(),
             output: out_dir.display().to_string(),
-            provider: format!("{:?}", args.provider).to_ascii_lowercase(),
+            provider: provider_name.to_string(),
             model: model.clone(),
             voice: voice.clone(),
+            cost_line: Some(cost_line.clone()),
+            chapters_total: chapter_count,
             total: plan.len(),
         })?;
         app.draw()?;
@@ -441,12 +597,18 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     };
 
     let fallback_tui_output = args.ui == UiMode::Tui && !use_tui;
-    let stitch_report = if args.stitch || args.m4b {
+    let stitch_report = if postprocess {
         Some(stitch_output(
             &report.manifest_path,
             &out_dir,
             format,
+            make_m4b,
             args.m4b,
+            args.single,
+            args.gap_chapter_ms,
+            args.gap_title_ms,
+            args.gap_paragraph_ms,
+            args.loudnorm,
             &book,
             human_output || fallback_tui_output,
         )?)
@@ -462,6 +624,21 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             report.files.len()
         );
         println!("Manifest: {}", report.manifest_path.display());
+        let chapter_files = stitch_report
+            .as_ref()
+            .map_or(0, |result| result.chapter_files.len());
+        println!(
+            "Artifacts: {} chunk files, {chapter_files} chapter files, book file: {}, single file: {}",
+            report.files.len(),
+            stitch_report
+                .as_ref()
+                .and_then(|result| result.book_file.as_ref())
+                .map_or("none".to_string(), |path| path.display().to_string()),
+            stitch_report
+                .as_ref()
+                .and_then(|result| result.single_file.as_ref())
+                .map_or("none".to_string(), |path| path.display().to_string()),
+        );
     } else if args.ui == UiMode::Json {
         println!(
             "{}",
@@ -472,16 +649,18 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 "cached": report.chunks_skipped,
                 "chunks": report.chunks_total,
                 "manifest": report.manifest_path,
+                "chunk_files": report.files,
                 "chapter_files": stitch_report.as_ref().map(|result| &result.chapter_files),
                 "audiobook": stitch_report.as_ref().and_then(|result| result.book_file.as_ref()),
+                "single_file": stitch_report.as_ref().and_then(|result| result.single_file.as_ref()),
                 "warnings": stitch_report.as_ref().map(|result| &result.warnings),
             })
         );
     }
 
-    if stitch_report.is_none() && human_output {
+    if stitch_report.is_none() && human_output && args.no_book_file {
         println!(
-            "Tip: pass --stitch to join each chapter into one file, or --m4b for a single audiobook file."
+            "Tip: pass --stitch to join each chapter, --m4b for a chapter-marked book, or --single for a flat whole-book file."
         );
     }
 
@@ -538,6 +717,213 @@ fn report_stale_chunks(stale: &[bookforge_audio::StaleChunk], deleted: bool) {
                 .unwrap_or_default(),
             format_bytes(chunk.bytes)
         );
+    }
+}
+
+pub(crate) fn parse_chapter_ranges(value: &str) -> Result<BTreeSet<usize>> {
+    let mut chapters = BTreeSet::new();
+    for raw_item in value.split(',') {
+        let item = raw_item.trim();
+        if item.is_empty() {
+            anyhow::bail!("chapter range contains an empty item");
+        }
+        if let Some((raw_start, raw_end)) = item.split_once('-') {
+            let start = parse_chapter_number(raw_start.trim())?;
+            let end = parse_chapter_number(raw_end.trim())?;
+            if start > end {
+                anyhow::bail!("chapter range {start}-{end} is reversed");
+            }
+            chapters.extend(start..=end);
+        } else {
+            chapters.insert(parse_chapter_number(item)?);
+        }
+    }
+    Ok(chapters)
+}
+
+fn parse_chapter_number(value: &str) -> Result<usize> {
+    let chapter = value
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("invalid chapter number '{value}'"))?;
+    if chapter == 0 {
+        anyhow::bail!("chapter numbers are 1-based; 0 is not valid");
+    }
+    Ok(chapter)
+}
+
+fn normalize_language_code(value: &str) -> Option<String> {
+    value
+        .trim()
+        .split(['-', '_'])
+        .next()
+        .filter(|primary| !primary.is_empty())
+        .map(str::to_ascii_lowercase)
+}
+
+fn resolve_language_code(
+    provider: AudioProviderKind,
+    model: &str,
+    explicit: Option<&str>,
+    metadata: Option<&str>,
+) -> Option<String> {
+    let language = explicit
+        .and_then(normalize_language_code)
+        .or_else(|| metadata.and_then(normalize_language_code));
+    if provider == AudioProviderKind::Elevenlabs
+        && matches!(model, "eleven_flash_v2_5" | "eleven_turbo_v2_5")
+    {
+        return language;
+    }
+    if provider == AudioProviderKind::Elevenlabs && language.is_some() {
+        eprintln!(
+            "warning: ElevenLabs model {model} rejects language_code; ignoring {} language",
+            if explicit.is_some() {
+                "the explicit --language"
+            } else {
+                "the EPUB"
+            }
+        );
+    } else if explicit.is_some() {
+        eprintln!(
+            "warning: --language is only applied to ElevenLabs flash/turbo v2.5 models; ignoring it for {}",
+            audio_provider_name(provider)
+        );
+    }
+    None
+}
+
+fn resolve_heading_break_tag(
+    provider: AudioProviderKind,
+    model: &str,
+    setting: BreakTagsArg,
+) -> Option<String> {
+    (setting == BreakTagsArg::Auto
+        && provider == AudioProviderKind::Elevenlabs
+        && matches!(
+            model,
+            "eleven_flash_v2_5" | "eleven_turbo_v2_5" | "eleven_multilingual_v2"
+        ))
+    .then(|| "<break time=\"0.6s\" />".to_string())
+}
+
+fn audio_provider_name(provider: AudioProviderKind) -> &'static str {
+    match provider {
+        AudioProviderKind::Mock => "mock",
+        AudioProviderKind::Openai => "openai",
+        AudioProviderKind::Gemini => "gemini",
+        AudioProviderKind::Elevenlabs => "elevenlabs",
+    }
+}
+
+fn format_audio_cost_line(cost: Option<AudioCost>) -> String {
+    match cost {
+        Some(AudioCost {
+            usd: Some(usd),
+            credits: Some(credits),
+        }) => format!("Estimated cost: ~${usd:.2} / ~{credits:.0} credits"),
+        Some(AudioCost { usd: Some(usd), .. }) => format!("Estimated cost: ~${usd:.2}"),
+        Some(AudioCost {
+            credits: Some(credits),
+            ..
+        }) => format!("Estimated cost: ~{credits:.0} credits"),
+        _ => "Estimated cost: no pricing for this model".to_string(),
+    }
+}
+
+async fn list_voices_and_exit(args: &AudiobookArgs) -> Result<()> {
+    if args.provider != AudioProviderKind::Elevenlabs {
+        anyhow::bail!("--list-voices requires --provider elevenlabs");
+    }
+    if args.timeout_seconds == 0 {
+        anyhow::bail!("--timeout-seconds must be greater than zero");
+    }
+    let base_url = args
+        .base_url
+        .as_deref()
+        .unwrap_or("https://api.elevenlabs.io/v1");
+    validate_audio_base_url(base_url)?;
+    let key_env = args.api_key_env.as_deref().unwrap_or("ELEVENLABS_API_KEY");
+    let api_key = std::env::var(key_env)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("environment variable '{key_env}' is not set"))?;
+    let voices = list_elevenlabs_voices(base_url, &api_key, args.timeout_seconds)
+        .await
+        .context("failed to list ElevenLabs voices")?;
+    let id_width = voices
+        .iter()
+        .map(|voice| voice.voice_id.chars().count())
+        .chain(std::iter::once("voice_id".len()))
+        .max()
+        .unwrap_or("voice_id".len());
+    let name_width = voices
+        .iter()
+        .map(|voice| voice.name.chars().count())
+        .chain(std::iter::once("name".len()))
+        .max()
+        .unwrap_or("name".len());
+    println!("{:<id_width$}  {:<name_width$}  labels", "voice_id", "name");
+    for voice in voices {
+        let labels = if voice.labels.is_empty() {
+            "-".to_string()
+        } else {
+            voice
+                .labels
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        println!(
+            "{:<id_width$}  {:<name_width$}  {labels}",
+            voice.voice_id, voice.name
+        );
+    }
+    Ok(())
+}
+
+async fn elevenlabs_quota_preflight(
+    args: &AudiobookArgs,
+    model: &str,
+    planned_chars: usize,
+) -> Option<QuotaInfo> {
+    if args.provider != AudioProviderKind::Elevenlabs {
+        return None;
+    }
+    let key_env = args.api_key_env.as_deref().unwrap_or("ELEVENLABS_API_KEY");
+    let key_is_set = std::env::var(key_env)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty());
+    if args.dry_run && !key_is_set {
+        return None;
+    }
+    let mut config = ElevenLabsTtsConfig::hosted(Some(model.to_string()));
+    if let Some(base_url) = args.base_url.clone() {
+        config.base_url = base_url;
+    }
+    if let Some(api_key_env) = args.api_key_env.clone() {
+        config.api_key_env = api_key_env;
+    }
+    config.timeout_seconds = args.timeout_seconds.min(15);
+    match fetch_elevenlabs_subscription(&config).await {
+        Ok(subscription) => {
+            let remaining = subscription
+                .character_limit
+                .saturating_sub(subscription.character_count);
+            if planned_chars as u64 > remaining {
+                eprintln!(
+                    "warning: planned audiobook has {planned_chars} characters, exceeding the ElevenLabs quota of {remaining} remaining characters"
+                );
+            }
+            Some(QuotaInfo {
+                remaining,
+                limit: subscription.character_limit,
+            })
+        }
+        Err(error) => {
+            eprintln!("warning: ElevenLabs quota preflight failed ({error}); continuing");
+            None
+        }
     }
 }
 
@@ -721,6 +1107,12 @@ fn stitch_output(
     out_dir: &std::path::Path,
     format: AudioFormat,
     make_m4b: bool,
+    require_m4b: bool,
+    make_single: bool,
+    gap_chapter_ms: u32,
+    gap_title_ms: u32,
+    gap_paragraph_ms: u32,
+    loudnorm: bool,
     book: &bookforge_core::ir::Book,
     human_output: bool,
 ) -> Result<bookforge_audio::StitchReport> {
@@ -737,6 +1129,12 @@ fn stitch_output(
         extension: format.extension().to_string(),
         make_m4b,
         title: book.metadata.title.clone(),
+        gap_chapter_ms,
+        gap_title_ms,
+        gap_paragraph_ms,
+        loudnorm,
+        make_single,
+        author: (!book.metadata.creators.is_empty()).then(|| book.metadata.creators.join(", ")),
     };
     let result = stitch(&manifest, &stitch_options);
     if human_output {
@@ -747,13 +1145,21 @@ fn stitch_output(
             println!("Chapter files: {}", result.chapter_files.len());
         }
     }
-    if make_m4b && result.book_file.is_none() {
+    if require_m4b && result.book_file.is_none() {
         anyhow::bail!(
             "--m4b was requested, but audiobook.m4b could not be assembled; install ffmpeg and review the stitch warnings above"
         );
     }
+    if make_single && result.single_file.is_none() {
+        anyhow::bail!(
+            "--single was requested, but the flat whole-book file could not be assembled; install ffmpeg and review the stitch warnings above"
+        );
+    }
     if human_output && let Some(book_file) = &result.book_file {
         println!("Audiobook: {}", book_file.display());
+    }
+    if human_output && let Some(single_file) = &result.single_file {
+        println!("Single file: {}", single_file.display());
     }
     Ok(result)
 }
@@ -790,7 +1196,10 @@ fn validate_audio_base_url(value: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_audio_base_url;
+    use super::{
+        AudioProviderKind, BreakTagsArg, normalize_language_code, parse_chapter_ranges,
+        resolve_heading_break_tag, resolve_language_code, validate_audio_base_url,
+    };
 
     #[test]
     fn audio_base_url_allows_https_and_loopback_http_only() {
@@ -799,5 +1208,94 @@ mod tests {
         assert!(validate_audio_base_url("http://127.0.0.1:8880/v1").is_ok());
         assert!(validate_audio_base_url("http://example.com/v1").is_err());
         assert!(validate_audio_base_url("https://token@example.com/v1").is_err());
+    }
+
+    #[test]
+    fn chapter_ranges_accept_singletons_ranges_and_whitespace() {
+        assert_eq!(
+            parse_chapter_ranges("1-3, 7").unwrap(),
+            [1, 2, 3, 7].into_iter().collect()
+        );
+        assert_eq!(
+            parse_chapter_ranges("4").unwrap(),
+            [4].into_iter().collect()
+        );
+    }
+
+    #[test]
+    fn chapter_ranges_reject_zero_reversed_empty_and_garbage() {
+        let zero = parse_chapter_ranges("0").unwrap_err().to_string();
+        assert!(zero.contains("1-based"));
+
+        let reversed = parse_chapter_ranges("5-2").unwrap_err().to_string();
+        assert!(reversed.contains("reversed"));
+
+        for value in ["", "1,,2", ",1", "1,"] {
+            let empty = parse_chapter_ranges(value).unwrap_err().to_string();
+            assert!(empty.contains("empty item"), "{value:?}: {empty}");
+        }
+
+        for value in ["x", "1-x", "1-2-3"] {
+            let garbage = parse_chapter_ranges(value).unwrap_err().to_string();
+            assert!(
+                garbage.contains("invalid chapter number"),
+                "{value:?}: {garbage}"
+            );
+        }
+    }
+
+    #[test]
+    fn language_normalization_uses_lowercase_primary_subtag() {
+        assert_eq!(normalize_language_code("en-US").as_deref(), Some("en"));
+        assert_eq!(normalize_language_code("PT_br").as_deref(), Some("pt"));
+        assert_eq!(normalize_language_code("  "), None);
+        assert_eq!(
+            resolve_language_code(
+                AudioProviderKind::Elevenlabs,
+                "eleven_flash_v2_5",
+                None,
+                Some("en-US")
+            )
+            .as_deref(),
+            Some("en")
+        );
+    }
+
+    #[test]
+    fn automatic_break_tags_follow_the_elevenlabs_model_policy() {
+        for model in [
+            "eleven_flash_v2_5",
+            "eleven_turbo_v2_5",
+            "eleven_multilingual_v2",
+        ] {
+            assert!(
+                resolve_heading_break_tag(AudioProviderKind::Elevenlabs, model, BreakTagsArg::Auto)
+                    .is_some()
+            );
+        }
+        assert!(
+            resolve_heading_break_tag(
+                AudioProviderKind::Elevenlabs,
+                "eleven_v3",
+                BreakTagsArg::Auto
+            )
+            .is_none()
+        );
+        assert!(
+            resolve_heading_break_tag(
+                AudioProviderKind::Openai,
+                "eleven_flash_v2_5",
+                BreakTagsArg::Auto
+            )
+            .is_none()
+        );
+        assert!(
+            resolve_heading_break_tag(
+                AudioProviderKind::Elevenlabs,
+                "eleven_flash_v2_5",
+                BreakTagsArg::Off
+            )
+            .is_none()
+        );
     }
 }

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -16,11 +16,12 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
+    ffi::OsString,
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, ExitStatus},
-    sync::{Arc, Mutex, MutexGuard},
-    time::Duration,
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
@@ -54,6 +55,10 @@ const MAX_UPLOAD_BYTES: usize = 64 * 1024 * 1024;
 
 /// Briefly check a detached translation child before reporting launch success.
 const CHILD_STARTUP_CHECK: Duration = Duration::from_millis(150);
+
+const ELEVENLABS_BASE_URL: &str = "https://api.elevenlabs.io/v1";
+const ELEVENLABS_VOICE_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const ELEVENLABS_VOICE_TIMEOUT_SECONDS: u64 = 10;
 
 /// Cloud providers the dashboard form offers, paired with the env var their
 /// runs read a key from when one is configured in the operator's environment.
@@ -130,6 +135,11 @@ const CSRF_TOKEN_PLACEHOLDER: &str = "__BOOKFORGE_CSRF_TOKEN__";
 /// millisecond never collide on a path (and delete each other's input mid-parse).
 static ESTIMATE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// `fetch_elevenlabs_subscription` resolves its key through a configured
+/// environment-variable name. Serialize the narrowly-scoped temporary key used
+/// for dashboard-session credentials, which otherwise live only in `AppState`.
+static ELEVENLABS_QUOTA_ENV_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
 #[derive(Debug, clap::Args)]
 pub struct ServeArgs {
     /// Address to bind. Must be loopback because the dashboard is unauthenticated
@@ -155,6 +165,9 @@ struct AppState {
     /// the lifetime of the server: never written to disk, never logged, and
     /// only injected into spawned runs through the child's environment.
     keys: Arc<Mutex<HashMap<String, String>>>,
+    /// Recently fetched public voice metadata. API keys remain exclusively in
+    /// `keys` (or the provider environment) and are never cached here.
+    elevenlabs_voices: Arc<Mutex<Option<ElevenLabsVoiceCache>>>,
     /// Browser-launched audiobook operations that can still be cancelled.
     audio_cancels: Arc<Mutex<HashMap<String, tokio_util::sync::CancellationToken>>>,
     /// Path to the job store's sqlite database, resolved once when the server
@@ -168,6 +181,12 @@ struct AppState {
     store_path: PathBuf,
     #[cfg(test)]
     resume_launches: Option<Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+#[derive(Clone)]
+struct ElevenLabsVoiceCache {
+    fetched_at: Instant,
+    voices: Vec<bookforge_audio::ElevenLabsVoice>,
 }
 
 /// The default job store path, relative to the current directory — identical
@@ -283,6 +302,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         csrf_token: generate_csrf_token()?,
         host_port: local.port(),
         keys: Arc::new(Mutex::new(HashMap::new())),
+        elevenlabs_voices: Arc::new(Mutex::new(None)),
         audio_cancels: Arc::new(Mutex::new(HashMap::new())),
         store_path: default_store_path(),
         #[cfg(test)]
@@ -339,8 +359,10 @@ fn dashboard_router(state: AppState) -> Router {
         .route("/api/jobs/{id}/stop", post(stop_job))
         .route("/api/options", get(dashboard_options))
         .route("/api/providers", get(provider_status))
+        .route("/api/audio/voices", get(audio_voices))
         .route("/api/estimate", post(estimate_translate))
         .route("/api/translate", post(launch_translate))
+        .route("/api/audiobook/estimate", post(estimate_audiobook))
         .route("/api/audiobook", post(launch_audiobook))
         .route("/api/audiobooks/{id}", get(audiobook_status))
         .route("/api/audiobooks/{id}/cancel", post(cancel_audiobook))
@@ -1100,6 +1122,170 @@ async fn launch_translate(
     .into_response())
 }
 
+/// Plan audiobook synthesis from an uploaded EPUB without making provider
+/// requests. Parsing and chunk construction are blocking, so both happen off
+/// the async worker after the upload has been saved to a temporary path.
+async fn estimate_audiobook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Result<Response, AppError> {
+    if let Some(response) = reject_mutation(&headers, &state) {
+        return Ok(response);
+    }
+
+    let mut file_bytes: Option<Vec<u8>> = None;
+    let mut fields = HashMap::<String, String>::new();
+    while let Some(field) = multipart.next_field().await? {
+        let name = field.name().unwrap_or_default().to_string();
+        if name == "file" {
+            file_bytes = Some(field.bytes().await?.to_vec());
+        } else {
+            fields.insert(name, field.text().await?);
+        }
+    }
+    let Some(bytes) = file_bytes.filter(|bytes| !bytes.is_empty()) else {
+        return Ok(bad_request("upload an EPUB file"));
+    };
+
+    let provider = field_value(&fields, "provider").unwrap_or_else(|| "mock".to_string());
+    if !matches!(
+        provider.as_str(),
+        "mock" | "openai" | "gemini" | "elevenlabs"
+    ) {
+        return Ok(bad_request("unsupported audiobook provider"));
+    }
+    let model = field_value(&fields, "model").unwrap_or_else(|| match provider.as_str() {
+        "openai" => "gpt-4o-mini-tts".to_string(),
+        "gemini" => "gemini-3.1-flash-tts-preview".to_string(),
+        "elevenlabs" => String::new(),
+        _ => "mock-silence".to_string(),
+    });
+    let max_chars = match fields.get("max_chars") {
+        Some(value) => match value.trim().parse::<usize>() {
+            Ok(value) => value,
+            Err(_) => return Ok(bad_request("max_chars must be a positive integer")),
+        },
+        None => 2_000,
+    };
+    let provider_max_chars = audio_provider_max_chars(&provider, &model);
+    if max_chars == 0 || max_chars > provider_max_chars {
+        return Ok(bad_request(&format!(
+            "{provider} accepts between 1 and {provider_max_chars} characters per request"
+        )));
+    }
+    let chapter_filter = match field_value(&fields, "chapters") {
+        Some(value) => match super::audiobook::parse_chapter_ranges(&value) {
+            Ok(chapters) => Some(chapters),
+            Err(error) => return Ok(bad_request(&format!("invalid chapters: {error}"))),
+        },
+        None => None,
+    };
+
+    let sequence = ESTIMATE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let temp_path = std::env::temp_dir().join(format!(
+        "bookforge-audio-estimate-{}-{}-{sequence}.epub",
+        std::process::id(),
+        now_ms(),
+    ));
+    std::fs::write(&temp_path, bytes)?;
+    let plan_path = temp_path.clone();
+    let plan_result = tokio::task::spawn_blocking(move || -> Result<(usize, usize, usize)> {
+        let book = bookforge_epub::read_epub(&plan_path)?;
+        let options = bookforge_audio::AudiobookOptions {
+            max_chars,
+            chapter_filter,
+            ..bookforge_audio::AudiobookOptions::default()
+        };
+        let plan = bookforge_audio::plan_chunks(&book, &options);
+        let chapters = plan
+            .iter()
+            .map(|chunk| chunk.chapter_index)
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+        let characters = plan.iter().map(|chunk| chunk.chars).sum();
+        Ok((chapters, plan.len(), characters))
+    })
+    .await;
+    let _ = std::fs::remove_file(&temp_path);
+    let result = match plan_result? {
+        Ok(result) => result,
+        Err(error) => {
+            return Ok(bad_request(&format!(
+                "could not estimate audiobook: {error}"
+            )));
+        }
+    };
+    let (chapters, chunks, characters) = result;
+    let cost = crate::audio_cost::estimate_audio_cost(&provider, &model, characters);
+    let mut payload = json!({
+        "chapters": chapters,
+        "chunks": chunks,
+        "characters": characters,
+        "est_cost_usd": cost.and_then(|value| value.usd),
+        "est_credits": cost.and_then(|value| value.credits),
+    });
+
+    if provider == "elevenlabs"
+        && let Some(api_key) = resolve_audio_provider_key(&state, "elevenlabs")?
+        && let Some(subscription) = fetch_dashboard_elevenlabs_subscription(&api_key, &model).await
+    {
+        let remaining = subscription
+            .character_limit
+            .saturating_sub(subscription.character_count);
+        if let Some(object) = payload.as_object_mut() {
+            object.insert(
+                "quota".to_string(),
+                json!({
+                    "remaining": remaining,
+                    "limit": subscription.character_limit,
+                    "fits": characters as u128 <= remaining as u128,
+                }),
+            );
+        }
+    }
+
+    Ok(Json(payload).into_response())
+}
+
+struct TemporaryEnvKey(String);
+
+impl Drop for TemporaryEnvKey {
+    fn drop(&mut self) {
+        // SAFETY: the name is unique to this request and access to temporary
+        // ElevenLabs quota variables is serialized by `ELEVENLABS_QUOTA_ENV_LOCK`.
+        unsafe { std::env::remove_var(&self.0) };
+    }
+}
+
+async fn fetch_dashboard_elevenlabs_subscription(
+    api_key: &str,
+    model: &str,
+) -> Option<bookforge_audio::ElevenLabsSubscription> {
+    let lock = ELEVENLABS_QUOTA_ENV_LOCK.get_or_init(|| tokio::sync::Mutex::new(()));
+    let _guard = lock.lock().await;
+    let sequence = ESTIMATE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let env_name = format!(
+        "BOOKFORGE_DASHBOARD_ELEVENLABS_KEY_{}_{}",
+        std::process::id(),
+        sequence
+    );
+    // SAFETY: this request-unique name is never read or written outside the
+    // serialized section guarded above, and the RAII guard removes it on every
+    // return path (including cancellation).
+    unsafe { std::env::set_var(&env_name, api_key) };
+    let _temporary_key = TemporaryEnvKey(env_name.clone());
+    let mut config = bookforge_audio::ElevenLabsTtsConfig::hosted(
+        (!model.is_empty()).then(|| model.to_string()),
+    );
+    config.api_key_env = env_name;
+    config.timeout_seconds = ELEVENLABS_VOICE_TIMEOUT_SECONDS;
+    config.max_attempts = 2;
+    bookforge_audio::fetch_elevenlabs_subscription(&config)
+        .await
+        .ok()
+}
+
 /// Launch audiobook synthesis directly from an uploaded source or translated
 /// EPUB. Progress is durable: the audio builder creates `manifest.json` before
 /// its first provider request and atomically checkpoints it after every chunk.
@@ -1140,9 +1326,10 @@ async fn launch_audiobook(
     let model = field_value(&fields, "model").unwrap_or_else(|| match provider.as_str() {
         "openai" => "gpt-4o-mini-tts".to_string(),
         "gemini" => "gemini-3.1-flash-tts-preview".to_string(),
-        "elevenlabs" => "eleven_multilingual_v2".to_string(),
+        "elevenlabs" => String::new(),
         _ => "mock-silence".to_string(),
     });
+    let auto_model = provider == "elevenlabs" && model.is_empty();
     let voice = field_value(&fields, "voice").or_else(|| match provider.as_str() {
         "openai" => Some("alloy".to_string()),
         "gemini" => Some("Kore".to_string()),
@@ -1201,6 +1388,11 @@ async fn launch_audiobook(
         .unwrap_or(2_000);
     let provider_max_chars = audio_provider_max_chars(&provider, &model);
     if max_chars == 0 || max_chars > provider_max_chars {
+        if auto_model {
+            return Ok(bad_request(
+                "ElevenLabs Auto accepts between 1 and 10000 characters per request; pick eleven_flash_v2_5 explicitly for larger values",
+            ));
+        }
         return Ok(bad_request(&format!(
             "{provider} accepts between 1 and {provider_max_chars} characters per request"
         )));
@@ -1209,6 +1401,41 @@ async fn launch_audiobook(
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(4)
         .clamp(1, 16);
+    let gap_chapter_ms = match parse_audio_gap(&fields, "gap_chapter_ms") {
+        Ok(value) => value,
+        Err(error) => return Ok(bad_request(&error)),
+    };
+    let gap_title_ms = match parse_audio_gap(&fields, "gap_title_ms") {
+        Ok(value) => value,
+        Err(error) => return Ok(bad_request(&error)),
+    };
+    let seed = match field_value(&fields, "seed") {
+        Some(value) => match value.parse::<u32>() {
+            Ok(value) => Some(value),
+            Err(_) => return Ok(bad_request("seed must be a valid unsigned 32-bit integer")),
+        },
+        None => None,
+    };
+    let language = match fields.get("language") {
+        Some(value) => {
+            let value = value.trim();
+            if !valid_audio_language(value) {
+                return Ok(bad_request(
+                    "language must be a code such as it, en-US, or pt-BR",
+                ));
+            }
+            Some(value.to_string())
+        }
+        None => None,
+    };
+    let advanced = AudiobookCommandOptions {
+        gap_chapter_ms,
+        gap_title_ms,
+        single: truthy_field(&fields, "single"),
+        loudnorm: truthy_field(&fields, "loudnorm"),
+        seed,
+        language,
+    };
     let make_m4b = truthy_field(&fields, "m4b");
     let stitch_audio = truthy_field(&fields, "stitch") || make_m4b;
     if stitch_audio && format == "pcm" {
@@ -1237,7 +1464,7 @@ async fn launch_audiobook(
         lock_keys(&state)?.insert(key_slot.clone(), key.clone());
         Some(key)
     } else {
-        lock_keys(&state)?.get(&key_slot).cloned()
+        resolve_audio_provider_key(&state, &provider)?
     };
     if provider != "mock"
         && key.is_none()
@@ -1263,47 +1490,30 @@ async fn launch_audiobook(
         return Ok(bad_request(&format!("could not read EPUB: {error}")));
     }
     std::fs::create_dir_all(&out_dir)?;
-    write_audio_process_state(&out_dir, "starting", None, None)?;
+    write_audio_process_state(&out_dir, "starting", None, None, auto_model)?;
 
     let exe = std::env::current_exe()?;
     let mut command = tokio::process::Command::new(exe);
-    command
-        .arg("audiobook")
-        .arg(&input_path)
-        .arg("--out")
-        .arg(&out_dir)
-        .arg("--provider")
-        .arg(&provider)
-        .arg("--model")
-        .arg(&model)
-        .arg("--voice")
-        .arg(&voice)
-        .arg("--format")
-        .arg(&format)
-        .arg("--speed")
-        .arg(speed.to_string())
-        .arg("--max-chars")
-        .arg(max_chars.to_string())
-        .arg("--concurrency")
-        .arg(concurrency.to_string())
-        .arg("--ui")
-        .arg("quiet");
-    if let Some(instructions) = instructions {
-        command.arg("--instructions").arg(instructions);
-    }
-    if let Some(base_url) = base_url {
-        command.arg("--base-url").arg(base_url);
-    }
-    if make_m4b {
-        command.arg("--m4b");
-    } else if stitch_audio {
-        command.arg("--stitch");
-    }
-    if provider != "mock"
-        && let Some(key) = key
-    {
-        let env = audio_provider_key_env(&provider).expect("audio provider was validated");
-        command.arg("--api-key-env").arg(env);
+    let api_key_env = (provider != "mock" && key.is_some())
+        .then(|| audio_provider_key_env(&provider).expect("audio provider was validated"));
+    command.args(audiobook_command_args(
+        &input_path,
+        &out_dir,
+        &provider,
+        (!auto_model).then_some(model.as_str()),
+        &voice,
+        &format,
+        speed,
+        max_chars,
+        concurrency,
+        instructions.as_deref(),
+        base_url.as_deref(),
+        make_m4b,
+        stitch_audio,
+        api_key_env,
+        &advanced,
+    ));
+    if let (Some(env), Some(key)) = (api_key_env, key) {
         command.env(env, key);
     }
 
@@ -1311,7 +1521,7 @@ async fn launch_audiobook(
         .spawn()
         .context("failed to spawn audiobook process")?;
     let pid = child.id();
-    write_audio_process_state(&out_dir, "running", pid, None)?;
+    write_audio_process_state(&out_dir, "running", pid, None, auto_model)?;
     let cancel = tokio_util::sync::CancellationToken::new();
     state
         .audio_cancels
@@ -1339,6 +1549,7 @@ async fn launch_audiobook(
             operation_state.0,
             pid,
             operation_state.1.as_deref(),
+            auto_model,
         );
         if let Ok(mut registry) = cancel_registry.lock() {
             registry.remove(&monitor_id);
@@ -1356,6 +1567,131 @@ async fn launch_audiobook(
         "pid": pid,
     }))
     .into_response())
+}
+
+#[derive(Debug, Default)]
+struct AudiobookCommandOptions {
+    gap_chapter_ms: Option<u32>,
+    gap_title_ms: Option<u32>,
+    single: bool,
+    loudnorm: bool,
+    seed: Option<u32>,
+    language: Option<String>,
+}
+
+fn clamp_audio_gap(value: u32) -> u32 {
+    value.min(10_000)
+}
+
+fn parse_audio_gap(
+    fields: &HashMap<String, String>,
+    name: &str,
+) -> std::result::Result<Option<u32>, String> {
+    let Some(value) = fields.get(name) else {
+        return Ok(None);
+    };
+    let value = value
+        .trim()
+        .parse::<u32>()
+        .map_err(|_| format!("{name} must be a non-negative integer"))?;
+    Ok(Some(clamp_audio_gap(value)))
+}
+
+fn valid_audio_language(value: &str) -> bool {
+    let mut parts = value.split('-');
+    let Some(primary) = parts.next() else {
+        return false;
+    };
+    if !(2..=3).contains(&primary.len()) || !primary.bytes().all(|byte| byte.is_ascii_alphabetic())
+    {
+        return false;
+    }
+    parts.all(|part| {
+        (2..=8).contains(&part.len()) && part.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn audiobook_command_args(
+    input_path: &Path,
+    out_dir: &Path,
+    provider: &str,
+    model: Option<&str>,
+    voice: &str,
+    format: &str,
+    speed: f32,
+    max_chars: usize,
+    concurrency: usize,
+    instructions: Option<&str>,
+    base_url: Option<&str>,
+    make_m4b: bool,
+    stitch_audio: bool,
+    api_key_env: Option<&str>,
+    advanced: &AudiobookCommandOptions,
+) -> Vec<OsString> {
+    let mut args = vec![
+        "audiobook".into(),
+        input_path.as_os_str().to_owned(),
+        "--out".into(),
+        out_dir.as_os_str().to_owned(),
+        "--provider".into(),
+        provider.into(),
+    ];
+    if let Some(model) = model.filter(|value| !value.is_empty()) {
+        args.extend([OsString::from("--model"), model.into()]);
+    }
+    args.extend([
+        "--voice".into(),
+        voice.into(),
+        "--format".into(),
+        format.into(),
+        "--speed".into(),
+        speed.to_string().into(),
+        "--max-chars".into(),
+        max_chars.to_string().into(),
+        "--concurrency".into(),
+        concurrency.to_string().into(),
+        "--ui".into(),
+        "quiet".into(),
+    ]);
+    if let Some(instructions) = instructions {
+        args.extend([OsString::from("--instructions"), instructions.into()]);
+    }
+    if let Some(base_url) = base_url {
+        args.extend([OsString::from("--base-url"), base_url.into()]);
+    }
+    if make_m4b {
+        args.push("--m4b".into());
+    } else if stitch_audio {
+        args.push("--stitch".into());
+    }
+    if let Some(env) = api_key_env {
+        args.extend([OsString::from("--api-key-env"), env.into()]);
+    }
+    if let Some(gap) = advanced.gap_chapter_ms {
+        args.extend([OsString::from("--gap-chapter-ms"), gap.to_string().into()]);
+    }
+    if let Some(gap) = advanced.gap_title_ms {
+        args.extend([OsString::from("--gap-title-ms"), gap.to_string().into()]);
+    }
+    if advanced.single {
+        args.push("--single".into());
+    }
+    if advanced.loudnorm {
+        args.push("--loudnorm".into());
+    }
+    if let Some(seed) = advanced.seed {
+        args.extend([OsString::from("--seed"), seed.to_string().into()]);
+    }
+    if let Some(language) = advanced.language.as_deref() {
+        args.extend([OsString::from("--language"), language.into()]);
+    }
+    args
+}
+
+fn resolved_model_from_synthesis_id(synthesis_id: &str) -> Option<&str> {
+    let (_, model) = synthesis_id.rsplit_once(':')?;
+    (!model.is_empty()).then_some(model)
 }
 
 async fn audiobook_status(AxumPath(id): AxumPath<String>) -> Result<Response, AppError> {
@@ -1386,10 +1722,16 @@ async fn audiobook_status(AxumPath(id): AxumPath<String>) -> Result<Response, Ap
                 "chunks": [],
             })
         });
+    let resolved_model = payload
+        .get("synthesis_id")
+        .and_then(serde_json::Value::as_str)
+        .and_then(resolved_model_from_synthesis_id)
+        .map(str::to_string);
     if let Some(object) = payload.as_object_mut() {
         object.insert("id".to_string(), json!(id));
         object.insert("out_dir".to_string(), json!(out_dir.display().to_string()));
         object.insert("process".to_string(), process.clone());
+        object.insert("resolved_model".to_string(), json!(resolved_model));
         match process.get("status").and_then(serde_json::Value::as_str) {
             Some("failed") => {
                 object.insert("status".to_string(), json!("failed"));
@@ -1444,7 +1786,15 @@ async fn cancel_audiobook(
     Ok(Json(json!({"ok": true, "status": "cancelling"})).into_response())
 }
 
-async fn audiobook_artifact(AxumPath(id): AxumPath<String>) -> Result<Response, AppError> {
+#[derive(Deserialize)]
+struct ArtifactQuery {
+    disposition: Option<String>,
+}
+
+async fn audiobook_artifact(
+    AxumPath(id): AxumPath<String>,
+    Query(query): Query<ArtifactQuery>,
+) -> Result<Response, AppError> {
     if !valid_audiobook_id(&id) {
         return Ok(bad_request("invalid audiobook operation id"));
     }
@@ -1465,17 +1815,17 @@ async fn audiobook_artifact(AxumPath(id): AxumPath<String>) -> Result<Response, 
         )
             .into_response());
     };
+    let inline = query.disposition.as_deref() == Some("inline");
+    let content_disposition = match (inline, download_name.ends_with(".m4b")) {
+        (true, true) => "inline; filename=\"audiobook.m4b\"",
+        (true, false) => "inline; filename=\"audiobook-audio.zip\"",
+        (false, true) => "attachment; filename=\"audiobook.m4b\"",
+        (false, false) => "attachment; filename=\"audiobook-audio.zip\"",
+    };
     Ok((
         [
             (axum::http::header::CONTENT_TYPE, content_type),
-            (
-                axum::http::header::CONTENT_DISPOSITION,
-                if download_name.ends_with(".m4b") {
-                    "attachment; filename=\"audiobook.m4b\""
-                } else {
-                    "attachment; filename=\"audiobook-audio.zip\""
-                },
-            ),
+            (axum::http::header::CONTENT_DISPOSITION, content_disposition),
         ],
         axum::body::Body::from_stream(tokio_util::io::ReaderStream::new(file)),
     )
@@ -1543,6 +1893,7 @@ fn write_audio_process_state(
     status: &str,
     pid: Option<u32>,
     error: Option<&str>,
+    auto_model: bool,
 ) -> Result<()> {
     let path = out_dir.join("process.json");
     let temp = out_dir.join("process.part.tmp");
@@ -1550,6 +1901,7 @@ fn write_audio_process_state(
         "status": status,
         "pid": pid,
         "error": error,
+        "auto_model": auto_model,
         "updated_at_ms": now_ms(),
     }))?;
     std::fs::write(&temp, bytes)?;
@@ -1654,6 +2006,68 @@ async fn provider_status(
         status.insert(format!("audio:{provider}"), json!(configured));
     }
     Ok(Json(serde_json::Value::Object(status)))
+}
+
+#[derive(Deserialize)]
+struct AudioVoicesQuery {
+    provider: Option<String>,
+}
+
+async fn audio_voices(
+    State(state): State<AppState>,
+    Query(query): Query<AudioVoicesQuery>,
+) -> Result<Response, AppError> {
+    if query.provider.as_deref() != Some("elevenlabs") {
+        return Ok(bad_request(
+            "voice listing is available for ElevenLabs only",
+        ));
+    }
+
+    let Some(api_key) = resolve_audio_provider_key(&state, "elevenlabs")? else {
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "ElevenLabs API key is not configured" })),
+        )
+            .into_response());
+    };
+
+    if let Some(voices) = state
+        .elevenlabs_voices
+        .lock()
+        .map_err(|_| anyhow::anyhow!("ElevenLabs voice cache is unavailable"))?
+        .as_ref()
+        .filter(|cache| cache.fetched_at.elapsed() < ELEVENLABS_VOICE_CACHE_TTL)
+        .map(|cache| cache.voices.clone())
+    {
+        return Ok(Json(json!({ "voices": voices })).into_response());
+    }
+
+    let voices = match bookforge_audio::list_elevenlabs_voices(
+        ELEVENLABS_BASE_URL,
+        &api_key,
+        ELEVENLABS_VOICE_TIMEOUT_SECONDS,
+    )
+    .await
+    {
+        Ok(voices) => voices,
+        Err(_) => {
+            return Ok((
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": "could not load ElevenLabs voices" })),
+            )
+                .into_response());
+        }
+    };
+    *state
+        .elevenlabs_voices
+        .lock()
+        .map_err(|_| anyhow::anyhow!("ElevenLabs voice cache is unavailable"))? =
+        Some(ElevenLabsVoiceCache {
+            fetched_at: Instant::now(),
+            voices: voices.clone(),
+        });
+
+    Ok(Json(json!({ "voices": voices })).into_response())
 }
 
 // ---------------------------------------------------------------------------
@@ -1837,6 +2251,16 @@ fn audio_provider_env_has_key(provider: &str) -> bool {
         .is_some_and(|value| !value.is_empty())
 }
 
+fn resolve_audio_provider_key(state: &AppState, provider: &str) -> Result<Option<String>> {
+    let key_slot = format!("audio:{provider}");
+    if let Some(key) = lock_keys(state)?.get(&key_slot).cloned() {
+        return Ok(Some(key));
+    }
+    Ok(audio_provider_key_env(provider)
+        .and_then(|env| std::env::var(env).ok())
+        .filter(|value| !value.is_empty()))
+}
+
 fn audio_base_url_is_loopback(value: &str) -> bool {
     reqwest::Url::parse(value)
         .ok()
@@ -1927,6 +2351,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 default_format: "wav",
                 requires_voice: false,
                 requires_key: false,
+                supports_auto_model: false,
                 supports_instructions: false,
                 supports_speed: true,
                 max_chars: 40_000,
@@ -1941,6 +2366,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 default_format: "mp3",
                 requires_voice: false,
                 requires_key: true,
+                supports_auto_model: false,
                 supports_instructions: true,
                 supports_speed: true,
                 max_chars: 4_096,
@@ -1955,6 +2381,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 default_format: "wav",
                 requires_voice: false,
                 requires_key: true,
+                supports_auto_model: false,
                 supports_instructions: true,
                 supports_speed: false,
                 max_chars: 4_096,
@@ -1963,12 +2390,13 @@ fn dashboard_options_payload() -> DashboardOptions {
                 id: "elevenlabs",
                 label: "ElevenLabs",
                 models: AUDIO_ELEVENLABS_MODELS,
-                default_model: "eleven_multilingual_v2",
+                default_model: "",
                 default_voice: "",
                 formats: &["mp3", "opus", "wav", "pcm"],
                 default_format: "mp3",
                 requires_voice: true,
                 requires_key: true,
+                supports_auto_model: true,
                 supports_instructions: false,
                 supports_speed: true,
                 max_chars: bookforge_audio::elevenlabs_model_max_input_chars(
@@ -1990,6 +2418,7 @@ fn field_value(fields: &HashMap<String, String>, key: &str) -> Option<String> {
 fn audio_provider_max_chars(provider: &str, model: &str) -> usize {
     match provider {
         "mock" => 40_000,
+        "elevenlabs" if model.is_empty() => 10_000,
         "elevenlabs" => bookforge_audio::elevenlabs_model_max_input_chars(model),
         "openai" | "gemini" => 4_096,
         _ => 4_096,
@@ -2378,6 +2807,7 @@ struct AudioProviderOption {
     default_format: &'static str,
     requires_voice: bool,
     requires_key: bool,
+    supports_auto_model: bool,
     supports_instructions: bool,
     supports_speed: bool,
     max_chars: usize,
@@ -2513,6 +2943,7 @@ mod tests {
             csrf_token: token.to_string(),
             host_port: 8765,
             keys: Arc::new(Mutex::new(HashMap::new())),
+            elevenlabs_voices: Arc::new(Mutex::new(None)),
             audio_cancels: Arc::new(Mutex::new(HashMap::new())),
             store_path: default_store_path(),
             resume_launches: None,
@@ -2623,11 +3054,13 @@ mod tests {
             .find(|provider| provider.id == "elevenlabs")
             .expect("ElevenLabs provider option should exist");
         assert!(elevenlabs.requires_voice);
+        assert!(elevenlabs.supports_auto_model);
         assert!(!elevenlabs.supports_instructions);
         assert_eq!(elevenlabs.models.first(), Some(&"eleven_v3"));
-        assert_eq!(elevenlabs.default_model, "eleven_multilingual_v2");
+        assert_eq!(elevenlabs.default_model, "");
         assert_eq!(elevenlabs.max_chars, 10_000);
         assert_eq!(audio_provider_max_chars("openai", "anything"), 4_096);
+        assert_eq!(audio_provider_max_chars("elevenlabs", ""), 10_000);
         assert_eq!(audio_provider_max_chars("elevenlabs", "eleven_v3"), 5_000);
         assert_eq!(
             audio_provider_max_chars("elevenlabs", "eleven_flash_v2_5"),
@@ -2773,6 +3206,152 @@ mod tests {
             .expect("route should respond");
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn audiobook_estimate_endpoint_rejects_missing_dashboard_token() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let body =
+            "--B\r\nContent-Disposition: form-data; name=\"provider\"\r\n\r\nmock\r\n--B--\r\n";
+        let response = dashboard_router(test_state("token-123"))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/audiobook/estimate")
+                    .header("host", TEST_HOST)
+                    .header("content-type", "multipart/form-data; boundary=B")
+                    .body(Body::from(body))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn elevenlabs_voices_without_key_returns_conflict() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let response = dashboard_router(test_state("token-123"))
+            .oneshot(
+                Request::builder()
+                    .uri("/api/audio/voices?provider=elevenlabs")
+                    .header("host", TEST_HOST)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn resolved_model_uses_last_synthesis_id_colon() {
+        assert_eq!(
+            resolved_model_from_synthesis_id(
+                "elevenlabs:https://api.elevenlabs.io:443/v1:eleven_v3"
+            ),
+            Some("eleven_v3")
+        );
+    }
+
+    #[test]
+    fn audiobook_command_args_omit_auto_model_and_include_explicit_model() {
+        let build = |model| {
+            audiobook_command_args(
+                Path::new("book.epub"),
+                Path::new("audio-out"),
+                "elevenlabs",
+                model,
+                "voice-id",
+                "mp3",
+                1.0,
+                2_000,
+                4,
+                None,
+                None,
+                true,
+                true,
+                Some("ELEVENLABS_API_KEY"),
+                &AudiobookCommandOptions::default(),
+            )
+        };
+
+        let auto = build(None);
+        assert!(!auto.iter().any(|arg| arg == "--model"));
+
+        let explicit = build(Some("eleven_flash_v2_5"));
+        let model_flag = explicit
+            .iter()
+            .position(|arg| arg == "--model")
+            .expect("explicit model should add --model");
+        assert_eq!(
+            explicit.get(model_flag + 1),
+            Some(&OsString::from("eleven_flash_v2_5"))
+        );
+    }
+
+    #[test]
+    fn audiobook_command_args_include_only_advanced_flags_that_are_set() {
+        let build = |advanced: &AudiobookCommandOptions| {
+            audiobook_command_args(
+                Path::new("book.epub"),
+                Path::new("audio-out"),
+                "elevenlabs",
+                Some("eleven_flash_v2_5"),
+                "voice-id",
+                "mp3",
+                1.0,
+                2_000,
+                4,
+                None,
+                None,
+                true,
+                true,
+                Some("ELEVENLABS_API_KEY"),
+                advanced,
+            )
+        };
+
+        let defaults = build(&AudiobookCommandOptions::default());
+        for flag in ["--single", "--loudnorm", "--seed", "--language"] {
+            assert!(!defaults.iter().any(|arg| arg == flag), "included {flag}");
+        }
+
+        let configured = build(&AudiobookCommandOptions {
+            single: true,
+            loudnorm: true,
+            seed: Some(u32::MAX),
+            language: Some("pt-BR".to_string()),
+            ..AudiobookCommandOptions::default()
+        });
+        for flag in ["--single", "--loudnorm", "--seed", "--language"] {
+            assert!(configured.iter().any(|arg| arg == flag), "omitted {flag}");
+        }
+        assert!(configured.iter().any(|arg| arg == "4294967295"));
+        assert!(configured.iter().any(|arg| arg == "pt-BR"));
+    }
+
+    #[test]
+    fn audiobook_language_validation_matches_dashboard_contract() {
+        for valid in ["it", "en-US", "pt-BR"] {
+            assert!(valid_audio_language(valid), "rejected {valid:?}");
+        }
+        for invalid in ["../etc", "toolongtoken", ""] {
+            assert!(!valid_audio_language(invalid), "accepted {invalid:?}");
+        }
+    }
+
+    #[test]
+    fn audiobook_gap_values_are_clamped_to_ten_seconds() {
+        assert_eq!(clamp_audio_gap(0), 0);
+        assert_eq!(clamp_audio_gap(600), 600);
+        assert_eq!(clamp_audio_gap(99_999), 10_000);
     }
 
     #[tokio::test]
@@ -2951,6 +3530,9 @@ mod tests {
             "function drawReview",
             "function drawValidation",
             "function renderGlossary",
+            "function bfAudioEstimate",
+            "/api/audiobook/estimate",
+            "Advanced",
         ] {
             assert!(DASHBOARD_HTML.contains(marker), "missing {marker}");
         }
@@ -2960,14 +3542,14 @@ mod tests {
     fn dashboard_assets_reassemble_byte_stably() {
         use sha2::{Digest, Sha256};
 
-        assert_eq!(DASHBOARD_HTML.len(), 97_182);
+        assert_eq!(DASHBOARD_HTML.len(), 106_868);
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_CSS}}"));
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_JS}}"));
         let digest = Sha256::digest(DASHBOARD_HTML.as_bytes());
         let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
         assert_eq!(
             digest_hex,
-            "6a7999e04b3714c0669b72387e4834ba6620b42585d3ca963797f8258da61440"
+            "648276dd25726153a19ea34c262f756193a8256addc1d04e62453914285f9690"
         );
 
         let crlf = |asset: &str| asset.replace("\r\n", "\n").replace('\n', "\r\n");

--- a/crates/bookforge-cli/src/commands/serve/dashboard.css
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.css
@@ -1,7 +1,7 @@
 :root{
   --bg:#f4f1ea; --panel:#fcfbf8; --card:#ffffff; --line:#e6dfd0; --soft:#f6f2ea;
   --ink:#2a2521; --muted:#7a7066; --faint:#a89e90; --accent:#cf8a2d; --accentink:#ffffff;
-  --chip:#efe9dd; --good:#5b8c5a; --goodbg:#eef3ec; --warn:#c98a2d; --danger:#c2502f;
+  --chip:#efe9dd; --good:#5b8c5a; --goodbg:#eef3ec; --warn:#c98a2d; --danger:#c2502f; --bad:#c2502f;
   --accentsoft:#faf3e6; --accentline:#ecd9b3;
   --sans:'IBM Plex Sans',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
   --serif:'Spectral',Georgia,'Times New Roman',serif;
@@ -10,7 +10,7 @@
 :root[data-theme="dark"]{
   --bg:#1b1814; --panel:#211d18; --card:#2a251e; --line:#3a332a; --soft:#241f19;
   --ink:#ece5da; --muted:#b3a99b; --faint:#7d7468; --accent:#d97a52; --accentink:#1a1713;
-  --chip:#2c2720; --good:#6aa765; --goodbg:#23291f; --warn:#d6a24a; --danger:#e07a55;
+  --chip:#2c2720; --good:#6aa765; --goodbg:#23291f; --warn:#d6a24a; --danger:#e07a55; --bad:#e07a55;
   --accentsoft:#2a221c; --accentline:#473829;
 }
 *{box-sizing:border-box}
@@ -161,6 +161,23 @@ main{min-height:calc(100vh - 60px)}
 .prog-bar > i{display:block;height:100%;border-radius:6px;background:repeating-linear-gradient(45deg,var(--accent) 0 10px,color-mix(in srgb,var(--accent) 78%,#000) 10px 20px);background-size:40px 40px;animation:bf-stripe 1s linear infinite;transition:width .3s ease}
 .prog-bar.done > i{background:var(--good);animation:none}
 .prog-actions{display:flex;gap:10px;margin-top:18px;align-items:center}
+.audio-chapters{margin:0 0 16px;border:1px solid var(--line);border-radius:12px;background:var(--card);overflow:hidden}
+.audio-chapters-head{padding:10px 14px;border-bottom:1px solid var(--line);font:600 10px var(--sans);text-transform:uppercase;letter-spacing:.06em;color:var(--faint)}
+.audio-chapter-list{max-height:240px;overflow:auto}
+.audio-chapter{display:flex;align-items:center;gap:9px;padding:9px 14px;border-bottom:1px solid var(--line);font:500 12px var(--sans);color:var(--muted)}
+.audio-chapter:last-child{border-bottom:none}
+.audio-chapter-check{width:18px;height:18px;flex:none;display:flex;align-items:center;justify-content:center;border:1px solid var(--line);border-radius:50%;font:700 11px var(--sans);color:var(--good)}
+.audio-chapter.complete .audio-chapter-check{border-color:var(--good);background:var(--goodbg)}
+.audio-chapter-title{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--ink)}
+.audio-chapter-count{font:500 11px var(--mono);color:var(--faint)}
+.audio-player{width:min(330px,45vw);height:38px}
+.audio-advanced{margin-top:8px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.audio-advanced summary{padding:13px 4px;cursor:pointer;font:600 13px var(--sans);color:var(--muted)}
+.audio-advanced-body{padding:4px 2px 16px}
+.audio-check{display:flex;align-items:center;gap:9px;min-height:42px;padding:10px 12px;border:1px solid var(--line);border-radius:10px;background:var(--card);font:500 12.5px var(--sans);color:var(--muted)}
+.audio-check input{accent-color:var(--accent)}
+.audio-estimate{margin:16px 2px -8px;font:500 12px/1.5 var(--sans);color:var(--muted)}
+.audio-estimate-bad{color:var(--bad)}
 .stat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:11px;margin-bottom:16px}
 .stat{padding:14px 15px;border:1px solid var(--line);border-radius:12px;background:var(--card)}
 .stat .k{font:500 10px var(--sans);text-transform:uppercase;letter-spacing:.05em;color:var(--faint);margin-bottom:6px}

--- a/crates/bookforge-cli/src/commands/serve/dashboard.js
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.js
@@ -45,6 +45,10 @@ const App = {
   wizard: null,
   audioWizard: null,
   audioSelected: null,
+  audioVoices: null,
+  audioVoicesLoading: false,
+  audioEstimateTimer: null,
+  audioEstimateRequest: 0,
   runtimeSettings: null,
   runtimeJob: null,
   runtimeRefreshPending: false,
@@ -62,7 +66,8 @@ function freshAudioWizard() {
   return { file:null, fileName:"", provider:"openai", model:"gpt-4o-mini-tts",
     voice:"alloy", format:"mp3", speed:1, maxChars:2000, concurrency:4,
     instructions:"", baseUrl:"", apiKey:"", stitch:canM4b, m4b:canM4b,
-    launching:false, status:"" };
+    advancedOpen:false, chapterGap:1200, single:false, loudnorm:false, seed:"", language:"",
+    estimate:null, launching:false, status:"" };
 }
 
 function applyTheme() {
@@ -382,7 +387,7 @@ function audioProviderOption(id) {
   return (App.options.audio_providers || []).find(p => p.id === id)
     || { id:"mock", label:"mock", models:["mock-silence"], default_model:"mock-silence",
       default_voice:"mock", formats:["wav"], default_format:"wav", requires_key:false,
-      requires_voice:false, supports_instructions:false, supports_speed:true, max_chars:40000 };
+      requires_voice:false, supports_auto_model:false, supports_instructions:false, supports_speed:true, max_chars:40000 };
 }
 function audioProviderMaxChars(provider, model) {
   if (provider.id === "elevenlabs") {
@@ -397,19 +402,19 @@ function bfAudioProvider(id) {
   const w = App.audioWizard, p = audioProviderOption(id);
   w.provider = id; w.model = p.default_model; w.voice = p.default_voice;
   w.maxChars = Math.min(w.maxChars, audioProviderMaxChars(p, w.model));
-  w.format = p.default_format; w.speed = 1; w.instructions = ""; w.status = "";
+  w.format = p.default_format; w.speed = 1; w.instructions = ""; w.status = ""; w.estimate = null;
   renderAudiobook($("#stage"));
 }
 function bfAudioFormat(format) { syncAudioInputs(); App.audioWizard.format = format; renderAudiobook($("#stage")); }
-function bfAudioModel() { syncAudioInputs(); const w=App.audioWizard, p=audioProviderOption(w.provider); w.maxChars=Math.min(w.maxChars,audioProviderMaxChars(p,w.model)); renderAudiobook($("#stage")); }
+function bfAudioModel() { syncAudioInputs(); const w=App.audioWizard, p=audioProviderOption(w.provider); w.maxChars=Math.min(w.maxChars,audioProviderMaxChars(p,w.model)); w.estimate=null; renderAudiobook($("#stage")); }
 function bfAudioPickFile(input) {
   const file = input.files && input.files[0]; if (!file) return;
-  App.audioWizard.file = file; App.audioWizard.fileName = file.name; renderAudiobook($("#stage"));
+  App.audioWizard.file = file; App.audioWizard.fileName = file.name; App.audioWizard.estimate = null; renderAudiobook($("#stage"));
 }
 function bfAudioDropFile(e) {
   const f = bfDroppedEpub(e);
   if (!f) { audioToast("drop an EPUB (.epub) file"); return; }
-  App.audioWizard.file = f; App.audioWizard.fileName = f.name; renderAudiobook($("#stage"));
+  App.audioWizard.file = f; App.audioWizard.fileName = f.name; App.audioWizard.estimate = null; renderAudiobook($("#stage"));
 }
 function syncAudioInputs() {
   const w = App.audioWizard; if (!w) return;
@@ -423,18 +428,88 @@ function syncAudioInputs() {
   const key = $("#a_key"); if (key) w.apiKey = key.value;
   const stitch = $("#a_stitch"); if (stitch) w.stitch = stitch.checked;
   const m4b = $("#a_m4b"); if (m4b) w.m4b = m4b.checked;
+  const chapterGap = $("#a_gap_chapter"); if (chapterGap) w.chapterGap = Math.max(0, Math.min(10000, parseInt(chapterGap.value,10)||0));
+  const single = $("#a_single"); if (single) w.single = single.checked;
+  const loudnorm = $("#a_loudnorm"); if (loudnorm) w.loudnorm = loudnorm.checked;
+  const seed = $("#a_seed"); if (seed) w.seed = seed.value.trim();
+  const language = $("#a_language"); if (language) w.language = language.value.trim();
 }
 function audioToast(message) { const el = $("#audio-status"); if (el) el.textContent = message; if (App.audioWizard) App.audioWizard.status = message; }
+
+function bfAudioEstimateDebounced() {
+  const w = App.audioWizard; if (!w) return;
+  syncAudioInputs(); w.estimate = null; App.audioEstimateRequest += 1;
+  const line = $("#audio-estimate"); if (line) line.hidden = true;
+  if (App.audioEstimateTimer) clearTimeout(App.audioEstimateTimer);
+  App.audioEstimateTimer = setTimeout(bfAudioEstimate, 300);
+}
+
+function audioEstimateHtml(estimate) {
+  if (!estimate) return "";
+  const parts = [`${num(estimate.chapters)} chapters`, `${num(estimate.chunks)} chunks`, `${num(estimate.characters)} characters`];
+  if (estimate.est_cost_usd != null) parts.push(`~$${Number(estimate.est_cost_usd).toFixed(2)}`);
+  if (estimate.est_credits != null) parts.push(`~${num(Math.round(Number(estimate.est_credits)))} credits`);
+  if (estimate.quota) {
+    const remaining = num(estimate.quota.remaining);
+    parts.push(estimate.quota.fits
+      ? `quota OK (${remaining} left)`
+      : `<span class="audio-estimate-bad">quota exceeded (${remaining} left)</span>`);
+  }
+  return parts.join(" Â· ");
+}
+
+async function bfAudioEstimate() {
+  const w = App.audioWizard; if (!w || !w.file || App.screen !== "audiobook" || App.audioSelected) return;
+  syncAudioInputs();
+  const request = ++App.audioEstimateRequest;
+  const fd = new FormData(); fd.append("file", w.file); fd.append("provider", w.provider);
+  if (w.model) fd.append("model", w.model);
+  fd.append("max_chars", String(w.maxChars));
+  try {
+    const response = await fetch("/api/audiobook/estimate", {method:"POST", headers:{[CSRF_HEADER]:CSRF_TOKEN}, body:fd});
+    const result = await response.json();
+    if (!response.ok || request !== App.audioEstimateRequest || App.audioWizard !== w) throw new Error();
+    w.estimate = result;
+    const line = $("#audio-estimate"); if (line) { line.innerHTML = audioEstimateHtml(result); line.hidden = false; }
+  } catch (error) {
+    if (request === App.audioEstimateRequest) { w.estimate = null; const line = $("#audio-estimate"); if (line) line.hidden = true; }
+  }
+}
+
+async function loadElevenLabsVoices() {
+  if (App.audioVoices !== null || App.audioVoicesLoading) return;
+  App.audioVoicesLoading = true;
+  try {
+    const response = await fetch("/api/audio/voices?provider=elevenlabs");
+    const result = await response.json();
+    App.audioVoices = response.ok && Array.isArray(result.voices) ? result.voices : [];
+  } catch (error) {
+    App.audioVoices = [];
+  } finally {
+    App.audioVoicesLoading = false;
+    if (App.screen === "audiobook" && App.audioWizard && App.audioWizard.provider === "elevenlabs" && !App.audioSelected) {
+      renderAudiobook($("#stage"));
+    }
+  }
+}
 
 function renderAudiobook(stage) {
   if (App.audioSelected) return renderAudiobookProgress(stage, App.audioSelected);
   const w = App.audioWizard || (App.audioWizard = freshAudioWizard());
   const p = audioProviderOption(w.provider);
+  const estimateLine = audioEstimateHtml(w.estimate);
   const needsKey = p.requires_key && App.providerKeys[`audio:${w.provider}`] !== true;
   const providerChips = (App.options.audio_providers || []).map(provider =>
     `<div class="chip ${w.provider===provider.id?"on":""}" onclick="bfAudioProvider('${provider.id}')">${esc(provider.label)}</div>`).join("");
   const formatChips = (p.formats || []).map(format =>
     `<div class="chip ${w.format===format?"on":""}" onclick="bfAudioFormat('${format}')">${format.toUpperCase()}</div>`).join("");
+  const modelField = p.supports_auto_model
+    ? `<select class="inp" id="a_model" onchange="bfAudioModel()"><option value="" ${w.model===""?"selected":""}>Auto (recommended)</option>${(p.models||[]).map(model=>`<option value="${esc(model)}" ${w.model===model?"selected":""}>${esc(model)}</option>`).join("")}</select>`
+    : `<input class="inp" id="a_model" value="${esc(w.model)}" list="audio-models" onchange="bfAudioModel()">`;
+  const voices = w.provider === "elevenlabs" && Array.isArray(App.audioVoices) ? App.audioVoices : [];
+  const voiceField = voices.length
+    ? `<select class="inp" id="a_voice"><option value="">Choose a voice</option>${voices.map(voice=>`<option value="${esc(voice.voice_id)}" ${w.voice===voice.voice_id?"selected":""}>${esc(voice.name)} — ${esc(voice.voice_id)}</option>`).join("")}</select>`
+    : `<input class="inp" id="a_voice" value="${esc(w.voice)}" placeholder="${p.requires_voice?"Required ElevenLabs voice ID":"Voice name"}">`;
   stage.innerHTML = `<div class="wrap">
     <div class="pagehead"><div><h1>Create an audiobook</h1><p>Narrate an original or translated EPUB directly. Translation is optional.</p></div>
       <button class="btn btn-ghost" onclick="bfGo('library')">Back to library</button></div>
@@ -446,10 +521,10 @@ function renderAudiobook(stage) {
       </div><input type="file" id="audio-file" accept=".epub" hidden onchange="bfAudioPickFile(this)">
       <div class="field-label" style="margin-top:20px">Speech provider</div><div class="chips">${providerChips}</div>
       <div class="adv-grid" style="margin-top:18px">
-        <div><div class="field-label">Model</div><input class="inp" id="a_model" value="${esc(w.model)}" list="audio-models" onchange="bfAudioModel()"></div>
-        <div><div class="field-label">${p.requires_voice?"Voice ID":"Voice"}</div><input class="inp" id="a_voice" value="${esc(w.voice)}" placeholder="${p.requires_voice?"Required ElevenLabs voice ID":"Voice name"}"></div>
+        <div><div class="field-label">Model</div>${modelField}</div>
+        <div><div class="field-label">${p.requires_voice?"Voice ID":"Voice"}</div>${voiceField}</div>
         <div><div class="field-label">Speed</div><input class="inp" id="a_speed" type="number" min="0.25" max="4" step="0.05" value="${w.speed}" ${p.supports_speed?"":"disabled"}></div>
-        <div><div class="field-label">Characters per request</div><input class="inp" id="a_chars" type="number" min="1" max="${audioProviderMaxChars(p,w.model)}" value="${w.maxChars}"></div>
+        <div><div class="field-label">Characters per request</div><input class="inp" id="a_chars" type="number" min="1" max="${audioProviderMaxChars(p,w.model)}" value="${w.maxChars}" oninput="bfAudioEstimateDebounced()"></div>
         <div><div class="field-label">Concurrency</div><input class="inp" id="a_conc" type="number" min="1" max="16" value="${w.concurrency}"></div>
         <div><div class="field-label">Format</div><div class="chips">${formatChips}</div></div>
       </div>
@@ -461,24 +536,46 @@ function renderAudiobook(stage) {
         <label class="fact"><div class="k">Chapter files</div><div class="v"><input id="a_stitch" type="checkbox" ${w.stitch?"checked":""}> Stitch each chapter</div></label>
         <label class="fact"><div class="k">Single book</div><div class="v"><input id="a_m4b" type="checkbox" ${w.m4b?"checked":""} ${App.options.ffmpeg_available?"":"disabled"}> Create M4B${App.options.ffmpeg_available?"":" (ffmpeg unavailable)"}</div></label>
       </div>
+      <details class="audio-advanced" ${w.advancedOpen?"open":""} ontoggle="if(App.audioWizard)App.audioWizard.advancedOpen=this.open">
+        <summary>Advanced</summary>
+        <div class="audio-advanced-body"><div class="adv-grid">
+          <div><div class="field-label">Chapter pause</div><select class="inp" id="a_gap_chapter">
+            <option value="0" ${w.chapterGap===0?"selected":""}>None</option>
+            <option value="600" ${w.chapterGap===600?"selected":""}>Short</option>
+            <option value="1200" ${w.chapterGap===1200?"selected":""}>Medium</option>
+            <option value="2000" ${w.chapterGap===2000?"selected":""}>Long</option>
+          </select></div>
+          <label class="audio-check"><input id="a_single" type="checkbox" ${w.single?"checked":""}> Flat audio file for on-the-go</label>
+          <label class="audio-check"><input id="a_loudnorm" type="checkbox" ${w.loudnorm?"checked":""}> Normalize loudness</label>
+          ${w.provider==="elevenlabs"?`<div><div class="field-label">Seed</div><input class="inp" id="a_seed" type="number" min="0" max="4294967295" step="1" value="${esc(w.seed)}" placeholder="unset"></div>
+          <div><div class="field-label">Language</div><input class="inp" id="a_language" value="${esc(w.language)}" placeholder="auto (from EPUB)"></div>`:""}
+        </div></div>
+      </details>
+      <div class="audio-estimate" id="audio-estimate" ${estimateLine?"":"hidden"}>${estimateLine}</div>
       <div class="wizfoot" style="padding:22px 0 0"><span class="launchstatus" id="audio-status">${esc(w.status||"")}</span><span class="grow"></span>
         <button class="btn btn-primary" id="audio-launch" onclick="bfLaunchAudiobook()">Start audiobook</button></div>
     </div></div>`;
+  if (w.provider === "elevenlabs" && App.providerKeys["audio:elevenlabs"] === true) loadElevenLabsVoices();
+  if (w.file && !w.estimate) bfAudioEstimateDebounced();
 }
 
 async function bfLaunchAudiobook() {
   syncAudioInputs(); const w = App.audioWizard, p = audioProviderOption(w.provider);
   if (!w.file) return audioToast("choose an EPUB file");
-  if (!w.model) return audioToast("model is required");
+  if (!w.model && !p.supports_auto_model) return audioToast("model is required");
   if (p.requires_voice && !w.voice) return audioToast("ElevenLabs voice ID is required");
   if (w.launching) return; w.launching = true;
   const button = $("#audio-launch"); if (button) { button.disabled=true; button.textContent="Starting…"; }
   audioToast("uploading and planning…");
   const fd = new FormData(); fd.append("file", w.file); fd.append("provider", w.provider);
-  fd.append("model", w.model); fd.append("voice", w.voice); fd.append("format", w.format);
+  if (w.model) fd.append("model", w.model); fd.append("voice", w.voice); fd.append("format", w.format);
   fd.append("speed", String(w.speed)); fd.append("max_chars", String(w.maxChars)); fd.append("concurrency", String(w.concurrency));
   if (w.instructions) fd.append("instructions", w.instructions); if (w.baseUrl) fd.append("base_url", w.baseUrl);
   if (w.apiKey) fd.append("api_key", w.apiKey); if (w.stitch) fd.append("stitch", "true"); if (w.m4b) fd.append("m4b", "true");
+  fd.append("gap_chapter_ms", String(w.chapterGap)); fd.append("gap_title_ms", String(Math.min(800, w.chapterGap)));
+  if (w.single) fd.append("single", "true"); if (w.loudnorm) fd.append("loudnorm", "true");
+  if (w.provider === "elevenlabs" && w.seed) fd.append("seed", w.seed);
+  if (w.provider === "elevenlabs" && w.language) fd.append("language", w.language);
   try {
     const response = await fetch("/api/audiobook", {method:"POST", headers:{[CSRF_HEADER]:CSRF_TOKEN}, body:fd});
     const result = await response.json();
@@ -491,6 +588,20 @@ async function renderAudiobookProgress(stage, id) {
   stage.innerHTML = `<div class="wrap"><div class="pagehead"><div><h1>Audiobook progress</h1><p>Every completed chunk is durably checkpointed.</p></div><button class="btn btn-primary" onclick="bfStartAudiobook()">+ New audiobook</button></div><div class="wizpanel" id="audio-progress"><div class="empty">Loading…</div></div></div>`;
   await pollAudiobook(id);
 }
+function audiobookChapterProgress(chunks) {
+  const chapters = [], byIndex = new Map();
+  for (const chunk of chunks) {
+    const key = String(chunk.chapter_index == null ? chapters.length : chunk.chapter_index);
+    let chapter = byIndex.get(key);
+    if (!chapter) {
+      chapter = { index:chunk.chapter_index, title:chunk.chapter_title || `Chapter ${chapters.length + 1}`, done:0, total:0 };
+      byIndex.set(key, chapter); chapters.push(chapter);
+    }
+    chapter.total += 1;
+    if (chunk.status === "synthesized" || chunk.status === "cached") chapter.done += 1;
+  }
+  return chapters;
+}
 async function pollAudiobook(id) {
   if (App.screen !== "audiobook" || App.audioSelected !== id) return;
   let data; try { const response=await fetch(`/api/audiobooks/${encodeURIComponent(id)}`); data=await response.json(); if(!response.ok) throw new Error(); }
@@ -499,16 +610,25 @@ async function pollAudiobook(id) {
   const processStatus = data.process && data.process.status;
   let status = data.status || processStatus || "starting";
   if (status === "succeeded" && processStatus === "running") status = "stitching";
+  const chapters = audiobookChapterProgress(chunks);
+  const chapterList = chapters.map(chapter => {
+    const complete = chapter.total > 0 && chapter.done === chapter.total;
+    return `<div class="audio-chapter ${complete?"complete":""}"><span class="audio-chapter-check">${complete?"✓":""}</span><span class="audio-chapter-title">${esc(chapter.title)}</span><span class="audio-chapter-count">${chapter.done}/${chapter.total}</span></div>`;
+  }).join("");
+  const autoSelected = data.process && data.process.auto_model === true;
   const panel = $("#audio-progress"); if (!panel) return;
   panel.innerHTML = `<div class="facts">
       <div class="fact"><div class="k">Status</div><div class="v"><span class="badge ${badgeClass(status)}">${esc(status)}</span></div></div>
       <div class="fact"><div class="k">Provider</div><div class="v mono">${esc(data.synthesis_id||"planning")}</div></div>
+      <div class="fact"><div class="k">Model</div><div class="v mono">${esc(data.resolved_model||"planning")}${autoSelected&&data.resolved_model?" (auto-selected)":""}</div></div>
       <div class="fact"><div class="k">Voice</div><div class="v">${esc(data.voice||"—")}</div></div>
       <div class="fact"><div class="k">Progress</div><div class="v mono">${done}/${total||"?"}</div></div>
     </div><div class="bar-track" style="margin:22px 0"><div class="bar-fill" style="width:${progress}%"></div></div>
+    ${chapterList?`<div class="audio-chapters"><div class="audio-chapters-head">Chapters</div><div class="audio-chapter-list">${chapterList}</div></div>`:""}
     <div class="costbox"><div><div class="ck">Output</div><div class="mono" style="margin-top:8px;word-break:break-all">${esc(data.artifact||data.out_dir||"")}</div></div><div class="cm">${progress}% complete<br>${num(chunks.reduce((sum,chunk)=>sum+(chunk.chars||0),0))} characters planned</div></div>
     <div class="wizfoot" style="padding:18px 0 0"><span class="grow"></span>
       ${!["succeeded","failed","cancelled"].includes(status)?`<button class="btn btn-ghost" onclick="bfCancelAudiobook('${esc(id)}')">Cancel</button>`:""}
+      ${status==="succeeded"&&data.artifact?`<audio class="audio-player" controls preload="none" src="/api/audiobooks/${encodeURIComponent(id)}/artifact?disposition=inline"></audio>`:""}
       ${status==="succeeded"?`<a class="btn btn-primary" href="/api/audiobooks/${encodeURIComponent(id)}/artifact">Download ${data.artifact?"M4B":"audio ZIP"}</a>`:""}
     </div>${data.error?`<div class="empty" style="color:var(--bad)">${esc(data.error)}</div>`:""}`;
   if (!["succeeded","failed","cancelled"].includes(status)) setTimeout(()=>pollAudiobook(id), 800);

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod audio_cost;
 mod checkpoint;
 mod commands;
 mod control;

--- a/crates/bookforge-cli/src/tui/mod.rs
+++ b/crates/bookforge-cli/src/tui/mod.rs
@@ -149,6 +149,8 @@ pub struct AudioTuiInfo {
     pub provider: String,
     pub model: String,
     pub voice: String,
+    pub cost_line: Option<String>,
+    pub chapters_total: usize,
     pub total: usize,
 }
 
@@ -280,15 +282,21 @@ fn render_audio_dashboard(
     );
 
     let synthesized = done.saturating_sub(cached);
-    let details = Text::from(vec![
+    let mut detail_lines = vec![
         Line::from(format!("Current: {current_chapter}")),
+        Line::from(format!("Resolved model: {}", info.model)),
         Line::from(format!(
             "Synthesized: {synthesized}   Cached: {cached}   Remaining: {}",
             info.total.saturating_sub(done)
         )),
+        Line::from(format!("Chapters: {} total", info.chapters_total)),
         Line::from(format!("Status: {status}")),
         Line::from("Progress is checkpointed to manifest.json after every chunk."),
-    ]);
+    ];
+    if let Some(cost_line) = &info.cost_line {
+        detail_lines.insert(2, Line::from(cost_line.clone()));
+    }
+    let details = Text::from(detail_lines);
     frame.render_widget(Paragraph::new(details).block(Block::bordered()), areas[2]);
     frame.render_widget(
         Paragraph::new(" q/Esc cancel and exit ").style(Style::new().fg(Color::DarkGray)),
@@ -822,6 +830,8 @@ mod tests {
             provider: "gemini".to_string(),
             model: "gemini-tts".to_string(),
             voice: "Kore".to_string(),
+            cost_line: Some("Estimated cost: ~$1.23".to_string()),
+            chapters_total: 4,
             total: 12,
         };
         let mut terminal = Terminal::new(TestBackend::new(90, 18)).unwrap();
@@ -841,6 +851,9 @@ mod tests {
         assert!(text.contains("5/12"));
         assert!(text.contains("Synthesized: 3"));
         assert!(text.contains("Cached: 2"));
+        assert!(text.contains("Resolved model: gemini-tts"));
+        assert!(text.contains("Estimated cost: ~$1.23"));
+        assert!(text.contains("Chapters: 4 total"));
         assert!(text.contains("q/Esc cancel"));
     }
 

--- a/crates/bookforge-cli/tests/audiobook.rs
+++ b/crates/bookforge-cli/tests/audiobook.rs
@@ -41,7 +41,7 @@ const OPF: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 
 const CHAPTER_ONE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head><title>Chapter One</title></head>
+<head></head>
 <body>
 <h1>The First Chapter</h1>
 <p>This is the first paragraph. It has a couple of sentences to narrate.</p>
@@ -51,7 +51,7 @@ const CHAPTER_ONE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 
 const CHAPTER_TWO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head><title>Chapter Two</title></head>
+<head></head>
 <body>
 <h1>The Second Chapter</h1>
 <p>The second chapter also has prose. Every sentence here should reach the narrator.</p>
@@ -120,7 +120,7 @@ fn audiobook_mock_writes_files_and_manifest() {
 
     let manifest_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&manifest).unwrap()).unwrap();
-    assert_eq!(manifest_json["schema_version"], 2);
+    assert_eq!(manifest_json["schema_version"], 3);
     assert_eq!(manifest_json["status"], "succeeded");
     assert_eq!(
         manifest_json["completed_chunks"],
@@ -131,6 +131,16 @@ fn audiobook_mock_writes_files_and_manifest() {
     let chunks = manifest_json["chunks"].as_array().unwrap();
     assert!(chunks.len() >= 2);
     assert_eq!(chunks[0]["synthesis_sha256"].as_str().unwrap().len(), 64);
+    if std::process::Command::new("ffmpeg")
+        .arg("-version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        assert!(
+            out.join("audiobook.m4b").exists(),
+            "ffmpeg availability should make the chapter-marked book file the default"
+        );
+    }
 }
 
 #[test]
@@ -195,6 +205,7 @@ fn elevenlabs_dry_run_without_model_uses_static_default_offline() {
 
     bookforge()
         .current_dir(temp.path())
+        .env_remove("ELEVENLABS_API_KEY")
         .args([
             "audiobook",
             input.to_str().unwrap(),
@@ -431,6 +442,7 @@ fn audiobook_elevenlabs_dry_run_accepts_native_provider_options() {
 
     let assert = bookforge()
         .current_dir(temp.path())
+        .env_remove("ELEVENLABS_API_KEY")
         .args([
             "audiobook",
             input.to_str().unwrap(),
@@ -449,6 +461,177 @@ fn audiobook_elevenlabs_dry_run_accepts_native_provider_options() {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert!(stdout.contains("Voice: JBFqnCBsd6RMkjVDRZzb | Format: mp3"));
     assert!(stdout.contains("Model: eleven_flash_v2_5"));
+}
+
+#[test]
+fn audiobook_chapter_filter_keeps_global_chapter_numbering() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+    let out = temp.path().join("audio-chapter-2");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "mock",
+            "--out",
+            out.to_str().unwrap(),
+            "--chapters",
+            "2",
+            "--no-book-file",
+        ])
+        .assert()
+        .success();
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("manifest.json")).unwrap()).unwrap();
+    let chunks = manifest["chunks"].as_array().unwrap();
+    assert!(!chunks.is_empty());
+    assert!(chunks.iter().all(|chunk| chunk["chapter_index"] == 1));
+    assert!(chunks.iter().all(|chunk| {
+        chunk["file"]
+            .as_str()
+            .is_some_and(|file| file.starts_with("chapter-002-part-"))
+    }));
+    assert_eq!(manifest["chapters"], 1);
+}
+
+#[test]
+fn audiobook_manifest_keeps_title_in_its_own_first_part() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+    let out = temp.path().join("audio-title-kind");
+
+    bookforge()
+        .current_dir(temp.path())
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "mock",
+            "--out",
+            out.to_str().unwrap(),
+            "--chapters",
+            "1",
+            "--no-book-file",
+        ])
+        .assert()
+        .success();
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(out.join("manifest.json")).unwrap()).unwrap();
+    let first = &manifest["chunks"].as_array().unwrap()[0];
+    assert_eq!(first["part"], 1);
+    assert_eq!(first["kind"], "title");
+    assert_eq!(first["chars"], "The First Chapter".chars().count());
+}
+
+#[test]
+fn audiobook_list_voices_requires_elevenlabs_provider() {
+    bookforge()
+        .args(["audiobook", "--list-voices"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--list-voices requires --provider elevenlabs",
+        ));
+}
+
+#[test]
+fn audiobook_requires_input_without_list_voices() {
+    bookforge()
+        .args(["audiobook", "--provider", "mock"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("INPUT is required"));
+}
+
+#[test]
+fn audiobook_seed_rejects_non_elevenlabs_provider() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+    bookforge()
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "mock",
+            "--seed",
+            "7",
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--seed is supported only with --provider elevenlabs",
+        ));
+}
+
+#[test]
+fn audiobook_dry_run_uses_audio_pricing_override() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+    let pricing = temp.path().join("audio-pricing.json");
+    fs::write(
+        &pricing,
+        r#"{
+          "schema_version": 1,
+          "updated_at": "2026-07-20",
+          "providers": {
+            "mock": {
+              "mock-silence": {
+                "usd_per_million_chars": 1000000.0,
+                "credits_per_char": null,
+                "note": "one dollar per character for an exact test"
+              }
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+
+    bookforge()
+        .current_dir(temp.path())
+        .env("BOOKFORGE_AUDIO_PRICING_PATH", &pricing)
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "mock",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Estimated cost: ~$"))
+        .stdout(predicates::str::contains(".00"));
+}
+
+#[test]
+fn unsupported_elevenlabs_language_warns_instead_of_failing() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let input = fixture(temp.path());
+
+    bookforge()
+        .current_dir(temp.path())
+        .env_remove("ELEVENLABS_API_KEY")
+        .args([
+            "audiobook",
+            input.to_str().unwrap(),
+            "--provider",
+            "elevenlabs",
+            "--voice",
+            "v",
+            "--model",
+            "eleven_multilingual_v2",
+            "--language",
+            "en-US",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("rejects language_code"));
 }
 
 #[test]

--- a/crates/bookforge-core/Cargo.toml
+++ b/crates/bookforge-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-core"
-version = "2.5.1"
+version = "2.6.0"
 description = "Core IR, segmentation, configuration, and progress types for BookForge."
 edition.workspace = true
 license.workspace = true

--- a/crates/bookforge-epub/Cargo.toml
+++ b/crates/bookforge-epub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-epub"
-version = "2.5.1"
+version = "2.6.0"
 description = "EPUB reading, validation, and deterministic rebuild support for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core" }
 quick-xml.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/crates/bookforge-llm/Cargo.toml
+++ b/crates/bookforge-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-llm"
-version = "2.5.1"
+version = "2.6.0"
 description = "Prompting, providers, batching, and validation for BookForge translation runs."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bookforge-pdf/Cargo.toml
+++ b/crates/bookforge-pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-pdf"
-version = "2.5.1"
+version = "2.6.0"
 description = "PDF ingestion for BookForge: poppler-based layout extraction and deterministic reconstruction into a translatable EPUB."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core" }
 quick-xml.workspace = true
 crc32fast = "1.5.0"
 flate2 = "1.1.9"
@@ -21,5 +21,5 @@ tracing.workspace = true
 zip.workspace = true
 
 [dev-dependencies]
-bookforge-epub = { version = "2.5.1", path = "../bookforge-epub" }
+bookforge-epub = { version = "2.6.0", path = "../bookforge-epub" }
 tempfile = "3"

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bookforge-store"
-version = "2.5.1"
+version = "2.6.0"
 description = "SQLite checkpoint and job store for BookForge."
 edition.workspace = true
 license.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bookforge-core = { version = "2.5.1", path = "../bookforge-core" }
+bookforge-core = { version = "2.6.0", path = "../bookforge-core" }
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,14 +1,14 @@
-# BookForge — Technical Roadmap, v1.0.1 through v3.0
+# BookForge — Technical Roadmap, v1.0.1 through v2.6.0
 
 **Document version:** 1.4.0
-**Last updated:** 2026-07-20
+**Last updated:** 2026-07-21
 **Status:** historical roadmap plus active follow-up notes
 **Audience:** project maintainer + Claude Code (or any other coding agent) implementing
 the milestones below.
 
-> **Current status:** v2.4.0 is the release candidate on
-> `codex/project-remediation` (2026-07-13); v2.3.0 is the latest published
-> release.
+> **Current status:** v2.5.1 is the latest published release (2026-07-16),
+> and the v2.6.0 audiobook narration quality and UI-parity milestone is in
+> progress.
 > This document is kept for architectural invariants, shipped-milestone
 > context, and deferred follow-up work. For current user behavior, start
 > with `README.md`, `CHANGELOG.md`, and `docs/v2-web-dashboard-plan.md`;
@@ -23,7 +23,8 @@ the milestones below.
 > releases v2.0.0–v2.0.3; milestone v1.6 (PDF hardening) → release
 > v2.1.0 (2026-07-03); milestone v1.7 (bilingual output) → release
 > v2.2.0 (2026-07-04). Reflow and cooperative controls shipped in v2.3.0;
-> durable corrections and live reconfiguration are the v2.4.0 scope.
+> durable corrections and live reconfiguration shipped in v2.4.0; the initial
+> audiobook pipeline shipped in v2.5.0, followed by the v2.5.1 dashboard fix.
 
 ---
 
@@ -123,7 +124,7 @@ via `java`, but the BookForge binary itself does not need Java to run.
 | v1.7 | Bilingual output (§9b) | 5–8 days | passive (release notes only) | **shipped 2026-07-04 as release v2.2.0** |
 | v1.8 | Structural credibility (EPUBCheck + corpus; was the planned v1.5 scope, §8) | 10–14 days | README final rewrite citing corpus | **shipped 2026-06-20** |
 | v2.0 | Monitoring UI (`RunState`, `watch`, `--ui tui`, local `serve`) | shipped scope | release notes | shipped; patch line completed at v2.0.3 (2026-07-02) |
-| v3.0 | Audiobook narration quality & UI parity (§16) | 8–12 days | release notes and updated audiobook guide | in progress |
+| v2.6.0 | Audiobook narration quality & UI parity (§16) | 8–12 days | release notes and updated audiobook guide | in progress |
 
 Priority note (2026-06): the owner needs PDF translation more than
 bilingual output — scientific papers (figures/tables must survive) and
@@ -2395,7 +2396,7 @@ visible reader-facing defect in the owner's actual library.
 > **Status note (2026-07-03):** "v2" shipped (releases v2.0.0–v2.1.0)
 > with a scope chosen at the time — the monitoring UI plus web dashboard.
 > The candidates sketched below were written before that decision; read
-> them as a v2.x/v3 idea list, not as the shipped v2's contents.
+> them as an open-ended follow-up idea list, not as the shipped v2's contents.
 
 The v2 list is what's interesting *as of writing*. The real v2
 priorities will be informed by:
@@ -2923,7 +2924,7 @@ externalized memory. When in doubt, ask.
 
 ---
 
-## 16. v3.0 — Audiobook narration quality & UI parity
+## 16. v2.6.0 — Audiobook narration quality & UI parity
 
 ### 16.1 Goal
 
@@ -2962,11 +2963,11 @@ informed decision before spending provider credits.
 - ElevenLabs continuity controls: same-chapter `previous_text` and `next_text`
   context (300 characters on each side), a reproducible seed, supported
   language selection, and text-normalization policy.
-- A chaptered `audiobook.m4b`, with chapter markers and title/author metadata,
-  as the default deliverable when ffmpeg is present. Users may opt out of the
-  book file or additionally request a flat single audio file for on-the-go
-  listening. Optional whole-book loudness normalization targets
-  `I=-18:TP=-2:LRA=11`.
+- A chaptered `audiobook.m4b`, with chapter markers and title/artist metadata
+  (using the EPUB author as the artist), as the default deliverable when ffmpeg
+  is present. Users may opt out of the book file or additionally request a flat
+  single audio file for on-the-go listening. Optional whole-book loudness
+  normalization targets `I=-18:TP=-2:LRA=11`.
 - Per-character provider pricing, plan/dry-run cost estimates, and a non-fatal
   ElevenLabs subscription-quota preflight before live synthesis.
 - Chapter-range selection and provider-backed ElevenLabs voice listing in the
@@ -2986,10 +2987,12 @@ informed decision before spending provider credits.
 - The synthesis cache domain tag changes from `bookforge-audio-v1` to
   `bookforge-audio-v2`. The new hash includes narration kind, neighbor context,
   seed, language, and text normalization, deliberately invalidating every
-  existing audio chunk cache.
-- New `pricing/audio-providers.json`, with `schema_version: 1`, records
-  per-character TTS pricing by provider and model (expressed as cost per
-  million characters and/or credits per character).
+  existing audio chunk cache. This is a one-time compatibility break for
+  users' on-disk audio caches, not a semver-major CLI or API change; rerun with
+  `--prune` to remove superseded chunks.
+- New `crates/bookforge-cli/pricing/audio-providers.json`, with
+  `schema_version: 1`, records per-character TTS pricing by provider and model
+  (expressed as cost per million characters and/or credits per character).
 
 ### 16.5 CLI surface
 
@@ -3001,7 +3004,7 @@ informed decision before spending provider credits.
 - `--seed <U32>`, `--language <CODE>`, and
   `--text-normalization <auto|on|off>` expose ElevenLabs consistency controls.
   Language defaults from the book metadata and is sent only to Flash/Turbo
-  v2.5, because ElevenLabs rejects it on Multilingual v2.
+  v2.5; BookForge warns and drops it for every other model or provider.
 - `--loudnorm` normalizes assembled book files; per-chapter files remain
   untouched to avoid independently normalized chapter-to-chapter level jumps.
 - A normal run creates the chaptered `.m4b` when ffmpeg is available.
@@ -3058,12 +3061,12 @@ informed decision before spending provider credits.
 3. ElevenLabs request-contract tests show same-chapter context, seed, language,
    and text-normalization fields when configured, omit them at defaults, and
    never carry context across a chapter boundary.
-4. Changing any v3 synthesis input changes the `bookforge-audio-v2` hash; a v2
-   manifest remains readable, while every v1-tagged cached chunk is treated as
-   stale.
+4. Changing any newly hashed synthesis input changes the
+   `bookforge-audio-v2` hash; a v2 manifest remains readable, while every
+   v1-tagged cached chunk is treated as stale.
 5. With ffmpeg available, an ordinary run emits a playable chaptered `.m4b`
-   with title, author, and chapter markers; `--no-book-file` suppresses it,
-   `--single` adds the flat artifact, and `--loudnorm` applies only during
+   with title/artist metadata and chapter markers; `--no-book-file` suppresses
+   it, `--single` adds the flat artifact, and `--loudnorm` applies only during
    whole-book assembly.
 6. Plan and dry-run output report character count and estimated dollars and/or
    credits from schema-1 pricing. An ElevenLabs run reports remaining quota,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
-# BookForge — Technical Roadmap, v1.0.1 through v2.0
+# BookForge — Technical Roadmap, v1.0.1 through v3.0
 
-**Document version:** 1.3.0
-**Last updated:** 2026-07-13
+**Document version:** 1.4.0
+**Last updated:** 2026-07-20
 **Status:** historical roadmap plus active follow-up notes
 **Audience:** project maintainer + Claude Code (or any other coding agent) implementing
 the milestones below.
@@ -123,6 +123,7 @@ via `java`, but the BookForge binary itself does not need Java to run.
 | v1.7 | Bilingual output (§9b) | 5–8 days | passive (release notes only) | **shipped 2026-07-04 as release v2.2.0** |
 | v1.8 | Structural credibility (EPUBCheck + corpus; was the planned v1.5 scope, §8) | 10–14 days | README final rewrite citing corpus | **shipped 2026-06-20** |
 | v2.0 | Monitoring UI (`RunState`, `watch`, `--ui tui`, local `serve`) | shipped scope | release notes | shipped; patch line completed at v2.0.3 (2026-07-02) |
+| v3.0 | Audiobook narration quality & UI parity (§16) | 8–12 days | release notes and updated audiobook guide | in progress |
 
 Priority note (2026-06): the owner needs PDF translation more than
 bilingual output — scientific papers (figures/tables must survive) and
@@ -2919,6 +2920,183 @@ This roadmap is a living document. After each milestone ships:
 
 The maintainer is the source of truth; this document is the maintainer's
 externalized memory. When in doubt, ask.
+
+---
+
+## 16. v3.0 — Audiobook narration quality & UI parity
+
+### 16.1 Goal
+
+Make BookForge narration sound and behave like a finished audiobook. Chapter
+titles and in-section headings become distinct narration units with deliberate
+pauses; neighboring ElevenLabs requests receive enough context to maintain a
+consistent delivery; and a metadata-bearing, chaptered `.m4b` becomes the
+default artifact whenever ffmpeg is available. The CLI and browser dashboard
+must expose the same planning, provider, output, and cost controls without
+requiring users to understand the internal chunk pipeline.
+
+### 16.2 Architectural rationale
+
+The v2.5 pipeline proved the provider abstraction and resumable audio cache,
+but flattened document hierarchy into prose and treated book assembly as an
+optional post-processing step. Those choices are visible to listeners as
+poorly announced chapter transitions, inconsistent joins, and an output layout
+that requires extra flags to reach the artifact most audiobook players expect.
+
+Hierarchy remains deterministic BookForge data: the EPUB/PDF readers identify
+titles, headings, and paragraphs; providers still receive text rather than
+document markup. Context and ElevenLabs-specific break tags are additive
+request hints, while pauses are inserted at stitch time so every provider gets
+the same structure and existing encoded chunks can still be concatenated with
+stream copy. Cost and quota checks happen before synthesis so users can make an
+informed decision before spending provider credits.
+
+### 16.3 Deliverables
+
+- A typed narration plan in which chapter titles, in-section headings, and
+  body paragraphs remain distinguishable. Title and heading blocks occupy
+  their own chunks and are never packed into adjacent prose.
+- Provider-independent silence insertion with defaults of 1200 ms between
+  chapters, 800 ms after titles/headings, and 0 ms between body chunks, plus
+  optional ElevenLabs `<break>` tags on supported models.
+- ElevenLabs continuity controls: same-chapter `previous_text` and `next_text`
+  context (300 characters on each side), a reproducible seed, supported
+  language selection, and text-normalization policy.
+- A chaptered `audiobook.m4b`, with chapter markers and title/author metadata,
+  as the default deliverable when ffmpeg is present. Users may opt out of the
+  book file or additionally request a flat single audio file for on-the-go
+  listening. Optional whole-book loudness normalization targets
+  `I=-18:TP=-2:LRA=11`.
+- Per-character provider pricing, plan/dry-run cost estimates, and a non-fatal
+  ElevenLabs subscription-quota preflight before live synthesis.
+- Chapter-range selection and provider-backed ElevenLabs voice listing in the
+  CLI.
+- Browser-dashboard parity: ElevenLabs `Auto (recommended)` model selection,
+  a server-side voice-list proxy (`GET /api/audio/voices`), pre-launch
+  cost/quota estimates (`POST /api/audiobook/estimate`), per-chapter progress,
+  in-page `.m4b` playback, and an Advanced section for chapter pause,
+  flat-file output, loudness normalization, seed, and language.
+
+### 16.4 Schema changes
+
+- Audiobook manifest `schema_version` moves from 2 to 3. Chunk records gain a
+  `kind` (`title`, `heading`, or `body`), and the manifest gains `seed`,
+  `language`, `text_normalization`, `gaps`, and `author`. Every new field is
+  serde-defaulted so v2 manifests remain readable by stitch and serve paths.
+- The synthesis cache domain tag changes from `bookforge-audio-v1` to
+  `bookforge-audio-v2`. The new hash includes narration kind, neighbor context,
+  seed, language, and text normalization, deliberately invalidating every
+  existing audio chunk cache.
+- New `pricing/audio-providers.json`, with `schema_version: 1`, records
+  per-character TTS pricing by provider and model (expressed as cost per
+  million characters and/or credits per character).
+
+### 16.5 CLI surface
+
+- `--gap-chapter-ms <MS>` (default `1200`), `--gap-title-ms <MS>` (default
+  `800`), and `--gap-paragraph-ms <MS>` (default `0`) control stitch-time
+  silence.
+- `--break-tags <auto|off>` (default `auto`) enables heading break tags only
+  for compatible ElevenLabs v2 models.
+- `--seed <U32>`, `--language <CODE>`, and
+  `--text-normalization <auto|on|off>` expose ElevenLabs consistency controls.
+  Language defaults from the book metadata and is sent only to Flash/Turbo
+  v2.5, because ElevenLabs rejects it on Multilingual v2.
+- `--loudnorm` normalizes assembled book files; per-chapter files remain
+  untouched to avoid independently normalized chapter-to-chapter level jumps.
+- A normal run creates the chaptered `.m4b` when ffmpeg is available.
+  `--no-book-file` opts out, while `--single` additionally creates a flat
+  single audio file. Existing `--stitch` and `--m4b` remain explicit
+  overrides.
+- `--chapters <RANGE>` selects one-based chapter numbers and ranges without
+  renumbering output files; `--list-voices` lists ElevenLabs voice IDs, names,
+  categories, and labels without requiring an input book.
+
+### 16.6 Implementation notes
+
+- This milestone builds on the v2.5.x ElevenLabs hardening: request validation,
+  retry behavior, provider-specific format handling, and model-specific
+  character limits (40,000 for Flash/Turbo v2.5, 10,000 for Multilingual v2,
+  and 5,000 for Eleven v3).
+- Omitted ElevenLabs models retain the established live preference chain:
+  `eleven_v3` → `eleven_flash_v2_5` → `eleven_turbo_v2_5` →
+  `eleven_multilingual_v2`. The dashboard's empty model value invokes that
+  resolver instead of maintaining a second selection policy.
+- The v2.5.x OCR endpoint work established the loopback/API-key detection and
+  server-side proxy foundations reused by audiobook voice and quota requests;
+  provider keys never enter browser responses, logs, or URLs.
+- Neighbor context is computed from the ordered plan and stops at chapter
+  boundaries. Editing chunk N intentionally invalidates the hashes for N and
+  its adjacent chunks. `previous_request_ids`/`next_request_ids` are not used,
+  because their serialization requirement conflicts with concurrent
+  synthesis.
+- Silence files are generated to match probed sample rate and channel count.
+  A missing or failed ffprobe warns and continues without gaps rather than
+  failing an otherwise usable narration run.
+- Loudness normalization happens once at whole-book assembly. The chaptered
+  and flat artifacts are re-encoded only when normalization is requested;
+  ordinary stitching retains stream-copy behavior.
+
+### 16.7 Out of scope (within milestone)
+
+- A per-chapter audio streaming route in the browser dashboard.
+- ElevenLabs `previous_request_ids`/`next_request_ids` serialization.
+- Unifying audiobook and translation operations under
+  `OperationKind::{Translation,Audiobook}`; the §10.1 owner decision of
+  2026-07-15 stands.
+- HTTP Range support on the audiobook artifact route. Inline playback ships
+  now; efficient seeking remains follow-up work.
+
+### 16.8 Acceptance criteria
+
+1. A fixture containing a chapter title, an in-section heading, and body prose
+   produces separate typed title/heading chunks, narrates the title exactly
+   once, and never merges either heading with body text.
+2. Deterministic tests prove the default title and chapter gaps appear in the
+   correct concat order, paragraph gaps remain disabled by default, and m4b
+   chapter-marker durations include inter-chapter silence.
+3. ElevenLabs request-contract tests show same-chapter context, seed, language,
+   and text-normalization fields when configured, omit them at defaults, and
+   never carry context across a chapter boundary.
+4. Changing any v3 synthesis input changes the `bookforge-audio-v2` hash; a v2
+   manifest remains readable, while every v1-tagged cached chunk is treated as
+   stale.
+5. With ffmpeg available, an ordinary run emits a playable chaptered `.m4b`
+   with title, author, and chapter markers; `--no-book-file` suppresses it,
+   `--single` adds the flat artifact, and `--loudnorm` applies only during
+   whole-book assembly.
+6. Plan and dry-run output report character count and estimated dollars and/or
+   credits from schema-1 pricing. An ElevenLabs run reports remaining quota,
+   warns when the plan exceeds it, and treats a failed quota preflight as
+   non-fatal.
+7. Chapter-range parsing accepts one-based comma-separated numbers and ranges,
+   rejects zero/reversed/invalid input, and filters plan, manifest, and output
+   consistently without changing original chapter numbers. Voice listing
+   works without an input EPUB and never exposes an API key.
+8. The dashboard's auto-model path omits an explicit model, the voice picker
+   degrades to free text if its proxy fails, the estimate endpoint is
+   CSRF-protected, progress is grouped per chapter, and the finished view
+   embeds the assembled `.m4b` for inline playback.
+9. **Un-mockable end-to-end:** narrate a real EPUB chapter with live
+   ElevenLabs Flash v2.5, verify audible title/heading and chapter gaps, inspect
+   the generated `.m4b` metadata and chapter markers, then play that artifact
+   successfully from the browser dashboard.
+10. The offline workspace test suite passes on Windows, and live checkpoints
+    stay within the explicitly approved ElevenLabs credit budget.
+
+### 16.9 Effort
+
+8–12 focused person-days, including offline coverage, three small live
+ElevenLabs checkpoints, and dashboard verification.
+
+### 16.10 Dependencies
+
+- The v2.5 audiobook pipeline, provider hardening, per-model ElevenLabs limits,
+  and automatic model resolver.
+- The v2.5.x local dashboard, server-side credential handling, and OCR endpoint
+  foundations.
+- ffmpeg for assembled book files and ffprobe for exact gaps and chapter-marker
+  timing; synthesis remains useful when those external tools are absent.
 
 ---
 

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -1,14 +1,21 @@
 # Audiobook Generation
 
 `bookforge audiobook` turns an EPUB into narrated audio. It works directly on
-a source EPUB as well as on a translated EPUB; translation is optional. It reuses the same
-design principle as the translation engine: deterministic Rust owns the
-structure — chapter extraction, chunking, file layout, and resume — and the
-speech provider only ever receives a plain text chunk and returns audio bytes.
+a source EPUB as well as on a translated EPUB; translation is optional. It
+reuses the same design principle as the translation engine: deterministic Rust
+owns structure — chapter extraction, narration hierarchy, chunking, file
+layout, and resume — and the speech provider only ever receives text and
+returns audio bytes.
 
-The workflow is available consistently in three places: the ordinary CLI,
-the full-screen terminal dashboard (`--ui tui`), and the Audiobooks screen in
-the local browser dashboard started by `bookforge serve`.
+The workflow is available consistently in three places: the ordinary CLI, the
+full-screen terminal dashboard (`--ui tui`), and the Audiobooks screen in the
+local browser dashboard started by `bookforge serve`.
+
+> **Upgrading to v3.0 invalidates all existing audio chunk caches.** The cache
+> hash moved to `bookforge-audio-v2` and the manifest to schema 3. Rerun the
+> audiobook command with `--prune` to remove superseded v2.5 chunk files after
+> reviewing the new plan; use `--prune --dry-run` to preview what will be
+> deleted.
 
 ## Pipeline
 
@@ -17,33 +24,51 @@ the local browser dashboard started by `bookforge serve`.
    reader builds for translation (OPF metadata, NCX table of contents) are
    skipped — you do not want a table of contents read aloud. Inline markers
    are stripped so the narrator hears clean prose.
-3. **Chunk** each chapter on sentence boundaries into pieces under
+3. **Preserve narration hierarchy.** A chapter title and every in-section
+   heading become their own typed narration blocks. Each title or heading gets
+   a separate chunk and is never packed into the following body prose. The
+   title remains present exactly once.
+4. **Chunk body prose** on sentence boundaries into pieces under
    `--max-chars` (default 2000; the maximum is provider-specific). Chunking is
-   a pure function of the text, so a resumed run re-derives the exact same
-   chunks.
-4. **Synthesize** each chunk through the TTS provider, `--concurrency` at a
+   a pure function of the text, so a resumed run re-derives the same plan.
+5. **Synthesize** each chunk through the TTS provider, `--concurrency` at a
    time, writing `chapter-NNN-part-NNN-<hash>.<ext>` atomically (temp file then
-   rename) so an interrupted write is never mistaken for a finished one. The
-   hash covers the text, provider/model identity, voice, format, speed, and
-   instructions.
-5. **Manifest**: a `manifest.json` records the plan and per-chunk metadata.
-6. **Stitch** (optional): with `--stitch` or `--m4b`, ffmpeg joins the parts.
+   rename) so an interrupted write is never mistaken for a finished one.
+6. **Manifest**: a schema-3 `manifest.json` records the plan, narration kind,
+   synthesis settings, gap settings, author, and per-chunk metadata.
+7. **Assemble**: when ffmpeg is available, a normal run creates a chaptered
+   `audiobook.m4b` with chapter markers and title/author metadata. The chunks
+   remain the resumable units on disk.
 
-## Resume
+## Narration hierarchy and continuity
 
-Re-run the exact same command and every matching hashed chunk already on disk
-is skipped. Changing the source text, model, endpoint, voice, format, speed, or
-instructions produces a new hash and therefore cannot silently reuse stale
-audio. This makes long books safe against network hiccups, rate-limit
-interruptions, and Ctrl-C while keeping old generations auditable. The run
-summary reports how many chunks were synthesized versus reused.
+The default pauses are intentionally audiobook-like without making ordinary
+prose sound halting:
 
-Because a changed voice, model, speed, format, or edited source produces new
-file names, the superseded chunks stay on disk. Nothing deletes them
-automatically. Pass `--prune` to remove the chunk files the *current* run does
-not use and free the space; combine it with `--dry-run` to list what would be
-removed without deleting anything. Stitched per-chapter outputs, the assembled
-`.m4b`, and `manifest.json` are never touched.
+- 1200 ms between chapters gives a clear scene break.
+- 800 ms after a chapter title or in-section heading lets the heading stand
+  apart from the prose it introduces.
+- 0 ms between body chunks avoids adding an audible pause at boundaries that
+  exist only because of a provider request limit.
+
+These gaps are inserted during stitching, not synthesized into every audio
+chunk. BookForge probes the first chunk's sample rate and channel count so the
+generated silence can be concatenated without re-encoding. If ffprobe is
+missing or cannot inspect the audio, BookForge warns and assembles without
+gaps rather than failing the run.
+
+For ElevenLabs, BookForge also sends up to 300 characters of `previous_text`
+and `next_text` around each request. Context never crosses a chapter boundary.
+This improves delivery across chunk joins while preserving parallel synthesis;
+editing one chunk can therefore invalidate its immediate neighbors as well.
+The optional seed, language, and text-normalization controls are included in
+the cache key.
+
+With `--break-tags auto`, BookForge appends an ElevenLabs
+`<break time="0.6s" />` tag to title and heading text for Flash v2.5, Turbo
+v2.5, and Multilingual v2. It never adds these tags for Eleven v3 or another
+provider. Use `--break-tags off` when the selected voice or model reads tags
+aloud instead of treating them as directives.
 
 ## Providers
 
@@ -63,7 +88,7 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
   (default `OPENAI_API_KEY`) and is never placed on the command line. Loopback
   endpoints (`localhost`, `127.0.0.1`, or `::1`) do not require a key.
 
-- **`gemini`** - Google's native Gemini Generate Content TTS API. The default
+- **`gemini`** — Google's native Gemini Generate Content TTS API. The default
   model is `gemini-3.1-flash-tts-preview`, the default voice is `Kore`, and the
   key defaults to `GEMINI_API_KEY`. Gemini returns 24 kHz mono PCM; BookForge
   wraps it in a real WAV by default so it can be played and stitched safely.
@@ -73,30 +98,35 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
   bookforge audiobook book.epub --provider gemini \
     --voice Kore \
     --instructions "Read as a calm, precise audiobook narrator." \
-    --format wav --m4b
+    --format wav
   ```
 
-- **`elevenlabs`** - ElevenLabs' native text-to-speech API, authenticated with
+- **`elevenlabs`** — ElevenLabs' native text-to-speech API, authenticated with
   `ELEVENLABS_API_KEY` by default. Pass an ElevenLabs voice ID with `--voice`;
-  voice names are not interchangeable with IDs. When `--model` is omitted on
-  a live run, BookForge checks the account's available TTS models and selects
-  the first compatible model in this order: `eleven_v3`,
-  `eleven_flash_v2_5`, `eleven_turbo_v2_5`, then
-  `eleven_multilingual_v2`. An explicit `--model` bypasses auto-selection. A
-  dry run stays offline and reports the static `eleven_multilingual_v2`
-  default instead. Supported outputs are MP3, Opus, WAV, and PCM.
+  voice names are not interchangeable with IDs. Run the following first to
+  discover the account's available voices:
+
+  ```bash
+  bookforge audiobook --provider elevenlabs --list-voices
+  ```
+
+  When `--model` is omitted on a live run, BookForge checks the account's
+  available TTS models and selects the first compatible model in this order:
+  `eleven_v3`, `eleven_flash_v2_5`, `eleven_turbo_v2_5`, then
+  `eleven_multilingual_v2`. An explicit `--model` bypasses auto-selection.
+  Supported outputs are MP3, Opus, WAV, and PCM.
 
   ```bash
   bookforge audiobook book.epub --provider elevenlabs \
     --voice JBFqnCBsd6RMkjVDRZzb \
-    --model eleven_multilingual_v2 --format mp3 --m4b
+    --model eleven_flash_v2_5 --format mp3
   ```
 
   ElevenLabs does not expose a free-form instructions field on this endpoint.
-  Configure the selected voice in ElevenLabs, use `--speed`, or place
-  model-supported audio tags directly in the source text. `eleven_v3` does not
-  support speed control on the TTS endpoint, so it requires `--speed 1.0`.
-  BookForge enforces the selected model's per-request character limit.
+  Configure the selected voice in ElevenLabs, use `--speed`, or enable the
+  heading break-tag policy. `eleven_v3` does not support speed control on the
+  TTS endpoint, so it requires `--speed 1.0`. BookForge enforces the selected
+  model's per-request character limit.
 
 - **`mock`** — a deterministic, offline provider that emits valid silent WAV
   clips scaled to the text length. Its format is always `wav`; BookForge uses
@@ -104,39 +134,138 @@ removed without deleting anything. Stitched per-chapter outputs, the assembled
 
 ## Options
 
+### General and planning
+
 | Flag | Default | Purpose |
 | --- | --- | --- |
 | `--out <dir>` | `<input>.audiobook` | Output directory. |
 | `--provider <mock\|openai\|gemini\|elevenlabs>` | `openai` | Speech backend. |
-| `--model <name>` | provider-specific | TTS model. |
+| `--model <name>` | provider-specific; auto for ElevenLabs | TTS model. |
 | `--voice <name-or-id>` | provider-specific | Voice name, or ElevenLabs voice ID. |
 | `--format <mp3\|opus\|aac\|flac\|wav\|pcm>` | provider-specific | Output codec/container. |
 | `--speed <f32>` | `1.0` | Playback speed multiplier. |
 | `--base-url <url>` | OpenAI | Endpoint override for local servers. |
-| `--api-key-env <VAR>` | provider-specific | Env var holding the key. |
-| `--max-chars <n>` | `2000` | Max characters per request. |
+| `--api-key-env <VAR>` | provider-specific | Environment variable holding the key. |
+| `--max-chars <n>` | `2000` | Maximum characters per request. |
 | `--concurrency <n>` | `4` | Parallel synthesis requests. |
 | `--timeout-seconds <n>` | `120` | Per-request timeout. |
 | `--instructions <text>` | none | Delivery or pronunciation guidance for models that support it. |
-| `--stitch` | off | Join each chapter's parts into one file (ffmpeg). |
-| `--m4b` | off | Also assemble a single `.m4b` with chapter markers. |
-| `--dry-run` | off | Print the chapter/chunk plan and exit. |
-| `--prune` | off | Delete chunk files from earlier runs the current plan does not use (report-only with `--dry-run`). |
+| `--chapters <RANGE>` | all chapters | Narrate one-based chapter numbers and ranges. |
+| `--list-voices` | off | List ElevenLabs voice IDs and metadata; no input EPUB is required. |
+| `--dry-run` | off | Print the chapter/chunk plan, cost estimate, and available quota, then exit. |
+| `--prune` | off | Delete superseded chunks not used by the current plan (report-only with `--dry-run`). |
 | `--ui <auto\|progress\|quiet\|json\|tui>` | `auto` | Select progress output or the full-screen terminal dashboard. |
 
-## Stitching
+Chapter numbers are the one-based numbers shown in the plan. Comma-separated
+items and inclusive ranges can be mixed:
 
-`--stitch` and `--m4b` shell out to `ffmpeg`. If it is not on `PATH`, plain
-`--stitch` keeps the per-chunk files and reports a warning. Explicit `--m4b`
-returns an error when the requested single-book artifact cannot be built; the
-completed chunk files remain available for a resumed stitch.
+```bash
+bookforge audiobook book.epub --chapters 2,5-7 --dry-run
+```
 
-- `--stitch` concatenates each chapter's parts into
-  `chapter-NNN-<title>.<ext>` with a stream copy (no re-encode).
-- `--m4b` additionally assembles a single `audiobook.m4b`. When `ffprobe` is
-  available it measures each chapter's duration and writes chapter markers so
-  players can jump between chapters; without `ffprobe` you still get a
-  playable `.m4b`, just without the marker list.
+Zero, reversed ranges, and invalid text are rejected. Selected chapters keep
+their original numbers in the manifest and output filenames.
+
+### Structure, consistency, and output
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--gap-chapter-ms <MS>` | `1200` | Silence between chapters. |
+| `--gap-title-ms <MS>` | `800` | Silence after titles and headings. |
+| `--gap-paragraph-ms <MS>` | `0` | Silence between body chunks. |
+| `--break-tags <auto\|off>` | `auto` | Add heading break tags on compatible ElevenLabs v2 models. |
+| `--seed <u32>` | none | Request reproducible ElevenLabs generation; rejected for other providers. |
+| `--language <code>` | primary subtag from EPUB metadata | Send a language code to ElevenLabs Flash/Turbo v2.5. |
+| `--text-normalization <auto\|on\|off>` | `auto` | Control ElevenLabs text normalization. |
+| `--loudnorm` | off | Normalize the assembled book to `I=-18:TP=-2:LRA=11`. |
+| `--no-book-file` | off | Do not create the default chaptered `.m4b`. |
+| `--single` | off | Also create a flat `audiobook.<format>` for on-the-go listening. |
+| `--stitch` | off | Explicitly request stitched per-chapter files. |
+| `--m4b` | automatic when ffmpeg is present | Explicitly request the chaptered `.m4b`. |
+
+`--language` normalizes metadata such as `en-US` to its primary subtag (`en`).
+ElevenLabs accepts this field only for Flash and Turbo v2.5. BookForge warns
+and drops it for Multilingual v2 and Eleven v3 because those APIs reject it.
+The `--text-normalization` setting maps to ElevenLabs'
+`apply_text_normalization` request field.
+
+## Cost and quota preflight
+
+After the `Plan:` summary, BookForge estimates the narration price from the
+bundled schema-1 `pricing/audio-providers.json` table and prints the available
+dollar and/or provider-credit estimate, for example:
+
+```text
+Estimated cost: ~$1.23 / ~4500 credits
+```
+
+Pricing is per character, so changing chunk size does not change the estimate.
+Treat it as planning information rather than an invoice: provider plans and
+rates can change.
+
+Before a live ElevenLabs run, BookForge queries `/v1/user/subscription` and
+prints a line such as `ElevenLabs quota: 12000 remaining of 20000`. It warns
+when the plan exceeds the remaining quota. A dry run performs the same check
+when the configured key environment variable is available. Network or quota
+preflight failure is always a warning and never prevents synthesis.
+
+## Book files, stitching, and loudness
+
+When ffmpeg is on `PATH`, the default deliverable is `audiobook.m4b`, with
+chapter markers plus the EPUB's title and author metadata. `--no-book-file`
+opts out. `--single` adds one flat `audiobook.<format>`; with MP3 output this is
+the convenient single-file MP3 for players that do not need chapter markers.
+The two book outputs can be requested together.
+
+`--stitch` and `--m4b` remain available as explicit overrides. Per-chapter
+stitching and ordinary flat-file assembly use stream copy. Raw PCM is rejected
+for stitching because it has no container-level sample metadata; choose WAV
+for uncompressed intermediates.
+
+`--loudnorm` applies ffmpeg's loudness filter once while assembling the `.m4b`
+and flat file. It deliberately does not normalize each chapter independently,
+which would allow target differences to create audible level jumps. Individual
+chapter downloads therefore remain unnormalized.
+
+If ffmpeg is unavailable, BookForge keeps the completed chunks and warns that
+it could not create the automatic book file. An explicitly requested `--m4b`
+fails clearly while preserving those chunks for a later resumed stitch.
+
+## Resume and cache cleanup
+
+Re-run the same command and every matching hashed chunk already on disk is
+skipped. The v3 cache key covers the text, narration kind, provider/model
+identity, voice, format, speed, instructions, seed, language, normalization,
+and same-chapter neighbor context. An interrupted write is never accepted as a
+finished chunk. The run summary reports how many chunks were synthesized and
+reused.
+
+Superseded chunks stay on disk so prior generations remain auditable. Pass
+`--prune` to remove chunk files the current run does not use and free the
+space; combine it with `--dry-run` to list them without deleting anything.
+Stitched per-chapter outputs, assembled book files, and `manifest.json` are
+never pruned.
+
+## Browser dashboard
+
+The Audiobooks screen mirrors the CLI's v3 workflow:
+
+- ElevenLabs offers `Auto (recommended)` model selection and retrieves the
+  account's voices through a server-side proxy; the API key never reaches the
+  browser. If voice retrieval fails, the form falls back to a voice-ID field.
+- A pre-launch estimate reports chapters, chunks, characters, cost, and
+  ElevenLabs quota before synthesis starts.
+- Running jobs show per-chapter completed/total progress and the resolved
+  auto-selected model.
+- The Advanced section exposes chapter pause, flat-file output, loudness
+  normalization, seed, and language. Chapter-pause presets map none/short/
+  medium/long to 0/600/1200/2000 ms; the title gap is derived as the smaller
+  of 800 ms and the selected chapter gap.
+- The finished panel plays the chaptered `.m4b` in-page and keeps the download
+  action available.
+
+The artifact route does not yet support HTTP Range requests, so seeking through
+a long `.m4b` may depend on browser buffering behavior.
 
 ## Notes
 
@@ -149,22 +278,18 @@ completed chunk files remain available for a resumed stitch.
 - Gemini TTS supports WAV and raw PCM in BookForge. ElevenLabs supports MP3,
   Opus, WAV, and raw PCM; some high-sample-rate formats require a qualifying
   ElevenLabs plan.
-- `--stitch`/`--m4b` reject raw PCM because it has no container-level sample
-  metadata. Use WAV when you need uncompressed intermediate files.
-- Cost and time scale with characters, not chunks. Use `--dry-run` to see the
-  character total before committing to a paid run.
+- Cost and time scale with characters, not chunks. Use `--dry-run` and
+  `--chapters` to inspect a small subset before committing to a paid run.
 
 ## Narrating a Toki Pona translation
 
 If a Toki Pona edition is desired, generate the translated EPUB first and then
-narrate that output. Current OpenAI
-speech models accept delivery instructions, which is useful for consistent
-Toki Pona pronunciation:
+narrate that output. Current OpenAI speech models accept delivery instructions,
+which is useful for consistent Toki Pona pronunciation:
 
 ```bash
 bookforge audiobook lipu.tok.epub \
   --model gpt-4o-mini-tts \
   --voice alloy \
-  --instructions "Speak Toki Pona clearly and evenly; pronounce every vowel consistently." \
-  --m4b
+  --instructions "Speak Toki Pona clearly and evenly; pronounce every vowel consistently."
 ```

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -11,7 +11,7 @@ The workflow is available consistently in three places: the ordinary CLI, the
 full-screen terminal dashboard (`--ui tui`), and the Audiobooks screen in the
 local browser dashboard started by `bookforge serve`.
 
-> **Upgrading to v3.0 invalidates all existing audio chunk caches.** The cache
+> **Upgrading to v2.6.0 invalidates all existing audio chunk caches.** The cache
 > hash moved to `bookforge-audio-v2` and the manifest to schema 3. Rerun the
 > audiobook command with `--prune` to remove superseded v2.5 chunk files after
 > reviewing the new plan; use `--prune --dry-run` to preview what will be
@@ -37,8 +37,8 @@ local browser dashboard started by `bookforge serve`.
 6. **Manifest**: a schema-3 `manifest.json` records the plan, narration kind,
    synthesis settings, gap settings, author, and per-chunk metadata.
 7. **Assemble**: when ffmpeg is available, a normal run creates a chaptered
-   `audiobook.m4b` with chapter markers and title/author metadata. The chunks
-   remain the resumable units on disk.
+   `audiobook.m4b` with chapter markers and title/artist metadata (using the
+   EPUB author as the artist). The chunks remain the resumable units on disk.
 
 ## Narration hierarchy and continuity
 
@@ -184,24 +184,24 @@ their original numbers in the manifest and output filenames.
 | `--m4b` | automatic when ffmpeg is present | Explicitly request the chaptered `.m4b`. |
 
 `--language` normalizes metadata such as `en-US` to its primary subtag (`en`).
-ElevenLabs accepts this field only for Flash and Turbo v2.5. BookForge warns
-and drops it for Multilingual v2 and Eleven v3 because those APIs reject it.
+It is sent only to ElevenLabs Flash and Turbo v2.5. BookForge warns and drops
+it for every other model or provider.
 The `--text-normalization` setting maps to ElevenLabs'
 `apply_text_normalization` request field.
 
 ## Cost and quota preflight
 
 After the `Plan:` summary, BookForge estimates the narration price from the
-bundled schema-1 `pricing/audio-providers.json` table and prints the available
-dollar and/or provider-credit estimate, for example:
+bundled schema-1 `crates/bookforge-cli/pricing/audio-providers.json` table and
+prints the applicable dollar and/or provider-credit estimate, for example:
 
 ```text
 Estimated cost: ~$1.23 / ~4500 credits
 ```
 
 Pricing is per character, so changing chunk size does not change the estimate.
-Treat it as planning information rather than an invoice: provider plans and
-rates can change.
+These figures are planning estimates, not invoices: provider plans and rates
+can change, and the provider's own billing is authoritative.
 
 Before a live ElevenLabs run, BookForge queries `/v1/user/subscription` and
 prints a line such as `ElevenLabs quota: 12000 remaining of 20000`. It warns
@@ -212,7 +212,8 @@ preflight failure is always a warning and never prevents synthesis.
 ## Book files, stitching, and loudness
 
 When ffmpeg is on `PATH`, the default deliverable is `audiobook.m4b`, with
-chapter markers plus the EPUB's title and author metadata. `--no-book-file`
+chapter markers plus title/artist metadata drawn from the EPUB's title and
+author. `--no-book-file`
 opts out. `--single` adds one flat `audiobook.<format>`; with MP3 output this is
 the convenient single-file MP3 for players that do not need chapter markers.
 The two book outputs can be requested together.
@@ -234,11 +235,11 @@ fails clearly while preserving those chunks for a later resumed stitch.
 ## Resume and cache cleanup
 
 Re-run the same command and every matching hashed chunk already on disk is
-skipped. The v3 cache key covers the text, narration kind, provider/model
-identity, voice, format, speed, instructions, seed, language, normalization,
-and same-chapter neighbor context. An interrupted write is never accepted as a
-finished chunk. The run summary reports how many chunks were synthesized and
-reused.
+skipped. The `bookforge-audio-v2` cache key covers the text, narration kind,
+provider/model identity, voice, format, speed, instructions, seed, language,
+normalization, and same-chapter neighbor context. An interrupted write is
+never accepted as a finished chunk. The run summary reports how many chunks
+were synthesized and reused.
 
 Superseded chunks stay on disk so prior generations remain auditable. Pass
 `--prune` to remove chunk files the current run does not use and free the
@@ -248,7 +249,7 @@ never pruned.
 
 ## Browser dashboard
 
-The Audiobooks screen mirrors the CLI's v3 workflow:
+The Audiobooks screen mirrors the CLI's current workflow:
 
 - ElevenLabs offers `Auto (recommended)` model selection and retrieves the
   account's voices through a server-side proxy; the API key never reaches the

--- a/docs/codex-handoff-v2.6.0.md
+++ b/docs/codex-handoff-v2.6.0.md
@@ -1,10 +1,14 @@
-# BookForge v3.0 — Codex handoff: audiobook narration quality + WebUI parity
+# BookForge v2.6.0 — Codex handoff: audiobook narration quality + WebUI parity
 
-**Status:** in progress. **Branch:** `feat/v3.0-audiobook` (stacked on `codex/audiobook-provider-and-chapter-fixes` / PR #40, with `main` merged in).
-**Worktree:** `tmp/worktrees/v3.0` — all v3.0 work happens there; `main`'s working tree carries unrelated uncommitted work and must not be touched.
+> **Renumbering note:** This work was drafted as v3.0 and renumbered to v2.6.0
+> before release. The branch and worktree names below intentionally retain
+> their original draft-era names.
+
+**Status:** v2.6.0 in progress. **Branch:** `feat/v3.0-audiobook` (stacked on `codex/audiobook-provider-and-chapter-fixes` / PR #40, with `main` merged in).
+**Worktree:** `tmp/worktrees/v3.0` — all audiobook milestone work happens there; `main`'s working tree carries unrelated uncommitted work and must not be touched.
 
 **How to use this document:** each `W#` brief below is a self-contained Codex task. Dispatch with
-`codex exec --full-auto "$(cat docs/codex-handoff-v3.0.md)"` scoped to one brief, or paste the brief plus the *Shared context* section. Workers never commit; the orchestrator reviews every diff, runs verification, and owns all live-credit spend.
+`codex exec --full-auto "$(cat docs/codex-handoff-v2.6.0.md)"` scoped to one brief, or paste the brief plus the *Shared context* section. Workers never commit; the orchestrator reviews every diff, runs verification, and owns all live-credit spend.
 
 **Execution order (dependency-driven — `bookforge-cli` will not compile until W1 lands):**
 | Phase | Workers | Why |
@@ -16,7 +20,7 @@
 
 ## Context
 
-Today's live E2E (the *Che fare* audiobook) exposed the limitations the user wants fixed for v3.0:
+Today's live E2E (the *Che fare* audiobook) exposed the limitations the user wants fixed for v2.6.0:
 
 1. **No narration hierarchy.** A chapter title is narrated as flat prose. Root cause: the section's first heading block produces `Chapter.title` *and* is emitted as the first paragraph of `Chapter.text`; `chunk_text` (`text.rs:400-440`) then packs that heading into the same chunk as the following body sentences, replacing the `\n\n` break with a single space. In-section h2–h6 headings are likewise flattened. The TTS request carries zero signal that a span is a title.
 2. **No true single-file output.** Only a chaptered `.m4b` exists, it requires an explicit flag, and it has no title/author metadata. No flat mp3.
@@ -24,7 +28,7 @@ Today's live E2E (the *Che fare* audiobook) exposed the limitations the user wan
 4. **Missing polish:** no loudness normalization, no inter-chapter/heading silence, no cost/quota estimate, no chapter-subset selection, no voice listing.
 5. **WebUI lags the CLI** — and it's the surface the user's partner actually uses: no auto-model, no voice picker, no playback, no cost/quota preview, none of the new knobs.
 
-**Goal:** v3.0 makes the audiobook *sound* like an audiobook (title/heading separation, consistent voice, clean joins), consolidates output, and brings all of it to the WebUI first.
+**Goal:** v2.6.0 makes the audiobook *sound* like an audiobook (title/heading separation, consistent voice, clean joins), consolidates output, and brings all of it to the WebUI first.
 
 **User decisions (locked):**
 - **Output:** chaptered file is the **default** deliverable (`.m4b` with chapter markers + title/author metadata, auto-enabled when ffmpeg is present). A **flat single mp3** is opt-in (`--single`, "flat mp3 for on-the-go" in the UI).
@@ -124,7 +128,7 @@ pub async fn fetch_elevenlabs_subscription(config: &ElevenLabsTtsConfig)
 
 ### W3 — docs skeleton *(Phase 1 — parallel with W1; touches no code)*
 **Owns:** `docs/ROADMAP.md`, `docs/audiobooks.md`, `CHANGELOG.md`.
-- ROADMAP: append `## 16. v3.0 — Audiobook narration quality & UI parity` immediately before `*End of document.*` (:2925), following the milestone template at :38-49 (Goal / Architectural rationale / Deliverables / Schema changes / CLI surface / Implementation notes / Out of scope / Acceptance criteria / Effort / Dependencies). Schema-changes section must list manifest v3, cache tag v2, and the new audio pricing file. Out of scope: per-chapter streaming route, `request_ids` serialization, OperationKind unification (§10.1), Range support on the artifact route. Acceptance criteria include one live end-to-end. Add a `v3.0` row to the §2 overview table (:113-125) with status `in progress`; bump the doc header to version 1.4.0 / 2026-07-20.
+- ROADMAP: append `## 16. v2.6.0 — Audiobook narration quality & UI parity` immediately before `*End of document.*` (:2925), following the milestone template at :38-49 (Goal / Architectural rationale / Deliverables / Schema changes / CLI surface / Implementation notes / Out of scope / Acceptance criteria / Effort / Dependencies). Schema-changes section must list manifest v3, cache tag v2, and the new audio pricing file. Out of scope: per-chapter streaming route, `request_ids` serialization, OperationKind unification (§10.1), Range support on the artifact route. Acceptance criteria include one live end-to-end. Add a `v2.6.0` row to the §2 overview table (:113-125) with status `in progress`; bump the doc header to version 1.4.0 / 2026-07-20.
 - `docs/audiobooks.md`: restructure for the full new flag surface (leave `TODO(worker)` markers for flags W4 finalizes); document gap semantics, the chaptered-by-default deliverable, flat-mp3 opt-in, `--list-voices`, quota/cost lines.
 - `CHANGELOG.md` `## Unreleased`: bullets for every WP, with a prominent **"existing audio chunk caches are invalidated (hash v2); rerun with `--prune`"** notice.
 
@@ -136,7 +140,7 @@ pub async fn fetch_elevenlabs_subscription(config: &ElevenLabsTtsConfig)
 - **Chaptered-by-default:** when ffmpeg is available a normal run now emits the chaptered `.m4b` (with title/author from `book.metadata`) without an explicit `--m4b`; add `--no-book-file` to opt out. Keep `--stitch`/`--m4b` working as explicit overrides. `--single` adds the flat file and is combinable.
 - `--chapters`: `parse_chapter_ranges(&str) -> Result<BTreeSet<usize>>` (1-based, matching printed chapter numbers; reject `0`, reversed ranges, garbage). Filter inside `build_plan` via `AudiobookOptions.chapter_filter` so plan/dry-run/manifest/serve all stay consistent; keep global chapter numbering in filenames.
 - `--list-voices`: make `input` optional and bail "INPUT is required" unless `--list-voices`; elevenlabs-only; print a `voice_id  name  labels` table. Improve the missing-`--voice` error to point at it.
-- **Cost + quota:** new `pricing/audio-providers.json` (`schema_version: 1`, per provider/model `{usd_per_million_chars?, credits_per_char?}`, at least one required; seed ElevenLabs from the observed **~0.27 credits/char** for v3 on payg plus published relative multipliers, and set `updated_at`). `audio_cost.rs` mirrors `cost.rs` (`include_str!`, `BOOKFORGE_AUDIO_PRICING_PATH` override, hard `schema_version == 1` check) exposing `estimate_audio_cost(provider, model, chars)`. Print `Estimated cost: ~$X.XX / ~N credits` after the existing `Plan:` line and add the fields to the `audiobook_plan` JSON event. On elevenlabs runs (live always; dry-run when the key env is set) call `fetch_elevenlabs_subscription` and print `ElevenLabs quota: N remaining of M`, warning when the plan exceeds it — **preflight failure is a warning, never fatal** (mirror the existing auto-selection fallback style).
+- **Cost + quota:** new `pricing/audio-providers.json` (`schema_version: 1`, per provider/model `{usd_per_million_chars?, credits_per_char?}`, at least one required; seed ElevenLabs from the observed **~0.27 credits/char** for `eleven_v3` on payg plus published relative multipliers, and set `updated_at`). `audio_cost.rs` mirrors `cost.rs` (`include_str!`, `BOOKFORGE_AUDIO_PRICING_PATH` override, hard `schema_version == 1` check) exposing `estimate_audio_cost(provider, model, chars)`. Print `Estimated cost: ~$X.XX / ~N credits` after the existing `Plan:` line and add the fields to the `audiobook_plan` JSON event. On elevenlabs runs (live always; dry-run when the key env is set) call `fetch_elevenlabs_subscription` and print `ElevenLabs quota: N remaining of M`, warning when the plan exceeds it — **preflight failure is a warning, never fatal** (mirror the existing auto-selection fallback style).
 - **TUI:** `AudioTuiInfo` gains a preformatted `cost_line: Option<String>` and `chapters_total`; render resolved model + cost; per-chapter progress if trivial.
 - **Tests:** `parse_chapter_ranges` unit tests; mock-provider `assert_cmd` runs asserting `--chapters 2` produces only chapter-002 records, that a `<h1>`+2`<p>` fixture yields the title alone in part 1 (inspect `manifest.json`), and both `--list-voices` misuse directions; `audio_cost` parse/reject-schema/lookup tests + a `BOOKFORGE_AUDIO_PRICING_PATH` temp-file test asserting the printed cost line; language-normalization unit test.
 
@@ -150,7 +154,7 @@ pub async fn fetch_elevenlabs_subscription(config: &ElevenLabsTtsConfig)
 - **Last step, once:** run `cargo test -p bookforge-cli --features serve dashboard_assets_reassemble_byte_stably`, take the actual byte length + SHA-256 from the failure output, update both literals in `serve.rs` (~:2924 and ~:2931). Add markers (`function bfAudioEstimate`, `Auto (recommended)`, `/api/audio/voices`) to the renderer/marker tests.
 
 ## Phase 4 — orchestrator
-Full `cargo test --workspace`; docs finalized (W3 `TODO(worker)` markers resolved against W4's real flags); release prep commit bumping all 7 crate versions to `3.0.0` + dated `## v3.0.0` CHANGELOG heading, mirroring commit `bd1faf11` (`git show bd1faf11` is the checklist). Tagging `v3.0.0` triggers cargo-dist `release.yml`.
+Full `cargo test --workspace`; docs finalized (W3 `TODO(worker)` markers resolved against W4's real flags); release prep commit bumping all 7 crate versions to `2.6.0` + dated `## v2.6.0` CHANGELOG heading, mirroring commit `bd1faf11` (`git show bd1faf11` is the checklist). Tagging `v2.6.0` triggers cargo-dist `release.yml`.
 
 ## Verification
 - `cargo test --workspace` green after each phase; all new tests offline/deterministic/Windows-friendly.

--- a/docs/codex-handoff-v3.0.md
+++ b/docs/codex-handoff-v3.0.md
@@ -1,0 +1,161 @@
+# BookForge v3.0 — Codex handoff: audiobook narration quality + WebUI parity
+
+**Status:** in progress. **Branch:** `feat/v3.0-audiobook` (stacked on `codex/audiobook-provider-and-chapter-fixes` / PR #40, with `main` merged in).
+**Worktree:** `tmp/worktrees/v3.0` — all v3.0 work happens there; `main`'s working tree carries unrelated uncommitted work and must not be touched.
+
+**How to use this document:** each `W#` brief below is a self-contained Codex task. Dispatch with
+`codex exec --full-auto "$(cat docs/codex-handoff-v3.0.md)"` scoped to one brief, or paste the brief plus the *Shared context* section. Workers never commit; the orchestrator reviews every diff, runs verification, and owns all live-credit spend.
+
+**Execution order (dependency-driven — `bookforge-cli` will not compile until W1 lands):**
+| Phase | Workers | Why |
+|---|---|---|
+| 1 | **W1** (bookforge-audio) ∥ **W3** (docs) | W3 touches no code, so it parallelizes safely |
+| 2 | **W2** (serve parity) ∥ **W4** (CLI wiring) | disjoint files; both need W1's crate to compile |
+| 3 | **W5** (serve knobs + byte literals) | same files as W2, needs W4's flags |
+| 4 | orchestrator | full test sweep, live checkpoints, release prep |
+
+## Context
+
+Today's live E2E (the *Che fare* audiobook) exposed the limitations the user wants fixed for v3.0:
+
+1. **No narration hierarchy.** A chapter title is narrated as flat prose. Root cause: the section's first heading block produces `Chapter.title` *and* is emitted as the first paragraph of `Chapter.text`; `chunk_text` (`text.rs:400-440`) then packs that heading into the same chunk as the following body sentences, replacing the `\n\n` break with a single space. In-section h2–h6 headings are likewise flattened. The TTS request carries zero signal that a span is a title.
+2. **No true single-file output.** Only a chaptered `.m4b` exists, it requires an explicit flag, and it has no title/author metadata. No flat mp3.
+3. **No prosody consistency.** Chunks are synthesized in isolation (`builder.rs:310-400`); neighbor text is knowable from the ordered plan but never threaded. ElevenLabs' continuity fields (`previous_text`, `next_text`, `seed`, `language_code`) are all dropped — the body sends only `{text, model_id, voice_settings}`.
+4. **Missing polish:** no loudness normalization, no inter-chapter/heading silence, no cost/quota estimate, no chapter-subset selection, no voice listing.
+5. **WebUI lags the CLI** — and it's the surface the user's partner actually uses: no auto-model, no voice picker, no playback, no cost/quota preview, none of the new knobs.
+
+**Goal:** v3.0 makes the audiobook *sound* like an audiobook (title/heading separation, consistent voice, clean joins), consolidates output, and brings all of it to the WebUI first.
+
+**User decisions (locked):**
+- **Output:** chaptered file is the **default** deliverable (`.m4b` with chapter markers + title/author metadata, auto-enabled when ffmpeg is present). A **flat single mp3** is opt-in (`--single`, "flat mp3 for on-the-go" in the UI).
+- **Live testing:** **multiple small live ElevenLabs checkpoints** — one tiny smoke after each of WP-A, WP-B, WP-C. Budget-conscious: ~15k credits remain, so each smoke uses `eleven_flash_v2_5` and only the ~2k-char *Correzione* chapter via `--chapters`. Hard stop at ≤90% of remaining.
+
+---
+
+## Shared context — paste into EVERY worker brief
+
+**Repo:** `C:\Users\gangi\Desktop\bookforge` (Rust workspace, 7 crates, edition 2024).
+**Branch:** `codex/audiobook-provider-and-chapter-fixes` — **check it out first**; the working tree may be on `main`. It already contains `cae960d3` (ElevenLabs model auto-selection; `resolve_preferred_elevenlabs_model` EXISTS in `crates/bookforge-audio/src/provider/elevenlabs.rs`) and `afcfe988` (OCR foundations). Build ON TOP.
+
+**Environment (Windows, GNU toolchain).** Before ANY cargo command:
+PowerShell — `$env:Path = "$env:USERPROFILE\.cargo\bin;$env:LOCALAPPDATA\mingw64\bin;$env:Path"`
+bash — `export PATH="$USERPROFILE/.cargo/bin:$LOCALAPPDATA/mingw64/bin:$PATH"`
+ffmpeg 8.0.1 + ffprobe are installed. python 3.14 available. poppler is NOT installed.
+
+**Rules for every worker:**
+- **Do NOT commit.** Leave changes uncommitted; the orchestrator reviews and commits.
+- Touch only the files listed in your brief — other workers own the rest, in parallel.
+- All new tests must be **offline, deterministic, Windows-friendly** (no `#[cfg(unix)]`, no poppler, no network). Existing idioms to reuse: `one_request_server` one-shot TCP mock (`bookforge-audio/src/provider.rs` test_support), `assert_cmd` CLI tests (`crates/bookforge-cli/tests/audiobook.rs`), the offline mock TTS provider.
+- Finish with `cargo fmt --all` + your brief's test gate, then report: files changed, test counts, and any deviation from spec with the reason.
+
+**Frozen contract (all workers code against these exact shapes):**
+```rust
+// bookforge-audio
+pub enum NarrationBlockKind { Title, Heading(u8), Paragraph }
+pub struct NarrationBlock { pub kind: NarrationBlockKind, pub text: String }
+pub enum ChunkKind { Title, Heading, Body }          // serde: "title"|"heading"|"body"
+pub struct NarrationChunk { pub kind: ChunkKind, pub text: String }
+
+// SpeechRequest gains (all Option, provider-ignored where unsupported); add #[derive(Default)]
+previous_text: Option<String>, next_text: Option<String>, seed: Option<u32>,
+language_code: Option<String>, text_normalization: Option<TextNormalization>, // Auto|On|Off
+
+// AudiobookOptions gains
+context_chars: usize, seed: Option<u32>, language_code: Option<String>,
+text_normalization: Option<TextNormalization>, heading_break_tag: Option<String>,
+chapter_filter: Option<std::collections::BTreeSet<usize>>,
+
+// StitchOptions gains
+gap_chapter_ms: u32, gap_title_ms: u32, gap_paragraph_ms: u32,
+loudnorm: bool, make_single: bool, author: Option<String>,
+
+pub async fn list_elevenlabs_voices(base_url: &str, api_key: &str, timeout_seconds: u64)
+    -> Result<Vec<ElevenLabsVoice>>;                  // ElevenLabsVoice{voice_id,name,category,labels}
+pub async fn fetch_elevenlabs_subscription(config: &ElevenLabsTtsConfig)
+    -> Result<ElevenLabsSubscription>;                 // {character_count, character_limit}
+```
+
+**Global schema changes (consistent across workers):**
+- **Cache tag** in `synthesis_hash` (`builder.rs:570-586`): `"bookforge-audio-v1"` → `"bookforge-audio-v2"`, and fold in — length-prefixed, in this order — seed, language_code, text_normalization, previous_context, next_context, chunk-kind tag. Break tags live in chunk *text*, so they hash automatically. **All existing chunk caches invalidate**; CHANGELOG must say "rerun with `--prune`".
+- **Manifest** `schema_version` 2 → 3. `ChunkRecord` gains `#[serde(default)] kind: ChunkKind`; `AudiobookManifest` gains `#[serde(default)]` `seed`, `language`, `text_normalization`, `gaps`, `author`. Serde-defaults keep v2 manifests readable by stitch/serve.
+- **No** `OperationKind` unification (ROADMAP §10.1, owner decision 2026-07-15 stands).
+
+---
+
+## Phase 1 — W1 ∥ W3
+
+### W1 — `bookforge-audio` core (the biggest; do WP-A → WP-B → WP-C-core → provider fns in order)
+**Owns:** `crates/bookforge-audio/src/{text.rs, builder.rs, stitch.rs, provider.rs, provider/elevenlabs.rs, lib.rs}`. **Gate:** `cargo test -p bookforge-audio` green.
+
+**WP-A narration structure**
+- `text.rs`: add `NarrationBlockKind`/`NarrationBlock`. `Chapter.text: String` → `blocks: Vec<NarrationBlock>`, keeping `pub fn text(&self) -> String` (join `"\n\n"`) and `is_empty()` so consumers port trivially. In `chapters_from_book_with_options` read `block.kind` (the EPUB reader already yields `BlockKind::Heading(level)`); tag the section's **first** heading `Title` — it stays in the list exactly once, preserving today's "narrated once" semantics while `Chapter.title` is still derived as before. Mirror in `chapters_from_pdf_pages` (detected chapter-label line becomes that chapter's `Title`; merging only ever joins Paragraph↔Paragraph).
+- `chunk_blocks(blocks, max_chars) -> Vec<NarrationChunk>`: Title/Heading blocks each become their **own** chunk (split only if one alone exceeds `max_chars`); Body reuses existing sentence-packing (`split_sentences`, `split_long_unit`); a chunk **never** spans a heading boundary. Keep `chunk_text` as a thin public wrapper.
+- `builder.rs`: `build_plan` calls `chunk_blocks`; `PlannedChunk` + `ChunkRecord` gain `kind`. Filenames unchanged (`chapter-XXX-part-YYY-{hash16}.{ext}`; part numbering runs across all kinds).
+- `stitch.rs` silence (**provider-independent, stream-copy preserving**): `StitchOptions` gains `gap_chapter_ms` (default 1200), `gap_title_ms` (800), `gap_paragraph_ms` (0). Add `probe_audio_params(path)` (ffprobe `stream=sample_rate,channels` of the first chunk) and `ensure_silence_file(out_dir, ms, ext, rate, channels)` → `ffmpeg -f lavfi -i anullsrc=r={rate}:cl={mono|stereo} -t {s} silence-{ms}.{ext}` with the ext's encoder (mp3→libmp3lame, wav→pcm_s16le, opus→libopus); cache by filename, clean up after. Insert entries into the existing concat lists: `gap_title_ms` after Title/Heading chunks, `gap_paragraph_ms` between body chunks when >0, `gap_chapter_ms` between chapters at book level. Add the inter-chapter gap to `assemble_m4b`'s running duration sum so markers stay correct. **ffprobe missing or probe fails → warn and stitch without gaps; never fail the run** (matches stitch's existing warning philosophy).
+- Break tags: `AudiobookOptions.heading_break_tag: Option<String>`; when set, `build_plan` appends `" <break time=\"0.6s\" />"` to Title/Heading chunk text (so it hashes and counts in `chars`). Policy lives in the CLI (W4), not here.
+- **Extract pure helpers for tests** so no ffmpeg is needed: `build_chapter_concat_entries(parts, gaps) -> Vec<String>` and the book-level equivalent.
+
+**WP-B consistency**
+- `provider.rs`: `SpeechRequest` gains the five context fields + `#[derive(Default)]` (keeps other providers' literals churn-free via `..Default::default()`). Mock/OpenAI/Gemini ignore them.
+- `builder.rs`: `AudiobookOptions` gains `context_chars` (default 300; 0 disables), `seed`, `language_code`, `text_normalization`. In `build_audiobook`, **before** the spawn loop, precompute each chunk's `(previous_text, next_text)` from `plan[i±1]` **restricted to the same `chapter_index`**, taking the tail/head `context_chars` characters via a char-boundary-safe `context_slice` helper. Concurrency-safe: all derived from the ordered plan. Do **not** use `previous/next_request_ids` (would force serialization).
+- `elevenlabs.rs`: `elevenlabs_request_body` emits `previous_text`, `next_text`, `seed`, `language_code`, `apply_text_normalization` when `Some`, omitted otherwise (mirror the existing `voice_settings`-at-default-speed omission).
+- `synthesis_hash`: apply the global cache-tag change above. Add a code comment noting neighbor context means editing chunk N invalidates N±1 — intended.
+- Loudness: `StitchOptions.loudnorm`; wire `-af loudnorm=I=-18:TP=-2:LRA=11` into the m4b re-encode (and the single-file re-encode below). Per-chapter files stay stream-copy — do **not** loudnorm chapters independently (per-chapter one-pass targets each chapter separately → level jumps).
+
+**WP-C single-file core**
+- `StitchOptions` gains `make_single`, `author`. New `assemble_single_file(...)` modeled on `assemble_m4b`: book-level concat list (with `gap_chapter_ms` silence) → `audiobook.{ext}`; **stream copy** when `!loudnorm` (silence is same-codec so copy stays valid), re-encode when loudnorm; add `-metadata title=... -metadata artist=...`. Reject `pcm`.
+- `assemble_m4b`: add `-metadata title/artist` alongside the existing FFMETADATA chapter markers.
+- `StitchReport` gains `single_file: Option<PathBuf>`.
+- Extract `single_file_ffmpeg_args(...) -> Vec<String>` as a pure, testable fn.
+
+**Provider fns (for W2/W4):** `fetch_elevenlabs_subscription` (GET `/v1/user/subscription`) and `list_elevenlabs_voices` (GET `/v1/voices`, takes an explicit `api_key` so the serve proxy can reuse it) in `elevenlabs.rs`, same `build_http_client`/`send_with_retry`/key-resolution shape as `resolve_preferred_elevenlabs_model`. Export via `provider.rs` + `lib.rs`.
+
+**W1 tests:** heading typed correctly from a synthetic Book; title emitted exactly once; `chunk_blocks` never merges heading+body; ported `chunk_text` sentence-packing tests; plan's first chunk per chapter is `Title`; hash changes when any new knob changes + a v2-tag regression literal; `context_slice` stops at chapter boundaries and honors 0; concat-entry pure-fn tests with gaps; `build_ffmetadata` duration sums including gaps; `one_request_server` contract tests for the new ElevenLabs body fields (present when set, absent at defaults), `/v1/user/subscription`, `/v1/voices` (+ garbage-body error cases).
+
+### W2 — WebUI parity, flag-independent half *(Phase 2 — run after W1 compiles)*
+**Owns:** `crates/bookforge-cli/src/commands/serve.rs` + `crates/bookforge-cli/src/commands/serve/dashboard.{html,css,js}`. **Do NOT touch the byte-length/SHA literals yet** (W5 does that, once, last).
+
+- **Auto model:** `AudioProviderOption` gains `supports_auto_model` (true only for elevenlabs). In `launch_audiobook`, an empty/absent `model` for elevenlabs means **omit `--model`** from the spawned child → the CLI's auto-selection engages. `audio_provider_max_chars` for the auto case validates against `10_000` (the resolver guarantees a model whose limit ≥ max_chars; error text should say "pick eleven_flash_v2_5 explicitly for >10k"). In `dashboard.js renderAudiobook`, render the elevenlabs model field as a `<select id="a_model">` whose first option is `Auto (recommended)` with value `""` (other providers keep free-text + datalist); `bfLaunchAudiobook` appends `model` only when non-empty; `audioProviderMaxChars` returns 10000 for `""`.
+- **Resolved model:** `audiobook_status` already returns the manifest's `synthesis_id` (`elevenlabs:{base_url}:{model}` — base_url contains colons, so split on the **last** `:`); add a `resolved_model` field and show `Model: X (auto-selected)` in `pollAudiobook`.
+- **Voice picker proxy:** new route `GET /api/audio/voices?provider=elevenlabs` → handler resolves the key exactly like `launch_audiobook` does (session key slot `audio:elevenlabs`, else the `ELEVENLABS_API_KEY` env detection), calls `bookforge_audio::list_elevenlabs_voices`, caches in `AppState` behind a 5-minute TTL. **Never** put the key in the response, logs, or a URL; return **409** (not 401-with-detail) when no key is stored. GET needs no CSRF (matches existing conventions). dashboard.js renders a `<select>` of `name — voice_id` when the fetch succeeds, silently falling back to the current free-text input otherwise.
+- **Playback:** support `?disposition=inline` on `audiobook_artifact` (`Content-Disposition: inline`); on the finished panel render `<audio controls preload="none" src=".../artifact?disposition=inline">` next to the existing Download button.
+- **Progress screen:** aggregate `chunks` client-side by `chapter_index`/`chapter_title` into a per-chapter done/total list (scrollable, check badge when complete); show the resolved model.
+- **Tests:** `audio_voices` with no key → 409; resolved-model split-on-last-colon unit test; refactor the child-process argv construction inside `launch_audiobook` into a testable `fn audiobook_command_args(...) -> Vec<OsString>` and assert the auto case omits `--model`. Keep `dashboard_ships_all_screen_renderers`, the no-`window.prompt` assertion, and the CSRF-header assertion green (every new mutating fetch must send `headers:{[CSRF_HEADER]:CSRF_TOKEN}`).
+
+### W3 — docs skeleton *(Phase 1 — parallel with W1; touches no code)*
+**Owns:** `docs/ROADMAP.md`, `docs/audiobooks.md`, `CHANGELOG.md`.
+- ROADMAP: append `## 16. v3.0 — Audiobook narration quality & UI parity` immediately before `*End of document.*` (:2925), following the milestone template at :38-49 (Goal / Architectural rationale / Deliverables / Schema changes / CLI surface / Implementation notes / Out of scope / Acceptance criteria / Effort / Dependencies). Schema-changes section must list manifest v3, cache tag v2, and the new audio pricing file. Out of scope: per-chapter streaming route, `request_ids` serialization, OperationKind unification (§10.1), Range support on the artifact route. Acceptance criteria include one live end-to-end. Add a `v3.0` row to the §2 overview table (:113-125) with status `in progress`; bump the doc header to version 1.4.0 / 2026-07-20.
+- `docs/audiobooks.md`: restructure for the full new flag surface (leave `TODO(worker)` markers for flags W4 finalizes); document gap semantics, the chaptered-by-default deliverable, flat-mp3 opt-in, `--list-voices`, quota/cost lines.
+- `CHANGELOG.md` `## Unreleased`: bullets for every WP, with a prominent **"existing audio chunk caches are invalidated (hash v2); rerun with `--prune`"** notice.
+
+## Phase 2 — W2 ∥ W4 (both require W1)
+
+### W4 — CLI wiring
+**Owns:** `crates/bookforge-cli/src/commands/audiobook.rs`, new `crates/bookforge-cli/src/audio_cost.rs`, new `crates/bookforge-cli/pricing/audio-providers.json`, `main.rs` (module registration), `crates/bookforge-cli/src/tui/mod.rs`, `crates/bookforge-cli/tests/audiobook.rs`.
+- **Flags:** `--gap-chapter-ms` (1200) / `--gap-title-ms` (800) / `--gap-paragraph-ms` (0); `--break-tags auto|off` (default auto → set the tag **only** for elevenlabs flash/turbo/multilingual v2; **never** eleven_v3, never other providers); `--seed <u32>` (error on non-elevenlabs); `--language <code>` (default auto from `book.metadata.language`, normalized to the primary subtag, e.g. `en-US`→`en`; applied **only** for flash/turbo v2.5 — on multilingual_v2/v3 warn and drop, since the API rejects it); `--text-normalization auto|on|off`; `--loudnorm`; `--single`; `--chapters <RANGE>`; `--list-voices`.
+- **Chaptered-by-default:** when ffmpeg is available a normal run now emits the chaptered `.m4b` (with title/author from `book.metadata`) without an explicit `--m4b`; add `--no-book-file` to opt out. Keep `--stitch`/`--m4b` working as explicit overrides. `--single` adds the flat file and is combinable.
+- `--chapters`: `parse_chapter_ranges(&str) -> Result<BTreeSet<usize>>` (1-based, matching printed chapter numbers; reject `0`, reversed ranges, garbage). Filter inside `build_plan` via `AudiobookOptions.chapter_filter` so plan/dry-run/manifest/serve all stay consistent; keep global chapter numbering in filenames.
+- `--list-voices`: make `input` optional and bail "INPUT is required" unless `--list-voices`; elevenlabs-only; print a `voice_id  name  labels` table. Improve the missing-`--voice` error to point at it.
+- **Cost + quota:** new `pricing/audio-providers.json` (`schema_version: 1`, per provider/model `{usd_per_million_chars?, credits_per_char?}`, at least one required; seed ElevenLabs from the observed **~0.27 credits/char** for v3 on payg plus published relative multipliers, and set `updated_at`). `audio_cost.rs` mirrors `cost.rs` (`include_str!`, `BOOKFORGE_AUDIO_PRICING_PATH` override, hard `schema_version == 1` check) exposing `estimate_audio_cost(provider, model, chars)`. Print `Estimated cost: ~$X.XX / ~N credits` after the existing `Plan:` line and add the fields to the `audiobook_plan` JSON event. On elevenlabs runs (live always; dry-run when the key env is set) call `fetch_elevenlabs_subscription` and print `ElevenLabs quota: N remaining of M`, warning when the plan exceeds it — **preflight failure is a warning, never fatal** (mirror the existing auto-selection fallback style).
+- **TUI:** `AudioTuiInfo` gains a preformatted `cost_line: Option<String>` and `chapters_total`; render resolved model + cost; per-chapter progress if trivial.
+- **Tests:** `parse_chapter_ranges` unit tests; mock-provider `assert_cmd` runs asserting `--chapters 2` produces only chapter-002 records, that a `<h1>`+2`<p>` fixture yields the title alone in part 1 (inspect `manifest.json`), and both `--list-voices` misuse directions; `audio_cost` parse/reject-schema/lookup tests + a `BOOKFORGE_AUDIO_PRICING_PATH` temp-file test asserting the printed cost line; language-normalization unit test.
+
+## Phase 3 — W5 (after W2 and W4)
+
+### W5 — serve knob wiring + the one byte-literal update
+**Owns:** `serve.rs` + `dashboard.{html,css,js}` (same files as W2 — run after it).
+- **Estimate endpoint:** `POST /api/audiobook/estimate` (CSRF-checked, multipart `file`/`provider`/`model`/`max_chars`/`chapters?`): temp-save the upload, `spawn_blocking` → `read_epub` + `plan_chunks`, delete the temp, respond `{chapters, chunks, characters, est_cost_usd, est_credits}` via `audio_cost`; when provider is elevenlabs and a key is available, add `quota: {remaining, limit, fits}` from `fetch_elevenlabs_subscription`. dashboard.js `bfAudioEstimate()` auto-fires debounced on file/provider/model/max-chars change (mirror the translate wizard's `requestEstimate`), rendering a cost + quota line above the launch button.
+- **Advanced knobs** in a `<details>` section (main form stays as-is): Chapter pause select none/short/medium/long → `gap_chapter_ms` 0/600/1200/2000 (title gap derived as `min(800, chapter_gap)`, no separate control); **Flat mp3 for on-the-go** → `--single`; **Normalize loudness** → `--loudnorm`; **Seed** (elevenlabs); **Language** (placeholder "auto (from EPUB)", flash/turbo only). Server parses and forwards with validation (`gap_chapter_ms` clamp 0..=10_000, `seed` u32, `language` `[a-zA-Z-]{2,8}`).
+- Verify the server/JS max-chars tables stay in sync (extend the existing test).
+- **Last step, once:** run `cargo test -p bookforge-cli --features serve dashboard_assets_reassemble_byte_stably`, take the actual byte length + SHA-256 from the failure output, update both literals in `serve.rs` (~:2924 and ~:2931). Add markers (`function bfAudioEstimate`, `Auto (recommended)`, `/api/audio/voices`) to the renderer/marker tests.
+
+## Phase 4 — orchestrator
+Full `cargo test --workspace`; docs finalized (W3 `TODO(worker)` markers resolved against W4's real flags); release prep commit bumping all 7 crate versions to `3.0.0` + dated `## v3.0.0` CHANGELOG heading, mirroring commit `bd1faf11` (`git show bd1faf11` is the checklist). Tagging `v3.0.0` triggers cargo-dist `release.yml`.
+
+## Verification
+- `cargo test --workspace` green after each phase; all new tests offline/deterministic/Windows-friendly.
+- **Live ElevenLabs checkpoints (orchestrator-run, small):** after **WP-A** — title/heading separation audible; after **WP-B** — consistency + seed reproducibility; after **WP-C** — flat mp3 + m4b metadata + dashboard playback. Each uses `tests/Che_fare_Lenin.it.epub` narrating only *Correzione* (~2k chars) via `--chapters`, on `eleven_flash_v2_5`. Track spend; hard stop at ≤90% of remaining credits.
+- **Milestone acceptance:** a full dashboard run — auto-model → voice picker → estimate/quota → launch → per-chapter progress → in-page playback → download.
+
+## Risks
+Break-tag support varies by model (auto set includes multilingual_v2 — live-smoke it; if tags get read aloud, drop it from the set: one line, hash-safe). Stream-copy concat with generated silence needs ffprobe-matched rate/channels; opus-in-ogg is the shakiest → warn-and-skip-gaps fallback, never a failed run. Loudnorm only at book assembly means per-chapter downloads are un-normalized (documented). Voice/quota proxy: key stays server-side, 409 not 401. Dashboard byte-test churn: only W5 updates the literals. Hash-context coupling: editing chunk N invalidates N±1 (documented). `<audio>` seeking on a long m4b is limited without Range support — ship inline playback now, Range as a §16 follow-up.


### PR DESCRIPTION
Stacked on #40 (targets that branch so the diff is only the v3.0 work; retargets to `main` automatically once #40 merges).

## Why
The live *Che fare* narration exposed concrete limitations: chapter titles were read as flat prose, there was no true single-file output, every chunk was synthesized in isolation with no shared context, and the web dashboard — the surface actually used day-to-day — lagged the CLI badly.

## What changed

**Narration hierarchy.** Titles and in-section headings are now typed narration blocks that always occupy their own synthesis chunk instead of being packed into adjacent prose. Configurable silence is inserted at chapter/title/paragraph boundaries at stitch time, using pre-encoded same-codec files so the concat stays a stream copy; if ffprobe is unavailable it warns and stitches without gaps rather than failing.

**Consistency.** ElevenLabs requests carry same-chapter `previous_text`/`next_text` context, plus `seed`, `language_code` and `apply_text_normalization`. Break tags and `language_code` are applied only to the models that accept them — never to `eleven_v3`.

**Output.** The chaptered `.m4b` (chapter markers + title/artist metadata) is now the default deliverable when ffmpeg is present; `--no-book-file` opts out and `--single` adds a flat file for on-the-go listening. Optional whole-book `--loudnorm`.

**Cost/quota.** New per-character TTS pricing catalog, plan cost estimates, and a non-fatal ElevenLabs quota preflight.

**WebUI parity.** Auto model selection, a server-side voice picker, pre-launch cost + quota estimate, per-chapter progress, in-page playback, and an Advanced section for the new knobs. Keys are resolved server-side and never returned.

## Breaking
Chunk cache tag moves to `bookforge-audio-v2` and the manifest to schema 3, so existing audio caches are invalidated — rerun with `--prune`. v2 manifests remain readable.

## Verification
- `cargo test --workspace`: **738 passed, 0 failed**.
- Docs/CLI flag reconciliation: every shipped flag documented, nothing documented that doesn't exist.
- Pricing sanity: the catalog predicts 4,162 credits for a run that actually billed 4,236 (within 2%).
- **Live ElevenLabs checkpoint** on the *Correzione* chapter (`eleven_flash_v2_5`): 5 chunks, chunk count for the full book rose 11 → 24 confirming title/heading separation; stitched chapter is 11,525 bytes larger than the sum of its chunks (≈0.72s, the title gap); `.m4b` carries `title=Che fare?` / `artist=V. I. Lenin` with a correct chapter marker; flat `.mp3` produced alongside.

Built by five Codex workers against `docs/codex-handoff-v3.0.md`; each diff reviewed. One bug caught in review and fixed: the silence-file cache key omitted sample rate and channel count, so a stitch interrupted before cleanup could feed mismatched silence into a later stream-copy concat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)