### PR TITLE
docs: correct the rusqlite pin comments after the 0.39 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       # which is not available at our MSRV of 1.88 (docs/msrv-audit.md). Taking
       # it would mean raising the floor and dropping the distro toolchains that
       # audit deliberately kept support for. Revisit when the MSRV moves for an
-      # independent reason, or if an advisory lands against 0.37.
+      # independent reason, or if an advisory lands against the 0.3x line.
       - dependency-name: rusqlite
         versions: [">=0.40"]
     groups:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 quick-xml = { version = "0.41", features = ["escape-html"] }
 zip = "8.6"
-# Held at 0.37 deliberately: 0.40 pulls a libsqlite3-sys that uses the
+# Held below 0.40 deliberately: 0.40 pulls a libsqlite3-sys that uses the
 # `cfg_select!` macro, which does not exist in our MSRV (see docs/msrv-audit.md
-# for why the floor is 1.88 and what it buys). Raising this means raising the
-# MSRV. Dependabot is told to skip >=0.40 in .github/dependabot.yml.
+# for why the floor is 1.88 and what it buys). Raising past 0.39 means raising
+# the MSRV. Dependabot is told to skip >=0.40 in .github/dependabot.yml.
 rusqlite = { version = "0.39", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "brotli"], default-features = false }
 base64 = "0.22"


### PR DESCRIPTION
Follow-up to #51.

Dependabot took rusqlite to 0.39.0 — which the `>=0.40` ignore rule steered it to, and which passes `msrv (1.88.0)` — but it left the comment above the dependency claiming it was "held at 0.37". Sitting directly above `version = "0.39"`, that reads as either a stale note or a broken pin.

The constraint was never a pin to one version; it is a ceiling below 0.40, where `libsqlite3-sys` starts using `cfg_select!` and requires a compiler above our MSRV. Both comments now say that.

No behaviour change.
