### PR TITLE
chore(pricing): add Kimi K3 to the OpenRouter catalog

### DIFF
--- a/crates/bookforge-cli/pricing/providers.json
+++ b/crates/bookforge-cli/pricing/providers.json
@@ -9,6 +9,11 @@
           "output_per_million_usd": 0.28,
           "input_cache_per_million_usd": 0.0028
         },
+        "moonshotai/kimi-k3": {
+          "input_per_million_usd": 3.00,
+          "output_per_million_usd": 15.00,
+          "input_cache_per_million_usd": 0.30
+        },
         "google/gemini-2.5-flash-lite": {
           "input_per_million_usd": 0.075,
           "output_per_million_usd": 0.30,

--- a/pricing/providers.json
+++ b/pricing/providers.json
@@ -9,6 +9,11 @@
           "output_per_million_usd": 0.28,
           "input_cache_per_million_usd": 0.0028
         },
+        "moonshotai/kimi-k3": {
+          "input_per_million_usd": 3.00,
+          "output_per_million_usd": 15.00,
+          "input_cache_per_million_usd": 0.30
+        },
         "google/gemini-2.5-flash-lite": {
           "input_per_million_usd": 0.075,
           "output_per_million_usd": 0.30,


### PR DESCRIPTION
Adds `moonshotai/kimi-k3` so cost estimation works for it instead of reporting `no pricing entry for openrouter / moonshotai/kimi-k3`.

| | per 1M |
| --- | --- |
| input | $3.00 |
| output | $15.00 |
| cached input | $0.30 |

List prices as of 2026-07-26. As the README already states, these are estimates and provider billing is authoritative.

Came up while using `examples/judge_flags` against Kimi K3 — the run worked but could not report its own cost.

Note for anyone adding a model later: there are **two** copies of this catalog, `pricing/providers.json` and the packaged `crates/bookforge-cli/pricing/providers.json`, and `cost::tests::workspace_pricing_catalog_matches_packaged_copy_when_present` asserts they are identical. It caught my one-sided edit. Both are updated here.

`cargo test -p bookforge-cli --bins` 198 passed / 0 failed; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)