### PR TITLE
docs: CLI guide and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of translation quality.
 
 ## Status
 
-BookForge v2.0 is usable for EPUB translation, PDF-to-EPUB ingestion, and
+BookForge v2.5.1 is usable for EPUB translation, PDF-to-EPUB ingestion, and
 local browser-based translation runs:
 
 - EPUB inspect, parse, segment, and rebuild
@@ -32,7 +32,8 @@ local browser-based translation runs:
 - Ollama and llama.cpp local-model presets
 - Bounded parallel segment translation with `--concurrency`
 - SQLite checkpoint store
-- Resume and retry commands
+- Cooperative pause, stop, resume, retry, and replacement-worker recovery
+- Live, cache-safe reconfiguration of concurrency, budgets, retries, and QA
 - Status and tail commands for persisted jobs
 - Live monitoring: terminal dashboard (`watch` / `--ui tui`) and a local
   browser dashboard (`serve`) over a shared, replayable run-state layer
@@ -44,10 +45,27 @@ local browser-based translation runs:
   command line
 - Segment-level cache reuse for compatible prior translations
 - Static side-by-side review HTML with flag export/import
+- Validated human corrections that are protected from model and cache overwrites
+- Replace and bilingual append output modes
 - QA reports in JSON and Markdown
 - Optional LLM QA review pass
 - Cost estimates for known provider/model pairs
 - Externalized, overridable provider pricing
+- Resumable audiobook generation with hosted and local TTS providers
+
+## Documentation
+
+| If you want to... | Start here |
+| --- | --- |
+| Install BookForge and run a first browser translation | [Install and setup](#install-and-setup) |
+| Understand every CLI command and a full job workflow | [CLI guide](docs/CLI_REFERENCE.md) |
+| Configure hosted or local translation providers | [Provider guide](docs/PROVIDERS.md) |
+| Diagnose installation, job, provider, EPUB, PDF, or audio problems | [Troubleshooting](docs/TROUBLESHOOTING.md) |
+| Understand checkpoints, resume, and cache reuse | [Checkpointing](docs/CHECKPOINTING.md) |
+| Generate audiobooks | [Audiobooks](docs/audiobooks.md) |
+| Understand EPUB parsing and rebuilding | [EPUB pipeline](docs/EPUB_PIPELINE.md) |
+| Understand the system design and crate boundaries | [Architecture](docs/ARCHITECTURE.md) |
+| Contribute code or documentation | [Contributing](CONTRIBUTING.md) |
 
 ## Install And Setup
 
@@ -202,14 +220,14 @@ directory; on Windows use the poppler-windows release zip):
 cargo run -p bookforge-cli -- convert paper.pdf --out paper.epub
 ```
 
-The converter detects two-column layouts per page (scientific papers),
-repairs hyphenated line breaks, joins paragraphs across pages, and maps
-oversized fonts to headings. It prints a fidelity report comparing the
-reconstructed text against the raw `pdftotext` baseline — check that
-coverage number (and `inspect` on the result) before spending tokens.
-Figures, tables-as-images, and low-confidence page fallbacks are
-roadmap items (ROADMAP §9b, phases P2–P4); for image-heavy PDFs expect
-text-only output for now.
+The converter detects one- and two-column layouts per page, repairs hyphenated
+line breaks, joins paragraphs across pages, and maps oversized fonts to
+headings. When Poppler's optional rendering and image tools are available, it
+also preserves detected figures, tables, and equations as page crops.
+Low-confidence pages can be linearized, preserved as images, or sent to a
+configured OCR endpoint. The generated fidelity report compares reconstructed
+text with the raw `pdftotext` baseline and itemizes layout decisions. Review
+that report and run `inspect` before spending translation tokens.
 
 Inspect an EPUB:
 

--- a/crates/bookforge-cli/src/commands/control.rs
+++ b/crates/bookforge-cli/src/commands/control.rs
@@ -4,11 +4,13 @@ use clap::Args;
 
 #[derive(Debug, Args)]
 pub struct PauseArgs {
+    /// Job to pause. The worker checkpoints completed work before parking.
     pub job_id: String,
 }
 
 #[derive(Debug, Args)]
 pub struct StopArgs {
+    /// Job to stop. Completed work remains resumable from its checkpoints.
     pub job_id: String,
 }
 

--- a/crates/bookforge-cli/src/commands/correct.rs
+++ b/crates/bookforge-cli/src/commands/correct.rs
@@ -21,11 +21,14 @@ use super::{
 
 #[derive(Debug, Args)]
 pub struct CorrectArgs {
+    /// Translation job containing the segment to correct.
     pub job_id: String,
 
+    /// Stable segment ID shown by the review page or job report.
     #[arg(long)]
     pub segment: String,
 
+    /// Replacement text for a segment that contains exactly one block.
     #[arg(
         long,
         conflicts_with = "from_file",
@@ -33,6 +36,7 @@ pub struct CorrectArgs {
     )]
     pub text: Option<String>,
 
+    /// Plain text, or a JSON correction document for a multi-block segment.
     #[arg(long, value_name = "PATH", conflicts_with = "text")]
     pub from_file: Option<PathBuf>,
 }

--- a/crates/bookforge-cli/src/commands/entity.rs
+++ b/crates/bookforge-cli/src/commands/entity.rs
@@ -20,9 +20,13 @@ pub struct EntitiesArgs {
 
 #[derive(Debug, Subcommand)]
 enum EntitiesCommand {
+    /// List stored entity sheets.
     List(ListArgs),
+    /// Import entities from a BookForge TOML file.
     Import(ImportArgs),
+    /// Remove all entities in a selected scope.
     Clear(ClearArgs),
+    /// Show the merged entity guidance for a translation context.
     Show(ShowArgs),
 }
 

--- a/crates/bookforge-cli/src/commands/glossary.rs
+++ b/crates/bookforge-cli/src/commands/glossary.rs
@@ -20,13 +20,21 @@ pub struct GlossaryArgs {
 
 #[derive(Debug, Subcommand)]
 enum GlossaryCommand {
+    /// List stored terms, optionally filtered by scope or language pair.
     List(ListArgs),
+    /// Add one source-to-target term.
     Add(AddArgs),
+    /// Remove a term by its numeric ID.
     Remove(RemoveArgs),
+    /// Remove all terms in a selected scope.
     Clear(ClearArgs),
+    /// Import terms from a BookForge glossary TOML file.
     Import(ImportArgs),
+    /// Export matching terms to a BookForge glossary TOML file.
     Export(ExportArgs),
+    /// Find repeated names and terms in an EPUB for later review.
     ExtractCandidates(ExtractCandidatesArgs),
+    /// Interactively accept, translate, or reject extracted candidates.
     ReviewCandidates(ReviewCandidatesArgs),
 }
 

--- a/crates/bookforge-cli/src/commands/style.rs
+++ b/crates/bookforge-cli/src/commands/style.rs
@@ -20,10 +20,15 @@ pub struct StyleArgs {
 
 #[derive(Debug, Subcommand)]
 enum StyleCommand {
+    /// List stored style sheets.
     List(ListArgs),
+    /// Import a BookForge style TOML file.
     Import(ImportArgs),
+    /// Export a stored style sheet to TOML.
     Export(ExportArgs),
+    /// Remove all style sheets in a selected scope.
     Clear(ClearArgs),
+    /// Show the merged style guidance for a translation context.
     Show(ShowArgs),
 }
 

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -53,31 +53,55 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Convert a PDF into a translation-ready EPUB.
     Convert(convert::ConvertArgs),
+    /// Repair paragraph flow in an EPUB without translating it.
     Reflow(reflow::ReflowArgs),
+    /// Inspect EPUB structure and translatable text coverage.
     Inspect(inspect::InspectArgs),
+    /// Generate resumable audiobook files from an EPUB.
     Audiobook(audiobook::AudiobookArgs),
+    /// Estimate translation tokens and provider cost.
     Estimate(estimate::EstimateArgs),
+    /// Translate an EPUB and checkpoint every completed segment.
     Translate(Box<translate::TranslateArgs>),
+    /// Ask a running job to pause after its current safe boundary.
     Pause(control_commands::PauseArgs),
+    /// Change cache-safe settings for an active or resumable job.
     Reconfigure(reconfigure::ReconfigureArgs),
+    /// Continue an interrupted, paused, stopped, or incomplete job.
     Resume(resume::ResumeArgs),
+    /// Ask a running job to stop after its current safe boundary.
     Stop(control_commands::StopArgs),
+    /// Replace a checkpointed segment with a validated human correction.
     Correct(correct::CorrectArgs),
+    /// Generate a side-by-side HTML review for a translation job.
     Review(review::ReviewArgs),
+    /// Import flags exported from a review page.
     IngestFlags(ingest_flags::IngestFlagsArgs),
+    /// Manage terminology and glossary candidates.
     Glossary(glossary::GlossaryArgs),
+    /// Mark failed or review-needed segments for another attempt.
     Retry(retry::RetryArgs),
+    /// Validate an EPUB and optionally run EPUBCheck.
     Validate(validate::ValidateArgs),
+    /// Measure provider latency and throughput with synthetic requests.
     Benchmark(Box<translate::BenchmarkArgs>),
+    /// Check storage, provider, PDF, and OCR dependencies.
     Doctor(doctor::DoctorArgs),
+    /// Manage reusable named-entity guidance.
     Entities(entity::EntitiesArgs),
+    /// Show persisted state, progress, and performance for a job.
     Status(status::StatusArgs),
+    /// Manage reusable translation style guidance.
     Style(style::StyleArgs),
+    /// Print recent events from a job's durable event log.
     Tail(tail::TailArgs),
     #[cfg(feature = "tui")]
+    /// Monitor and control a job in a full-screen terminal UI.
     Watch(watch::WatchArgs),
     #[cfg(feature = "serve")]
+    /// Run the local browser dashboard.
     Serve(serve::ServeArgs),
 }
 
@@ -346,5 +370,21 @@ mod tests {
         let help = String::from_utf8(help).expect("help should be utf-8");
 
         assert!(help.contains("Run `bookforge` without a command"));
+    }
+
+    #[test]
+    fn every_top_level_command_has_help_text() {
+        let command = Cli::command();
+        let missing = command
+            .get_subcommands()
+            .filter(|subcommand| subcommand.get_about().is_none())
+            .map(|subcommand| subcommand.get_name().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            missing.is_empty(),
+            "top-level commands without help text: {}",
+            missing.join(", ")
+        );
     }
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,0 +1,303 @@
+# BookForge CLI guide
+
+This guide explains how the commands fit together. Run `bookforge <command>
+--help` for the complete, version-specific option list.
+
+Examples below assume that BookForge is installed. From a source checkout,
+replace `bookforge` with `cargo run -p bookforge-cli --`.
+
+## Before you run a command
+
+BookForge stores its job database and run artifacts under `.bookforge/` in the
+current working directory. Start later commands such as `status`, `resume`, and
+`review` from the same directory where you started the translation. This also
+means that two folders can have independent BookForge job libraries.
+
+Provider keys can be pasted into the local dashboard for that server session,
+or supplied to CLI commands through environment variables. See
+[PROVIDERS.md](PROVIDERS.md) for provider presets, endpoints, and key names.
+
+## Command map
+
+| Command | Purpose |
+| --- | --- |
+| `serve` | Run the local browser dashboard. Running `bookforge` with no command does the same thing and opens the browser. |
+| `inspect` | Report EPUB structure, metadata, and translatable text coverage. |
+| `estimate` | Estimate input/output tokens and price before a hosted-provider run. |
+| `translate` | Start a checkpointed EPUB translation. |
+| `watch` | Monitor and control a job in a full-screen terminal UI. |
+| `status` | Print persisted progress, settings, token use, artifacts, and performance. |
+| `tail` | Print recent durable job events, optionally as JSON. |
+| `pause` | Park a running worker at the next safe boundary. |
+| `stop` | Ask a running worker to checkpoint and exit at the next safe boundary. |
+| `reconfigure` | Change cache-safe scheduling and quality settings for remaining work. |
+| `resume` | Continue a paused, stopped, interrupted, or incomplete job. |
+| `retry` | Mark failed or review-needed segments as `retry_pending`. |
+| `review` | Generate a private, side-by-side HTML review page. |
+| `ingest-flags` | Import flags exported by the static review page. |
+| `correct` | Save a validated human correction and rebuild the output EPUB. |
+| `validate` | Run BookForge structural checks and EPUBCheck when available. |
+| `convert` | Convert a PDF into a translation-ready EPUB. |
+| `reflow` | Repair paragraph flow in an EPUB without translating it. |
+| `glossary` | Manage terminology and extract book-specific candidates. |
+| `style` | Manage reusable translation-style guidance. |
+| `entities` | Manage names, target forms, gender, and role guidance. |
+| `doctor` | Check storage, provider access, PDF tools, or an OCR endpoint. |
+| `benchmark` | Measure provider latency and throughput with synthetic requests. |
+| `audiobook` | Generate resumable audio chunks and optional stitched audio from an EPUB. |
+
+## A complete translation workflow
+
+Inspect the source before spending provider tokens. The coverage report calls
+out visible text that BookForge would not send for translation.
+
+```bash
+bookforge inspect book.epub
+```
+
+Test storage and provider access, then estimate the run:
+
+```bash
+bookforge doctor --storage
+bookforge doctor --provider openrouter --model google/gemini-2.5-flash-lite
+bookforge estimate book.epub \
+  --source English \
+  --target Italian \
+  --provider openrouter \
+  --model google/gemini-2.5-flash-lite
+```
+
+Start the translation. Presets bundle a provider, model, endpoint, and suitable
+defaults; explicit provider flags remain available when you need them.
+
+```bash
+bookforge translate book.epub \
+  --source English \
+  --target Italian \
+  --provider-preset open-router-paid-fast \
+  --concurrency 4 \
+  --validate-output \
+  --out book.it.epub
+```
+
+The command prints a job ID. Keep it: every lifecycle, monitoring, review, and
+recovery command uses that stable ID.
+
+```bash
+bookforge status <job-id>
+bookforge watch <job-id>
+bookforge tail <job-id> --last 40
+```
+
+After translation, review and validate the output:
+
+```bash
+bookforge review <job-id> --open
+bookforge validate book.it.epub --report book.it.validation.json
+```
+
+The review HTML and JSON include the book's full source and translated text.
+Treat `.bookforge/runs/<job-id>/review/` as private data.
+
+## Job lifecycle and recovery
+
+Pause and stop are cooperative. An in-flight provider request or finalization
+step may finish before the worker reaches a safe boundary.
+
+```bash
+bookforge pause <job-id>
+bookforge resume <job-id>
+
+bookforge stop <job-id>
+bookforge resume <job-id>
+```
+
+`pause` parks the current worker. `stop` asks it to exit while preserving all
+completed checkpoints. `resume` first tries to wake a live worker and otherwise
+starts one replacement worker. Avoid `resume --force` unless a paused worker is
+known to be gone; forcing a second live worker can duplicate requests.
+
+`retry` changes segment state but does not itself run the provider. Mark the
+desired scope and then resume:
+
+```bash
+bookforge retry <job-id> --only failed
+bookforge retry <job-id> --only needs-review
+bookforge resume <job-id>
+```
+
+Completed compatible segments are loaded from checkpoints or cache rather than
+translated again. The input snapshot and run configuration recorded with the
+job protect resume behavior from later changes to the original input.
+
+For the persistence model and state transitions, see
+[CHECKPOINTING.md](CHECKPOINTING.md).
+
+## Change a run safely
+
+`reconfigure` applies only to work that has not crossed the relevant boundary.
+It never mutates an in-flight request or retranslates completed segments.
+
+```bash
+bookforge reconfigure <job-id> \
+  --concurrency 2 \
+  --batch-target-tokens 2400 \
+  --provider-max-attempts 4 \
+  --qa suspicious
+```
+
+Mutable settings include concurrency, batch item/token budgets, provider
+attempts, adaptive concurrency and batch sizing, QA, double-check mode, and
+output validation. Provider, model, language, prompt, context, glossary, style,
+entity, profile, and segmentation changes are rejected because they would make
+existing checkpoints incompatible. Start a new job for those changes.
+
+The command records a revisioned override file under the job's run directory.
+`status` shows active overrides and the worker reports when it applies them.
+
+## Review, flag, and correct
+
+The static review page can export `flags.json`. Importing the file persists the
+flags; wrong-translation flags mark segments as needing review, while accepted
+name guidance can seed the glossary.
+
+```bash
+bookforge review <job-id> --open
+bookforge ingest-flags <job-id> --flags flags.json
+bookforge retry <job-id> --only needs-review
+bookforge resume <job-id>
+```
+
+For a one-block segment, apply an exact human correction directly:
+
+```bash
+bookforge correct <job-id> --segment <segment-id> --text "Corrected translation"
+```
+
+Use a file for long text. A multi-block segment requires JSON containing every
+block in that segment:
+
+```json
+{
+  "blocks": [
+    {"block_id": "block-1", "text": "First corrected block."},
+    {"block_id": "block-2", "text": "Second corrected block."}
+  ]
+}
+```
+
+```bash
+bookforge correct <job-id> --segment <segment-id> --from-file correction.json
+```
+
+BookForge validates marker constraints, stages and validates a rebuilt EPUB,
+then persists the correction and atomically replaces the output. Saved human
+corrections are protected from later cache, QA, and model overwrites.
+
+## Bilingual output
+
+Translation and output layout are separate. `replace` writes only the target
+text; the append modes retain the source and add the target text.
+
+```bash
+bookforge translate book.epub \
+  --target Italian \
+  --provider-preset open-router-paid-fast \
+  --mode append-block \
+  --bilingual-style minimal \
+  --out book.bilingual.epub
+```
+
+Available modes are `replace`, `append-text`, and `append-block`. Because mode
+is a rebuild concern, compatible translations can be reused when you switch
+between them.
+
+## PDF ingestion and EPUB reflow
+
+PDF conversion requires Poppler. Check the dependency before a large run:
+
+```bash
+bookforge doctor --pdf
+bookforge convert paper.pdf --out paper.epub
+bookforge inspect paper.epub
+```
+
+Review the conversion report before translating. It records text coverage,
+layout decisions, preserved media, and low-confidence pages. See
+[EPUB_PIPELINE.md](EPUB_PIPELINE.md) for pipeline details.
+
+`reflow` is an explicit preprocessing command for broken paragraph flow; normal
+EPUB reading does not silently rewrite the source.
+
+```bash
+bookforge reflow source.epub --output source.reflowed.epub --dry-run
+bookforge reflow source.epub --output source.reflowed.epub
+```
+
+Use `--aggressive` only after reviewing the dry-run report. Use `--pdf-cleanup`
+for EPUBs produced from PDF HTML where page furniture remains.
+
+## Glossaries, styles, and entities
+
+These three stores provide reusable guidance at global, series, or book scope:
+
+- `glossary` maps source terms to required target terms.
+- `style` describes register, voice, and unwanted tendencies.
+- `entities` records names, target forms, gender, and narrative roles.
+
+Inspect nested command help before editing a store:
+
+```bash
+bookforge glossary --help
+bookforge style --help
+bookforge entities --help
+```
+
+You can also pass TOML files directly to `translate` with repeatable
+`--glossary`, `--style`, and `--entities` flags. Stored scoped guidance is
+selected with `--book-id` and `--series-id`. Files and stored guidance are
+fingerprinted into the job configuration so incompatible cache entries are not
+reused.
+
+## Validation, diagnostics, and machine-readable progress
+
+BookForge always applies its deterministic translation validators. `validate`
+checks a completed EPUB and uses EPUBCheck when it can find it:
+
+```bash
+bookforge validate output.epub
+bookforge validate output.epub --strict-epubcheck
+```
+
+Set `BOOKFORGE_EPUBCHECK` to an EPUBCheck executable, its directory, or an
+`epubcheck.jar` when automatic discovery is insufficient. Without EPUBCheck,
+the report records `unavailable`; BookForge's own checks still run.
+
+For automation, select JSON progress and a durable event file:
+
+```bash
+bookforge translate book.epub \
+  --target Italian \
+  --provider mock \
+  --model mock-prefix-target \
+  --ui json \
+  --progress-jsonl .bookforge/runs/example/events.jsonl
+```
+
+Use `tail <job-id> --json` for persisted event objects after launch. See
+[events.md](events.md) for the event schema and folding rules.
+
+## Audiobooks
+
+Audiobook generation is independent of translation; its input can be a source
+or translated EPUB. A dry run shows chapter and chunk counts without calling a
+provider:
+
+```bash
+bookforge audiobook book.epub --provider mock --dry-run
+bookforge audiobook book.epub --voice alloy --format mp3 --stitch
+```
+
+See [audiobooks.md](audiobooks.md) for providers, formats, resume hashing,
+pruning, ffmpeg stitching, and M4B assembly.
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,265 @@
+# Troubleshooting BookForge
+
+Start with these three checks:
+
+```bash
+bookforge --version
+bookforge doctor --storage
+bookforge status <job-id>
+```
+
+Then use the section that matches the failure. Error reports should include the
+BookForge version, operating system, provider and model, the command with all
+secrets removed, and a redacted validation or QA report.
+
+## `bookforge` is not found
+
+Close and reopen the terminal after using a prebuilt installer so its `PATH`
+refreshes. Confirm the binary from a new terminal:
+
+```bash
+bookforge --version
+```
+
+When running from a source checkout, use:
+
+```bash
+cargo run -p bookforge-cli -- --version
+```
+
+Building from source requires Rust 1.88 or newer. The prebuilt installers do
+not require Rust, Cargo, Git, Python, or Node.
+
+## The dashboard does not open
+
+Start it explicitly and open the printed address yourself:
+
+```bash
+bookforge serve --open
+```
+
+The default address is `http://127.0.0.1:8765`. BookForge intentionally
+accepts only a loopback bind because the dashboard is unauthenticated and can
+launch runs with session-only provider keys. Do not expose it through a public
+interface or reverse proxy.
+
+If port 8765 is occupied, choose another loopback port:
+
+```bash
+bookforge serve --bind 127.0.0.1:8877 --open
+```
+
+## A job is missing
+
+BookForge opens `.bookforge/jobs.sqlite` relative to the current working
+directory. Return to the directory where the job was created and retry:
+
+```bash
+bookforge status <job-id>
+```
+
+The dashboard follows the same rule. Starting it from another folder displays
+that folder's independent job library.
+
+Do not move only `jobs.sqlite`: run directories contain event logs, snapshots,
+review artifacts, and control files referenced by the database. Move or back
+up the entire `.bookforge/` directory together.
+
+## The API key is missing or rejected
+
+The browser dashboard accepts a key for the life of that server process and
+does not write it to disk. CLI commands read keys from environment variables.
+
+Bash or zsh:
+
+```bash
+export DEEPSEEK_API_KEY="..."
+export OPENROUTER_API_KEY="..."
+export OPENAI_API_KEY="..."
+```
+
+PowerShell:
+
+```powershell
+$env:DEEPSEEK_API_KEY = "..."
+$env:OPENROUTER_API_KEY = "..."
+$env:OPENAI_API_KEY = "..."
+```
+
+Check the exact provider and model before translating:
+
+```bash
+bookforge doctor --provider openrouter --model google/gemini-2.5-flash-lite
+```
+
+For a custom OpenAI-compatible endpoint, make the key variable explicit with
+`--api-key-env`, and check that `--base-url` includes the provider's `/v1` base
+when required. See [PROVIDERS.md](PROVIDERS.md).
+
+## A translation appears stuck
+
+First inspect persisted state rather than restarting blindly:
+
+```bash
+bookforge status <job-id>
+bookforge tail <job-id> --last 60
+bookforge watch <job-id>
+```
+
+An in-flight provider request can take up to the configured timeout. Rate-limit
+backoff and response validation retries also make a segment take longer without
+losing earlier checkpoints.
+
+If the worker is no longer running, `resume` starts a replacement and reuses
+completed work:
+
+```bash
+bookforge resume <job-id>
+```
+
+If the job is paused and its original worker is still alive, normal `resume`
+wakes it. Use `resume --force` only when you know that paused process is gone;
+two live workers can duplicate provider requests.
+
+## Pause or stop is not immediate
+
+Both controls are cooperative. BookForge finishes or safely abandons the
+current request, checkpoint, or finalize-stage boundary before changing state.
+This protects the EPUB and job database from partial writes.
+
+Use `status` or `tail` to confirm the resulting state:
+
+```bash
+bookforge pause <job-id>
+bookforge status <job-id>
+```
+
+## Reconfiguration is rejected
+
+Only settings that preserve checkpoint and cache compatibility can change on
+an existing job. Concurrency, batch budgets, provider attempts, adaptive
+sizing, QA, double-check, and output validation are mutable.
+
+Provider, model, languages, prompt/profile, segmentation, context, glossary,
+style, and entity guidance are immutable for that job. Start a new translation
+when one of those needs to change. Also check that the job is running, paused,
+or stopped and still has remaining work.
+
+## Segments are `failed` or `needs_review`
+
+`failed` usually means provider attempts were exhausted. `needs_review` means
+BookForge preserved safety by refusing to accept suspect output, or that a
+human flag requested review.
+
+Generate the side-by-side report before retrying everything:
+
+```bash
+bookforge review <job-id> --open
+```
+
+Then choose a scope and resume:
+
+```bash
+bookforge retry <job-id> --only failed
+bookforge retry <job-id> --only needs-review
+bookforge resume <job-id>
+```
+
+`retry` only marks segments `retry_pending`; `resume` performs the requests.
+For a known correct translation, use `bookforge correct` instead of spending
+another provider request. See [CLI_REFERENCE.md](CLI_REFERENCE.md#review-flag-and-correct).
+
+## Validation cannot find EPUBCheck
+
+BookForge's built-in structural validation still runs. Missing EPUBCheck is
+reported as `status: unavailable` and is non-fatal unless your own workflow
+requires it.
+
+Set `BOOKFORGE_EPUBCHECK` to one of:
+
+- the EPUBCheck executable;
+- the directory containing the executable; or
+- an `epubcheck.jar` file.
+
+Run validation again and inspect the JSON report:
+
+```bash
+bookforge validate output.epub --report output.validation.json
+```
+
+`--strict-epubcheck` turns EPUBCheck warnings into validation failures; omit it
+when warnings are acceptable.
+
+## EPUB inspection reports low text coverage
+
+Do not start a paid translation until you understand the missing coverage.
+`inspect` lists files whose visible text sits outside supported translatable
+blocks. That text would otherwise remain in the source language.
+
+If the EPUB came from a PDF or contains broken paragraph boundaries, preview an
+explicit reflow:
+
+```bash
+bookforge reflow source.epub --output source.reflowed.epub --dry-run
+```
+
+Review the report before running without `--dry-run`. Reflow repairs flow; it
+does not make arbitrary page layouts or image-only text translatable.
+
+## PDF conversion cannot find Poppler
+
+Check the dependency:
+
+```bash
+bookforge doctor --pdf
+```
+
+Install Poppler command-line tools and put their binary directory on `PATH`, or
+set `POPPLER_PATH` to that directory. On Windows, use a Poppler for Windows
+release and point `POPPLER_PATH` at its `bin` directory.
+
+Conversion can degrade when optional render/extraction tools are missing, so
+read both `doctor --pdf` and the generated conversion report before
+translating. Image-heavy, scanned, or unusual-layout PDFs may need OCR or manual
+review even when conversion succeeds.
+
+## Audiobook stitching or M4B assembly fails
+
+Synthesis chunks are checkpointed independently, so a stitching failure does
+not require you to pay for synthesis again. Install `ffmpeg` for `--stitch` and
+both `ffmpeg` and `ffprobe` for chapterized `--m4b`, then rerun the same command.
+
+Use a dry run to verify provider, voice, format, chapter count, and chunk plan:
+
+```bash
+bookforge audiobook book.epub --provider mock --dry-run
+```
+
+See [audiobooks.md](audiobooks.md) for provider-specific formats and limits.
+
+## Cost estimates are unavailable or stale
+
+Pricing comes from the bundled `pricing/providers.json`. A custom or newly
+released model may not have a known price even though translation works.
+Override the catalog per command or environment:
+
+```bash
+bookforge estimate book.epub --target Italian --pricing custom-pricing.json
+```
+
+Set `BOOKFORGE_PRICING_PATH` to use the same custom catalog across commands.
+Treat estimates as planning values; provider billing is authoritative.
+
+## What is safe to share
+
+Do not publish `.bookforge/` or generated review artifacts. They can contain:
+
+- the uploaded or snapshotted book;
+- full source and translated text;
+- provider/model settings and event logs;
+- human review notes and corrections.
+
+BookForge does not persist dashboard-pasted API keys, but redact commands,
+screenshots, URLs, reports, and logs before attaching them to an issue. Never
+include an API key or a copyrighted book in a public bug report.
+


### PR DESCRIPTION
Adds two user-facing guides and makes `bookforge --help` self-explanatory.

- **`docs/CLI_REFERENCE.md`** — task-oriented guide to how the commands fit together, deliberately delegating per-area detail to the existing topic guides (e.g. audiobook flags stay in `docs/audiobooks.md`) so it does not go stale against them.
- **`docs/TROUBLESHOOTING.md`** — starts from `--version` / `doctor` / `status` and works outward.
- A one-line description on every subcommand, so the top-level help listing explains itself.
- README links the new guides.

Merges `main` (v2.6.0). The README conflict was resolved by keeping the tighter converter paragraph from this branch and preserving main's OCR example and `docs/pdf-ocr.md` link.

## Verification
`cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean; workspace tests pass.

One pre-existing flake surfaced during a loaded full-workspace run — `cli_pause_and_resume_live_mock_run` (lifecycle.rs:1771), a timing-sensitive pause assertion. It passes 3/3 in isolation and 2/2 for the full lifecycle suite, and this branch touches no runtime logic. Tracked separately rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)