### PR TITLE
fix(validation): stop endnote markers being read as math, and build the instrument that found it

### DIFF
--- a/crates/bookforge-cli/examples/judge_flags.rs
+++ b/crates/bookforge-cli/examples/judge_flags.rs
@@ -1,0 +1,1232 @@
+//! `judge_flags` — adjudicate BookForge validator flags with an LLM judge.
+//!
+//! BookForge's deterministic validators flag translated segments as
+//! `needs_review`. On real books they flag hundreds of segments, and a large
+//! fraction of those flags are false positives from a single heuristic
+//! misfiring. Hand-adjudicating them takes hours. This example asks a judge
+//! model one narrow question per flag — *is this validator complaint real?* —
+//! and reports, per validator kind, what fraction of its flags are true
+//! positives. That aggregate is the point: it tells the maintainer which
+//! validators to fix and which to delete.
+//!
+//! # This is dev-time test tooling only
+//!
+//! BookForge's load-bearing architectural invariant is that models never repair
+//! structure and never gate correctness. This example therefore:
+//!
+//! * must never be wired into the `translate` runtime path,
+//! * never accepts, rewrites, or repairs a translation,
+//! * never feeds a malformed model response to a second "repair" model —
+//!   unparseable output is recorded as `unclear` and left alone.
+//!
+//! It reads data and writes a report. Nothing else.
+//!
+//! # Usage
+//!
+//! ```text
+//! # write the built-in sample pairs file, then render prompts and price the run
+//! cargo run --example judge_flags -- --write-fixture pairs.jsonl
+//! cargo run --example judge_flags -- --pairs pairs.jsonl --dry-run
+//!
+//! # actually judge (costs money; capped at --limit units, cached on disk)
+//! cargo run --example judge_flags -- --pairs pairs.jsonl --out verdicts.jsonl
+//! ```
+//!
+//! The API key is never a CLI argument. The provider reads it itself from the
+//! environment variable named by `--api-key-env` (or the provider preset's
+//! default), exactly as the rest of BookForge does.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use bookforge_core::{JsonMode, RetryAfterPolicy};
+use bookforge_llm::{
+    CompletionRequest, LlmProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
+    RequestMetadata, ResponseFormat,
+};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Bumped whenever the prompt changes. It is part of the cache key, so an
+/// edited prompt invalidates every cached verdict instead of silently mixing
+/// verdicts from two different questions.
+const PROMPT_VERSION: &str = "judge_flags/v1";
+
+/// A judge verdict is a handful of tokens. Anything larger than this is not a
+/// verdict, so it is refused before parsing rather than after.
+const MAX_JUDGE_RESPONSE_BYTES: usize = 8 * 1024;
+
+/// Rationales are for a human skimming a report, not for storage.
+const MAX_RATIONALE_CHARS: usize = 300;
+
+/// Rough per-unit output budget used only by `--dry-run` pricing.
+const ESTIMATED_OUTPUT_TOKENS_PER_UNIT: u64 = 80;
+
+/// The pricing catalog shipped with the CLI. `crates/bookforge-cli/src/cost.rs`
+/// owns the real loader; examples cannot import it (the crate has no lib
+/// target), so this is a minimal read-only re-implementation over the same file.
+const EMBEDDED_PRICING: &str = include_str!("../pricing/providers.json");
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "judge_flags",
+    about = "Adjudicate BookForge validator flags with an LLM judge (dev-time tooling only)."
+)]
+struct Args {
+    /// Pairs JSONL: one flagged (source, translation, validator_flags) object per line.
+    #[arg(long, required_unless_present = "write_fixture")]
+    pairs: Option<PathBuf>,
+
+    /// Write verdict JSONL here. Defaults to stdout (the report then goes to stderr).
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// Provider preset: deepseek, openrouter, or openai-compatible.
+    #[arg(long, default_value = "deepseek")]
+    provider: String,
+
+    /// Model override. Defaults to the provider preset's model.
+    #[arg(long)]
+    model: Option<String>,
+
+    /// Base URL override. Required for `--provider openai-compatible`.
+    #[arg(long)]
+    base_url: Option<String>,
+
+    /// NAME of the environment variable holding the API key. Never a key value.
+    #[arg(long)]
+    api_key_env: Option<String>,
+
+    /// Sampling temperature. Adjudication wants determinism, so this defaults to 0.
+    #[arg(long, default_value_t = 0.0)]
+    temperature: f32,
+
+    /// Hard cap on judge output tokens per unit.
+    #[arg(long, default_value_t = 400)]
+    max_output_tokens: u32,
+
+    /// Per-request timeout.
+    #[arg(long, default_value_t = 120)]
+    timeout_seconds: u64,
+
+    /// Cap on how many flags are judged. 0 removes the cap and spends real money.
+    #[arg(long, default_value_t = 25)]
+    limit: usize,
+
+    /// Only judge flags of this validator kind. Repeatable.
+    #[arg(long = "kind")]
+    kinds: Vec<String>,
+
+    /// Render prompts and estimate cost without calling the provider at all.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Directory for the on-disk verdict cache.
+    #[arg(long, default_value = ".bookforge/judge-cache")]
+    cache: PathBuf,
+
+    /// Disable the verdict cache.
+    #[arg(long)]
+    no_cache: bool,
+
+    /// Pricing catalog override. Falls back to the catalog bundled with the CLI.
+    #[arg(long)]
+    pricing: Option<PathBuf>,
+
+    /// Write the built-in sample pairs JSONL to this path and exit.
+    #[arg(long)]
+    write_fixture: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Frozen input schema
+// ---------------------------------------------------------------------------
+
+/// One flagged segment as exported by the pairs producer. Unknown fields are
+/// tolerated on purpose: the exporter may grow columns this tool ignores.
+#[derive(Debug, Deserialize)]
+struct JudgePair {
+    job_id: String,
+    segment_id: String,
+    block_id: String,
+    source_language: String,
+    target_language: String,
+    source_text: String,
+    translated_text: String,
+    validator_flags: Vec<ValidatorFlag>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ValidatorFlag {
+    kind: String,
+    message: String,
+}
+
+/// One unit of work: a single flag on a single segment. A segment carrying two
+/// flags is judged twice, because the two complaints can have different answers.
+#[derive(Debug, Clone)]
+struct JudgeTask {
+    job_id: String,
+    segment_id: String,
+    block_id: String,
+    source_language: String,
+    target_language: String,
+    source_text: String,
+    translated_text: String,
+    kind: String,
+    message: String,
+}
+
+// ---------------------------------------------------------------------------
+// Frozen output schema
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum VerdictLabel {
+    TruePositive,
+    FalsePositive,
+    Unclear,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VerdictRecord {
+    segment_id: String,
+    kind: String,
+    verdict: VerdictLabel,
+    confidence: f64,
+    rationale: String,
+}
+
+/// The shape the judge model is required to return.
+#[derive(Debug, Deserialize)]
+struct JudgeResponse {
+    verdict: VerdictLabel,
+    confidence: f64,
+    rationale: String,
+}
+
+// ---------------------------------------------------------------------------
+// Scorer seam
+// ---------------------------------------------------------------------------
+
+/// A rendered judge prompt. `--dry-run` prints these instead of sending them.
+#[derive(Debug, Clone)]
+struct RenderedPrompt {
+    system: String,
+    user: String,
+}
+
+/// One scored flag.
+#[derive(Debug, Clone)]
+struct ScoreOutcome {
+    verdict: VerdictLabel,
+    confidence: f64,
+    rationale: String,
+    /// `false` when the response could not be parsed strictly and was forced to
+    /// `Unclear`. Reported separately so a flood of unparseable output is
+    /// visible rather than hiding inside the `unclear` rate.
+    parsed: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+}
+
+/// A per-item scoring failure (network, HTTP, auth). Not a verdict: it is
+/// counted in the report's `errors` column and never written to the verdict
+/// stream, so a flaky provider cannot skew the true/false-positive rates.
+#[derive(Debug)]
+struct ScoreError(String);
+
+// SEAM: the owner intends to add a vision-backed scorer later — render a
+// rebuilt EPUB page and check *visually* that footnote markers and layout
+// survived. That scorer is a second `impl FlagScorer` and nothing else: the
+// harness below (task expansion, `--limit`, caching, verdict JSONL, the
+// aggregate report) is generic over `S: FlagScorer` and does not change.
+// `render` is on the trait rather than free-standing precisely because a vision
+// scorer renders something different — an image reference plus a shorter text
+// prompt — and `--dry-run` must still be able to show it without calling out.
+//
+// The async-fn-in-trait shape deliberately mirrors `bookforge_llm::LlmProvider`.
+// It is not dyn-compatible, which is intended: dispatch stays static and there
+// is no `Box<dyn>` in the hot path.
+trait FlagScorer {
+    fn name(&self) -> &'static str;
+
+    fn render(&self, task: &JudgeTask) -> RenderedPrompt;
+
+    fn score(
+        &self,
+        task: &JudgeTask,
+    ) -> impl std::future::Future<Output = Result<ScoreOutcome, ScoreError>> + Send;
+}
+
+/// The only scorer implemented today: text-in, JSON-verdict-out, over
+/// BookForge's existing OpenAI-compatible provider.
+struct TextScorer {
+    provider: OpenAiCompatibleProvider,
+    endpoint: Endpoint,
+    temperature: f32,
+    max_output_tokens: u32,
+}
+
+impl FlagScorer for TextScorer {
+    fn name(&self) -> &'static str {
+        "text"
+    }
+
+    fn render(&self, task: &JudgeTask) -> RenderedPrompt {
+        RenderedPrompt {
+            system: JUDGE_SYSTEM_PROMPT.to_string(),
+            user: render_user_prompt(task),
+        }
+    }
+
+    async fn score(&self, task: &JudgeTask) -> Result<ScoreOutcome, ScoreError> {
+        let prompt = self.render(task);
+        let request = CompletionRequest {
+            system: prompt.system,
+            user: prompt.user,
+            response_format: ResponseFormat::Json,
+            temperature: self.temperature,
+            max_output_tokens: Some(self.max_output_tokens),
+            metadata: RequestMetadata {
+                segment_id: Some(task.segment_id.clone()),
+                block_ids: vec![task.block_id.clone()],
+                prompt_template: Some("judge_flag".to_string()),
+                prompt_version: Some(PROMPT_VERSION.to_string()),
+                provider: Some(self.endpoint.provider.clone()),
+                model: Some(self.endpoint.model.clone()),
+                ..RequestMetadata::default()
+            },
+        };
+
+        let response = self
+            .provider
+            .complete(request)
+            .await
+            .map_err(|error| ScoreError(error.to_string()))?;
+
+        Ok(interpret_response(
+            &response.content,
+            response.input_tokens.unwrap_or_default(),
+            response.output_tokens.unwrap_or_default(),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+const JUDGE_SYSTEM_PROMPT: &str = r#"You are auditing a deterministic validator, not a translation.
+
+BookForge translates EPUBs one segment at a time and then runs mechanical,
+string-level checks over each translation. When a check fires, the segment is
+flagged for human review. These checks have no model of meaning, so they
+produce false positives.
+
+Your only job is to decide whether ONE specific validator complaint is correct
+about ONE specific translation.
+
+  true_positive  - the defect the validator describes is really present in the
+                   translated text.
+  false_positive - the translated text is fine with respect to this complaint;
+                   the validator is wrong.
+  unclear        - you genuinely cannot tell from what you were given.
+
+Rules:
+
+1. Judge ONLY the stated complaint. Do not grade translation quality, style,
+   register, fluency, or accuracy. A mediocre translation that does not have the
+   specific defect described is a false_positive for this complaint.
+
+2. A protected span is content that must survive translation AS DATA: numbers,
+   dates, measurements, identifiers, code, citations, URLs. Ordinary
+   source-language words are not data. If the complaint demands that a
+   source-language WORD appear verbatim in the target text, and the translation
+   renders that word correctly in the target language, the complaint is a
+   false_positive. The data part of the span - digits, punctuation, symbols -
+   must still be present and unaltered for the complaint to be a false_positive.
+
+3. Inline markers look like <m1>...</m1> or <m4/>. They carry EPUB structure:
+   footnote anchors, links, emphasis. Every marker id in the source must appear
+   exactly once in the translation, and no marker id may be invented. Moving a
+   marker to a different position to suit target-language word order is allowed.
+   Dropping, duplicating, or inventing one is not.
+
+4. Prefer unclear over a guess. Do not invent context you were not given.
+
+Return ONLY a JSON object, with no prose, no commentary, and no code fences:
+
+{"verdict":"true_positive"|"false_positive"|"unclear","confidence":0.0,"rationale":"one sentence, at most 200 characters"}"#;
+
+/// The source and translation are delimited with `<<<SOURCE` / `SOURCE` rather
+/// than markdown fences so that book text containing backticks cannot break out
+/// of its block.
+fn render_user_prompt(task: &JudgeTask) -> String {
+    let JudgeTask {
+        job_id,
+        segment_id,
+        block_id,
+        source_language,
+        target_language,
+        source_text,
+        translated_text,
+        kind,
+        message,
+    } = task;
+    let explanation = validator_kind_explanation(kind);
+
+    format!(
+        "Source language: {source_language}\n\
+         Target language: {target_language}\n\
+         Segment: {segment_id} (block {block_id}, job {job_id})\n\
+         \n\
+         Validator kind: {kind}\n\
+         What this validator checks: {explanation}\n\
+         Exact complaint: {message}\n\
+         \n\
+         Source text:\n\
+         <<<SOURCE\n\
+         {source_text}\n\
+         SOURCE\n\
+         \n\
+         Translated text:\n\
+         <<<TRANSLATION\n\
+         {translated_text}\n\
+         TRANSLATION\n\
+         \n\
+         Is this complaint correct about this translation? \
+         Answer with the JSON object only.\n"
+    )
+}
+
+/// Plain-language description of what each validator actually asserts. These
+/// track the real implementations in `bookforge-llm` (`batch/rendering.rs`
+/// `batch_item_validation_error`, and `validation.rs`), and they matter: the
+/// judge cannot tell a misfire from a defect without knowing what the check was
+/// trying to do.
+fn validator_kind_explanation(kind: &str) -> &'static str {
+    match kind {
+        "protected_span_missing" => {
+            "the listed span must appear in the translation. It exists to protect data that must \
+             survive translation unchanged - numbers, dates, citations, identifiers - and it \
+             matches literally, so it misfires when the span also contains ordinary \
+             source-language words that were correctly translated."
+        }
+        "inline_marker_missing" => {
+            "every inline marker id present in the source must also appear in the translation; \
+             this one did not appear at all."
+        }
+        "inline_marker_duplicated" => {
+            "each inline marker id may appear at most once in the translation; this one appears \
+             more than once."
+        }
+        "unknown_inline_marker" => {
+            "the translation contains an inline marker id that does not exist in the source, so \
+             the model invented structure."
+        }
+        "marker_structure" => {
+            "paired inline markers must be balanced and properly nested; this translation has an \
+             unclosed, mis-nested, or wrongly closed marker tag."
+        }
+        "source_copy" => {
+            "the translation still reproduces the source-language prose - either identical to the \
+             source, or overlapping it by a very high fraction of words - which usually means the \
+             model echoed the input instead of translating it."
+        }
+        "target_language" => {
+            "the translation violates a hard constraint of the configured target language, such as \
+             source-language leakage or invented vocabulary in a constrained language like Toki \
+             Pona."
+        }
+        _ => {
+            "this validator kind is not known to the judging harness. Reason from the complaint \
+             text itself and prefer 'unclear' if the complaint is not self-explanatory."
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response handling
+// ---------------------------------------------------------------------------
+
+fn interpret_response(content: &str, input_tokens: u64, output_tokens: u64) -> ScoreOutcome {
+    let unusable = |reason: &str| ScoreOutcome {
+        verdict: VerdictLabel::Unclear,
+        confidence: 0.0,
+        rationale: reason.to_string(),
+        parsed: false,
+        input_tokens,
+        output_tokens,
+    };
+
+    if content.len() > MAX_JUDGE_RESPONSE_BYTES {
+        return unusable("judge response exceeded the response-size bound");
+    }
+
+    let body = strip_json_code_fence(content.trim());
+    let Ok(parsed) = serde_json::from_str::<JudgeResponse>(body) else {
+        // Deliberately terminal. Sending malformed output to a second "repair"
+        // model is the pattern this project rejects, so an unparseable verdict
+        // stays unparseable and is reported as such.
+        return unusable("judge response was not a valid verdict object");
+    };
+
+    if !(0.0..=1.0).contains(&parsed.confidence) {
+        return unusable("judge returned a confidence outside 0.0..=1.0");
+    }
+
+    ScoreOutcome {
+        verdict: parsed.verdict,
+        confidence: parsed.confidence,
+        rationale: truncate_chars(&parsed.rationale, MAX_RATIONALE_CHARS),
+        parsed: true,
+        input_tokens,
+        output_tokens,
+    }
+}
+
+/// Unwrap a whole-response ```json fence. This is a deterministic unwrap, not a
+/// repair: nothing inside is rewritten, and if the contents still do not parse
+/// the response is recorded as `unclear`.
+fn strip_json_code_fence(body: &str) -> &str {
+    let Some(inner) = body.strip_prefix("```") else {
+        return body;
+    };
+    let Some(inner) = inner.strip_suffix("```") else {
+        return body;
+    };
+    let Some((tag, payload)) = inner.split_once('\n') else {
+        return body;
+    };
+    let tag = tag.trim();
+    if tag.is_empty() || tag.eq_ignore_ascii_case("json") {
+        payload.trim()
+    } else {
+        body
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    text.chars().take(max_chars).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Provider configuration
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Endpoint {
+    provider: String,
+    base_url: String,
+    /// The NAME of the environment variable. The value is read by the provider
+    /// itself at request time and never touched, printed, or logged here.
+    api_key_env: String,
+    model: String,
+}
+
+/// Mirrors the preset table in `crates/bookforge-cli/src/commands/doctor.rs` so
+/// the judge is configured exactly like every other BookForge provider call.
+fn resolve_endpoint(args: &Args) -> Result<Endpoint> {
+    let (default_url, default_key_env, default_model) = match args.provider.as_str() {
+        "deepseek" => (
+            "https://api.deepseek.com/v1",
+            "DEEPSEEK_API_KEY",
+            "deepseek-v4-flash",
+        ),
+        "openrouter" => (
+            "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY",
+            "openrouter/auto",
+        ),
+        "openai-compatible" => {
+            if args.base_url.is_none() {
+                bail!("--provider openai-compatible requires --base-url");
+            }
+            ("", "OPENAI_API_KEY", "local-model")
+        }
+        other => {
+            bail!("unsupported provider '{other}'; use deepseek, openrouter, or openai-compatible")
+        }
+    };
+
+    Ok(Endpoint {
+        provider: args.provider.clone(),
+        base_url: args
+            .base_url
+            .clone()
+            .unwrap_or_else(|| default_url.to_string()),
+        api_key_env: args
+            .api_key_env
+            .clone()
+            .unwrap_or_else(|| default_key_env.to_string()),
+        model: args
+            .model
+            .clone()
+            .unwrap_or_else(|| default_model.to_string()),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Verdict cache
+// ---------------------------------------------------------------------------
+
+/// Content-addressed verdict cache. Re-running the same pairs against the same
+/// model costs nothing. Cache problems are warnings, never failures: a miss is
+/// always a legal answer.
+struct VerdictCache {
+    dir: Option<PathBuf>,
+}
+
+impl VerdictCache {
+    fn get(&self, key: &str) -> Option<VerdictRecord> {
+        let path = self.dir.as_ref()?.join(format!("{key}.json"));
+        let body = fs::read_to_string(path).ok()?;
+        serde_json::from_str(&body).ok()
+    }
+
+    fn put(&self, key: &str, record: &VerdictRecord) {
+        let Some(dir) = self.dir.as_ref() else {
+            return;
+        };
+        if let Err(error) = fs::create_dir_all(dir) {
+            eprintln!(
+                "warning: cannot create cache directory {}: {error}",
+                dir.display()
+            );
+            return;
+        }
+        let path = dir.join(format!("{key}.json"));
+        let body = match serde_json::to_string(record) {
+            Ok(body) => body,
+            Err(error) => {
+                eprintln!("warning: cannot serialize cache entry: {error}");
+                return;
+            }
+        };
+        if let Err(error) = fs::write(&path, body) {
+            eprintln!(
+                "warning: cannot write cache entry {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn cache_key(scorer: &str, endpoint: &Endpoint, task: &JudgeTask) -> String {
+    const SEPARATOR: &[u8] = b"\x1f";
+
+    let mut hasher = Sha256::new();
+    for field in [
+        PROMPT_VERSION,
+        scorer,
+        endpoint.provider.as_str(),
+        endpoint.model.as_str(),
+        task.source_language.as_str(),
+        task.target_language.as_str(),
+        task.kind.as_str(),
+        task.message.as_str(),
+        task.source_text.as_str(),
+        task.translated_text.as_str(),
+    ] {
+        hasher.update(field.as_bytes());
+        hasher.update(SEPARATOR);
+    }
+    hex_digest(hasher.finalize().as_slice())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Pricing (dry-run estimate only)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct PricingFile {
+    schema_version: u32,
+    providers: BTreeMap<String, ProviderPricing>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderPricing {
+    models: BTreeMap<String, ModelPricing>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct ModelPricing {
+    input_per_million_usd: f64,
+    output_per_million_usd: f64,
+}
+
+struct PricingCatalog {
+    file: PricingFile,
+    label: String,
+}
+
+impl PricingCatalog {
+    fn model_pricing(&self, provider: &str, model: &str) -> Option<ModelPricing> {
+        self.file
+            .providers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(provider))
+            .and_then(|(_, pricing)| {
+                pricing
+                    .models
+                    .iter()
+                    .find(|(name, _)| name.eq_ignore_ascii_case(model))
+                    .map(|(_, pricing)| *pricing)
+            })
+    }
+}
+
+fn load_pricing(path: Option<&Path>) -> Result<PricingCatalog> {
+    let (body, label) = match path {
+        Some(path) => (
+            fs::read_to_string(path)
+                .with_context(|| format!("reading pricing catalog {}", path.display()))?,
+            path.display().to_string(),
+        ),
+        None => (
+            EMBEDDED_PRICING.to_string(),
+            "embedded pricing catalog".to_string(),
+        ),
+    };
+
+    let file: PricingFile = serde_json::from_str(&body).context("parsing pricing catalog")?;
+    if file.schema_version != 1 {
+        bail!(
+            "unsupported pricing schema_version {}; expected 1",
+            file.schema_version
+        );
+    }
+    Ok(PricingCatalog { file, label })
+}
+
+/// Same 4-chars-per-token approximation the rest of the CLI uses for estimates.
+/// It is an estimate, and the report says so.
+fn estimate_tokens(text: &str) -> u64 {
+    text.chars().count().div_ceil(4) as u64
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone, Copy)]
+struct KindStats {
+    judged: usize,
+    true_positive: usize,
+    false_positive: usize,
+    unclear: usize,
+    unparsed: usize,
+    errors: usize,
+}
+
+impl KindStats {
+    fn record(&mut self, verdict: VerdictLabel, parsed: bool) {
+        self.judged += 1;
+        if !parsed {
+            self.unparsed += 1;
+        }
+        match verdict {
+            VerdictLabel::TruePositive => self.true_positive += 1,
+            VerdictLabel::FalsePositive => self.false_positive += 1,
+            VerdictLabel::Unclear => self.unclear += 1,
+        }
+    }
+
+    fn merge(&mut self, other: &KindStats) {
+        self.judged += other.judged;
+        self.true_positive += other.true_positive;
+        self.false_positive += other.false_positive;
+        self.unclear += other.unclear;
+        self.unparsed += other.unparsed;
+        self.errors += other.errors;
+    }
+
+    fn false_positive_rate(&self) -> f64 {
+        if self.judged == 0 {
+            0.0
+        } else {
+            self.false_positive as f64 / self.judged as f64
+        }
+    }
+}
+
+/// Human-readable output goes to stdout normally, but must move to stderr when
+/// the verdict JSONL is being streamed to stdout, so the two stay separable.
+struct Human {
+    to_stderr: bool,
+}
+
+impl Human {
+    fn say(&self, line: impl AsRef<str>) {
+        if self.to_stderr {
+            eprintln!("{}", line.as_ref());
+        } else {
+            println!("{}", line.as_ref());
+        }
+    }
+}
+
+fn percent(part: usize, whole: usize) -> String {
+    if whole == 0 {
+        "-".to_string()
+    } else {
+        format!("{:.1}%", part as f64 * 100.0 / whole as f64)
+    }
+}
+
+fn print_aggregate(human: &Human, stats: &BTreeMap<String, KindStats>) {
+    let mut rows = stats.iter().collect::<Vec<_>>();
+    rows.sort_by(|(left_kind, left), (right_kind, right)| {
+        right
+            .false_positive_rate()
+            .total_cmp(&left.false_positive_rate())
+            .then_with(|| left_kind.cmp(right_kind))
+    });
+
+    let width = rows
+        .iter()
+        .map(|(kind, _)| kind.len())
+        .chain(["kind".len(), "ALL".len()])
+        .max()
+        .unwrap_or(4);
+
+    human.say(format!(
+        "{:<width$} {:>7} {:>8} {:>8} {:>8} {:>7}",
+        "kind", "judged", "true+", "false+", "unclear", "errors"
+    ));
+    let rule = "-".repeat(width + 42);
+    human.say(&rule);
+
+    let mut total = KindStats::default();
+    for (kind, entry) in &rows {
+        total.merge(entry);
+        human.say(format!(
+            "{:<width$} {:>7} {:>8} {:>8} {:>8} {:>7}",
+            kind,
+            entry.judged,
+            percent(entry.true_positive, entry.judged),
+            percent(entry.false_positive, entry.judged),
+            percent(entry.unclear, entry.judged),
+            entry.errors,
+        ));
+    }
+
+    human.say(&rule);
+    human.say(format!(
+        "{:<width$} {:>7} {:>8} {:>8} {:>8} {:>7}",
+        "ALL",
+        total.judged,
+        percent(total.true_positive, total.judged),
+        percent(total.false_positive, total.judged),
+        percent(total.unclear, total.judged),
+        total.errors,
+    ));
+
+    if total.unparsed > 0 {
+        human.say(format!(
+            "\n{} verdict(s) were unparseable and counted as unclear.",
+            total.unparsed
+        ));
+    }
+
+    if let Some((kind, entry)) =
+        rows.iter()
+            .filter(|(_, entry)| entry.judged > 0)
+            .max_by(|(_, left), (_, right)| {
+                left.false_positive_rate()
+                    .total_cmp(&right.false_positive_rate())
+            })
+        && entry.false_positive > 0
+    {
+        human.say(format!(
+            "\nHighest false-positive rate: {kind} ({} of {} flags)",
+            percent(entry.false_positive, entry.judged),
+            entry.judged
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct RunSummary {
+    stats: BTreeMap<String, KindStats>,
+    cached: usize,
+    called: usize,
+    errors: usize,
+    /// Provider-reported usage for the calls that actually happened.
+    input_tokens: u64,
+    output_tokens: u64,
+    /// `--dry-run` only: what the run *would* have cost.
+    estimated_input_tokens: u64,
+    estimated_output_tokens: u64,
+}
+
+/// Judged sequentially on purpose. `--limit` keeps runs small, and one request
+/// at a time makes provider rate-limit behaviour predictable and the log
+/// readable; there is nothing here worth a concurrency budget.
+async fn run_judgement<S: FlagScorer>(
+    scorer: &S,
+    endpoint: &Endpoint,
+    tasks: &[JudgeTask],
+    cache: &VerdictCache,
+    dry_run: bool,
+    human: &Human,
+    verdicts: &mut dyn Write,
+) -> Result<RunSummary> {
+    let mut summary = RunSummary::default();
+
+    for task in tasks {
+        if dry_run {
+            let prompt = scorer.render(task);
+            summary.estimated_input_tokens +=
+                estimate_tokens(&prompt.system) + estimate_tokens(&prompt.user);
+            summary.estimated_output_tokens += ESTIMATED_OUTPUT_TOKENS_PER_UNIT;
+            human.say(format!(
+                "----- {} / {} [{}] -----",
+                task.segment_id, task.block_id, task.kind
+            ));
+            human.say("--- system prompt ---");
+            human.say(&prompt.system);
+            human.say("--- user prompt ---");
+            human.say(&prompt.user);
+            continue;
+        }
+
+        let key = cache_key(scorer.name(), endpoint, task);
+        if let Some(record) = cache.get(&key) {
+            summary.cached += 1;
+            summary
+                .stats
+                .entry(task.kind.clone())
+                .or_default()
+                .record(record.verdict, true);
+            write_verdict(verdicts, &record)?;
+            continue;
+        }
+
+        match scorer.score(task).await {
+            Ok(outcome) => {
+                summary.called += 1;
+                summary.input_tokens += outcome.input_tokens;
+                summary.output_tokens += outcome.output_tokens;
+                let record = VerdictRecord {
+                    segment_id: task.segment_id.clone(),
+                    kind: task.kind.clone(),
+                    verdict: outcome.verdict,
+                    confidence: outcome.confidence,
+                    rationale: outcome.rationale,
+                };
+                summary
+                    .stats
+                    .entry(task.kind.clone())
+                    .or_default()
+                    .record(record.verdict, outcome.parsed);
+                write_verdict(verdicts, &record)?;
+                cache.put(&key, &record);
+            }
+            Err(error) => {
+                // Per-item failure: counted, reported, and skipped. One bad
+                // request must not abort a paid run, and an error is not a
+                // verdict, so it never reaches the verdict stream.
+                summary.errors += 1;
+                summary.stats.entry(task.kind.clone()).or_default().errors += 1;
+                eprintln!(
+                    "warning: {} [{}]: judge call failed: {}",
+                    task.segment_id, task.kind, error.0
+                );
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn write_verdict(sink: &mut dyn Write, record: &VerdictRecord) -> Result<()> {
+    let line = serde_json::to_string(record).context("serializing verdict")?;
+    writeln!(sink, "{line}").context("writing verdict")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+/// A tiny hand-written pairs file so the harness is runnable and reviewable
+/// before the real exporter lands. It is embedded rather than shipped as a
+/// separate data file, and written out on demand with `--write-fixture`.
+///
+/// Line 1 is the known false positive that motivated this tool: the validator
+/// demanded the English word `vaccine` survive into Italian. Line 2 is a real
+/// defect of the same kind, so the two are not distinguishable by kind alone —
+/// which is exactly the discrimination the judge has to make.
+const FIXTURE_JSONL: &str = r#"{"job_id":"job-demo","segment_id":"seg-0142","block_id":"b17","source_language":"English","target_language":"Italian","source_text":"Parents were advised to delay the MMR vaccine.*2","translated_text":"Ai genitori fu consigliato di rimandare il vaccino.*2","validator_flags":[{"kind":"protected_span_missing","message":"protected span missing: vaccine.*2"}]}
+{"job_id":"job-demo","segment_id":"seg-0311","block_id":"b42","source_language":"English","target_language":"Italian","source_text":"The trial enrolled 1,247 children between 1998 and 2001.","translated_text":"Lo studio ha arruolato dei bambini tra il 1998 e il 2001.","validator_flags":[{"kind":"protected_span_missing","message":"protected span missing: 1,247"}]}
+{"job_id":"job-demo","segment_id":"seg-0523","block_id":"b8","source_language":"English","target_language":"Italian","source_text":"He cited the Lancet paper<m4/> throughout his testimony.","translated_text":"Ha citato lo studio del Lancet in tutta la sua testimonianza.","validator_flags":[{"kind":"inline_marker_missing","message":"inline marker missing: m4"}]}
+{"job_id":"job-demo","segment_id":"seg-0704","block_id":"b3","source_language":"English","target_language":"Italian","source_text":"See Appendix B for the full list of excluded studies and the reason for each exclusion.","translated_text":"See Appendix B for the full list of excluded studies and the reason for each exclusion.","validator_flags":[{"kind":"source_copy","message":"translation is unchanged from the source-language prose"}]}
+"#;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if let Some(path) = args.write_fixture.as_deref() {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(path, FIXTURE_JSONL)
+            .with_context(|| format!("writing fixture to {}", path.display()))?;
+        println!(
+            "wrote {} fixture pairs to {}",
+            FIXTURE_JSONL
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .count(),
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let pairs_path = args
+        .pairs
+        .clone()
+        .context("--pairs is required unless --write-fixture is used")?;
+    let endpoint = resolve_endpoint(&args)?;
+
+    // Verdicts stream to stdout when no --out is given, so the human-readable
+    // report has to move aside. A dry run writes no verdicts at all, so it can
+    // keep stdout.
+    let human = Human {
+        to_stderr: args.out.is_none() && !args.dry_run,
+    };
+
+    let (pairs, skipped) = read_pairs(&pairs_path)?;
+    let mut tasks = expand_tasks(&pairs, &args.kinds);
+    let flags_found = tasks.len();
+
+    if args.limit == 0 {
+        eprintln!("warning: --limit 0 removes the spend cap; {flags_found} flag(s) will be judged");
+    } else if tasks.len() > args.limit {
+        tasks.truncate(args.limit);
+    }
+
+    let cache = VerdictCache {
+        dir: if args.no_cache {
+            None
+        } else {
+            Some(args.cache.clone())
+        },
+    };
+
+    let mut verdict_sink: Box<dyn Write> = match args.out.as_deref() {
+        Some(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            Box::new(std::io::BufWriter::new(
+                fs::File::create(path).with_context(|| format!("creating {}", path.display()))?,
+            ))
+        }
+        None => Box::new(std::io::stdout().lock()),
+    };
+
+    let scorer = build_text_scorer(&args, &endpoint)?;
+    let summary = run_judgement(
+        &scorer,
+        &endpoint,
+        &tasks,
+        &cache,
+        args.dry_run,
+        &human,
+        verdict_sink.as_mut(),
+    )
+    .await?;
+    verdict_sink.flush().context("flushing verdict output")?;
+
+    human.say("");
+    human.say("=== Validator flag adjudication ===");
+    human.say(format!(
+        "scorer   : {} ({PROMPT_VERSION})",
+        FlagScorer::name(&scorer)
+    ));
+    human.say(format!("provider : {}", endpoint.provider));
+    human.say(format!("model    : {}", endpoint.model));
+    human.say(format!(
+        "key env  : {} (value never read here)",
+        endpoint.api_key_env
+    ));
+    human.say(format!(
+        "pairs read: {}    flags found: {}    units judged: {}",
+        pairs.len(),
+        flags_found,
+        tasks.len()
+    ));
+    if skipped > 0 {
+        human.say(format!("skipped {skipped} unparsable input line(s)"));
+    }
+    human.say("");
+
+    if args.dry_run {
+        print_dry_run_estimate(&human, &args, &endpoint, &tasks, &summary)?;
+    } else {
+        human.say(format!(
+            "cached {}    called {}    errors {}",
+            summary.cached, summary.called, summary.errors
+        ));
+        human.say("");
+        print_aggregate(&human, &summary.stats);
+    }
+
+    Ok(())
+}
+
+fn build_text_scorer(args: &Args, endpoint: &Endpoint) -> Result<TextScorer> {
+    let config = OpenAiCompatibleConfig {
+        base_url: endpoint.base_url.clone(),
+        api_key_env: endpoint.api_key_env.clone(),
+        model: endpoint.model.clone(),
+        timeout_seconds: args.timeout_seconds,
+        // Adjudication is a side quest: fail the item fast rather than paying
+        // for long retry storms.
+        provider_max_attempts: 3,
+        thinking_disabled: true,
+        retry_after_policy: RetryAfterPolicy::JitteredExponential,
+        max_backoff_seconds: 30,
+        max_idle_per_host: 4,
+        json_mode: JsonMode::Auto,
+    };
+    let provider = OpenAiCompatibleProvider::new(config)
+        .map_err(|error| anyhow::anyhow!("building provider: {error}"))?;
+
+    Ok(TextScorer {
+        provider,
+        endpoint: endpoint.clone(),
+        temperature: args.temperature,
+        max_output_tokens: args.max_output_tokens,
+    })
+}
+
+fn print_dry_run_estimate(
+    human: &Human,
+    args: &Args,
+    endpoint: &Endpoint,
+    tasks: &[JudgeTask],
+    summary: &RunSummary,
+) -> Result<()> {
+    let pricing = load_pricing(args.pricing.as_deref())?;
+
+    human.say("=== Dry run estimate ===");
+    human.say("mode       : DRY RUN - no provider calls were made");
+    human.say(format!("units      : {}", tasks.len()));
+    human.say(format!(
+        "est. input : {} tokens",
+        summary.estimated_input_tokens
+    ));
+    human.say(format!(
+        "est. output: {} tokens",
+        summary.estimated_output_tokens
+    ));
+
+    match pricing.model_pricing(&endpoint.provider, &endpoint.model) {
+        Some(prices) => {
+            let cost = summary.estimated_input_tokens as f64 / 1_000_000.0
+                * prices.input_per_million_usd
+                + summary.estimated_output_tokens as f64 / 1_000_000.0
+                    * prices.output_per_million_usd;
+            human.say(format!(
+                "est. cost  : ${cost:.6} ({} / {}, {})",
+                endpoint.provider, endpoint.model, pricing.label
+            ));
+        }
+        None => human.say(format!(
+            "est. cost  : no pricing entry for {} / {} in {}; cannot estimate cost",
+            endpoint.provider, endpoint.model, pricing.label
+        )),
+    }
+
+    Ok(())
+}
+
+fn read_pairs(path: &Path) -> Result<(Vec<JudgePair>, usize)> {
+    let file =
+        fs::File::open(path).with_context(|| format!("opening pairs file {}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut pairs = Vec::new();
+    let mut skipped = 0usize;
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading {}", path.display()))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<JudgePair>(trimmed) {
+            Ok(pair) => pairs.push(pair),
+            Err(error) => {
+                skipped += 1;
+                eprintln!(
+                    "warning: {}:{}: skipping unparsable pair: {error}",
+                    path.display(),
+                    index + 1
+                );
+            }
+        }
+    }
+
+    Ok((pairs, skipped))
+}
+
+fn expand_tasks(pairs: &[JudgePair], kinds: &[String]) -> Vec<JudgeTask> {
+    pairs
+        .iter()
+        .flat_map(|pair| {
+            pair.validator_flags
+                .iter()
+                .filter(|flag| kinds.is_empty() || kinds.iter().any(|kind| kind == &flag.kind))
+                .map(|flag| JudgeTask {
+                    job_id: pair.job_id.clone(),
+                    segment_id: pair.segment_id.clone(),
+                    block_id: pair.block_id.clone(),
+                    source_language: pair.source_language.clone(),
+                    target_language: pair.target_language.clone(),
+                    source_text: pair.source_text.clone(),
+                    translated_text: pair.translated_text.clone(),
+                    kind: flag.kind.clone(),
+                    message: flag.message.clone(),
+                })
+        })
+        .collect()
+}

--- a/crates/bookforge-cli/examples/replay_validation.rs
+++ b/crates/bookforge-cli/examples/replay_validation.rs
@@ -123,11 +123,12 @@ struct EmittedPair {
 struct Totals {
     jobs_considered: usize,
     jobs_replayed: usize,
+    settings_resolved: usize,
+    skipped_settings_unreadable: usize,
     skipped_no_snapshot_path: usize,
     skipped_missing_snapshot: usize,
     skipped_epub_unreadable: usize,
     skipped_segmentation_failed: usize,
-    jobs_without_config_snapshot: usize,
 
     stored_block_rows: usize,
     pairs_replayed: usize,
@@ -219,17 +220,26 @@ fn main() -> Result<()> {
         totals.jobs_considered += 1;
 
         let snapshot = match store.load_job_config_snapshot(&job.id) {
-            Ok(snapshot) => snapshot,
+            Ok(Some(snapshot)) => {
+                totals.settings_resolved += 1;
+                snapshot
+            }
+            Ok(None) => {
+                totals.skipped_settings_unreadable += 1;
+                warn(&format!(
+                    "{}: no run configuration snapshot; skipping rather than replaying with defaults",
+                    job.id
+                ));
+                continue;
+            }
             Err(error) => {
+                totals.skipped_settings_unreadable += 1;
                 warn(&format!("{}: config snapshot unreadable: {error}", job.id));
-                None
+                continue;
             }
         };
-        if snapshot.is_none() {
-            totals.jobs_without_config_snapshot += 1;
-        }
 
-        let Some(epub_path) = resolve_snapshot_path(&root, job, snapshot.as_ref()) else {
+        let Some(epub_path) = resolve_snapshot_path(&root, job, &snapshot) else {
             totals.skipped_no_snapshot_path += 1;
             warn(&format!("{}: no input snapshot recorded", job.id));
             continue;
@@ -256,7 +266,7 @@ fn main() -> Result<()> {
             }
         };
 
-        let (segmentation, batch_config, profile) = replay_settings(snapshot.as_ref());
+        let (segmentation, batch_config, profile) = replay_settings(&snapshot);
         let segments = match build_segments(&book, &segmentation) {
             Ok(segments) => segments,
             Err(error) => {
@@ -270,18 +280,11 @@ fn main() -> Result<()> {
         let section_titles = section_titles(&segments);
 
         let source_lang = snapshot
-            .as_ref()
-            .and_then(|snapshot| snapshot.source_language.clone())
-            .or_else(|| job.source_lang.clone())
+            .source_language
+            .clone()
             .filter(|lang| !lang.trim().is_empty());
-        let target_lang = snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.target_language.clone())
-            .unwrap_or_else(|| job.target_lang.clone());
-        let provider = snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.provider.clone())
-            .unwrap_or_else(|| job.provider.clone());
+        let target_lang = snapshot.target_language.clone();
+        let provider = snapshot.provider.clone();
 
         // Mirrors bookforge_llm::validation::should_validate_source_copy, which
         // is pub(crate) and therefore not reachable from an example.
@@ -541,12 +544,12 @@ fn store_root(db_path: &Path) -> PathBuf {
 fn resolve_snapshot_path(
     root: &Path,
     job: &JobRecord,
-    snapshot: Option<&RunConfigSnapshot>,
+    snapshot: &RunConfigSnapshot,
 ) -> Option<PathBuf> {
     let recorded = job
         .input_snapshot_path
         .clone()
-        .or_else(|| snapshot.and_then(|snapshot| snapshot.input_snapshot_path.clone()));
+        .or_else(|| snapshot.input_snapshot_path.clone());
     if let Some(path) = recorded {
         let resolved = if path.is_absolute() {
             path
@@ -566,22 +569,9 @@ fn resolve_snapshot_path(
 }
 
 fn replay_settings(
-    snapshot: Option<&RunConfigSnapshot>,
+    snapshot: &RunConfigSnapshot,
 ) -> (SegmentationConfig, BatchConfig, TranslationProfile) {
-    let Some(settings) = snapshot.map(|snapshot| snapshot.settings.to_settings()) else {
-        return (
-            SegmentationConfig::default(),
-            BatchConfig {
-                enabled: true,
-                target_tokens: REPLAY_TARGET_TOKENS,
-                max_items: REPLAY_MAX_ITEMS,
-                adaptive_sizing: false,
-                split_on_json_failure: true,
-                repair_invalid_items: true,
-            },
-            TranslationProfile::Balanced,
-        );
-    };
+    let settings = snapshot.settings.to_settings();
     let batch = BatchConfig {
         enabled: true,
         target_tokens: settings.batch.target_tokens.max(REPLAY_TARGET_TOKENS),
@@ -697,6 +687,11 @@ fn print_report(
     println!("\n=== jobs ===");
     println!("considered                 : {}", totals.jobs_considered);
     println!("replayed                   : {}", totals.jobs_replayed);
+    println!("settings resolved          : {}", totals.settings_resolved);
+    println!(
+        "skipped: settings unreadable: {}",
+        totals.skipped_settings_unreadable
+    );
     println!(
         "skipped: no snapshot path  : {}",
         totals.skipped_no_snapshot_path
@@ -713,11 +708,6 @@ fn print_report(
         "skipped: segmentation fail : {}",
         totals.skipped_segmentation_failed
     );
-    println!(
-        "without config snapshot    : {}",
-        totals.jobs_without_config_snapshot
-    );
-
     println!("\n=== pairs ===");
     println!("stored block rows          : {}", totals.stored_block_rows);
     println!("pairs replayed             : {}", totals.pairs_replayed);

--- a/crates/bookforge-cli/examples/replay_validation.rs
+++ b/crates/bookforge-cli/examples/replay_validation.rs
@@ -1,0 +1,816 @@
+//! Replay BookForge's batch translation validator over the on-disk job store.
+//!
+//! `batch_item_validation_error` is a pure function over (source block, model
+//! output). Every ingredient it needs is already on disk: the `input.epub`
+//! snapshot of every job plus the per-block translations the run stored. This
+//! example re-derives the blocks from the snapshots, re-runs the validator over
+//! the stored translations, and diffs the result against the flags the original
+//! run recorded in `segments.error`. Zero API calls, zero cost.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --release --example replay_validation -- --db .bookforge/jobs.sqlite
+//! ```
+//!
+//! The owner's database is never mutated: `JobStore::open` migrates on open, so
+//! the store file (and its WAL sidecars) is copied into a temporary directory
+//! first and the copy is what gets opened.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fs,
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use bookforge_core::{
+    config::{BatchConfig, SegmentationConfig, TranslationProfile},
+    run_snapshot::RunConfigSnapshot,
+    segment::{Segment, build_segments},
+};
+use bookforge_epub::read_epub;
+use bookforge_llm::{
+    TranslationBatchItem, batch::batch_item_validation_error, build_translation_batches,
+};
+use bookforge_store::{JobRecord, JobStore};
+use clap::Parser;
+use serde::Serialize;
+
+/// Kinds the replay and the stored errors are bucketed into. Kept small and
+/// stable: `--emit-pairs` consumers key off these strings.
+const KIND_PROTECTED_SPAN_MISSING: &str = "protected_span_missing";
+const KIND_INLINE_MARKER_MISSING: &str = "inline_marker_missing";
+const KIND_INLINE_MARKER_DUPLICATED: &str = "inline_marker_duplicated";
+const KIND_UNKNOWN_INLINE_MARKER: &str = "unknown_inline_marker";
+const KIND_BATCH_BLOCK_MISMATCH: &str = "batch_translation_block_mismatch";
+const KIND_TRANSLATION_UNCHANGED: &str = "translation_unchanged";
+const KIND_TARGET_LANGUAGE_GATE: &str = "target_language_gate";
+const KIND_OTHER: &str = "other";
+
+const ALL_KINDS: &[&str] = &[
+    KIND_PROTECTED_SPAN_MISSING,
+    KIND_INLINE_MARKER_MISSING,
+    KIND_INLINE_MARKER_DUPLICATED,
+    KIND_UNKNOWN_INLINE_MARKER,
+    KIND_BATCH_BLOCK_MISMATCH,
+    KIND_TRANSLATION_UNCHANGED,
+    KIND_TARGET_LANGUAGE_GATE,
+    KIND_OTHER,
+];
+
+/// Batching only groups items; it never changes the per-item fields the
+/// validator reads. Real runs often ran with batching disabled, which would
+/// make `build_translation_batches` return nothing, so the replay forces it on
+/// with a generous budget.
+const REPLAY_TARGET_TOKENS: usize = 4_000;
+const REPLAY_MAX_ITEMS: usize = 64;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "replay_validation",
+    about = "Replay the translation validator over stored jobs at zero API cost",
+    long_about = "Re-derives every block from each job's input.epub snapshot, pairs it with the \
+                  translation the run stored, re-runs batch_item_validation_error, and reports \
+                  the delta against the flags recorded in segments.error."
+)]
+struct Args {
+    /// Path to the job store. Opened read-only via a throwaway copy.
+    #[arg(long, default_value = ".bookforge/jobs.sqlite")]
+    db: PathBuf,
+
+    /// Only replay these job ids (repeatable).
+    #[arg(long = "job")]
+    jobs: Vec<String>,
+
+    /// Only replay jobs with these target languages (repeatable, case-insensitive).
+    #[arg(long = "target-lang")]
+    target_langs: Vec<String>,
+
+    /// Write every flagged pair to this file as JSONL.
+    #[arg(long)]
+    emit_pairs: Option<PathBuf>,
+
+    /// How many example rows to print per delta bucket.
+    #[arg(long, default_value_t = 10)]
+    max_examples: usize,
+
+    /// Suppress the per-job progress lines.
+    #[arg(long)]
+    quiet: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidatorFlag {
+    kind: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EmittedPair {
+    job_id: String,
+    segment_id: String,
+    block_id: String,
+    source_language: String,
+    target_language: String,
+    source_text: String,
+    translated_text: String,
+    validator_flags: Vec<ValidatorFlag>,
+}
+
+#[derive(Debug, Default)]
+struct Totals {
+    jobs_considered: usize,
+    jobs_replayed: usize,
+    skipped_no_snapshot_path: usize,
+    skipped_missing_snapshot: usize,
+    skipped_epub_unreadable: usize,
+    skipped_segmentation_failed: usize,
+    jobs_without_config_snapshot: usize,
+
+    stored_block_rows: usize,
+    pairs_replayed: usize,
+    unmatched_block_rows: usize,
+    empty_translations: usize,
+    items_without_translation: usize,
+    preserved_source_pairs: usize,
+
+    flagged_pairs: usize,
+    flagged_preserved_source_pairs: usize,
+}
+
+#[derive(Debug, Default)]
+struct DeltaTotals {
+    stored_flagged_segments: usize,
+    replay_flagged_segments: usize,
+    new_flags: usize,
+    lost_replayable: usize,
+    lost_no_pairs: usize,
+    both_kinds_agree: usize,
+    both_kinds_differ: usize,
+}
+
+struct DeltaExample {
+    job_id: String,
+    segment_id: String,
+    stored_kinds: Vec<&'static str>,
+    replay_kinds: Vec<&'static str>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let db_path = args.db.clone();
+    if !db_path.exists() {
+        anyhow::bail!("job store not found: {}", db_path.display());
+    }
+
+    let temp = tempfile::tempdir().context("creating a scratch dir for the store copy")?;
+    let copy_path = copy_store(&db_path, temp.path())?;
+    println!(
+        "store       : {} (replayed against a throwaway copy; the original is never written)",
+        db_path.display()
+    );
+
+    let store = JobStore::open(&copy_path).context("opening the copied job store")?;
+    let root = store_root(&db_path);
+
+    let job_filter: HashSet<&str> = args.jobs.iter().map(String::as_str).collect();
+    let lang_filter: Vec<String> = args
+        .target_langs
+        .iter()
+        .map(|lang| lang.to_ascii_lowercase())
+        .collect();
+
+    let mut totals = Totals::default();
+    let mut flagged_by_kind: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut flagged_by_kind_model_output: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut other_messages: BTreeMap<String, usize> = BTreeMap::new();
+
+    let mut delta = DeltaTotals::default();
+    let mut stored_segment_kinds: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut replay_segment_kinds: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut new_flag_examples: Vec<DeltaExample> = Vec::new();
+    let mut lost_flag_examples: Vec<DeltaExample> = Vec::new();
+    let mut differ_examples: Vec<DeltaExample> = Vec::new();
+
+    let mut emitter = match args.emit_pairs.as_ref() {
+        Some(path) => Some(BufWriter::new(fs::File::create(path).with_context(
+            || format!("creating {} for --emit-pairs", path.display()),
+        )?)),
+        None => None,
+    };
+
+    let summaries = store
+        .list_job_summaries()
+        .context("listing jobs from the store")?;
+
+    for (job, _summary) in &summaries {
+        if !job_filter.is_empty() && !job_filter.contains(job.id.as_str()) {
+            continue;
+        }
+        if !lang_filter.is_empty()
+            && !lang_filter
+                .iter()
+                .any(|lang| job.target_lang.eq_ignore_ascii_case(lang))
+        {
+            continue;
+        }
+        totals.jobs_considered += 1;
+
+        let snapshot = match store.load_job_config_snapshot(&job.id) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                warn(&format!("{}: config snapshot unreadable: {error}", job.id));
+                None
+            }
+        };
+        if snapshot.is_none() {
+            totals.jobs_without_config_snapshot += 1;
+        }
+
+        let Some(epub_path) = resolve_snapshot_path(&root, job, snapshot.as_ref()) else {
+            totals.skipped_no_snapshot_path += 1;
+            warn(&format!("{}: no input snapshot recorded", job.id));
+            continue;
+        };
+        if !epub_path.exists() {
+            totals.skipped_missing_snapshot += 1;
+            warn(&format!(
+                "{}: input snapshot missing at {}",
+                job.id,
+                epub_path.display()
+            ));
+            continue;
+        }
+
+        let book = match read_epub(&epub_path) {
+            Ok(book) => book,
+            Err(error) => {
+                totals.skipped_epub_unreadable += 1;
+                warn(&format!(
+                    "{}: input snapshot does not parse: {error}",
+                    job.id
+                ));
+                continue;
+            }
+        };
+
+        let (segmentation, batch_config, profile) = replay_settings(snapshot.as_ref());
+        let segments = match build_segments(&book, &segmentation) {
+            Ok(segments) => segments,
+            Err(error) => {
+                totals.skipped_segmentation_failed += 1;
+                warn(&format!("{}: segmentation failed: {error}", job.id));
+                continue;
+            }
+        };
+
+        let items = derive_items(&segments, &batch_config, profile);
+        let section_titles = section_titles(&segments);
+
+        let source_lang = snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.source_language.clone())
+            .or_else(|| job.source_lang.clone())
+            .filter(|lang| !lang.trim().is_empty());
+        let target_lang = snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.target_language.clone())
+            .unwrap_or_else(|| job.target_lang.clone());
+        let provider = snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.provider.clone())
+            .unwrap_or_else(|| job.provider.clone());
+
+        // Mirrors bookforge_llm::validation::should_validate_source_copy, which
+        // is pub(crate) and therefore not reachable from an example.
+        let is_mock = provider.eq_ignore_ascii_case("mock");
+        let validate_source_copy = !is_mock
+            && source_lang
+                .as_deref()
+                .map(|source| !source.eq_ignore_ascii_case(&target_lang))
+                .unwrap_or(true);
+        // Mirrors the call site in bookforge_llm::batch::execution.
+        let target_language_arg = (!is_mock).then_some(target_lang.as_str());
+
+        let stored_blocks = match store.load_block_translations(&job.id) {
+            Ok(blocks) => blocks,
+            Err(error) => {
+                warn(&format!(
+                    "{}: block translations unreadable: {error}",
+                    job.id
+                ));
+                continue;
+            }
+        };
+        let segment_records = match store.segment_records(&job.id) {
+            Ok(records) => records,
+            Err(error) => {
+                warn(&format!("{}: segment records unreadable: {error}", job.id));
+                continue;
+            }
+        };
+
+        totals.jobs_replayed += 1;
+        totals.stored_block_rows += stored_blocks.len();
+
+        let mut job_pairs = 0usize;
+        let mut job_flagged = 0usize;
+        let mut segments_with_pairs: HashSet<String> = HashSet::new();
+        let mut replay_flags_by_segment: HashMap<String, BTreeSet<&'static str>> = HashMap::new();
+        let mut matched_items: HashSet<(String, String)> = HashSet::new();
+
+        for stored in &stored_blocks {
+            let key = (stored.segment_id.clone(), stored.block_id.clone());
+            let Some(item) = items.get(&key) else {
+                totals.unmatched_block_rows += 1;
+                continue;
+            };
+            matched_items.insert(key);
+            if stored.text.trim().is_empty() {
+                totals.empty_translations += 1;
+                continue;
+            }
+
+            let preserved_source = item.source_text == stored.text;
+            if preserved_source {
+                totals.preserved_source_pairs += 1;
+            }
+            totals.pairs_replayed += 1;
+            job_pairs += 1;
+            segments_with_pairs.insert(stored.segment_id.clone());
+
+            let section_title = section_titles.get(&stored.segment_id).map(String::as_str);
+            let Some(message) = batch_item_validation_error(
+                item,
+                &stored.text,
+                validate_source_copy,
+                section_title,
+                target_language_arg,
+            ) else {
+                continue;
+            };
+
+            let kinds = classify_kinds(&message);
+            totals.flagged_pairs += 1;
+            job_flagged += 1;
+            for kind in &kinds {
+                *flagged_by_kind.entry(*kind).or_default() += 1;
+                if !preserved_source {
+                    *flagged_by_kind_model_output.entry(*kind).or_default() += 1;
+                }
+                if *kind == KIND_OTHER {
+                    *other_messages.entry(message_prefix(&message)).or_default() += 1;
+                }
+            }
+            if preserved_source {
+                totals.flagged_preserved_source_pairs += 1;
+            }
+            replay_flags_by_segment
+                .entry(stored.segment_id.clone())
+                .or_default()
+                .extend(kinds.iter().copied());
+
+            if let Some(writer) = emitter.as_mut() {
+                let pair = EmittedPair {
+                    job_id: job.id.clone(),
+                    segment_id: stored.segment_id.clone(),
+                    block_id: stored.block_id.clone(),
+                    source_language: source_lang.clone().unwrap_or_default(),
+                    target_language: target_lang.clone(),
+                    source_text: item.source_text.clone(),
+                    translated_text: stored.text.clone(),
+                    validator_flags: kinds
+                        .iter()
+                        .map(|kind| ValidatorFlag {
+                            kind,
+                            message: message.clone(),
+                        })
+                        .collect(),
+                };
+                let line = serde_json::to_string(&pair)
+                    .context("serializing a flagged pair for --emit-pairs")?;
+                writer.write_all(line.as_bytes())?;
+                writer.write_all(b"\n")?;
+            }
+        }
+
+        totals.items_without_translation += items.len() - matched_items.len();
+
+        for record in &segment_records {
+            let stored_kinds: BTreeSet<&'static str> = record
+                .error
+                .as_deref()
+                .map(str::trim)
+                .filter(|error| !error.is_empty())
+                .map(|error| classify_kinds(error).into_iter().collect())
+                .unwrap_or_default();
+            let replay_kinds = replay_flags_by_segment
+                .get(&record.id)
+                .cloned()
+                .unwrap_or_default();
+
+            if !stored_kinds.is_empty() {
+                delta.stored_flagged_segments += 1;
+                for kind in &stored_kinds {
+                    *stored_segment_kinds.entry(*kind).or_default() += 1;
+                }
+            }
+            if !replay_kinds.is_empty() {
+                delta.replay_flagged_segments += 1;
+                for kind in &replay_kinds {
+                    *replay_segment_kinds.entry(*kind).or_default() += 1;
+                }
+            }
+
+            match (stored_kinds.is_empty(), replay_kinds.is_empty()) {
+                (true, true) => {}
+                (true, false) => {
+                    delta.new_flags += 1;
+                    push_example(
+                        &mut new_flag_examples,
+                        args.max_examples,
+                        &job.id,
+                        &record.id,
+                        &stored_kinds,
+                        &replay_kinds,
+                    );
+                }
+                (false, true) => {
+                    if segments_with_pairs.contains(&record.id) {
+                        delta.lost_replayable += 1;
+                        push_example(
+                            &mut lost_flag_examples,
+                            args.max_examples,
+                            &job.id,
+                            &record.id,
+                            &stored_kinds,
+                            &replay_kinds,
+                        );
+                    } else {
+                        delta.lost_no_pairs += 1;
+                    }
+                }
+                (false, false) => {
+                    if stored_kinds == replay_kinds {
+                        delta.both_kinds_agree += 1;
+                    } else {
+                        delta.both_kinds_differ += 1;
+                        push_example(
+                            &mut differ_examples,
+                            args.max_examples,
+                            &job.id,
+                            &record.id,
+                            &stored_kinds,
+                            &replay_kinds,
+                        );
+                    }
+                }
+            }
+        }
+
+        if !args.quiet {
+            println!(
+                "  {} [{}] pairs={job_pairs} flagged={job_flagged}",
+                job.id, target_lang
+            );
+        }
+    }
+
+    if let Some(mut writer) = emitter {
+        writer.flush().context("flushing --emit-pairs output")?;
+    }
+
+    print_report(
+        &args,
+        &totals,
+        &flagged_by_kind,
+        &flagged_by_kind_model_output,
+        &other_messages,
+        &delta,
+        &stored_segment_kinds,
+        &replay_segment_kinds,
+        &new_flag_examples,
+        &lost_flag_examples,
+        &differ_examples,
+    );
+
+    Ok(())
+}
+
+fn warn(message: &str) {
+    eprintln!("warning: {message}");
+}
+
+fn copy_store(db_path: &Path, dir: &Path) -> Result<PathBuf> {
+    let name = db_path
+        .file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("jobs.sqlite"));
+    let target = dir.join(&name);
+    fs::copy(db_path, &target)
+        .with_context(|| format!("copying {} into a scratch dir", db_path.display()))?;
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = sidecar_path(db_path, suffix);
+        if sidecar.exists() {
+            let sidecar_target = sidecar_path(&target, suffix);
+            fs::copy(&sidecar, &sidecar_target)
+                .with_context(|| format!("copying {}", sidecar.display()))?;
+        }
+    }
+    Ok(target)
+}
+
+fn sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// `<root>/.bookforge/jobs.sqlite` -> `<root>`; run snapshot paths are stored
+/// relative to that root.
+fn store_root(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn resolve_snapshot_path(
+    root: &Path,
+    job: &JobRecord,
+    snapshot: Option<&RunConfigSnapshot>,
+) -> Option<PathBuf> {
+    let recorded = job
+        .input_snapshot_path
+        .clone()
+        .or_else(|| snapshot.and_then(|snapshot| snapshot.input_snapshot_path.clone()));
+    if let Some(path) = recorded {
+        let resolved = if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        };
+        if resolved.exists() {
+            return Some(resolved);
+        }
+    }
+    let fallback = root
+        .join(".bookforge")
+        .join("runs")
+        .join(&job.id)
+        .join("input.epub");
+    fallback.exists().then_some(fallback)
+}
+
+fn replay_settings(
+    snapshot: Option<&RunConfigSnapshot>,
+) -> (SegmentationConfig, BatchConfig, TranslationProfile) {
+    let Some(settings) = snapshot.map(|snapshot| snapshot.settings.to_settings()) else {
+        return (
+            SegmentationConfig::default(),
+            BatchConfig {
+                enabled: true,
+                target_tokens: REPLAY_TARGET_TOKENS,
+                max_items: REPLAY_MAX_ITEMS,
+                adaptive_sizing: false,
+                split_on_json_failure: true,
+                repair_invalid_items: true,
+            },
+            TranslationProfile::Balanced,
+        );
+    };
+    let batch = BatchConfig {
+        enabled: true,
+        target_tokens: settings.batch.target_tokens.max(REPLAY_TARGET_TOKENS),
+        max_items: settings.batch.max_items.max(REPLAY_MAX_ITEMS),
+        ..settings.batch.clone()
+    };
+    (settings.segmentation, batch, settings.profile)
+}
+
+fn derive_items(
+    segments: &[Segment],
+    batch_config: &BatchConfig,
+    profile: TranslationProfile,
+) -> HashMap<(String, String), TranslationBatchItem> {
+    build_translation_batches(segments, batch_config, profile)
+        .into_iter()
+        .flat_map(|batch| batch.items)
+        .map(|item| ((item.segment_id.0.clone(), item.block_id.0.clone()), item))
+        .collect()
+}
+
+fn section_titles(segments: &[Segment]) -> HashMap<String, String> {
+    segments
+        .iter()
+        .filter_map(|segment| {
+            segment
+                .metadata
+                .section_title
+                .as_ref()
+                .map(|title| (segment.id.0.clone(), title.clone()))
+        })
+        .collect()
+}
+
+/// Bucket a validator message. Stored `segments.error` strings are `; `-joined
+/// and can mention several failures, so this returns every kind it finds.
+fn classify_kinds(message: &str) -> Vec<&'static str> {
+    let mut kinds = Vec::new();
+    if message.contains("protected span missing") {
+        kinds.push(KIND_PROTECTED_SPAN_MISSING);
+    }
+    if message.contains("inline marker missing") {
+        kinds.push(KIND_INLINE_MARKER_MISSING);
+    }
+    if message.contains("inline marker duplicated") {
+        kinds.push(KIND_INLINE_MARKER_DUPLICATED);
+    }
+    if message.contains("unknown inline marker") {
+        kinds.push(KIND_UNKNOWN_INLINE_MARKER);
+    }
+    if message.contains("batch translation block mismatch")
+        || message.contains("batch translation missing block translation")
+        || message.contains("item missing from batch response")
+    {
+        kinds.push(KIND_BATCH_BLOCK_MISMATCH);
+    }
+    if message.contains("translation is unchanged") {
+        kinds.push(KIND_TRANSLATION_UNCHANGED);
+    }
+    if message.contains("Toki Pona")
+        || message.contains("unapproved lowercase word")
+        || message.contains("pathological repeated")
+        || message.contains("must not be followed by li")
+        || message.contains("pi must group")
+        || message.contains("en may only coordinate")
+    {
+        kinds.push(KIND_TARGET_LANGUAGE_GATE);
+    }
+    if kinds.is_empty() {
+        kinds.push(KIND_OTHER);
+    }
+    kinds
+}
+
+fn message_prefix(message: &str) -> String {
+    let trimmed: String = message.chars().take(60).collect();
+    trimmed.replace(['\n', '\r'], " ")
+}
+
+fn push_example(
+    sink: &mut Vec<DeltaExample>,
+    limit: usize,
+    job_id: &str,
+    segment_id: &str,
+    stored: &BTreeSet<&'static str>,
+    replay: &BTreeSet<&'static str>,
+) {
+    if sink.len() >= limit {
+        return;
+    }
+    sink.push(DeltaExample {
+        job_id: job_id.to_string(),
+        segment_id: segment_id.to_string(),
+        stored_kinds: stored.iter().copied().collect(),
+        replay_kinds: replay.iter().copied().collect(),
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_report(
+    args: &Args,
+    totals: &Totals,
+    flagged_by_kind: &BTreeMap<&'static str, usize>,
+    flagged_model_output: &BTreeMap<&'static str, usize>,
+    other_messages: &BTreeMap<String, usize>,
+    delta: &DeltaTotals,
+    stored_segment_kinds: &BTreeMap<&'static str, usize>,
+    replay_segment_kinds: &BTreeMap<&'static str, usize>,
+    new_flag_examples: &[DeltaExample],
+    lost_flag_examples: &[DeltaExample],
+    differ_examples: &[DeltaExample],
+) {
+    println!("\n=== jobs ===");
+    println!("considered                 : {}", totals.jobs_considered);
+    println!("replayed                   : {}", totals.jobs_replayed);
+    println!(
+        "skipped: no snapshot path  : {}",
+        totals.skipped_no_snapshot_path
+    );
+    println!(
+        "skipped: snapshot missing  : {}",
+        totals.skipped_missing_snapshot
+    );
+    println!(
+        "skipped: epub unreadable   : {}",
+        totals.skipped_epub_unreadable
+    );
+    println!(
+        "skipped: segmentation fail : {}",
+        totals.skipped_segmentation_failed
+    );
+    println!(
+        "without config snapshot    : {}",
+        totals.jobs_without_config_snapshot
+    );
+
+    println!("\n=== pairs ===");
+    println!("stored block rows          : {}", totals.stored_block_rows);
+    println!("pairs replayed             : {}", totals.pairs_replayed);
+    println!(
+        "  of which preserved source: {}",
+        totals.preserved_source_pairs
+    );
+    println!(
+        "block rows with no item    : {}",
+        totals.unmatched_block_rows
+    );
+    println!("empty translations         : {}", totals.empty_translations);
+    println!(
+        "items with no translation  : {}",
+        totals.items_without_translation
+    );
+
+    println!("\n=== flagged pairs (current code) ===");
+    println!("total flagged              : {}", totals.flagged_pairs);
+    print_kind_table(flagged_by_kind);
+
+    let model_output_flagged = totals
+        .flagged_pairs
+        .saturating_sub(totals.flagged_preserved_source_pairs);
+    println!(
+        "\n=== flagged pairs excluding preserved-source pairs ({model_output_flagged}) ===\n\
+         (a needs-review segment stores the preserved SOURCE text, so those pairs say nothing\n\
+          about the model's output; this is the number that measures the validator)"
+    );
+    print_kind_table(flagged_model_output);
+
+    if !other_messages.is_empty() {
+        println!("\n=== `other` messages (top 15 by count) ===");
+        let mut rows: Vec<(&String, &usize)> = other_messages.iter().collect();
+        rows.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        for (prefix, count) in rows.into_iter().take(15) {
+            println!("  {count:>6}  {prefix}");
+        }
+    }
+
+    println!("\n=== delta vs the stored run (per segment) ===");
+    println!(
+        "stored flagged segments    : {}",
+        delta.stored_flagged_segments
+    );
+    print_kind_table(stored_segment_kinds);
+    println!(
+        "replay flagged segments    : {}",
+        delta.replay_flagged_segments
+    );
+    print_kind_table(replay_segment_kinds);
+    println!("new flags (replay only)    : {}", delta.new_flags);
+    println!(
+        "lost flags (stored only)    : {} replayable + {} with nothing to replay",
+        delta.lost_replayable, delta.lost_no_pairs
+    );
+    println!(
+        "flagged on both sides       : {} agree / {} differ",
+        delta.both_kinds_agree, delta.both_kinds_differ
+    );
+
+    print_examples("new flags", new_flag_examples, args.max_examples);
+    print_examples(
+        "lost flags (replayable)",
+        lost_flag_examples,
+        args.max_examples,
+    );
+    print_examples("kinds differ", differ_examples, args.max_examples);
+}
+
+fn print_kind_table(counts: &BTreeMap<&'static str, usize>) {
+    let mut rows: Vec<(&'static str, usize)> = ALL_KINDS
+        .iter()
+        .map(|kind| (*kind, counts.get(kind).copied().unwrap_or(0)))
+        .collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    for (kind, count) in rows {
+        println!("  {count:>6}  {kind}");
+    }
+}
+
+fn print_examples(label: &str, examples: &[DeltaExample], limit: usize) {
+    if examples.is_empty() {
+        return;
+    }
+    println!("\n--- {label} (up to {limit}) ---");
+    for example in examples {
+        println!(
+            "  {} {} stored=[{}] replay=[{}]",
+            example.job_id,
+            example.segment_id,
+            example.stored_kinds.join(","),
+            example.replay_kinds.join(",")
+        );
+    }
+}

--- a/crates/bookforge-cli/src/commands/review.rs
+++ b/crates/bookforge-cli/src/commands/review.rs
@@ -11,7 +11,7 @@ use bookforge_core::{
     GlossaryTerm, RunConfigSnapshot, segment::build_segments, target_matches, term_matches,
 };
 use bookforge_epub::read_epub;
-use bookforge_store::{JobRecord, JobStore};
+use bookforge_store::{JobRecord, JobStore, QaFindingCount, StoredQaFinding};
 use clap::Args;
 use serde::Serialize;
 
@@ -45,7 +45,26 @@ pub(crate) struct ReviewDocument {
     source_book_author: Option<String>,
     source_input_snapshot: Option<String>,
     totals: ReviewTotals,
+    /// Per-kind classification of every flagged segment, count-descending.
+    /// Mirrors what `bookforge status <job-id>` prints; both read the same
+    /// `qa_findings` rows so the two surfaces can never disagree.
+    finding_breakdown: Vec<ReviewFindingCount>,
     segments: Vec<ReviewSegment>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ReviewFindingCount {
+    kind: String,
+    severity: String,
+    count: usize,
+    share_percent: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReviewFinding {
+    kind: String,
+    severity: String,
+    message: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -69,6 +88,9 @@ pub(crate) struct ReviewSegment {
     human_corrected: bool,
     corrected_at: Option<String>,
     flagged: bool,
+    /// Structured QA findings persisted for this segment, one per distinct
+    /// failure parsed out of `segments.error`.
+    findings: Vec<ReviewFinding>,
     soft_warnings: Vec<ReviewWarning>,
     tokens: ReviewTokens,
     status: String,
@@ -160,6 +182,8 @@ pub(crate) fn generate_review_document(store: &JobStore, job_id: &str) -> Result
         &flagged_segment_ids,
         &summary,
         &glossary_terms,
+        &store.qa_finding_breakdown(&job.id)?,
+        &store.segment_qa_findings(&job.id)?,
     ))
 }
 
@@ -243,7 +267,21 @@ fn build_review_document(
     flagged_segment_ids: &std::collections::HashSet<String>,
     summary: &bookforge_store::JobSummary,
     glossary_terms: &[GlossaryTerm],
+    finding_counts: &[QaFindingCount],
+    stored_findings: &[StoredQaFinding],
 ) -> ReviewDocument {
+    let mut findings_by_segment: HashMap<&str, Vec<ReviewFinding>> = HashMap::new();
+    for finding in stored_findings {
+        findings_by_segment
+            .entry(finding.segment_id.as_str())
+            .or_default()
+            .push(ReviewFinding {
+                kind: finding.kind.clone(),
+                severity: finding.severity.clone(),
+                message: finding.message.clone(),
+            });
+    }
+
     let records_by_id = records
         .iter()
         .map(|record| (record.id.as_str(), record))
@@ -303,6 +341,10 @@ fn build_review_document(
                 corrected_at: stored_translation
                     .and_then(|translation| translation.corrected_at.clone()),
                 flagged: flagged_segment_ids.contains(&segment.id.0),
+                findings: findings_by_segment
+                    .get(segment.id.0.as_str())
+                    .cloned()
+                    .unwrap_or_default(),
                 soft_warnings: soft_warnings(
                     record,
                     &segment.source.text,
@@ -349,8 +391,24 @@ fn build_review_document(
                 summary.output_tokens,
             ),
         },
+        finding_breakdown: review_finding_counts(finding_counts),
         segments: review_segments,
     }
+}
+
+/// Re-shape the store's breakdown for the review document, precomputing each
+/// kind's share so the HTML never has to derive percentages of its own.
+fn review_finding_counts(counts: &[QaFindingCount]) -> Vec<ReviewFindingCount> {
+    let total = counts.iter().map(|count| count.count).sum::<usize>();
+    counts
+        .iter()
+        .map(|count| ReviewFindingCount {
+            kind: count.kind.clone(),
+            severity: count.severity.clone(),
+            count: count.count,
+            share_percent: count.share_percent(total),
+        })
+        .collect()
 }
 
 fn soft_warnings(
@@ -563,6 +621,12 @@ body {
   background: var(--bg);
   color: var(--text);
   font: 14px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  /* Column layout so the flag breakdown strip can be inserted between the
+     header and the panes without the panes' height needing to know how tall
+     the chrome above them happens to be. */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 header {
   position: sticky;
@@ -597,13 +661,40 @@ input[type="search"] {
   padding: 7px 9px;
   background: white;
 }
+.breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.breakdown[hidden] { display: none; }
+.breakdown-label { color: var(--muted); font-size: 12px; text-transform: uppercase; }
+.finding-chip {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 3px 9px 5px;
+  font-size: 12px;
+}
+.finding-chip[aria-pressed="true"] { border-color: var(--accent); background: #e7f5f2; }
+.chip-kind { font-weight: 600; }
+.chip-share { color: var(--muted); }
+.chip-bar { position: absolute; left: 0; bottom: 0; height: 2px; background: var(--warn); }
+.finding-chip.sev-error .chip-bar { background: var(--bad); }
 .review-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  height: calc(100vh - 64px);
+  flex: 1 1 auto;
+  min-height: 0;
 }
 .pane {
   overflow: auto;
+  min-height: 0;
   padding: 12px;
   border-right: 1px solid var(--line);
 }
@@ -647,11 +738,13 @@ input[type="search"] {
   padding: 1px 7px;
   font-size: 11px;
 }
-.badge.status-needs_review, .badge.status-failed, .badge.glossary-mismatch {
+.badge.status-needs_review, .badge.status-failed, .badge.glossary-mismatch,
+.badge.finding.sev-error {
   border-color: #fecaca;
   background: #fef2f2;
   color: var(--bad);
 }
+.badge.finding { border-style: dashed; }
 .flag-panel {
   display: none;
   margin-top: 10px;
@@ -673,7 +766,7 @@ footer { padding: 10px 16px; color: var(--muted); font-size: 12px; border-top: 1
 @media (max-width: 840px) {
   header { grid-template-columns: 1fr; }
   .toolbar { justify-content: flex-start; }
-  .review-shell { grid-template-columns: 1fr; height: auto; }
+  .review-shell { grid-template-columns: 1fr; flex: 0 0 auto; }
   .pane { height: 50vh; border-right: 0; border-bottom: 1px solid var(--line); }
   input[type="search"] { min-width: 0; width: 100%; }
   .suggestions { grid-template-columns: 1fr; }
@@ -708,6 +801,7 @@ const REVIEW_HTML_MIDDLE: &str = r#"
     <button id="export" class="primary">Export flags</button>
   </div>
 </header>
+<section class="breakdown" id="breakdown" hidden></section>
 <main class="review-shell">
   <section class="pane" id="sourcePane"><div class="pane-title">Source</div><div id="sourceList"></div></section>
   <section class="pane" id="targetPane"><div class="pane-title">Translation</div><div id="targetList"></div></section>
@@ -722,6 +816,7 @@ const REVIEW_HTML_SUFFIX: &str = r#"
 let data;
 let flags = {};
 let filter = "all";
+let filterKind = null;
 let syncing = false;
 
 const kinds = ["name", "register", "wrong_translation", "formatting", "tone", "other"];
@@ -756,6 +851,58 @@ function updateMeta() {
   document.getElementById("meta").textContent =
     `${data.provider}/${data.model} | ${totals.segments} segments | ${flagged} flagged | ` +
     `${totals.tokens_input} input, ${totals.tokens_input_cached} cached, ${totals.tokens_output} output tokens`;
+}
+
+function kindLabel(kind) {
+  return kind.replaceAll("_", " ");
+}
+
+// The per-kind strip is the whole point of the findings table: a single kind
+// holding most of the flags means one validator is misfiring, which is
+// invisible when every flag just reads "needs review".
+function renderBreakdown() {
+  const host = document.getElementById("breakdown");
+  host.textContent = "";
+  const rows = data.finding_breakdown || [];
+  host.hidden = rows.length === 0;
+  if (host.hidden) return;
+
+  const total = rows.reduce((sum, row) => sum + row.count, 0);
+  const label = document.createElement("span");
+  label.className = "breakdown-label";
+  label.textContent = `Flags by kind (${total})`;
+  host.appendChild(label);
+
+  for (const row of rows) {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = `finding-chip sev-${row.severity}`;
+    chip.title = `${row.count} of ${total} findings (${row.severity})`;
+    chip.setAttribute("aria-pressed", String(filter === "kind" && filterKind === row.kind));
+
+    const name = document.createElement("span");
+    name.className = "chip-kind";
+    name.textContent = kindLabel(row.kind);
+    const share = document.createElement("span");
+    share.className = "chip-share";
+    share.textContent = `${row.count} · ${row.share_percent}%`;
+    const bar = document.createElement("span");
+    bar.className = "chip-bar";
+    bar.style.width = `${Math.max(2, row.share_percent)}%`;
+    chip.append(name, share, bar);
+
+    chip.addEventListener("click", () => {
+      if (filter === "kind" && filterKind === row.kind) {
+        filter = "all";
+        filterKind = null;
+      } else {
+        filter = "kind";
+        filterKind = row.kind;
+      }
+      render();
+    });
+    host.appendChild(chip);
+  }
 }
 
 function warningLabel(w) {
@@ -795,6 +942,13 @@ function renderSegment(segment, side) {
     const b = document.createElement("span");
     b.className = `badge status-${segment.status}`;
     b.textContent = segment.status.replaceAll("_", " ");
+    badges.appendChild(b);
+  }
+  for (const finding of segment.findings || []) {
+    const b = document.createElement("span");
+    b.className = `badge finding sev-${finding.severity}`;
+    b.textContent = kindLabel(finding.kind);
+    b.title = finding.message;
     badges.appendChild(b);
   }
   for (const warning of segment.soft_warnings) {
@@ -891,6 +1045,10 @@ function renderFlagPanel(segment) {
 function render() {
   document.getElementById("title").textContent = data.source_book_title || "BookForge Review";
   updateMeta();
+  renderBreakdown();
+  document.querySelectorAll("[data-filter]").forEach(button => {
+    button.classList.toggle("active", button.dataset.filter === filter);
+  });
   const query = document.getElementById("search").value.trim().toLowerCase();
   const sourceList = document.getElementById("sourceList");
   const targetList = document.getElementById("targetList");
@@ -904,6 +1062,7 @@ function render() {
        (filter === "flagged" && hasFlag) ||
        (filter === "warnings" && segment.soft_warnings.length > 0) ||
        (filter === "needs_review" && segment.status === "needs_review") ||
+       (filter === "kind" && (segment.findings || []).some(finding => finding.kind === filterKind)) ||
        (filter === "completed" && (segment.status === "succeeded" || segment.status === "skipped_cached")));
     if (!visible) continue;
     sourceList.appendChild(renderSegment(segment, "source"));
@@ -952,7 +1111,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.querySelectorAll("[data-filter]").forEach(button => {
     button.addEventListener("click", () => {
       filter = button.dataset.filter;
-      document.querySelectorAll("[data-filter]").forEach(b => b.classList.toggle("active", b === button));
+      filterKind = null;
       render();
     });
   });
@@ -982,6 +1141,30 @@ mod tests {
         let html = render_html(&json!({"schema_version": 1, "x": "<tag>"}).to_string());
         assert!(html.contains("embedded-review-json"));
         assert!(html.contains("\\u003ctag\\u003e"));
+    }
+
+    #[test]
+    fn review_finding_counts_precompute_each_kind_share() {
+        let counts = review_finding_counts(&[
+            QaFindingCount {
+                kind: "protected_span_missing".to_string(),
+                severity: "error".to_string(),
+                count: 478,
+            },
+            QaFindingCount {
+                kind: "source_copy_unchanged".to_string(),
+                severity: "warning".to_string(),
+                count: 191,
+            },
+        ]);
+
+        assert_eq!(counts[0].share_percent, 71.4);
+        assert_eq!(counts[1].share_percent, 28.6);
+    }
+
+    #[test]
+    fn review_finding_counts_are_empty_without_findings() {
+        assert!(review_finding_counts(&[]).is_empty());
     }
 
     #[test]

--- a/crates/bookforge-cli/src/commands/status.rs
+++ b/crates/bookforge-cli/src/commands/status.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use std::path::PathBuf;
 
 use bookforge_core::RunConfigSnapshot;
-use bookforge_store::{JobRecord, JobStore, JobSummary};
+use bookforge_store::{JobRecord, JobStore, JobSummary, QaFindingCount};
 
 use crate::{
     commands::reconfigure,
@@ -61,6 +61,9 @@ pub async fn run(args: StatusArgs) -> anyhow::Result<()> {
     println!("  needs review: {}", summary.needs_review);
     println!("  failed:      {}", summary.failed);
     println!("  retry pending: {}", summary.retry_pending);
+    for line in format_finding_breakdown(&store.qa_finding_breakdown(&args.job_id)?) {
+        println!("{line}");
+    }
     println!();
     println!("Tokens:");
     println!("  input:  {}", summary.input_tokens);
@@ -114,6 +117,36 @@ fn report_path_for_status(job: &JobRecord, snapshot: Option<&RunConfigSnapshot>)
         .clone()
         .or_else(|| snapshot.and_then(|snapshot| snapshot.report_markdown_path.clone()))
         .unwrap_or(fallback_reports.markdown)
+}
+
+/// Render the per-kind breakdown of a job's stored QA findings.
+///
+/// `segments.error` records *that* a segment was flagged and carries the raw
+/// detail, but only a count per kind makes a systematic problem visible: one
+/// kind sitting at 70% of all flags is a bug in that one validator, not
+/// hundreds of independently bad translations. Returns an empty vector when
+/// the job has no findings so the caller prints nothing at all.
+fn format_finding_breakdown(findings: &[QaFindingCount]) -> Vec<String> {
+    if findings.is_empty() {
+        return Vec::new();
+    }
+
+    let total = findings.iter().map(|finding| finding.count).sum::<usize>();
+    let width = findings
+        .iter()
+        .map(|finding| finding.kind.len())
+        .max()
+        .unwrap_or_default();
+
+    let mut lines = vec![String::new(), format!("Flag breakdown ({total} findings):")];
+    lines.extend(findings.iter().map(|finding| {
+        let kind = &finding.kind;
+        let count = finding.count;
+        let share = finding.share_percent(total);
+        let severity = &finding.severity;
+        format!("  {kind:<width$}  {count:>6}  {share:>5.1}%  {severity}")
+    }));
+    lines
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,6 +327,35 @@ mod tests {
         };
 
         assert_eq!(guidance_for_summary(&summary), Some(StatusGuidance::Resume));
+    }
+
+    fn finding_count(kind: &str, severity: &str, count: usize) -> QaFindingCount {
+        QaFindingCount {
+            kind: kind.to_string(),
+            severity: severity.to_string(),
+            count,
+        }
+    }
+
+    #[test]
+    fn finding_breakdown_is_omitted_when_a_job_has_no_findings() {
+        assert!(format_finding_breakdown(&[]).is_empty());
+    }
+
+    #[test]
+    fn finding_breakdown_reports_each_kind_with_its_share_of_all_flags() {
+        let lines = format_finding_breakdown(&[
+            finding_count("protected_span_missing", "error", 478),
+            finding_count("source_copy_unchanged", "warning", 191),
+        ]);
+
+        assert_eq!(lines[0], "");
+        assert_eq!(lines[1], "Flag breakdown (669 findings):");
+        assert_eq!(lines[2], "  protected_span_missing     478   71.4%  error");
+        assert_eq!(
+            lines[3],
+            "  source_copy_unchanged      191   28.6%  warning"
+        );
     }
 
     #[test]

--- a/crates/bookforge-cli/src/report.rs
+++ b/crates/bookforge-cli/src/report.rs
@@ -7,7 +7,9 @@ use std::{
 use anyhow::Result;
 use bookforge_core::segment::Segment;
 use bookforge_llm::QaSegmentReview;
-use bookforge_store::{JobRecord, JobSummary, SegmentRecord};
+use bookforge_store::{
+    JobRecord, JobSummary, SegmentRecord, aggregate_findings, classify_segment_error,
+};
 use serde::Serialize;
 
 use crate::cost::estimate_cost_usd_with_cached;
@@ -89,7 +91,16 @@ struct QaReport {
     estimated_cost: Option<f64>,
     qa_reviewed_segments: usize,
     qa_warnings: Vec<QaWarning>,
+    finding_breakdown: Vec<QaFindingBreakdownEntry>,
     performance: Option<RunPerformanceSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QaFindingBreakdownEntry {
+    kind: String,
+    severity: String,
+    count: usize,
+    share_percent: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -130,6 +141,7 @@ pub(crate) fn write_report(input: ReportInput<'_>) -> Result<ReportFiles> {
         ),
         qa_reviewed_segments: input.qa_reviews.len(),
         qa_warnings: qa_warnings(&input),
+        finding_breakdown: finding_breakdown(input.segment_records),
         performance: input.performance.clone(),
     };
 
@@ -151,6 +163,37 @@ pub(crate) fn report_paths(output: &Path) -> ReportFiles {
         json: parent.join(format!("{stem}.report.json")),
         markdown: parent.join(format!("{stem}.report.md")),
     }
+}
+
+/// Per-kind classification of every flagged segment in this run.
+///
+/// `qa_warnings` above lists each flag individually, which buries the shape of
+/// the problem once a book produces hundreds of them. This rolls the same
+/// failures up by kind so a single misfiring validator is obvious at the top of
+/// the list.
+///
+/// The report is written as a run finalizes, so it classifies straight from the
+/// segment records rather than reading `qa_findings` back out of the store.
+/// Both paths run [`classify_segment_error`], so the report and
+/// `bookforge status` cannot drift apart.
+fn finding_breakdown(records: &[SegmentRecord]) -> Vec<QaFindingBreakdownEntry> {
+    let counts = aggregate_findings(
+        records
+            .iter()
+            .filter(|record| matches!(record.status.as_str(), "failed" | "needs_review"))
+            .filter_map(|record| record.error.as_deref())
+            .flat_map(classify_segment_error),
+    );
+    let total = counts.iter().map(|count| count.count).sum::<usize>();
+    counts
+        .iter()
+        .map(|count| QaFindingBreakdownEntry {
+            kind: count.kind.clone(),
+            severity: count.severity.clone(),
+            count: count.count,
+            share_percent: count.share_percent(total),
+        })
+        .collect()
 }
 
 fn qa_warnings(input: &ReportInput<'_>) -> Vec<QaWarning> {
@@ -626,6 +669,18 @@ fn render_markdown(report: &QaReport) -> String {
         }
     }
 
+    output.push_str("\n## Flag Breakdown\n\n");
+    if report.finding_breakdown.is_empty() {
+        output.push_str("No flagged segments.\n");
+    } else {
+        for entry in &report.finding_breakdown {
+            output.push_str(&format!(
+                "- `{}` ({}): {} ({:.1}%)\n",
+                entry.kind, entry.severity, entry.count, entry.share_percent
+            ));
+        }
+    }
+
     output.push_str("\n## Performance\n\n");
     if let Some(perf) = &report.performance {
         output.push_str(&format!("- Requests: {}\n", perf.request_count));
@@ -673,6 +728,80 @@ fn optional_u64(value: Option<u64>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn segment_record(id: &str, status: &str, error: Option<&str>) -> SegmentRecord {
+        SegmentRecord {
+            id: id.to_string(),
+            status: status.to_string(),
+            attempts: 1,
+            error: error.map(ToString::to_string),
+            input_tokens: None,
+            input_cached_tokens: None,
+            output_tokens: None,
+            tokens_estimated: false,
+        }
+    }
+
+    #[test]
+    fn finding_breakdown_rolls_flagged_segments_up_by_kind() {
+        let records = [
+            segment_record(
+                "seg_0",
+                "needs_review",
+                Some("protected span missing from segment 'seg_0': 4th"),
+            ),
+            segment_record(
+                "seg_1",
+                "needs_review",
+                Some("protected span missing from segment 'seg_1': 5.16"),
+            ),
+            segment_record(
+                "seg_2",
+                "failed",
+                Some("translation checkpoint failure: provider error: HTTP status 503: down"),
+            ),
+            // Succeeded segments never contribute, even if a stale error string
+            // is still attached to the record.
+            segment_record("seg_3", "succeeded", Some("protected span missing: x")),
+        ];
+
+        let breakdown = finding_breakdown(&records);
+
+        assert_eq!(breakdown.len(), 2);
+        assert_eq!(breakdown[0].kind, "protected_span_missing");
+        assert_eq!(breakdown[0].count, 2);
+        assert_eq!(breakdown[0].share_percent, 66.7);
+        assert_eq!(breakdown[1].kind, "provider_error");
+        assert_eq!(breakdown[1].count, 1);
+    }
+
+    #[test]
+    fn finding_breakdown_counts_each_failure_in_a_concatenated_error() {
+        let records = [segment_record(
+            "seg_0",
+            "needs_review",
+            Some(
+                "translation is unchanged from the source-language prose; \
+                 batch translation block mismatch: missing=[\"b_000853\"], extra=[], duplicate=[]",
+            ),
+        )];
+
+        let breakdown = finding_breakdown(&records);
+
+        assert_eq!(
+            breakdown
+                .iter()
+                .map(|entry| entry.kind.as_str())
+                .collect::<Vec<_>>(),
+            vec!["batch_block_mismatch", "source_copy_unchanged"]
+        );
+        assert!(breakdown.iter().all(|entry| entry.count == 1));
+    }
+
+    #[test]
+    fn finding_breakdown_is_empty_without_flagged_segments() {
+        assert!(finding_breakdown(&[segment_record("seg_0", "succeeded", None)]).is_empty());
+    }
 
     #[test]
     fn missing_number_message_accepts_decimal_comma_localization() {

--- a/crates/bookforge-core/src/marker.rs
+++ b/crates/bookforge-core/src/marker.rs
@@ -19,6 +19,12 @@ pub struct MarkerClose {
     pub len: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerInnerText {
+    pub id: String,
+    pub text: String,
+}
+
 pub fn marker_ids_in_text(text: &str) -> Vec<String> {
     let mut ids = Vec::new();
     let mut rest = text;
@@ -39,6 +45,46 @@ pub fn marker_ids_in_text(text: &str) -> Vec<String> {
     }
 
     ids
+}
+
+/// Inner text of every paired inline marker, with nested marker tags removed.
+pub fn marker_inner_texts(text: &str) -> Vec<MarkerInnerText> {
+    let mut inner_texts = Vec::new();
+    let mut stack = Vec::<(String, String, usize)>::new();
+    let mut offset = 0;
+
+    while offset < text.len() {
+        let rest = &text[offset..];
+        let Some(index) = rest.find('<') else {
+            break;
+        };
+        let tag_start = offset + index;
+        let tag = &text[tag_start..];
+
+        if let Some(open) = parse_paired_marker_open(tag) {
+            offset = tag_start + open.len;
+            stack.push((open.tag_name, open.id, offset));
+        } else if let Some(empty) = parse_empty_marker(tag) {
+            offset = tag_start + empty.len;
+        } else if let Some(close) = parse_marker_close(tag) {
+            offset = tag_start + close.len;
+            if let Some(frame_index) = stack
+                .iter()
+                .rposition(|(tag_name, _, _)| tag_name == &close.tag_name)
+            {
+                for (_, id, content_start) in stack.drain(frame_index..) {
+                    inner_texts.push(MarkerInnerText {
+                        id,
+                        text: strip_marker_tokens(&text[content_start..tag_start]),
+                    });
+                }
+            }
+        } else {
+            offset = tag_start + 1;
+        }
+    }
+
+    inner_texts
 }
 
 /// Return a deterministic error when paired inline markers are unbalanced,
@@ -272,6 +318,39 @@ mod tests {
             marker_ids_in_text(r#"A <m1>bold <r1/> text</m1> and <m id="m000000_000">old</m>."#);
 
         assert_eq!(ids, vec!["m1", "r1", "m000000_000"]);
+    }
+
+    #[test]
+    fn marker_inner_texts_strip_nested_marker_tags() {
+        assert_eq!(
+            marker_inner_texts("Parola.<m0><m1>*2</m1></m0> Segue."),
+            vec![
+                MarkerInnerText {
+                    id: "m1".to_string(),
+                    text: "*2".to_string(),
+                },
+                MarkerInnerText {
+                    id: "m0".to_string(),
+                    text: "*2".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn marker_inner_texts_support_legacy_markers() {
+        assert_eq!(
+            marker_inner_texts(r#"A <m id="m000000_000">†3</m> B"#),
+            vec![MarkerInnerText {
+                id: "m000000_000".to_string(),
+                text: "†3".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn marker_inner_texts_ignore_empty_markers() {
+        assert!(marker_inner_texts("A <r3/> B <m4/> C").is_empty());
     }
 
     #[test]

--- a/crates/bookforge-core/src/marker.rs
+++ b/crates/bookforge-core/src/marker.rs
@@ -87,6 +87,52 @@ pub fn marker_inner_texts(text: &str) -> Vec<MarkerInnerText> {
     inner_texts
 }
 
+/// Paired-marker prose must remain free to change during translation. Only a
+/// non-empty, at-most-eight-character token with no letters, at least one
+/// digit or reference symbol, and otherwise only reference punctuation is
+/// protected as non-translatable marker reference text.
+pub fn marker_reference_token(text: &str) -> Option<&str> {
+    let token = text.trim();
+    let length = token.chars().count();
+    if length == 0 || length > 8 || token.chars().any(char::is_alphabetic) {
+        return None;
+    }
+    if !token
+        .chars()
+        .any(|ch| ch.is_ascii_digit() || is_reference_symbol(ch))
+    {
+        return None;
+    }
+    token
+        .chars()
+        .all(|ch| {
+            ch.is_ascii_digit()
+                || ch.is_ascii_whitespace()
+                || is_reference_symbol(ch)
+                || matches!(
+                    ch,
+                    '[' | ']'
+                        | '('
+                        | ')'
+                        | '{'
+                        | '}'
+                        | '.'
+                        | ','
+                        | '-'
+                        | '–'
+                        | '—'
+                        | '/'
+                        | ':'
+                        | ';'
+                )
+        })
+        .then_some(token)
+}
+
+fn is_reference_symbol(ch: char) -> bool {
+    matches!(ch, '*' | '†' | '‡' | '§' | '¶' | '#')
+}
+
 /// Return a deterministic error when paired inline markers are unbalanced,
 /// mis-nested, or closed by the wrong marker tag. ID-presence checks alone
 /// cannot detect `<m1>text` with a missing `</m1>`, which is valid prose JSON
@@ -351,6 +397,20 @@ mod tests {
     #[test]
     fn marker_inner_texts_ignore_empty_markers() {
         assert!(marker_inner_texts("A <r3/> B <m4/> C").is_empty());
+    }
+
+    #[test]
+    fn marker_reference_tokens_are_narrowly_classified() {
+        for token in ["1", "*2", "† 3", "[12]", "12–14"] {
+            assert_eq!(marker_reference_token(token), Some(token), "{token}");
+        }
+        for prose_or_data in ["", "beautiful", "E=mc^2", "42%", "123456789"] {
+            assert_eq!(
+                marker_reference_token(prose_or_data),
+                None,
+                "{prose_or_data}"
+            );
+        }
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1189,7 +1189,7 @@ fn build_block(
     } else {
         text_runs
     };
-    let protected_spans = detect_protected_spans(&visible_text);
+    let protected_spans = detect_protected_spans_in_text_runs(&text_runs);
 
     Block {
         id: BlockId(format!("b_{ordinal:06}")),
@@ -1295,6 +1295,40 @@ fn detect_protected_spans(text: &str) -> Vec<ProtectedSpan> {
     spans
 }
 
+fn marker_aware_prose_segments(text_runs: &[TextRun]) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+
+    for run in text_runs {
+        if is_marker_token(&run.text) {
+            // Marker boundaries separate otherwise adjacent prose tokens.
+            let segment = normalize_space(&current);
+            if !segment.is_empty() {
+                segments.push(segment);
+            }
+            current.clear();
+        } else {
+            current.push_str(&run.text);
+        }
+    }
+
+    let segment = normalize_space(&current);
+    if !segment.is_empty() {
+        segments.push(segment);
+    }
+    segments
+}
+
+fn detect_protected_spans_in_text_runs(text_runs: &[TextRun]) -> Vec<ProtectedSpan> {
+    let mut spans = marker_aware_prose_segments(text_runs)
+        .into_iter()
+        .flat_map(|segment| detect_protected_spans(&segment))
+        .collect::<Vec<_>>();
+    spans.sort_by(|left, right| left.text.cmp(&right.text));
+    spans.dedup_by(|left, right| left.kind == right.kind && left.text == right.text);
+    spans
+}
+
 fn detect_chapter_numeral_spans(text: &str) -> Vec<String> {
     let tokens = text
         .split_whitespace()
@@ -1374,6 +1408,13 @@ fn detect_math_spans(text: &str) -> Vec<String> {
 fn looks_like_inline_math_token(value: &str) -> bool {
     let chars = value.chars().collect::<Vec<_>>();
     if chars.len() < 3 {
+        return false;
+    }
+    // Sentence punctuation followed by an operator signals a fused endnote marker.
+    if chars
+        .windows(2)
+        .any(|pair| matches!(pair[0], '.' | ',') && is_strong_inline_math_operator(pair[1]))
+    {
         return false;
     }
     let has_operand = chars.iter().any(|ch| ch.is_ascii_alphanumeric());
@@ -1870,6 +1911,101 @@ mod tests {
     }
 
     #[test]
+    fn endnote_markers_never_fuse_prose_into_protected_spans() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml = r##"<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<body>
+  <p>Doubts about the vaccine.<sup><a epub:type="noteref" href="#n2">*2</a></sup></p>
+  <p>The source was opaque,<sup><a epub:type="noteref" href="#n8">*8</a></sup></p>
+  <p>The plan supported well-being.<sup><a epub:type="noteref" href="#n6">*6</a></sup></p>
+  <p>The answer was B.<sup><a epub:type="noteref" href="#n3">*3</a></sup></p>
+  <p>Other Americans.<sup><a epub:type="noteref" href="#n3">*3</a></sup></p>
+  <p>The citations.<sup><a epub:type="noteref" href="#n12">*12</a></sup></p>
+</body>
+</html>"##;
+        let blocks = extract_blocks(xhtml, "chapter.xhtml", &section_id, 0)
+            .expect("block extraction should succeed");
+        let protected_texts = blocks
+            .iter()
+            .flat_map(|block| block.protected_spans.iter())
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>();
+
+        // Marker boundaries keep endnote text independent from adjacent prose.
+        let fused = [
+            "vaccine.*2",
+            "opaque,*8",
+            "well-being.*6",
+            "B.*3",
+            "Americans.*3",
+            "citations.*12",
+        ];
+        assert!(
+            !protected_texts.iter().any(|text| fused.contains(text)),
+            "fused protected span found: {protected_texts:?}"
+        );
+        assert!(
+            protected_texts
+                .iter()
+                .all(|text| !text.chars().any(|ch| ch.is_ascii_alphabetic())),
+            "prose leaked into protected spans: {protected_texts:?}"
+        );
+    }
+
+    #[test]
+    fn endnote_marker_without_punctuation_still_never_fuses() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml = r##"<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<body><p>the vaccine<sup><a epub:type="noteref" href="#n2">*2</a></sup> works</p></body>
+</html>"##;
+        let blocks = extract_blocks(xhtml, "chapter.xhtml", &section_id, 0)
+            .expect("block extraction should succeed");
+
+        // The marker-aware split protects cases the punctuation guard cannot detect.
+        assert!(blocks.iter().all(|block| {
+            block
+                .protected_spans
+                .iter()
+                .all(|span| !span.text.contains("vaccine"))
+        }));
+    }
+
+    #[test]
+    fn protected_spans_survive_inside_inline_markers() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml = r#"<html xmlns="http://www.w3.org/1999/xhtml"><body>
+<p>Einstein wrote <em>E = mc^2</em> in 1905, see https://example.com and file.txt.</p>
+<p>Chapter 12-14 covers p&lt;0.05 and #anchor and mail@example.com.</p>
+<p>CAPITOLO I Il buonsenso</p>
+</body></html>"#;
+        let blocks = extract_blocks(xhtml, "chapter.xhtml", &section_id, 0)
+            .expect("block extraction should succeed");
+        let protected_texts = blocks
+            .iter()
+            .flat_map(|block| block.protected_spans.iter())
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>();
+
+        // Each marker-delimited prose segment still runs every existing detector.
+        for expected in [
+            "E = mc^2",
+            "1905",
+            "https://example.com",
+            "file.txt",
+            "12-14",
+            "p<0.05",
+            "#anchor",
+            "mail@example.com",
+            "I",
+        ] {
+            assert!(
+                protected_texts.contains(&expected),
+                "missing {expected}: {protected_texts:?}"
+            );
+        }
+    }
+
+    #[test]
     fn protected_spans_preserve_all_exact_digits() {
         let spans = detect_protected_spans(
             "Chapter 1 cites https://example.com, file.txt, #anchor, and pages 12-14.",
@@ -1978,6 +2114,17 @@ mod tests {
                 .iter()
                 .any(|span| span.kind == ProtectedSpanKind::Math)
         );
+    }
+
+    #[test]
+    fn inline_math_rejects_prose_glued_to_an_endnote_marker() {
+        // Sentence punctuation before a marker operator is not mathematical syntax.
+        for value in ["vaccine.*2", "opaque,*8", "citations.*12"] {
+            assert!(!looks_like_inline_math_token(value), "{value}");
+        }
+        for value in ["mc^2", "p<0.05", "x_12"] {
+            assert!(looks_like_inline_math_token(value), "{value}");
+        }
     }
 
     fn block_text(block: &Block) -> String {

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -10,7 +10,10 @@ use bookforge_core::{
         Block, BlockId, BlockKind, Book, BookFormat, BookId, DomPath, InlineMark, Metadata,
         ProtectedSpan, ProtectedSpanKind, Resource, Section, SectionId, SpineItem, TextRun,
     },
-    marker::{is_marker_token, strip_marker_tokens},
+    marker::{
+        is_marker_token, marker_reference_token, parse_marker_close, parse_paired_marker_open,
+        strip_marker_tokens,
+    },
 };
 use quick_xml::{
     Reader,
@@ -1295,18 +1298,24 @@ fn detect_protected_spans(text: &str) -> Vec<ProtectedSpan> {
     spans
 }
 
-fn marker_aware_prose_segments(text_runs: &[TextRun]) -> Vec<String> {
+fn marker_aware_prose_segments(text_runs: &[TextRun]) -> Vec<(String, bool)> {
     let mut segments = Vec::new();
     let mut current = String::new();
+    let mut marker_depth = 0usize;
 
     for run in text_runs {
         if is_marker_token(&run.text) {
-            // Marker boundaries separate otherwise adjacent prose tokens.
             let segment = normalize_space(&current);
             if !segment.is_empty() {
-                segments.push(segment);
+                segments.push((segment, marker_depth > 0));
             }
             current.clear();
+            let marker = run.text.trim();
+            if parse_paired_marker_open(marker).is_some() {
+                marker_depth += 1;
+            } else if parse_marker_close(marker).is_some() {
+                marker_depth = marker_depth.saturating_sub(1);
+            }
         } else {
             current.push_str(&run.text);
         }
@@ -1314,7 +1323,7 @@ fn marker_aware_prose_segments(text_runs: &[TextRun]) -> Vec<String> {
 
     let segment = normalize_space(&current);
     if !segment.is_empty() {
-        segments.push(segment);
+        segments.push((segment, marker_depth > 0));
     }
     segments
 }
@@ -1322,7 +1331,16 @@ fn marker_aware_prose_segments(text_runs: &[TextRun]) -> Vec<String> {
 fn detect_protected_spans_in_text_runs(text_runs: &[TextRun]) -> Vec<ProtectedSpan> {
     let mut spans = marker_aware_prose_segments(text_runs)
         .into_iter()
-        .flat_map(|segment| detect_protected_spans(&segment))
+        .flat_map(|(segment, inside_marker)| {
+            // Reference text inside a marker is validated by the marker reference-text check.
+            // Protected spans cover prose outside markers and non-reference data that the
+            // specialized marker check intentionally does not own.
+            if inside_marker && marker_reference_token(&segment).is_some() {
+                Vec::new()
+            } else {
+                detect_protected_spans(&segment)
+            }
+        })
         .collect::<Vec<_>>();
     spans.sort_by(|left, right| left.text.cmp(&right.text));
     spans.dedup_by(|left, right| left.kind == right.kind && left.text == right.text);
@@ -1417,12 +1435,37 @@ fn looks_like_inline_math_token(value: &str) -> bool {
     {
         return false;
     }
+    if is_alphabetic_word_with_only_edge_operators(&chars) {
+        return false;
+    }
     let has_operand = chars.iter().any(|ch| ch.is_ascii_alphanumeric());
     let has_strong_operator = chars.iter().any(|ch| is_strong_inline_math_operator(*ch));
     let has_numeric_subscript = chars.contains(&'_') && chars.iter().any(|ch| ch.is_ascii_digit());
     has_operand
         && (has_strong_operator || has_numeric_subscript)
         && chars.iter().all(|ch| is_math_token_char(*ch))
+}
+
+fn is_alphabetic_word_with_only_edge_operators(chars: &[char]) -> bool {
+    if chars.iter().any(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    let Some(first_alpha) = chars.iter().position(|ch| ch.is_ascii_alphabetic()) else {
+        return false;
+    };
+    let last_alpha = chars
+        .iter()
+        .rposition(|ch| ch.is_ascii_alphabetic())
+        .expect("first alphabetic character exists");
+    let has_edge_operator = first_alpha > 0 || last_alpha + 1 < chars.len();
+    has_edge_operator
+        && chars[first_alpha..=last_alpha]
+            .iter()
+            .all(|ch| ch.is_ascii_alphabetic())
+        && chars[..first_alpha]
+            .iter()
+            .chain(&chars[last_alpha + 1..])
+            .all(|ch| is_inline_math_operator(*ch))
 }
 
 fn looks_like_math_operand(value: &str) -> bool {
@@ -1971,7 +2014,7 @@ mod tests {
     }
 
     #[test]
-    fn protected_spans_survive_inside_inline_markers() {
+    fn protected_spans_delegate_marker_references_and_preserve_other_data() {
         let section_id = SectionId("sec_000000".to_string());
         let xhtml = r#"<html xmlns="http://www.w3.org/1999/xhtml"><body>
 <p>Einstein wrote <em>E = mc^2</em> in 1905, see https://example.com and file.txt.</p>
@@ -1986,7 +2029,7 @@ mod tests {
             .map(|span| span.text.as_str())
             .collect::<Vec<_>>();
 
-        // Each marker-delimited prose segment still runs every existing detector.
+        // Marker-inner prose and data that is not reference text still runs every detector.
         for expected in [
             "E = mc^2",
             "1905",
@@ -2003,6 +2046,29 @@ mod tests {
                 "missing {expected}: {protected_texts:?}"
             );
         }
+    }
+
+    #[test]
+    fn endnote_reference_text_is_not_a_protected_span_but_outer_year_is() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml = r##"<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<body><p>word.<sup><a epub:type="noteref" href="#n2">*2</a></sup> Ordinary 2020.</p></body>
+</html>"##;
+        let blocks = extract_blocks(xhtml, "chapter.xhtml", &section_id, 0)
+            .expect("block extraction should succeed");
+        let protected_texts = blocks[0]
+            .protected_spans
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(
+            protected_texts
+                .iter()
+                .all(|text| !text.contains('2') || *text == "2020"),
+            "marker reference leaked into protected spans: {protected_texts:?}"
+        );
+        assert!(protected_texts.contains(&"2020"));
     }
 
     #[test]
@@ -2122,7 +2188,12 @@ mod tests {
         for value in ["vaccine.*2", "opaque,*8", "citations.*12"] {
             assert!(!looks_like_inline_math_token(value), "{value}");
         }
-        for value in ["mc^2", "p<0.05", "x_12"] {
+        // An otherwise alphabetic word with an operator only at its edge is prose, not math.
+        for value in ["Revolution*", "and^"] {
+            assert!(!looks_like_inline_math_token(value), "{value}");
+        }
+        // Digits or an operator between operands remain valid mathematical evidence.
+        for value in ["I*16", "mc^2", "p<0.05", "x_12", "E=mc^2"] {
             assert!(looks_like_inline_math_token(value), "{value}");
         }
     }

--- a/crates/bookforge-epub/tests/inspect.rs
+++ b/crates/bookforge-epub/tests/inspect.rs
@@ -307,7 +307,8 @@ fn parses_complex_generated_fixture_shapes() {
         table_row_text
             .protected_spans
             .iter()
-            .any(|span| span.text == "2024")
+            .all(|span| span.text != "2024"),
+        "bare marker reference text is owned by marker validation"
     );
     assert!(
         table_row_text

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -48,8 +48,7 @@ use planning::{
     repartition_pending_batches, set_batch_output_override, split_batch_with_config,
     take_batch_output_override, token_estimate,
 };
-#[cfg(test)]
-use rendering::batch_item_validation_error;
+pub use rendering::batch_item_validation_error;
 pub use rendering::parse_batch_response;
 use rendering::{parse_batch_response_with_validation, render_batch_items};
 

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -1,7 +1,7 @@
 use super::*;
 use serde::Deserialize;
 
-pub(super) fn batch_item_validation_error(
+pub fn batch_item_validation_error(
     item: &TranslationBatchItem,
     translation: &str,
     validate_source_copy: bool,
@@ -26,6 +26,11 @@ pub(super) fn batch_item_validation_error(
         if !expected.contains(marker) {
             return Some(format!("unknown inline marker: {marker}"));
         }
+    }
+    if let Some(error) =
+        crate::validation::marker_reference_text_error(&item.source_text, translation)
+    {
+        return Some(error);
     }
     for span in &item.protected_spans {
         if !span.trim().is_empty() && !crate::validation::protected_span_present(span, translation)
@@ -554,6 +559,77 @@ fn wrap_text_only_translation_with_source_markers(source: &str, translation: &st
         return translation;
     }
     format!("{prefix}{translation}")
+}
+
+#[cfg(test)]
+mod noteref_marker_validation_tests {
+    use super::*;
+
+    /// `word.<sup><a epub:type="noteref">*2</a></sup>` reaches the model as
+    /// `word.<m0><m1>*2</m1></m0>`. Every marker ID survives when the model
+    /// drops the `*2`, so only the inner-text check can catch it.
+    fn noteref_item() -> TranslationBatchItem {
+        TranslationBatchItem {
+            item_id: "item_noteref".to_string(),
+            segment_id: SegmentId("seg_noteref".to_string()),
+            section_id: bookforge_core::ir::SectionId("section_noteref".to_string()),
+            block_id: bookforge_core::ir::BlockId("block_noteref".to_string()),
+            ordinal: 0,
+            kind: "paragraph".to_string(),
+            source_text: "The word.<m0><m1>*2</m1></m0> It follows.".to_string(),
+            text_runs: Vec::new(),
+            protected_spans: Vec::new(),
+            required_markers: vec!["m0".to_string(), "m1".to_string()],
+            checksum: "checksum_noteref".to_string(),
+        }
+    }
+
+    #[test]
+    fn dropped_noteref_token_fails_batch_item_validation() {
+        let error = batch_item_validation_error(
+            &noteref_item(),
+            "La parola.<m0><m1></m1></m0> Segue.",
+            false,
+            None,
+            None,
+        )
+        .expect("a dropped endnote reference must fail validation");
+
+        assert!(error.contains("lost its reference text"), "got: {error}");
+        assert!(error.contains("*2"), "got: {error}");
+    }
+
+    #[test]
+    fn preserved_noteref_token_passes_batch_item_validation() {
+        assert_eq!(
+            batch_item_validation_error(
+                &noteref_item(),
+                "La parola.<m0><m1>*2</m1></m0> Segue.",
+                false,
+                None,
+                None,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn translated_marker_prose_still_passes_batch_item_validation() {
+        let mut item = noteref_item();
+        item.source_text = "A <m0>beautiful</m0> day.".to_string();
+        item.required_markers = vec!["m0".to_string()];
+
+        assert_eq!(
+            batch_item_validation_error(
+                &item,
+                "Una <m0>bellissima</m0> giornata.",
+                false,
+                None,
+                None
+            ),
+            None
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/bookforge-llm/src/validation.rs
+++ b/crates/bookforge-llm/src/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bookforge_core::marker::strip_marker_tokens;
+use bookforge_core::marker::{marker_inner_texts, strip_marker_tokens};
 
 const MIN_SOURCE_CHARS: usize = 120;
 const MIN_OVERLAP_WORDS: usize = 30;
@@ -624,6 +624,96 @@ fn is_toki_phrase_boundary_char(ch: char) -> bool {
     )
 }
 
+/// Reject translations that kept a marker's ID but silently dropped the
+/// reference text it wrapped. Endnote references arrive as
+/// `word.<sup><a epub:type="noteref">*2</a></sup>`, i.e. `word.<m0><m1>*2</m1></m0>`,
+/// so every marker-ID check can pass while the `*2` is gone from the finished
+/// book. Marker prose stays free to change; only reference tokens are pinned.
+pub(crate) fn marker_reference_text_error(source: &str, translation: &str) -> Option<String> {
+    let translated_inner_texts = marker_inner_texts(translation)
+        .into_iter()
+        .map(|marker| (marker.id, marker.text))
+        .collect::<HashMap<_, _>>();
+
+    for marker in marker_inner_texts(source) {
+        let Some(token) = reference_token(&marker.text) else {
+            continue;
+        };
+        let Some(translated_text) = translated_inner_texts.get(&marker.id) else {
+            continue;
+        };
+        let compact_token = remove_whitespace(token);
+        let compact_translation = remove_whitespace(translated_text);
+        if exact_protected_span_present(&compact_token, &compact_translation)
+            || numeric_tokens_equivalent(&compact_token, &compact_translation)
+        {
+            continue;
+        }
+        return Some(format!(
+            "inline marker {} lost its reference text '{token}'",
+            marker.id
+        ));
+    }
+
+    None
+}
+
+/// Paired-marker prose must remain free to change during translation. Only a
+/// non-empty, at-most-eight-character token with no letters, at least one
+/// digit or reference symbol, and otherwise only reference punctuation is
+/// protected as non-translatable reference text.
+fn reference_token(text: &str) -> Option<&str> {
+    let token = text.trim();
+    let length = token.chars().count();
+    if length == 0 || length > 8 || token.chars().any(char::is_alphabetic) {
+        return None;
+    }
+    if !token
+        .chars()
+        .any(|ch| ch.is_ascii_digit() || is_reference_symbol(ch))
+    {
+        return None;
+    }
+    token
+        .chars()
+        .all(|ch| {
+            ch.is_ascii_digit()
+                || ch.is_ascii_whitespace()
+                || is_reference_symbol(ch)
+                || matches!(
+                    ch,
+                    '[' | ']'
+                        | '('
+                        | ')'
+                        | '{'
+                        | '}'
+                        | '.'
+                        | ','
+                        | '-'
+                        | '–'
+                        | '—'
+                        | '/'
+                        | ':'
+                        | ';'
+                )
+        })
+        .then_some(token)
+}
+
+fn is_reference_symbol(ch: char) -> bool {
+    matches!(ch, '*' | '†' | '‡' | '§' | '¶' | '#')
+}
+
+fn remove_whitespace(value: &str) -> String {
+    value.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn numeric_tokens_equivalent(left: &str, right: &str) -> bool {
+    let left_forms = canonical_number_forms(left);
+    let right_forms = canonical_number_forms(right);
+    !left_forms.is_empty() && left_forms.iter().any(|form| right_forms.contains(form))
+}
+
 pub(crate) fn protected_span_present(span: &str, translation: &str) -> bool {
     dangling_numeric_span(span)
         || exact_protected_span_present(span, translation)
@@ -634,6 +724,7 @@ pub(crate) fn protected_span_present(span: &str, translation: &str) -> bool {
                 .iter()
                 .any(|candidate| canonical_decimal_number(candidate).as_deref() == Some(&expected))
         })
+        || numeric_span_present(span, translation)
 }
 
 fn exact_protected_span_present(span: &str, translation: &str) -> bool {
@@ -657,6 +748,215 @@ fn exact_protected_span_present(span: &str, translation: &str) -> bool {
                 .is_none_or(|ch| !ch.is_alphanumeric());
         left_boundary && right_boundary
     })
+}
+
+/// Every canonical reading of one numeric token. Empty when `token` is not a number.
+///
+/// Separators are classified rather than replaced blindly: repeated identical
+/// separators can be strict three-digit grouping, while a final `.` or `,`
+/// can be decimal after differently styled grouping. A single separator with
+/// a three-digit suffix deliberately yields both readings.
+fn canonical_number_forms(token: &str) -> Vec<String> {
+    let normalized = normalize_number_signs(token);
+    let (sign, unsigned) = if let Some(unsigned) = normalized.strip_prefix('-') {
+        ("-", unsigned)
+    } else if let Some(unsigned) = normalized.strip_prefix('+') {
+        ("+", unsigned)
+    } else {
+        ("", normalized.as_str())
+    };
+    let (numeric, percent) = if let Some(numeric) = unsigned.strip_suffix('%') {
+        (numeric, "%")
+    } else {
+        (unsigned, "")
+    };
+    if numeric.is_empty() {
+        return Vec::new();
+    }
+
+    let mut groups = Vec::new();
+    let mut separators = Vec::new();
+    let mut current = String::new();
+    for ch in numeric.chars() {
+        if ch.is_ascii_digit() {
+            current.push(ch);
+        } else if is_number_separator(ch) {
+            if current.is_empty() {
+                return Vec::new();
+            }
+            groups.push(std::mem::take(&mut current));
+            separators.push(ch);
+        } else {
+            return Vec::new();
+        }
+    }
+    if current.is_empty() {
+        return Vec::new();
+    }
+    groups.push(current);
+
+    let grouped_integer = groups.concat();
+    let integer_reading = if separators.is_empty() {
+        true
+    } else {
+        let first_separator = separators[0];
+        separators
+            .iter()
+            .all(|separator| *separator == first_separator)
+            && (1..=3).contains(&groups[0].len())
+            && groups[1..].iter().all(|group| group.len() == 3)
+    };
+
+    let decimal_reading = separators.last().is_some_and(|last_separator| {
+        if !matches!(last_separator, '.' | ',') {
+            return false;
+        }
+        if separators.len() == 1 {
+            return true;
+        }
+        let earlier_separators = &separators[..separators.len() - 1];
+        let grouping_separator = earlier_separators[0];
+        grouping_separator != *last_separator
+            && earlier_separators
+                .iter()
+                .all(|separator| *separator == grouping_separator)
+            && (1..=3).contains(&groups[0].len())
+            && groups[1..groups.len() - 1]
+                .iter()
+                .all(|group| group.len() == 3)
+    });
+
+    let mut forms = Vec::new();
+    if integer_reading {
+        forms.push(format!("{sign}{grouped_integer}{percent}"));
+    }
+    if decimal_reading {
+        let integer = groups[..groups.len() - 1].concat();
+        let fractional = &groups[groups.len() - 1];
+        let decimal = format!("{sign}{integer}.{fractional}{percent}");
+        if !forms.contains(&decimal) {
+            forms.push(decimal);
+        }
+    }
+    forms
+}
+
+fn is_number_separator(ch: char) -> bool {
+    matches!(ch, '.' | ',' | ' ' | '\u{00a0}' | '\u{202f}' | '\u{2009}')
+}
+
+fn numeric_candidate_ranges(text: &str) -> Vec<(usize, usize, String)> {
+    let chars = text.char_indices().collect::<Vec<_>>();
+    let mut candidates = Vec::new();
+    let mut index = 0;
+
+    while index < chars.len() {
+        if !chars[index].1.is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+
+        let start_index = if index > 0
+            && matches!(normalize_number_sign(chars[index - 1].1), '-' | '+')
+            && (index == 1 || !chars[index - 2].1.is_alphanumeric())
+        {
+            index - 1
+        } else {
+            index
+        };
+        let mut end_index = index + 1;
+        while end_index < chars.len() {
+            let ch = chars[end_index].1;
+            if ch.is_ascii_digit()
+                || (matches!(ch, '.' | ',')
+                    && chars
+                        .get(end_index + 1)
+                        .is_some_and(|(_, next)| next.is_ascii_digit()))
+                || (is_space_grouping_separator(ch)
+                    && has_strict_three_digit_group(&chars, end_index))
+            {
+                end_index += 1;
+            } else {
+                break;
+            }
+        }
+        if chars
+            .get(end_index)
+            .is_some_and(|(_, trailing)| *trailing == '%')
+        {
+            end_index += 1;
+        }
+
+        let start = chars[start_index].0;
+        let end = chars
+            .get(end_index)
+            .map_or(text.len(), |(offset, _)| *offset);
+        candidates.push((start, end, normalize_number_signs(&text[start..end])));
+        index = end_index;
+    }
+
+    candidates
+}
+
+fn is_space_grouping_separator(ch: char) -> bool {
+    matches!(ch, ' ' | '\u{00a0}' | '\u{202f}' | '\u{2009}')
+}
+
+fn has_strict_three_digit_group(chars: &[(usize, char)], separator_index: usize) -> bool {
+    (1..=3).all(|offset| {
+        chars
+            .get(separator_index + offset)
+            .is_some_and(|(_, ch)| ch.is_ascii_digit())
+    }) && chars
+        .get(separator_index + 4)
+        .is_none_or(|(_, ch)| !ch.is_ascii_digit())
+}
+
+/// Numeric substrings of `text`, including space-grouped forms such as `90 000 000`.
+fn numeric_candidates(text: &str) -> Vec<String> {
+    numeric_candidate_ranges(text)
+        .into_iter()
+        .map(|(_, _, candidate)| candidate)
+        .collect()
+}
+
+/// Locale-insensitive presence check for spans that contain numbers.
+fn numeric_span_present(span: &str, translation: &str) -> bool {
+    let span_numbers = numeric_candidates(span);
+    if span_numbers.is_empty() {
+        return false;
+    }
+
+    let mut translated_number_forms = numeric_candidates(translation)
+        .iter()
+        .map(|candidate| canonical_number_forms(candidate))
+        .collect::<Vec<_>>();
+    for span_number in span_numbers {
+        let required_forms = canonical_number_forms(&span_number);
+        if required_forms.is_empty() {
+            return false;
+        }
+        let Some(match_index) = translated_number_forms.iter().position(|candidate_forms| {
+            required_forms
+                .iter()
+                .any(|required| candidate_forms.contains(required))
+        }) else {
+            return false;
+        };
+        translated_number_forms.remove(match_index);
+    }
+
+    let mut literal_remainder = String::with_capacity(span.len());
+    let mut copied_until = 0;
+    for (start, end, _) in numeric_candidate_ranges(span) {
+        literal_remainder.push_str(&span[copied_until..start]);
+        literal_remainder.push(' ');
+        copied_until = end;
+    }
+    literal_remainder.push_str(&span[copied_until..]);
+    literal_remainder
+        .split_whitespace()
+        .all(|token| exact_protected_span_present(token, translation))
 }
 
 fn normalized_prose(text: &str) -> String {
@@ -947,11 +1247,78 @@ mod tests {
     }
 
     #[test]
+    fn protected_span_presence_accepts_localized_statistical_decimals() {
+        assert!(protected_span_present(
+            "p < 0.05",
+            "Il risultato era p < 0,05."
+        ));
+        assert!(protected_span_present(
+            "F = 3.86",
+            "Il valore osservato era F = 3,86."
+        ));
+    }
+
+    #[test]
+    fn protected_span_presence_accepts_localized_digit_grouping() {
+        assert!(protected_span_present(
+            "90,000,000",
+            "La popolazione raggiunse 90.000.000 di persone."
+        ));
+        assert!(protected_span_present(
+            "90,000,000",
+            "La popolazione raggiunse 90 000 000 di persone."
+        ));
+        assert!(protected_span_present(
+            "1,000,000,000",
+            "Il totale era 1.000.000.000."
+        ));
+    }
+
+    #[test]
+    fn protected_span_presence_rejects_missing_or_wrong_statistical_number() {
+        assert!(!protected_span_present(
+            "p < 0.05",
+            "Il risultato non conteneva alcun valore numerico."
+        ));
+        assert!(!protected_span_present(
+            "p < 0.05",
+            "Il risultato era p < 0,06."
+        ));
+    }
+
+    #[test]
     fn protected_span_presence_still_rejects_absent_numbers() {
         assert!(!protected_span_present(
             "5.16",
             "Si noti che questa forma di rettificazione deriva dai canali aperti."
         ));
+    }
+
+    #[test]
+    fn marker_reference_text_rejects_dropped_token() {
+        let source = "Parola.<m0><m1>*2</m1></m0> Segue.";
+        let translation = "Parola.<m0><m1></m1></m0> Segue.";
+
+        assert_eq!(
+            marker_reference_text_error(source, translation).as_deref(),
+            Some("inline marker m1 lost its reference text '*2'")
+        );
+    }
+
+    #[test]
+    fn marker_reference_text_accepts_preserved_token() {
+        let source = "Parola.<m0><m1>*2</m1></m0> Segue.";
+        let translation = "Parola.<m0><m1>*2</m1></m0> Continua.";
+
+        assert_eq!(marker_reference_text_error(source, translation), None);
+    }
+
+    #[test]
+    fn marker_reference_text_allows_prose_to_change() {
+        let source = "Una <m0>beautiful</m0> giornata";
+        let translation = "Una <m0>bellissima</m0> giornata";
+
+        assert_eq!(marker_reference_text_error(source, translation), None);
     }
 
     #[test]

--- a/crates/bookforge-llm/src/validation.rs
+++ b/crates/bookforge-llm/src/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bookforge_core::marker::{marker_inner_texts, strip_marker_tokens};
+use bookforge_core::marker::{marker_inner_texts, marker_reference_token, strip_marker_tokens};
 
 const MIN_SOURCE_CHARS: usize = 120;
 const MIN_OVERLAP_WORDS: usize = 30;
@@ -636,7 +636,7 @@ pub(crate) fn marker_reference_text_error(source: &str, translation: &str) -> Op
         .collect::<HashMap<_, _>>();
 
     for marker in marker_inner_texts(source) {
-        let Some(token) = reference_token(&marker.text) else {
+        let Some(token) = marker_reference_token(&marker.text) else {
             continue;
         };
         let Some(translated_text) = translated_inner_texts.get(&marker.id) else {
@@ -656,52 +656,6 @@ pub(crate) fn marker_reference_text_error(source: &str, translation: &str) -> Op
     }
 
     None
-}
-
-/// Paired-marker prose must remain free to change during translation. Only a
-/// non-empty, at-most-eight-character token with no letters, at least one
-/// digit or reference symbol, and otherwise only reference punctuation is
-/// protected as non-translatable reference text.
-fn reference_token(text: &str) -> Option<&str> {
-    let token = text.trim();
-    let length = token.chars().count();
-    if length == 0 || length > 8 || token.chars().any(char::is_alphabetic) {
-        return None;
-    }
-    if !token
-        .chars()
-        .any(|ch| ch.is_ascii_digit() || is_reference_symbol(ch))
-    {
-        return None;
-    }
-    token
-        .chars()
-        .all(|ch| {
-            ch.is_ascii_digit()
-                || ch.is_ascii_whitespace()
-                || is_reference_symbol(ch)
-                || matches!(
-                    ch,
-                    '[' | ']'
-                        | '('
-                        | ')'
-                        | '{'
-                        | '}'
-                        | '.'
-                        | ','
-                        | '-'
-                        | '–'
-                        | '—'
-                        | '/'
-                        | ':'
-                        | ';'
-                )
-        })
-        .then_some(token)
-}
-
-fn is_reference_symbol(ch: char) -> bool {
-    matches!(ch, '*' | '†' | '‡' | '§' | '¶' | '#')
 }
 
 fn remove_whitespace(value: &str) -> String {

--- a/crates/bookforge-store/migrations/0008_v2_7_qa_findings.sql
+++ b/crates/bookforge-store/migrations/0008_v2_7_qa_findings.sql
@@ -1,0 +1,10 @@
+-- v2.7: make the long-dormant qa_findings table the record of *why* a segment
+-- was flagged. The table itself dates back to 0001_initial.sql but nothing ever
+-- wrote to it, so free-text `segments.error` was the only evidence available.
+--
+-- Only the read indexes are expressible here. The row backfill for jobs that
+-- predate v2.7 runs in Rust (schema::backfill_qa_findings driving
+-- bookforge_store::classify_segment_error) because splitting a concatenated
+-- `segments.error` string into a taxonomy is not expressible in SQL.
+CREATE INDEX IF NOT EXISTS idx_qa_findings_job ON qa_findings(job_id, kind);
+CREATE INDEX IF NOT EXISTS idx_qa_findings_segment ON qa_findings(job_id, segment_id);

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -18,12 +18,17 @@ use rusqlite::{Connection, OptionalExtension, params, types::Type};
 use sha2::{Digest, Sha256};
 use std::str::FromStr;
 
+mod findings;
 mod flags;
 mod glossary;
 mod jobs;
 mod schema;
 mod translations;
 
+pub use findings::{
+    QaFinding, QaFindingCount, QaFindingKind, QaFindingSeverity, StoredQaFinding,
+    aggregate_findings, classify_segment_error,
+};
 pub use flags::RetryScope;
 pub use schema::run_doctor;
 #[cfg(test)]

--- a/crates/bookforge-store/src/db/findings.rs
+++ b/crates/bookforge-store/src/db/findings.rs
@@ -1,0 +1,354 @@
+use super::*;
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum QaFindingKind {
+    ProtectedSpanMissing,
+    InlineMarkerMissing,
+    InlineMarkerDuplicated,
+    InlineMarkerUnknown,
+    MarkerStructure,
+    BatchBlockMismatch,
+    SourceCopyUnchanged,
+    TargetLanguageGate,
+    ProviderError,
+    Interrupted,
+    Other,
+}
+
+impl QaFindingKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProtectedSpanMissing => "protected_span_missing",
+            Self::InlineMarkerMissing => "inline_marker_missing",
+            Self::InlineMarkerDuplicated => "inline_marker_duplicated",
+            Self::InlineMarkerUnknown => "inline_marker_unknown",
+            Self::MarkerStructure => "marker_structure",
+            Self::BatchBlockMismatch => "batch_block_mismatch",
+            Self::SourceCopyUnchanged => "source_copy_unchanged",
+            Self::TargetLanguageGate => "target_language_gate",
+            Self::ProviderError => "provider_error",
+            Self::Interrupted => "interrupted",
+            Self::Other => "other",
+        }
+    }
+
+    pub fn severity(self) -> QaFindingSeverity {
+        match self {
+            Self::ProtectedSpanMissing
+            | Self::InlineMarkerMissing
+            | Self::InlineMarkerDuplicated
+            | Self::InlineMarkerUnknown
+            | Self::MarkerStructure
+            | Self::BatchBlockMismatch
+            | Self::ProviderError
+            | Self::Other => QaFindingSeverity::Error,
+            Self::SourceCopyUnchanged | Self::TargetLanguageGate | Self::Interrupted => {
+                QaFindingSeverity::Warning
+            }
+        }
+    }
+}
+
+/// `error` means the output is structurally unusable or the run could not
+/// produce output at all (protocol, transport, or an unclassified hard
+/// failure). `warning` means the output is intact and renderable but a
+/// heuristic validator judged the content suspect, or the operator stopped
+/// the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QaFindingSeverity {
+    Error,
+    Warning,
+}
+
+impl QaFindingSeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaFinding {
+    pub kind: QaFindingKind,
+    pub severity: QaFindingSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredQaFinding {
+    pub id: String,
+    pub segment_id: String,
+    pub kind: String,
+    pub severity: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaFindingCount {
+    pub kind: String,
+    pub severity: String,
+    pub count: usize,
+}
+
+impl QaFindingCount {
+    pub fn share_percent(&self, total: usize) -> f64 {
+        if total == 0 {
+            return 0.0;
+        }
+        (self.count as f64 * 1_000.0 / total as f64).round() / 10.0
+    }
+}
+
+pub fn classify_segment_error(error: &str) -> Vec<QaFinding> {
+    let error = error.trim();
+    if error.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings: Vec<QaFinding> = Vec::new();
+    for fragment in error
+        .split("; ")
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        let kind = classify_failure(fragment);
+        if kind == QaFindingKind::Other
+            && let Some(previous) = findings.last_mut()
+        {
+            // Some real messages contain a literal "; " (for example the Toki
+            // Pona gate's offending context). Merging unclassifiable tails back
+            // keeps the row count equal to the number of real failures.
+            previous.message.push_str("; ");
+            previous.message.push_str(fragment);
+            continue;
+        }
+        findings.push(QaFinding {
+            kind,
+            severity: kind.severity(),
+            message: fragment.to_string(),
+        });
+    }
+    findings
+}
+
+fn classify_failure(fragment: &str) -> QaFindingKind {
+    let lower = fragment.to_lowercase();
+
+    // First match wins. This order moves specific structural and validator
+    // failures ahead of broad transport wording so wrapped errors retain their
+    // most useful classification. In particular, Interrupted must precede
+    // ProviderError because the real string is "provider error: interrupted by
+    // user" after LlmError::Provider wraps the operator interrupt.
+    if lower.contains("interrupted by user") {
+        QaFindingKind::Interrupted
+    } else if lower.contains("protected span missing") {
+        QaFindingKind::ProtectedSpanMissing
+    } else if lower.contains("inline marker missing") {
+        QaFindingKind::InlineMarkerMissing
+    } else if lower.contains("inline marker duplicated") {
+        QaFindingKind::InlineMarkerDuplicated
+    } else if lower.contains("unknown inline marker") {
+        QaFindingKind::InlineMarkerUnknown
+    } else if [
+        "invalid inline marker structure",
+        "unexpected inline marker close",
+        "is closed by",
+        "is missing closing tag",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        QaFindingKind::MarkerStructure
+    } else if [
+        "batch translation block mismatch",
+        "missing block translations",
+        "block translations, got",
+        "returned duplicate block_id",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        QaFindingKind::BatchBlockMismatch
+    } else if [
+        "unchanged from the source-language prose",
+        "of the source-language words",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        QaFindingKind::SourceCopyUnchanged
+    } else if [
+        "toki pona",
+        "pi must group at least two following words",
+        "en may only coordinate subjects",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        QaFindingKind::TargetLanguageGate
+    } else if [
+        "provider error",
+        "http error",
+        "http status",
+        "rate limit",
+        "unauthorized",
+        "invalid api key",
+        "connection",
+        "timed out",
+        "timeout",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+    {
+        QaFindingKind::ProviderError
+    } else {
+        QaFindingKind::Other
+    }
+}
+
+pub fn aggregate_findings(findings: impl IntoIterator<Item = QaFinding>) -> Vec<QaFindingCount> {
+    let mut counts = BTreeMap::<(QaFindingKind, &'static str), usize>::new();
+    for finding in findings {
+        *counts
+            .entry((finding.kind, finding.severity.as_str()))
+            .or_default() += 1;
+    }
+
+    let mut breakdown = counts
+        .into_iter()
+        .map(|((kind, severity), count)| QaFindingCount {
+            kind: kind.as_str().to_string(),
+            severity: severity.to_string(),
+            count,
+        })
+        .collect::<Vec<_>>();
+    breakdown.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.kind.cmp(&right.kind))
+    });
+    breakdown
+}
+
+impl JobStore {
+    /// Replace the stored findings for one segment with the classification of
+    /// `error`. Returns how many rows were written.
+    pub fn record_segment_findings(
+        &self,
+        job_id: &str,
+        segment_id: &str,
+        error: &str,
+    ) -> Result<usize> {
+        let findings = classify_segment_error(error);
+        let mut conn = self.conn.borrow_mut();
+        let tx = conn.transaction()?;
+        let exists = tx.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM segments WHERE job_id = ?1 AND id = ?2
+             )",
+            params![job_id, segment_id],
+            |row| row.get::<_, bool>(0),
+        )?;
+        if !exists {
+            return Ok(0);
+        }
+
+        tx.execute(
+            "DELETE FROM qa_findings WHERE job_id = ?1 AND segment_id = ?2",
+            params![job_id, segment_id],
+        )?;
+        for (index, finding) in findings.iter().enumerate() {
+            let hash = stable_hash(&format!("{job_id}\u{1f}{segment_id}\u{1f}{index}"));
+            let id = format!("qaf_{}", &hash[..24]);
+            tx.execute(
+                "INSERT OR REPLACE INTO qa_findings
+                 (id, segment_id, job_id, severity, kind, message)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id,
+                    segment_id,
+                    job_id,
+                    finding.severity.as_str(),
+                    finding.kind.as_str(),
+                    finding.message,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(findings.len())
+    }
+
+    /// Drop every finding recorded against one segment (used when a segment
+    /// reaches a clean terminal state and `segments.error` goes back to NULL).
+    pub fn clear_segment_findings(&self, job_id: &str, segment_id: &str) -> Result<()> {
+        let conn = self.conn.borrow();
+        conn.execute(
+            "DELETE FROM qa_findings WHERE job_id = ?1 AND segment_id = ?2",
+            params![job_id, segment_id],
+        )?;
+        Ok(())
+    }
+
+    /// Drop findings for any segment in the job that no longer carries an error.
+    pub fn prune_stale_findings(&self, job_id: &str) -> Result<usize> {
+        let conn = self.conn.borrow();
+        Ok(conn.execute(
+            "DELETE FROM qa_findings
+             WHERE job_id = ?1
+               AND segment_id IN (
+                 SELECT id FROM segments
+                 WHERE job_id = ?1 AND (error IS NULL OR TRIM(error) = '')
+               )",
+            params![job_id],
+        )?)
+    }
+
+    /// Every stored finding for a job, ordered by segment then id.
+    pub fn segment_qa_findings(&self, job_id: &str) -> Result<Vec<StoredQaFinding>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT id, segment_id, kind, severity, message
+             FROM qa_findings
+             WHERE job_id = ?1
+             ORDER BY segment_id, id",
+        )?;
+        let rows = stmt.query_map(params![job_id], |row| {
+            Ok(StoredQaFinding {
+                id: row.get(0)?,
+                segment_id: row.get(1)?,
+                kind: row.get(2)?,
+                severity: row.get(3)?,
+                message: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    /// Count of findings per (kind, severity), count-descending then
+    /// kind-ascending.
+    pub fn qa_finding_breakdown(&self, job_id: &str) -> Result<Vec<QaFindingCount>> {
+        let conn = self.conn.borrow();
+        let mut stmt = conn.prepare(
+            "SELECT kind, severity, COUNT(*)
+             FROM qa_findings
+             WHERE job_id = ?1
+             GROUP BY kind, severity
+             ORDER BY COUNT(*) DESC, kind ASC",
+        )?;
+        let rows = stmt.query_map(params![job_id], |row| {
+            Ok(QaFindingCount {
+                kind: row.get(0)?,
+                severity: row.get(1)?,
+                count: row.get::<_, i64>(2)? as usize,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+}

--- a/crates/bookforge-store/src/db/flags.rs
+++ b/crates/bookforge-store/src/db/flags.rs
@@ -21,6 +21,9 @@ impl JobStore {
             let conn = self.conn.borrow();
             conn.execute(&sql, params![job_id])?
         };
+        // Findings are instrumentation, so a failed findings write must never
+        // fail the surrounding translation checkpoint.
+        let _ = self.prune_stale_findings(job_id);
         self.touch_job_unless_status(job_id, "retry_pending", &["stopped"])?;
         Ok(count)
     }
@@ -65,6 +68,10 @@ impl JobStore {
         tx.execute(
             "DELETE FROM segment_flags
              WHERE job_id = ?1 AND segment_id = ?2 AND kind = 'dashboard_retry'",
+            params![job_id, segment_id],
+        )?;
+        tx.execute(
+            "DELETE FROM qa_findings WHERE job_id = ?1 AND segment_id = ?2",
             params![job_id, segment_id],
         )?;
         if let Some(guidance) = guidance.filter(|value| !value.trim().is_empty()) {
@@ -201,6 +208,11 @@ impl JobStore {
                 params.push(id);
             }
             updated += conn.execute(&sql, params.as_slice())?;
+        }
+        for segment_id in segment_ids {
+            // Findings are instrumentation, so a failed findings write must
+            // never fail the surrounding translation checkpoint.
+            let _ = self.record_segment_findings(job_id, segment_id, reason);
         }
         if updated > 0 {
             self.mark_job_needs_review(job_id)?;

--- a/crates/bookforge-store/src/db/jobs.rs
+++ b/crates/bookforge-store/src/db/jobs.rs
@@ -237,6 +237,9 @@ impl JobStore {
                 params![error, job_id, segment_id],
             )?;
         }
+        // Findings are instrumentation, so a failed findings write must never
+        // fail the surrounding translation checkpoint.
+        let _ = self.record_segment_findings(job_id, segment_id, error);
         self.mark_job_failed(job_id)?;
         Ok(())
     }
@@ -247,7 +250,7 @@ impl JobStore {
         segment_id: &str,
         error: &str,
     ) -> Result<()> {
-        {
+        let updated = {
             let conn = self.conn.borrow();
             conn.execute(
                 "UPDATE segments
@@ -256,7 +259,12 @@ impl JobStore {
                    AND id = ?3
                    AND status NOT IN ('succeeded', 'skipped_cached', 'needs_review')",
                 params![error, job_id, segment_id],
-            )?;
+            )?
+        };
+        if updated > 0 {
+            // Findings are instrumentation, so a failed findings write must
+            // never fail the surrounding translation checkpoint.
+            let _ = self.record_segment_findings(job_id, segment_id, error);
         }
         self.mark_job_failed(job_id)?;
         Ok(())
@@ -279,7 +287,14 @@ impl JobStore {
             let placeholders = std::iter::repeat_n("?", chunk.len())
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
+            let select_sql = format!(
+                "SELECT id FROM segments
+                 WHERE job_id = ?
+                   AND id IN ({placeholders})
+                   AND status NOT IN ('succeeded', 'skipped_cached', 'needs_review')
+                 ORDER BY id"
+            );
+            let update_sql = format!(
                 "UPDATE segments
                  SET status = 'failed', attempts = attempts + 1, error = ?
                  WHERE job_id = ?
@@ -287,14 +302,36 @@ impl JobStore {
                    AND status NOT IN ('succeeded', 'skipped_cached', 'needs_review')"
             );
 
-            let conn = self.conn.borrow();
-            let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(chunk.len() + 2);
-            params.push(&error);
-            params.push(&job_id);
-            for id in chunk {
-                params.push(id);
+            let (chunk_updated, failed_segment_ids) = {
+                let conn = self.conn.borrow();
+                let mut select_params: Vec<&dyn rusqlite::types::ToSql> =
+                    Vec::with_capacity(chunk.len() + 1);
+                select_params.push(&job_id);
+                for id in chunk {
+                    select_params.push(id);
+                }
+                let mut stmt = conn.prepare(&select_sql)?;
+                let failed_segment_ids = stmt
+                    .query_map(select_params.as_slice(), |row| row.get::<_, String>(0))?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                drop(stmt);
+
+                let mut update_params: Vec<&dyn rusqlite::types::ToSql> =
+                    Vec::with_capacity(chunk.len() + 2);
+                update_params.push(&error);
+                update_params.push(&job_id);
+                for id in chunk {
+                    update_params.push(id);
+                }
+                let chunk_updated = conn.execute(&update_sql, update_params.as_slice())?;
+                (chunk_updated, failed_segment_ids)
+            };
+            updated += chunk_updated;
+            for segment_id in failed_segment_ids {
+                // Findings are instrumentation, so a failed findings write
+                // must never fail the surrounding translation checkpoint.
+                let _ = self.record_segment_findings(job_id, &segment_id, error);
             }
-            updated += conn.execute(&sql, params.as_slice())?;
         }
 
         if updated > 0 {

--- a/crates/bookforge-store/src/db/schema.rs
+++ b/crates/bookforge-store/src/db/schema.rs
@@ -310,7 +310,11 @@ impl JobStore {
              CREATE INDEX IF NOT EXISTS idx_style_lookup
              ON style_sheets(target_language, scope_kind, scope_id);
              CREATE INDEX IF NOT EXISTS idx_entity_lookup
-             ON entities(source_language, target_language, scope_kind, scope_id);",
+             ON entities(source_language, target_language, scope_kind, scope_id);
+             CREATE INDEX IF NOT EXISTS idx_qa_findings_job
+             ON qa_findings(job_id, kind);
+             CREATE INDEX IF NOT EXISTS idx_qa_findings_segment
+             ON qa_findings(job_id, segment_id);",
         )?;
         record_migration(&conn, 1, "initial")?;
         record_migration(&conn, 2, "v1_0_1_input_snapshot")?;
@@ -319,6 +323,12 @@ impl JobStore {
         record_migration(&conn, 5, "v1_2_1_nullable_glossary_candidate_targets")?;
         record_migration(&conn, 6, "v1_3_context_styles_entities")?;
         record_migration(&conn, 7, "v2_4_human_corrections")?;
+        // Unlike the preceding idempotent DDL migrations, version 8 drives a
+        // one-time data backfill and therefore must be gated explicitly.
+        if !migration_applied(&conn, 8)? {
+            backfill_qa_findings(&conn)?;
+            record_migration(&conn, 8, "v2_7_qa_findings")?;
+        }
         Ok(())
     }
 }
@@ -438,6 +448,61 @@ fn record_migration(conn: &Connection, version: i64, name: &str) -> rusqlite::Re
         params![version, name, timestamp_string()],
     )?;
     Ok(())
+}
+
+fn migration_applied(conn: &Connection, version: i64) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _migrations WHERE version = ?1)",
+        params![version],
+        |row| row.get::<_, bool>(0),
+    )
+}
+
+fn backfill_qa_findings(conn: &Connection) -> rusqlite::Result<usize> {
+    let rows = {
+        let mut stmt = conn.prepare(
+            "SELECT s.job_id, s.id, s.error
+             FROM segments s
+             WHERE s.status IN ('needs_review', 'failed')
+               AND s.error IS NOT NULL
+               AND TRIM(s.error) <> ''
+               AND NOT EXISTS (
+                 SELECT 1 FROM qa_findings f
+                 WHERE f.job_id = s.job_id AND f.segment_id = s.id
+               )
+             ORDER BY s.job_id, s.id",
+        )?;
+        stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+    };
+
+    let mut inserted = 0usize;
+    for (job_id, segment_id, error) in rows {
+        for (index, finding) in classify_segment_error(&error).into_iter().enumerate() {
+            let hash = stable_hash(&format!("{job_id}\u{1f}{segment_id}\u{1f}{index}"));
+            let id = format!("qaf_{}", &hash[..24]);
+            inserted += conn.execute(
+                "INSERT OR REPLACE INTO qa_findings
+                 (id, segment_id, job_id, severity, kind, message)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id,
+                    segment_id,
+                    job_id,
+                    finding.severity.as_str(),
+                    finding.kind.as_str(),
+                    finding.message,
+                ],
+            )?;
+        }
+    }
+    Ok(inserted)
 }
 
 #[cfg(all(test, unix))]

--- a/crates/bookforge-store/src/db/tests.rs
+++ b/crates/bookforge-store/src/db/tests.rs
@@ -2413,3 +2413,360 @@ fn glossary_term(
         source_count: 0,
     }
 }
+
+const MULTI_FINDING_ERROR: &str = "translation is unchanged from the source-language prose; batch translation block mismatch: missing=[\"b_000853\"], extra=[], duplicate=[]";
+
+fn setup_findings_store(
+    name: &str,
+    segment_count: usize,
+) -> (PathBuf, PathBuf, JobStore, JobRecord) {
+    let db_path = temp_path(name);
+    let input_path = temp_path("findings_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("store should open");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("findings_output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let segments = (0..segment_count)
+        .map(|ordinal| segment(&format!("seg_{ordinal}"), ordinal))
+        .collect::<Vec<_>>();
+    store
+        .insert_segments(
+            &job.id,
+            &segments,
+            "v1",
+            "mock",
+            "mock-prefix",
+            "findings_ns",
+        )
+        .expect("segments should insert");
+    (db_path, input_path, store, job)
+}
+
+fn save_two_findings(store: &JobStore, job_id: &str) {
+    store
+        .save_needs_review(SaveNeedsReview {
+            job_id,
+            segment_id: "seg_0",
+            preserved_text: "Source 0",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "Source 0".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            error: MULTI_FINDING_ERROR,
+            input_tokens: Some(5),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(5),
+            tokens_estimated: false,
+        })
+        .expect("review translation should save");
+}
+
+#[test]
+fn classifies_real_qa_failure_strings_into_every_taxonomy_kind() {
+    let cases = [
+        (
+            "protected span missing from segment 'seg_0007': 4th",
+            QaFindingKind::ProtectedSpanMissing,
+            QaFindingSeverity::Error,
+            "protected_span_missing",
+        ),
+        (
+            "inline marker missing from segment 'seg_0012': m1",
+            QaFindingKind::InlineMarkerMissing,
+            QaFindingSeverity::Error,
+            "inline_marker_missing",
+        ),
+        (
+            "inline marker duplicated: m3",
+            QaFindingKind::InlineMarkerDuplicated,
+            QaFindingSeverity::Error,
+            "inline_marker_duplicated",
+        ),
+        (
+            "unknown inline marker: m9",
+            QaFindingKind::InlineMarkerUnknown,
+            QaFindingSeverity::Error,
+            "inline_marker_unknown",
+        ),
+        (
+            "inline marker <i> is missing closing tag </i>",
+            QaFindingKind::MarkerStructure,
+            QaFindingSeverity::Error,
+            "marker_structure",
+        ),
+        (
+            "segment 'seg_0003' expected 4 block translations, got 3",
+            QaFindingKind::BatchBlockMismatch,
+            QaFindingSeverity::Error,
+            "batch_block_mismatch",
+        ),
+        (
+            "translation is unchanged from the source-language prose",
+            QaFindingKind::SourceCopyUnchanged,
+            QaFindingSeverity::Warning,
+            "source_copy_unchanged",
+        ),
+        (
+            "unapproved lowercase word in strict Toki Pona output: kalama",
+            QaFindingKind::TargetLanguageGate,
+            QaFindingSeverity::Warning,
+            "target_language_gate",
+        ),
+        (
+            "translation checkpoint failure: provider error: HTTP status 503: upstream unavailable",
+            QaFindingKind::ProviderError,
+            QaFindingSeverity::Error,
+            "provider_error",
+        ),
+        (
+            "batch translation checkpoint failure: provider error: interrupted by user",
+            QaFindingKind::Interrupted,
+            QaFindingSeverity::Warning,
+            "interrupted",
+        ),
+        (
+            "something nobody has seen before",
+            QaFindingKind::Other,
+            QaFindingSeverity::Error,
+            "other",
+        ),
+    ];
+
+    for (error, expected_kind, expected_severity, expected_wire_kind) in cases {
+        let findings = classify_segment_error(error);
+        assert_eq!(findings.len(), 1, "{error}");
+        assert_eq!(findings[0].kind, expected_kind, "{error}");
+        assert_eq!(findings[0].severity, expected_severity, "{error}");
+        assert_eq!(findings[0].kind.as_str(), expected_wire_kind, "{error}");
+        assert_eq!(
+            findings[0].severity.as_str(),
+            expected_severity.as_str(),
+            "{error}"
+        );
+        assert_eq!(findings[0].message, error, "{error}");
+    }
+}
+
+#[test]
+fn classifies_concatenated_failures_as_distinct_findings() {
+    let findings = classify_segment_error(MULTI_FINDING_ERROR);
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0].kind, QaFindingKind::SourceCopyUnchanged);
+    assert_eq!(
+        findings[0].message,
+        "translation is unchanged from the source-language prose"
+    );
+    assert_eq!(findings[1].kind, QaFindingKind::BatchBlockMismatch);
+    assert_eq!(
+        findings[1].message,
+        "batch translation block mismatch: missing=[\"b_000853\"], extra=[], duplicate=[]"
+    );
+
+    let breakdown = aggregate_findings(findings);
+    assert_eq!(breakdown.len(), 2);
+    assert_eq!(breakdown[0].share_percent(2), 50.0);
+    assert_eq!(breakdown[0].share_percent(0), 0.0);
+}
+
+#[test]
+fn embedded_separator_in_validator_context_stays_in_one_finding() {
+    let error = "pi must group at least two following words; offending context: jan pi mute";
+    let findings = classify_segment_error(error);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].kind, QaFindingKind::TargetLanguageGate);
+    assert_eq!(findings[0].message, error);
+}
+
+#[test]
+fn empty_segment_errors_produce_no_findings() {
+    assert!(classify_segment_error("").is_empty());
+    assert!(classify_segment_error(" \t\r\n ").is_empty());
+}
+
+#[test]
+fn save_needs_review_records_each_distinct_failure() {
+    let (db_path, input_path, store, job) =
+        setup_findings_store("save_needs_review_findings.sqlite", 1);
+    save_two_findings(&store, &job.id);
+
+    let findings = store
+        .segment_qa_findings(&job.id)
+        .expect("findings should load");
+    assert_eq!(findings.len(), 2);
+    assert!(findings.iter().all(|finding| finding.segment_id == "seg_0"));
+    let breakdown = store
+        .qa_finding_breakdown(&job.id)
+        .expect("breakdown should load");
+    assert_eq!(breakdown.len(), 2);
+    assert_eq!(breakdown[0].kind, "batch_block_mismatch");
+    assert_eq!(breakdown[1].kind, "source_copy_unchanged");
+
+    drop(store);
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn repeated_needs_review_save_replaces_findings_without_duplication() {
+    let (db_path, input_path, store, job) =
+        setup_findings_store("replace_needs_review_findings.sqlite", 1);
+    save_two_findings(&store, &job.id);
+    let first_ids = store
+        .segment_qa_findings(&job.id)
+        .expect("first findings should load")
+        .into_iter()
+        .map(|finding| finding.id)
+        .collect::<Vec<_>>();
+
+    save_two_findings(&store, &job.id);
+    let second_ids = store
+        .segment_qa_findings(&job.id)
+        .expect("replacement findings should load")
+        .into_iter()
+        .map(|finding| finding.id)
+        .collect::<Vec<_>>();
+    assert_eq!(second_ids.len(), 2);
+    assert_eq!(second_ids, first_ids);
+
+    drop(store);
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn successful_translation_clears_previous_findings() {
+    let (db_path, input_path, store, job) =
+        setup_findings_store("clear_translation_findings.sqlite", 1);
+    save_two_findings(&store, &job.id);
+    assert_eq!(store.segment_qa_findings(&job.id).unwrap().len(), 2);
+
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job.id,
+            segment_id: "seg_0",
+            translated_text: "Tradotto",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "Tradotto".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(4),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(3),
+            tokens_estimated: false,
+        })
+        .expect("successful translation should save");
+    assert!(store.segment_qa_findings(&job.id).unwrap().is_empty());
+
+    drop(store);
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn migration_eight_backfills_existing_segment_errors_once() {
+    let (db_path, input_path, store, job) = setup_findings_store("backfill_qa_findings.sqlite", 1);
+    {
+        let conn = store.conn.borrow();
+        conn.execute(
+            "UPDATE segments
+             SET status = 'needs_review', error = ?1
+             WHERE job_id = ?2 AND id = 'seg_0'",
+            params![MULTI_FINDING_ERROR, job.id],
+        )
+        .expect("legacy segment should update");
+        conn.execute("DELETE FROM qa_findings", [])
+            .expect("findings should clear");
+        conn.execute("DELETE FROM _migrations WHERE version = 8", [])
+            .expect("migration marker should clear");
+    }
+    drop(store);
+
+    let reopened = JobStore::open(&db_path).expect("legacy store should reopen");
+    let findings = reopened
+        .segment_qa_findings(&job.id)
+        .expect("backfilled findings should load");
+    assert_eq!(findings.len(), 2);
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.kind == "source_copy_unchanged")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.kind == "batch_block_mismatch")
+    );
+    let migration_count = reopened
+        .conn
+        .borrow()
+        .query_row(
+            "SELECT COUNT(*) FROM _migrations WHERE version = 8",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("migration marker should query");
+    assert_eq!(migration_count, 1);
+
+    drop(reopened);
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn qa_finding_breakdown_orders_counts_descending() {
+    let (db_path, input_path, store, job) =
+        setup_findings_store("qa_finding_breakdown_order.sqlite", 6);
+    let errors = [
+        "batch translation block mismatch: missing=[], extra=[], duplicate=[]",
+        "missing block translations: b_1",
+        "segment 'seg_2' expected 2 block translations, got 1",
+        "provider error: upstream unavailable",
+        "HTTP status 503: upstream unavailable",
+        "translation is unchanged from the source-language prose",
+    ];
+    for (ordinal, error) in errors.into_iter().enumerate() {
+        assert_eq!(
+            store
+                .record_segment_findings(&job.id, &format!("seg_{ordinal}"), error)
+                .expect("finding should record"),
+            1
+        );
+    }
+
+    let breakdown = store
+        .qa_finding_breakdown(&job.id)
+        .expect("breakdown should load");
+    assert_eq!(
+        breakdown
+            .iter()
+            .map(|entry| (entry.kind.as_str(), entry.count))
+            .collect::<Vec<_>>(),
+        vec![
+            ("batch_block_mismatch", 3),
+            ("provider_error", 2),
+            ("source_copy_unchanged", 1),
+        ]
+    );
+
+    drop(store);
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}

--- a/crates/bookforge-store/src/db/translations.rs
+++ b/crates/bookforge-store/src/db/translations.rs
@@ -83,6 +83,9 @@ impl JobStore {
                 ],
             )?;
         }
+        // Findings are instrumentation, so a failed findings write must never
+        // fail the surrounding translation checkpoint.
+        let _ = self.clear_segment_findings(request.job_id, request.segment_id);
         self.consume_dashboard_retry_guidance(request.job_id, request.segment_id)?;
         self.touch_job_unless_status(request.job_id, "running", &["paused", "stopped"])?;
         Ok(())
@@ -138,6 +141,9 @@ impl JobStore {
                 ],
             )?;
         }
+        // Findings are instrumentation, so a failed findings write must never
+        // fail the surrounding translation checkpoint.
+        let _ = self.record_segment_findings(request.job_id, request.segment_id, request.error);
         self.consume_dashboard_retry_guidance(request.job_id, request.segment_id)?;
         self.touch_job_unless_status(request.job_id, "needs_review", &["paused", "stopped"])?;
         Ok(())
@@ -179,6 +185,9 @@ impl JobStore {
                 params![translated_hash, request.job_id, request.segment_id],
             )?;
         }
+        // Findings are instrumentation, so a failed findings write must never
+        // fail the surrounding translation checkpoint.
+        let _ = self.clear_segment_findings(request.job_id, request.segment_id);
         self.consume_dashboard_retry_guidance(request.job_id, request.segment_id)?;
         self.touch_job_unless_status(request.job_id, "running", &["paused", "stopped"])?;
         Ok(())

--- a/crates/bookforge-store/src/lib.rs
+++ b/crates/bookforge-store/src/lib.rs
@@ -3,8 +3,9 @@ pub mod db;
 pub use db::{
     CacheLookupRequest, CachedTranslation, CreateJob, GlossaryCandidateUpsertResult,
     GlossaryFilter, JobRecord, JobStore, JobSummary, NewEntity, NewGlossaryCandidate,
-    NewSegmentFlag, NewStyleSheet, RetryScope, SaveCachedTranslation, SaveManualCorrection,
-    SaveNeedsReview, SaveTranslation, SegmentRecord, StorageDoctor, StoreError,
-    StoredBlockTranslation, StoredEntity, StoredGlossaryCandidate, StoredSegmentTranslation,
-    StoredStyleSheet, run_doctor,
+    NewSegmentFlag, NewStyleSheet, QaFinding, QaFindingCount, QaFindingKind, QaFindingSeverity,
+    RetryScope, SaveCachedTranslation, SaveManualCorrection, SaveNeedsReview, SaveTranslation,
+    SegmentRecord, StorageDoctor, StoreError, StoredBlockTranslation, StoredEntity,
+    StoredGlossaryCandidate, StoredQaFinding, StoredSegmentTranslation, StoredStyleSheet,
+    aggregate_findings, classify_segment_error, run_doctor,
 };


### PR DESCRIPTION
Every one of the 13 Italian jobs in the local job store ended in `needs_review`. Not one clean run on a real book. `qa_findings` held **0 rows**, so nothing ever said why.

## Root cause

Source EPUBs mark endnotes as `word.<sup><a epub:type="noteref">*2</a></sup>`.

`BlockBuilder` recorded marker boundaries only into `text_runs`, never into `visible_text` — so `visible_text` held the fused token `vaccine.*2`. `looks_like_inline_math_token` accepted it (`*` is a strong math operator, `.` an allowed math char, rest alphanumeric) and it became a `Math` protected span. Validation then demanded that literal English string survive into Italian. `vaccine` must become `vaccino`, so **the check could never pass.**

Implicated in **57% of engine-side quality flags**: 153 of 216 protected-span failures, 227 spurious violation messages.

## Measured, not asserted

The validator is a pure function over (source block, model output), and every ingredient was already on disk — 30 `input.epub` snapshots plus the stored per-block translations. So this PR includes `examples/replay_validation`, which replays the validator over real book data at **zero API cost**, and the numbers below come from it (29 jobs, 40,303 pairs):

| | before | after |
|---|---|---|
| protected-span flags | 600 | **371** (−38%) |
| distinct spans demanded | 373 | **191** (−49%) |
| prose+symbol fused shapes | 142 | **7** (−95%) |

Building the instrument first paid for itself immediately: the first run disproved two of my own assumptions. There is no persisted `validate_source_copy` flag, and — the important one — **a needs-review segment stores the preserved SOURCE text as its translation**, so replaying those pairs compares source to source. That artifact accounted for 4,750 of 5,139 raw flags. Without the harness those would have looked like a catastrophic regression.

## Changes

- **epub** — derive protected spans from the marker-aware run sequence so a token can never fuse across a marker boundary. Track marker depth and delegate reference tokens to the positional marker check: *structure inside a marker is validated by marker reference text; protected spans cover prose outside markers.* The delegation is deliberately narrow — markers also wrap table cells, so a blanket rule would drop protection for values like `42%`.
- **llm** — validate that a marker's inner reference token survives. Marker IDs all passed while the `*2` vanished: a 10,266-character Italian segment contained **zero** asterisks, meaning endnote references were being silently dropped from finished books with nothing to catch it. Ordinary marker prose stays free to change.
- **llm** — compare numeric protected spans locale-insensitively. `p < 0,05` and `90.000.000` are correct Italian and were being flagged. Ambiguous groupings yield both readings rather than a guess; a genuinely wrong number still fails.
- **store/cli** — persist `qa_findings` with a real taxonomy and severity, one row per failure in a concatenated error, backfilled for existing jobs, surfaced as a per-kind breakdown in `status` and the review HTML. This is the instrument whose absence let the misfire hide across 13 books.
- **examples** — `replay_validation` (offline, free) and `judge_flags` (asks a model whether a flag is a true or false positive, via the existing provider abstraction, with `--dry-run` and a spend cap). Both are dev-time tooling and are **never** wired into the translate path — a model that auto-accepted work would violate the project's load-bearing invariant.

## Deliberately not chased further

103 flags still demand a bare one- or two-digit span, which is a weak check. 7 fused shapes survive — `I*16` is genuine math (digit plus interior operator) and rejecting it would also reject `x*2`.

Whether the remainder are true or false positives is a question for `judge_flags`, not for more heuristic guessing. Grinding the heuristic without that data is how the original bug got written.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **797 passed / 0 failed / 3 ignored** (was 762).

One lifecycle test (`cli_live_reconfigure_...`) flaked once under full-workspace build load with a 60s timeout, then passed 3/3 in isolation at ~2.2s and clean on a full re-run — consistent with the flakes addressed in #49.

The live job store was verified byte-identical (SHA-256) before and after every replay; the harness opens a throwaway copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)