### PR TITLE
docs: reconcile README, architecture, CLI reference and dashboard history with shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of translation quality.
 
 ## Status
 
-BookForge v2.5.1 is usable for EPUB translation, PDF-to-EPUB ingestion, and
+BookForge v2.6.1 is usable for EPUB translation, PDF-to-EPUB ingestion, and
 local browser-based translation runs:
 
 - EPUB inspect, parse, segment, and rebuild
@@ -52,6 +52,29 @@ local browser-based translation runs:
 - Cost estimates for known provider/model pairs
 - Externalized, overridable provider pricing
 - Resumable audiobook generation with hosted and local TTS providers
+- Typed audiobook narration chunks for chapter titles, in-section headings,
+  and body prose
+- Default chaptered `audiobook.m4b` assembly with title/artist metadata,
+  chapter markers, `--no-book-file` opt-out, `--single` flat output, and
+  whole-book-only `--loudnorm`
+- ElevenLabs consistency controls with `--seed`, model-aware `--language`,
+  `--text-normalization auto|on|off`, and up to 300 characters of same-chapter
+  context
+- Per-character TTS cost estimates and non-fatal ElevenLabs quota preflight,
+  plus one-based `--chapters` subsets and `--list-voices` discovery
+- ElevenLabs model selection preferring Eleven v3, Flash v2.5, Turbo v2.5,
+  then Multilingual v2, with consistent character limits across all interfaces
+- Browser audiobook voice discovery, pre-launch cost/quota estimates,
+  chapter-grouped progress, `.m4b` playback, and advanced generation controls
+- `bookforge-audio-v2` synthesis caching and manifest schema 3, invalidating
+  earlier chunk caches and supporting `--prune` cleanup
+- Optional low-confidence PDF OCR through OpenAI-compatible `--ocr-endpoint`
+  services, including the `--ocr-dialect unlimited-ocr` SGLang dialect,
+  `action=ocr` reporting, and loopback endpoint diagnostics
+- Bounded EPUB decompression, capped provider/OCR/event-log reads, and
+  time-limited poppler tools with scrubbed environments and private temp dirs
+- Least-privilege provider-key handling for quota checks and dashboard jobs,
+  hardened dashboard headers, and private `.bookforge` data on Unix
 
 ## Documentation
 
@@ -599,6 +622,7 @@ respect.
 ```txt
 crates/bookforge-core   IR, segmentation, shared config
 crates/bookforge-epub   EPUB inspect/read/rebuild
+crates/bookforge-pdf    PDF ingestion: poppler, reconstruction, OCR, EPUB emit
 crates/bookforge-llm    prompts, providers, scheduler, validators
 crates/bookforge-llm/prompts  Versioned prompt templates
 crates/bookforge-audio  Audiobook TTS: chunking, providers, stitch

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,10 +5,12 @@ Bookforge is an EPUB-first translation engine. The program owns document structu
 ## Crates
 
 - `bookforge-core` defines the IR, segmentation, run settings, progress events, cache namespace rules, glossary/style/entity helpers, and marker parsing.
+- `bookforge-pdf` owns Poppler-backed PDF layout extraction, deterministic reconstruction, optional OCR recovery, synthetic EPUB assembly, and fidelity reports.
 - `bookforge-epub` reads EPUB containers into the IR and rebuilds EPUBs by patching original XML resources in place.
 - `bookforge-llm` owns prompt rendering, provider calls, batching, validation, repair, QA, context registries, and telemetry.
 - `bookforge-store` owns the SQLite job store, segment records, block translations, cache lookup, retry state, and run snapshots.
-- `bookforge-cli` wires those pieces into commands such as `translate`, `resume`, `retry`, `review`, `inspect`, `validate`, and `status`.
+- `bookforge-audio` owns chapter extraction, typed narration chunking, TTS providers, resumable synthesis, stale-chunk cleanup, and optional ffmpeg stitching.
+- `bookforge-cli` wires those pieces into commands such as `translate`, `resume`, `retry`, `review`, `inspect`, `validate`, `status`, `convert`, `audiobook`, and `serve`.
 
 ## Translation Flow
 
@@ -21,4 +23,24 @@ Bookforge is an EPUB-first translation engine. The program owns document structu
 7. The EPUB writer patches translated blocks back into the original resources and writes a report next to the output.
 
 The key invariant is that models never produce EPUB structure. They produce JSON translations of prose strings. Rust validates the response, maps marker-protected prose back to known blocks, and patches the original package resources.
+
+## PDF Conversion Flow
+
+1. The `convert` command uses Poppler's `pdftohtml -xml` output as the raw layout and `pdftotext` as the comparison baseline.
+2. `parse.rs` turns the XML into pages of positioned fragments and styled spans.
+3. `reconstruct.rs` merges fragments into lines, detects columns and reading order, clusters paragraphs, repairs line-end hyphenation, and derives headings from font sizes.
+4. When an OCR endpoint is configured, `ocr.rs` uses an `OcrEngine` and `OcrDialect` to recover low-confidence pages through an OpenAI-compatible API.
+5. `epub.rs` writes the synthetic EPUB. `report.rs` compares reconstruction with the `pdftotext` baseline and records per-page column decisions, low-confidence actions, media counts, and layout warnings.
+
+The produced EPUB then flows through the ordinary BookForge pipeline. The PDF crate is an ingestion front end, not a parallel translation path.
+
+## Audiobook Flow
+
+1. `text.rs` turns a parsed `bookforge_core::ir::Book` into chapters and typed title, heading, and body narration chunks. It splits within the configured provider character limit at sentence boundaries where possible.
+2. `provider.rs` and `provider/` define `TtsProvider` and provide OpenAI-compatible, Gemini, ElevenLabs, and deterministic mock providers.
+3. `builder.rs` orchestrates book to chunks to audio files with bounded concurrency, atomic per-chunk writes, content-and-settings-hashed file-based resume, and a JSON manifest.
+4. The `--prune` path uses `cleanup.rs` to identify and remove managed chunk files that the current plan no longer uses.
+5. `stitch.rs` optionally joins chunks per chapter and assembles a chaptered `.m4b` through `ffmpeg`. If `ffmpeg` is absent, it warns and leaves the per-chunk files intact.
+
+The same invariant applies as in translation: deterministic Rust owns chapter extraction, chunking, file layout, and resume. Providers receive plain text chunks and return audio bytes.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -46,6 +46,62 @@ or supplied to CLI commands through environment variables. See
 | `benchmark` | Measure provider latency and throughput with synthetic requests. |
 | `audiobook` | Generate resumable audio chunks and optional stitched audio from an EPUB. |
 
+## Local browser dashboard
+
+The local dashboard is the default front door. Running `bookforge` without a
+subcommand starts it on `127.0.0.1:8765` and opens the default browser. The
+explicit command uses the same address and 250 ms server-sent-events refresh
+interval, but opens a browser only when `--open` is present:
+
+```bash
+bookforge
+bookforge serve --open
+```
+
+Use `--bind` to select another loopback address or port. `--refresh-ms` controls
+the live-update interval; values are clamped to the range from 50 through 5,000
+milliseconds.
+
+```bash
+bookforge serve --bind 127.0.0.1:9000 --refresh-ms 500
+```
+
+The dashboard lists jobs and shows their details and live events. It can
+estimate and launch translations, review and validate results, save manual
+translations, flag or retry segments, and manage glossary entries. It also
+routes the reconfigure, pause, resume, and stop controls described below. The
+audiobook flow can estimate and launch a run, report its status, cancel it, and
+download its artifact. The dashboard is therefore a control surface, not only
+a monitor.
+
+Before binding, `serve` checks whether the current working directory can hold
+`.bookforge/`. A writable directory is left unchanged. On Windows, an
+unwritable directory is replaced with `%LOCALAPPDATA%\BookForge`, falling back
+to `%USERPROFILE%\BookForge`. On other platforms it uses
+`$XDG_DATA_HOME/bookforge`, falling back to `$HOME/.local/share/bookforge`.
+Uploads, job state, outputs, and dashboard-launched child processes then use
+that relocated working directory.
+
+The dashboard is deliberately unauthenticated and may hold provider API keys,
+so it is only for the person at that machine. This is enforced at the network
+boundary: `--bind` rejects every non-loopback address and directs remote users
+to an SSH tunnel. Keys pasted into the dashboard remain in server memory only
+for the lifetime of the process. They are never written to disk, logged, or
+placed on a child process's command line; spawned runs receive them through
+their environment.
+
+Mutating requests require the per-server CSRF token in the
+`x-bookforge-csrf` header, and Host-header middleware rejects requests that do
+not name the bound loopback port. Request bodies are capped at 64 MiB. The
+dashboard page carries a content security policy, `X-Frame-Options: DENY`,
+`X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and
+`Cache-Control: no-store`.
+
+`watch` and `serve` are default-on build features (`tui` / `serve`); build with
+`--no-default-features` for a minimal binary without them. Such a build has no
+`serve` subcommand, and running `bookforge` without a command prints help
+instead of starting the dashboard.
+
 ## A complete translation workflow
 
 Inspect the source before spending provider tokens. The coverage report calls
@@ -286,6 +342,45 @@ bookforge translate book.epub \
 
 Use `tail <job-id> --json` for persisted event objects after launch. See
 [events.md](events.md) for the event schema and folding rules.
+
+## Benchmark provider latency and throughput
+
+`benchmark` sends a fixed synthetic translation request to a real provider. It
+makes one provider call for each sample, so the default `--samples 5` makes five
+potentially billable calls. `--tokens` defaults to 1,000 and sets each request's
+maximum output tokens; it is a response-length cap, not a total token budget.
+
+```bash
+bookforge benchmark \
+  --base-url https://openrouter.ai/api/v1 \
+  --api-key-env OPENROUTER_API_KEY \
+  --model openrouter/auto \
+  --samples 5 \
+  --tokens 1000
+```
+
+The command accepts the shared `--provider`, `--model`, `--base-url`,
+`--api-key-env`, and `--timeout-seconds` flags. Its implementation does not,
+however, read the `--provider` name: even though that parsed value defaults to
+`deepseek`, it does not select a preset. Without explicit overrides,
+`benchmark` constructs an OpenAI-compatible client for
+`https://openrouter.ai/api/v1`, reads `OPENROUTER_API_KEY`, uses
+`openrouter/auto`, and applies a 120-second timeout.
+
+Samples currently run one at a time. `--concurrency` defaults to 1, but its
+value appears only in the printed header and does not make requests parallel.
+
+Each sample prints success or failure. Successful lines include latency, token
+counts, and approximate output tokens per second. The results block always
+reports success, failure, HTTP 429, and timeout counts; when requests succeed,
+it also reports p50, p95, and average latency and average output throughput.
+With at least one success, the recommendation classifies a rate-limited or very
+slow result as `free-tier`, a fast result without rate limits as `fastest`, and
+the remainder as `balanced`; it prints the selected profile name with suggested
+concurrency and timeout values.
+
+See [benchmarks.md](benchmarks.md) for the wider set of metrics to retain when
+recording provider and end-to-end benchmarks.
 
 ## Audiobooks
 

--- a/docs/v2-web-dashboard-plan.md
+++ b/docs/v2-web-dashboard-plan.md
@@ -54,7 +54,9 @@ already existed, newly exposed over HTTP:
   preview), then `POST /api/translate`. The launch now also forwards the wizard's
   Advanced fields — `--concurrency`, `--qa`, `--context-window`, `--validate-output`
   — each validated before reaching the child argv.
-- **Progress** ← `GET /api/jobs/{id}` + SSE. Monitor-only (see below).
+- **Progress** ← `GET /api/jobs/{id}` + SSE, with lifecycle controls:
+  `POST /api/jobs/{id}/pause`, `POST /api/jobs/{id}/resume`, and
+  `POST /api/jobs/{id}/stop` (see below).
 - **Review** ← **`GET /api/jobs/{id}/review`** (new; shares
   `review::generate_review_document` with the CLI `review` command): side-by-side
   source/target, soft-warning badges, client-side flags in `localStorage`.
@@ -65,10 +67,18 @@ already existed, newly exposed over HTTP:
   glossary methods): list/add/remove terms by language pair and scope (default
   global).
 
-**Deferred to the roadmap (§10.1):** the Progress screen's **Pause/Stop**. Runs
-are spawned detached and the engine has no cooperative pause primitive, so the
-controls are omitted rather than faked; checkpoints already make a run resumable
-via `bookforge resume`.
+**Status: SUPERSEDED — SHIPPED** (v2.3.0, 2026-07-05). This update originally
+deferred the Progress screen's **Pause/Stop** to roadmap §10.1 because runs were
+spawned detached and the engine had no cooperative pause primitive at the time;
+the controls were omitted rather than faked, while checkpoints already made a
+run resumable via `bookforge resume`. Cooperative pause, resume, and stop later
+shipped across the engine, CLI, terminal watcher, and browser dashboard, with
+completed segments checkpointed before parking and finalize-stage QA and
+double-check requests honoring the controls. The dashboard registers
+`POST /api/jobs/{id}/pause`, `POST /api/jobs/{id}/resume`, and
+`POST /api/jobs/{id}/stop`. v2.4.0 (2026-07-13) then added live, cache-safe
+reconfiguration through both `GET /api/jobs/{id}/reconfigure` and
+`POST /api/jobs/{id}/reconfigure`.
 
 ## Archived Original Plan
 


### PR DESCRIPTION
Documentation had drifted behind the code in four places. Found during a state-of-the-project audit; each item was verified against source rather than against other docs.

## What was stale

| Document | Problem |
| --- | --- |
| `README.md` | Status section opened "BookForge **v2.5.1** is usable…" — two releases behind. v2.6.0 and v2.6.1 features were entirely absent. `crates/bookforge-pdf` was also missing from Repository Layout. |
| `docs/ARCHITECTURE.md` | Listed **5 of 7 crates**. `bookforge-audio` (~5,065 lines) and `bookforge-pdf` (~7,947 lines) were undocumented — roughly 13k lines of the codebase. Only the translation flow was described. |
| `docs/v2-web-dashboard-plan.md` | Still said dashboard Pause/Stop was deferred because "the engine has no cooperative pause primitive." That shipped in v2.3.0; `serve.rs` routes `/pause`, `/resume`, `/stop`, `/reconfigure`. |
| `docs/CLI_REFERENCE.md` | Documented 22 of 24 subcommands. `serve` — the entry point for non-developers — and `benchmark` were both missing. |

## Verification

Every flag, default, constant, header and route was read at its definition site, not inferred: `ServeArgs`/`BenchmarkArgs` from the structs; routes from `dashboard_router()`; `require_loopback_bind`, `MAX_UPLOAD_BYTES` (64 MiB), `CSRF_HEADER`, `refresh_ms.clamp(50, 5_000)` and the five `index` response headers each at their definition; feature gating from `Cargo.toml` (`default = ["tui", "serve"]`); `ELEVENLABS_PREFERRED_MODELS`, `context_chars: 300`, `schema_version: 3`, `bookforge-audio-v2` and the `archive_limits.rs` constants in source.

## Two warts documented honestly

Writing the `benchmark` entry surfaced that two of its flags are inert:

- `--provider` is parsed (defaulting to `deepseek`) but never read by `run_benchmark`, which always builds an OpenAI-compatible client against OpenRouter.
- `--concurrency` reaches only the printed header; the sampling loop is strictly sequential, which makes the reported throughput misleading.

These are described as-is rather than papered over. Fixing or removing them is tracked separately — the docs should not have to wait on it.

No Rust changed; `fmt` and `clippy` confirmed still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)