### PR TITLE
chore(deps): hold rusqlite at 0.37 to preserve the 1.88 MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       time: "06:00"
       timezone: Europe/Rome
     open-pull-requests-limit: 5
+    ignore:
+      # rusqlite >=0.40 depends on a libsqlite3-sys that uses `cfg_select!`,
+      # which is not available at our MSRV of 1.88 (docs/msrv-audit.md). Taking
+      # it would mean raising the floor and dropping the distro toolchains that
+      # audit deliberately kept support for. Revisit when the MSRV moves for an
+      # independent reason, or if an advisory lands against 0.37.
+      - dependency-name: rusqlite
+        versions: [">=0.40"]
     groups:
       rust-patch-and-minor:
         update-types:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 quick-xml = { version = "0.41", features = ["escape-html"] }
 zip = "8.6"
+# Held at 0.37 deliberately: 0.40 pulls a libsqlite3-sys that uses the
+# `cfg_select!` macro, which does not exist in our MSRV (see docs/msrv-audit.md
+# for why the floor is 1.88 and what it buys). Raising this means raising the
+# MSRV. Dependabot is told to skip >=0.40 in .github/dependabot.yml.
 rusqlite = { version = "0.37", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "brotli"], default-features = false }
 base64 = "0.22"


### PR DESCRIPTION
Closes the loop on #42, which cannot merge as proposed.

## Why
#42 fails `msrv (1.88.0)` with `error: cannot find macro cfg_select in this scope`. rusqlite 0.40 pulls a `libsqlite3-sys` that uses a macro unavailable in Rust 1.88 — so the bump is really an MSRV raise wearing a dependency bump's clothes.

`docs/msrv-audit.md` lowered the floor from 1.95 to 1.88 on 2026-06-03 deliberately, because Debian stable, Ubuntu 22.04 LTS, RHEL 9 and NixOS stable ship older `rustc`, and the crates are publishable so `cargo install bookforge-cli` runs on the user's own toolchain. That audit also asked for a `cargo +1.88 check` job specifically to "enforce the floor against future API drift" — this is that job working on its first real test.

Nothing in BookForge needs 0.40, and RustSec reports no advisory against 0.37, so there is no forcing function. The floor wins.

## What changed
No version constraint change is needed — `version = "0.37"` already resolves to `>=0.37.0, <0.38.0` under Cargo's 0.x rules. This documents *why* at the declaration and adds a dependabot `ignore` for `>=0.40` so the PR does not reopen weekly.

Revisit if an advisory lands against 0.37, or when the MSRV moves for a reason of its own — 0.40 comes along free at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
