### PR TITLE
fix(validation): demote low-precision protected-span violations to warnings

### DIFF
--- a/crates/bookforge-cli/examples/replay_validation.rs
+++ b/crates/bookforge-cli/examples/replay_validation.rs
@@ -345,7 +345,7 @@ fn main() -> Result<()> {
             segments_with_pairs.insert(stored.segment_id.clone());
 
             let section_title = section_titles.get(&stored.segment_id).map(String::as_str);
-            let Some(message) = batch_item_validation_error(
+            let Some(validation) = batch_item_validation_error(
                 item,
                 &stored.text,
                 validate_source_copy,
@@ -354,6 +354,7 @@ fn main() -> Result<()> {
             ) else {
                 continue;
             };
+            let message = validation.to_string();
 
             let kinds = classify_kinds(&message);
             totals.flagged_pairs += 1;

--- a/crates/bookforge-cli/src/checkpoint.rs
+++ b/crates/bookforge-cli/src/checkpoint.rs
@@ -194,19 +194,22 @@ fn apply(store: &JobStore, cmd: CheckpointCommand) -> Result<()> {
             let joined = translation.joined_text();
             match translation.status {
                 SegmentStatus::Succeeded => {
-                    store.save_translation(SaveTranslation {
-                        job_id: &job_id,
-                        segment_id: &translation.segment_id.0,
-                        translated_text: &joined,
-                        blocks: &translation.blocks,
-                        provider: &provider,
-                        model: &model,
-                        prompt_version: &prompt_version,
-                        input_tokens: translation.input_tokens,
-                        input_cached_tokens: translation.input_cached_tokens,
-                        output_tokens: translation.output_tokens,
-                        tokens_estimated: translation.tokens_estimated,
-                    })?;
+                    store.save_translation_with_findings(
+                        SaveTranslation {
+                            job_id: &job_id,
+                            segment_id: &translation.segment_id.0,
+                            translated_text: &joined,
+                            blocks: &translation.blocks,
+                            provider: &provider,
+                            model: &model,
+                            prompt_version: &prompt_version,
+                            input_tokens: translation.input_tokens,
+                            input_cached_tokens: translation.input_cached_tokens,
+                            output_tokens: translation.output_tokens,
+                            tokens_estimated: translation.tokens_estimated,
+                        },
+                        translation.error.as_deref(),
+                    )?;
                 }
                 SegmentStatus::NeedsReview => {
                     store.save_needs_review(SaveNeedsReview {
@@ -417,6 +420,84 @@ mod tests {
         assert_eq!(summary.needs_review, 1, "one needs review");
         assert_eq!(summary.total_segments, 2);
 
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
+    }
+
+    #[test]
+    fn succeeded_translation_persists_warning_finding_round_trip() {
+        let db_path = temp_path("warning_round_trip.sqlite");
+        let input_path = temp_path("warning_input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture writable");
+
+        let store = JobStore::open(&db_path).expect("store open for setup");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("warning_output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-model",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("job created");
+        store
+            .insert_segments(
+                &job.id,
+                &[test_segment("seg_warning", 0)],
+                "v1",
+                "mock",
+                "mock-model",
+                "test_ns",
+            )
+            .expect("segment inserted");
+
+        let mut translation = test_translation("seg_warning", 0, SegmentStatus::Succeeded);
+        translation.error = Some("warning: protected span missing: E=mc^2 [kind=math]".to_string());
+        apply(
+            &store,
+            CheckpointCommand::SaveTranslation {
+                job_id: job.id.clone(),
+                translation: Box::new(translation),
+                provider: "mock".to_string(),
+                model: "mock-model".to_string(),
+                prompt_version: "v1".to_string(),
+            },
+        )
+        .expect("successful translation with warning should checkpoint");
+        drop(store);
+
+        let store = JobStore::open(&db_path).expect("store re-open");
+        let summary = store
+            .summary(&job.id)
+            .expect("summary query")
+            .expect("summary exists");
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.needs_review, 0);
+        assert_eq!(
+            store
+                .prune_stale_findings(&job.id)
+                .expect("pruning stale errors"),
+            0,
+            "a warning on a succeeded segment is not stale"
+        );
+        let findings = store
+            .segment_qa_findings(&job.id)
+            .expect("warning findings load");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].segment_id, "seg_warning");
+        assert_eq!(findings[0].kind, "protected_span_missing");
+        assert_eq!(findings[0].severity, "warning");
+        assert_eq!(
+            findings[0].message,
+            "protected span missing: E=mc^2 [kind=math]"
+        );
+
+        drop(store);
         let _ = fs::remove_file(db_path);
         let _ = fs::remove_file(input_path);
     }

--- a/crates/bookforge-core/src/ir.rs
+++ b/crates/bookforge-core/src/ir.rs
@@ -115,7 +115,7 @@ pub struct InlineMark {
     pub kind: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProtectedSpan {
     pub kind: ProtectedSpanKind,
     pub text: String,
@@ -132,4 +132,36 @@ pub enum ProtectedSpanKind {
     InternalAnchor,
     Citation,
     FootnoteReference,
+}
+
+impl ProtectedSpanKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Url => "url",
+            Self::Email => "email",
+            Self::Code => "code",
+            Self::Math => "math",
+            Self::Number => "number",
+            Self::Filename => "filename",
+            Self::InternalAnchor => "internal_anchor",
+            Self::Citation => "citation",
+            Self::FootnoteReference => "footnote_reference",
+        }
+    }
+}
+
+/// Severity shared by deterministic validation and durable QA findings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QaFindingSeverity {
+    Error,
+    Warning,
+}
+
+impl QaFindingSeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
 }

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 use crate::{
     BookforgeError, Result,
     config::SegmentationConfig,
-    ir::{Block, BlockId, BlockKind, Book, Section, SectionId},
+    ir::{Block, BlockId, BlockKind, Book, ProtectedSpan, Section, SectionId},
 };
 
 /// Bumped when the cache key derivation changes incompatibly.
@@ -161,7 +161,7 @@ pub struct SegmentBlock {
     pub kind: String,
     pub text: String,
     pub text_runs: Vec<SegmentTextRun>,
-    pub protected_spans: Vec<String>,
+    pub protected_spans: Vec<ProtectedSpan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -317,12 +317,12 @@ fn push_segment(
     let segment_blocks = blocks
         .iter()
         .map(|block| {
-            let mut spans = block
-                .protected_spans
-                .iter()
-                .map(|span| span.text.clone())
-                .collect::<Vec<_>>();
-            spans.sort();
+            let mut spans = block.protected_spans.clone();
+            spans.sort_by(|left, right| {
+                left.text
+                    .cmp(&right.text)
+                    .then_with(|| left.kind.as_str().cmp(right.kind.as_str()))
+            });
             spans.dedup();
             SegmentBlock {
                 block_id: block.id.clone(),
@@ -471,7 +471,8 @@ fn tail_words(text: &str, max_words: usize) -> String {
 mod tests {
     use super::*;
     use crate::ir::{
-        BlockKind, BookFormat, BookId, DomPath, Metadata, Resource, Section, SpineItem, TextRun,
+        BlockKind, BookFormat, BookId, DomPath, Metadata, ProtectedSpanKind, Resource, Section,
+        SpineItem, TextRun,
     };
 
     #[test]
@@ -526,6 +527,68 @@ mod tests {
         };
 
         assert!(build_segments(&book, &config).is_err());
+    }
+
+    #[test]
+    fn segment_blocks_carry_protected_span_kinds_directly() {
+        let spans = vec![
+            ProtectedSpan {
+                kind: ProtectedSpanKind::Math,
+                text: "E=mc^2".to_string(),
+            },
+            ProtectedSpan {
+                kind: ProtectedSpanKind::Url,
+                text: "https://example.com".to_string(),
+            },
+            ProtectedSpan {
+                kind: ProtectedSpanKind::Number,
+                text: "42".to_string(),
+            },
+        ];
+        let mut book = book_with_two_sections();
+        book.blocks[0].protected_spans = spans.clone();
+
+        let segments = build_segments(
+            &book,
+            &SegmentationConfig {
+                max_segment_tokens: 100,
+                context_tokens: 0,
+            },
+        )
+        .expect("segments should build");
+
+        let mut expected = spans;
+        expected.sort_by(|left, right| {
+            left.text
+                .cmp(&right.text)
+                .then_with(|| left.kind.as_str().cmp(right.kind.as_str()))
+        });
+        assert_eq!(segments[0].source.blocks[0].protected_spans, expected);
+    }
+
+    #[test]
+    fn protected_span_metadata_does_not_change_segment_checksum_or_id() {
+        let config = SegmentationConfig {
+            max_segment_tokens: 100,
+            context_tokens: 0,
+        };
+        let baseline = book_with_two_sections();
+        let baseline_segments =
+            build_segments(&baseline, &config).expect("baseline segments should build");
+
+        let mut with_span = baseline;
+        with_span.blocks[0].protected_spans = vec![ProtectedSpan {
+            kind: ProtectedSpanKind::Number,
+            text: "1".to_string(),
+        }];
+        let segments_with_span =
+            build_segments(&with_span, &config).expect("segments with spans should build");
+
+        assert_eq!(
+            segments_with_span[0].checksum,
+            baseline_segments[0].checksum
+        );
+        assert_eq!(segments_with_span[0].id, baseline_segments[0].id);
     }
 
     #[test]

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1428,6 +1428,19 @@ fn looks_like_inline_math_token(value: &str) -> bool {
     if chars.len() < 3 {
         return false;
     }
+    // OCR scans commonly substitute operators such as `^` for missing
+    // letters/spaces. Multiple operators without any digit are stronger
+    // evidence of mangled prose than of an inline equation.
+    if !chars.iter().any(|ch| ch.is_ascii_digit())
+        && chars
+            .iter()
+            .filter(|ch| is_inline_math_operator(**ch))
+            .take(2)
+            .count()
+            >= 2
+    {
+        return false;
+    }
     // Sentence punctuation followed by an operator signals a fused endnote marker.
     if chars
         .windows(2)
@@ -2180,6 +2193,27 @@ mod tests {
                 .iter()
                 .any(|span| span.kind == ProtectedSpanKind::Math)
         );
+    }
+
+    #[test]
+    fn inline_math_rejects_operator_heavy_ocr_garbage_without_digits() {
+        for value in ["Thei^is^ood^reason", "^I^sually^o^tbe"] {
+            assert!(
+                !detect_protected_spans(value)
+                    .iter()
+                    .any(|span| span.kind == ProtectedSpanKind::Math),
+                "{value}"
+            );
+        }
+
+        for value in ["E=mc^2", "p<0.05", "x_12", "mc^2", "3.5*2"] {
+            assert!(
+                detect_protected_spans(value)
+                    .iter()
+                    .any(|span| span.kind == ProtectedSpanKind::Math && span.text == value),
+                "{value}"
+            );
+        }
     }
 
     #[test]

--- a/crates/bookforge-epub/src/validate.rs
+++ b/crates/bookforge-epub/src/validate.rs
@@ -178,7 +178,7 @@ pub fn validate_block_translations(
             }
 
             for span in &block.protected_spans {
-                if block.text.contains(span) && !translated.contains(span) {
+                if block.text.contains(&span.text) && !translated.contains(&span.text) {
                     issues.push(EpubValidationIssue {
                         severity: ValidationSeverity::Warning,
                         kind: "missing_protected_span".to_string(),
@@ -186,7 +186,7 @@ pub fn validate_block_translations(
                         block_id: Some(block.block_id.0.clone()),
                         message: format!(
                             "Protected span '{}' may be missing in block {}",
-                            span, block.block_id.0
+                            span.text, block.block_id.0
                         ),
                     });
                 }
@@ -231,7 +231,7 @@ mod tests {
         block_text: &str,
         protected_spans: Vec<String>,
     ) -> (Segment, bookforge_core::ir::BlockId) {
-        use bookforge_core::ir::{BlockId, SectionId};
+        use bookforge_core::ir::{BlockId, ProtectedSpan, ProtectedSpanKind, SectionId};
         use bookforge_core::segment::{
             SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
             SegmentSource, SegmentTextRun,
@@ -253,7 +253,13 @@ mod tests {
                         id: "r0".to_string(),
                         text: block_text.to_string(),
                     }],
-                    protected_spans,
+                    protected_spans: protected_spans
+                        .into_iter()
+                        .map(|text| ProtectedSpan {
+                            kind: ProtectedSpanKind::Number,
+                            text,
+                        })
+                        .collect(),
                 }],
                 token_estimate: 1,
             },

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -1,7 +1,7 @@
 use bookforge_core::{
     config::{BatchConfig, ProviderRequestMetric, TranslationProfile},
     glossary::GlossaryFormat,
-    ir::BlockId,
+    ir::{BlockId, ProtectedSpan, ProtectedSpanKind, QaFindingSeverity},
     segment::{BlockTranslation, Segment, SegmentId, SegmentStatus, SegmentTextRun},
 };
 use std::collections::{HashMap, VecDeque, hash_map::Entry};
@@ -92,7 +92,7 @@ pub struct TranslationBatchItem {
     pub kind: String,
     pub source_text: String,
     pub text_runs: Vec<SegmentTextRun>,
-    pub protected_spans: Vec<String>,
+    pub protected_spans: Vec<ProtectedSpan>,
     pub required_markers: Vec<String>,
     pub checksum: String,
 }
@@ -112,10 +112,79 @@ pub struct BatchItemTranslation {
     pub item_id: String,
     pub segment_id: SegmentId,
     pub text: String,
+    /// Severity-prefixed findings carried by a successful item. Only warning
+    /// violations can reach this field.
+    pub warning: Option<String>,
     pub input_tokens: Option<u64>,
     pub input_cached_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub tokens_estimated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchItemValidationViolation {
+    pub severity: QaFindingSeverity,
+    pub protected_span_kind: Option<ProtectedSpanKind>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchItemValidationError {
+    violations: Vec<BatchItemValidationViolation>,
+    message: String,
+}
+
+impl BatchItemValidationError {
+    fn new(violations: Vec<BatchItemValidationViolation>) -> Option<Self> {
+        if violations.is_empty() {
+            return None;
+        }
+        let message = violations
+            .iter()
+            .map(|violation| violation.message.as_str())
+            .collect::<Vec<_>>()
+            .join("; ");
+        Some(Self {
+            violations,
+            message,
+        })
+    }
+
+    pub fn violations(&self) -> &[BatchItemValidationViolation] {
+        &self.violations
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.violations
+            .iter()
+            .any(|violation| violation.severity == QaFindingSeverity::Error)
+    }
+
+    fn persistence_message(&self) -> String {
+        self.violations
+            .iter()
+            .map(|violation| format!("{}: {}", violation.severity.as_str(), violation.message))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    pub fn contains(&self, pattern: &str) -> bool {
+        self.message.contains(pattern)
+    }
+}
+
+impl std::fmt::Display for BatchItemValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::ops::Deref for BatchItemValidationError {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.message
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bookforge-llm/src/batch/execution.rs
+++ b/crates/bookforge-llm/src/batch/execution.rs
@@ -673,6 +673,9 @@ where
                                     tokens_estimated: false,
                                 });
                             add_usage(entry, item);
+                            if let Some(warning) = &item.warning {
+                                append_translation_error(entry, warning);
+                            }
                             if !entry
                                 .blocks
                                 .iter()
@@ -1162,6 +1165,9 @@ where
                     )
                 });
             add_usage(entry, translation);
+            if let Some(warning) = &translation.warning {
+                append_translation_error(entry, warning);
+            }
             if let Some(source_item) = all_items.get(&translation.item_id) {
                 entry.blocks.push(BlockTranslation {
                     block_id: source_item.block_id.clone(),
@@ -1335,11 +1341,16 @@ where
                         .items
                         .iter()
                         .map(|item| {
+                            let protected = item
+                                .protected_spans
+                                .iter()
+                                .map(|span| span.text.as_str())
+                                .collect::<Vec<_>>();
                             serde_json::json!({
                                 "id": item.item_id,
                                 "source_text": item.source_text,
                                 "required_markers": item.required_markers,
-                                "protected": item.protected_spans,
+                                "protected": protected,
                             })
                         })
                         .collect();
@@ -1352,7 +1363,7 @@ where
                                 "id": item.item_id,
                                 "error": repair_errors
                                     .get(&item.item_id)
-                                    .cloned()
+                                    .map(|error| provider_safe_validation_error(error))
                                     .unwrap_or_else(|| "invalid batch item".to_string()),
                             })
                         })
@@ -1535,7 +1546,12 @@ where
                             segment_translations.get_mut(&translation.segment_id.0)
                         {
                             existing.status = SegmentStatus::Succeeded;
-                            existing.error = None;
+                            let retained_warnings =
+                                existing.error.as_deref().and_then(warning_findings_only);
+                            existing.error = retained_warnings;
+                            if let Some(warning) = &translation.warning {
+                                append_translation_error(existing, warning);
+                            }
                             if let Some(block) = existing
                                 .blocks
                                 .iter_mut()
@@ -1909,6 +1925,26 @@ fn append_translation_error(entry: &mut SegmentTranslation, error: &str) {
     }
 }
 
+fn warning_findings_only(error: &str) -> Option<String> {
+    let warnings = error
+        .split("; ")
+        .filter(|fragment| fragment.starts_with("warning: "))
+        .collect::<Vec<_>>()
+        .join("; ");
+    (!warnings.is_empty()).then_some(warnings)
+}
+
+fn provider_safe_validation_error(error: &str) -> String {
+    let mut message = error.to_string();
+    while let Some(start) = message.find(" [kind=") {
+        let Some(relative_end) = message[start..].find(']') else {
+            break;
+        };
+        message.replace_range(start..=start + relative_end, "");
+    }
+    message
+}
+
 fn repairable_batch_failure(failure: &BatchItemFailure) -> bool {
     !matches!(
         failure.error.as_str(),
@@ -2008,5 +2044,22 @@ pub(super) fn request_status_for_controller<T>(result: &Result<T, LlmError>) -> 
         }
         Err(LlmError::InvalidResponse(_)) | Err(LlmError::Json(_)) => RequestStatus::InvalidJson,
         Err(_) => RequestStatus::OtherError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provider_safe_validation_error;
+
+    #[test]
+    fn provider_validation_errors_omit_protected_span_kinds() {
+        let error = "error: protected span missing: https://example.com [kind=url]; \
+                     warning: protected span missing: E=mc^2 [kind=math]";
+
+        assert_eq!(
+            provider_safe_validation_error(error),
+            "error: protected span missing: https://example.com; \
+             warning: protected span missing: E=mc^2"
+        );
     }
 }

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -7,51 +7,250 @@ pub fn batch_item_validation_error(
     validate_source_copy: bool,
     section_title: Option<&str>,
     target_language: Option<&str>,
-) -> Option<String> {
+) -> Option<BatchItemValidationError> {
+    let mut violations = Vec::new();
     if let Some(error) = bookforge_core::marker::marker_structure_error(translation) {
-        return Some(error);
+        violations.push(hard_violation(error));
     }
     let expected = bookforge_core::marker::marker_ids_in_text(&item.source_text);
     let actual = bookforge_core::marker::marker_ids_in_text(translation);
     for marker in &expected {
         let count = actual.iter().filter(|found| *found == marker).count();
         if count == 0 {
-            return Some(format!("inline marker missing: {marker}"));
+            violations.push(hard_violation(format!("inline marker missing: {marker}")));
         }
         if count > 1 {
-            return Some(format!("inline marker duplicated: {marker}"));
+            violations.push(hard_violation(format!(
+                "inline marker duplicated: {marker}"
+            )));
         }
     }
     for marker in &actual {
         if !expected.contains(marker) {
-            return Some(format!("unknown inline marker: {marker}"));
+            violations.push(hard_violation(format!("unknown inline marker: {marker}")));
         }
     }
     if let Some(error) =
         crate::validation::marker_reference_text_error(&item.source_text, translation)
     {
-        return Some(error);
+        violations.push(hard_violation(error));
     }
-    for span in &item.protected_spans {
-        if !span.trim().is_empty() && !crate::validation::protected_span_present(span, translation)
-        {
-            return Some(format!("protected span missing: {span}"));
-        }
-    }
+    violations.extend(protected_span_violations(item, translation));
     if let Some(error) = source_copy_error(item, translation, validate_source_copy, section_title) {
-        return Some(error);
+        violations.push(hard_violation(error));
     }
+    let protected_spans = protected_span_texts(item);
     if let Some(error) = target_language.and_then(|target_language| {
         crate::validation::target_language_validation_error(
             target_language,
             &item.source_text,
             translation,
-            &item.protected_spans,
+            &protected_spans,
         )
     }) {
-        return Some(error);
+        violations.push(hard_violation(error));
     }
-    None
+    BatchItemValidationError::new(violations)
+}
+
+fn turbo_batch_item_validation_error(
+    item: &TranslationBatchItem,
+    translation: &str,
+    validate_source_copy: bool,
+    section_title: Option<&str>,
+    target_language: Option<&str>,
+) -> Option<BatchItemValidationError> {
+    let mut violations = protected_span_violations(item, translation);
+    if let Some(error) = source_copy_error(item, translation, validate_source_copy, section_title) {
+        violations.push(hard_violation(error));
+    }
+    let protected_spans = protected_span_texts(item);
+    if let Some(error) = target_language.and_then(|target_language| {
+        crate::validation::target_language_validation_error(
+            target_language,
+            &item.source_text,
+            translation,
+            &protected_spans,
+        )
+    }) {
+        violations.push(hard_violation(error));
+    }
+    BatchItemValidationError::new(violations)
+}
+
+fn hard_violation(message: String) -> BatchItemValidationViolation {
+    BatchItemValidationViolation {
+        severity: QaFindingSeverity::Error,
+        protected_span_kind: None,
+        message,
+    }
+}
+
+fn protected_span_violations(
+    item: &TranslationBatchItem,
+    translation: &str,
+) -> Vec<BatchItemValidationViolation> {
+    item.protected_spans
+        .iter()
+        .filter(|span| {
+            !span.text.trim().is_empty()
+                && !crate::validation::protected_span_present(&span.text, translation)
+        })
+        .map(|span| {
+            let severity = protected_span_severity(item, span.kind, &span.text);
+            let kind_suffix = format!(" [kind={}]", span.kind.as_str());
+            BatchItemValidationViolation {
+                severity,
+                protected_span_kind: Some(span.kind),
+                message: format!("protected span missing: {}{kind_suffix}", span.text),
+            }
+        })
+        .collect()
+}
+
+fn protected_span_texts(item: &TranslationBatchItem) -> Vec<String> {
+    item.protected_spans
+        .iter()
+        .map(|span| span.text.clone())
+        .collect()
+}
+
+fn protected_span_severity(
+    item: &TranslationBatchItem,
+    kind: ProtectedSpanKind,
+    text: &str,
+) -> QaFindingSeverity {
+    match kind {
+        ProtectedSpanKind::Math => QaFindingSeverity::Warning,
+        ProtectedSpanKind::Number => number_violation_severity(item, text),
+        ProtectedSpanKind::Url
+        | ProtectedSpanKind::Email
+        | ProtectedSpanKind::Code
+        | ProtectedSpanKind::Filename
+        | ProtectedSpanKind::InternalAnchor
+        | ProtectedSpanKind::Citation
+        | ProtectedSpanKind::FootnoteReference => QaFindingSeverity::Error,
+    }
+}
+
+fn number_violation_severity(item: &TranslationBatchItem, text: &str) -> QaFindingSeverity {
+    let digit_count = text.chars().filter(char::is_ascii_digit).count();
+    let has_currency = text
+        .chars()
+        .any(|ch| matches!(ch, '$' | '\u{20ac}' | '\u{00a3}' | '\u{00a5}'));
+    let chars = text.chars().collect::<Vec<_>>();
+    let has_decimal = chars.windows(3).any(|window| {
+        window[0].is_ascii_digit() && matches!(window[1], '.' | ',') && window[2].is_ascii_digit()
+    });
+    let numeric_components = text
+        .split(|ch: char| !ch.is_ascii_digit())
+        .filter(|component| !component.is_empty())
+        .count();
+    let bare_small_integer =
+        (1..=2).contains(&digit_count) && text.chars().all(|ch| ch.is_ascii_digit());
+    let critical_small_integer = bare_small_integer
+        && (item.kind == "list_item"
+            || starts_numbered_item(&item.source_text, text)
+            || number_adjacent_to_month(&item.source_text, text));
+
+    if digit_count >= 3
+        || has_currency
+        || has_decimal
+        || numeric_components >= 2
+        || critical_small_integer
+    {
+        QaFindingSeverity::Error
+    } else {
+        QaFindingSeverity::Warning
+    }
+}
+
+fn starts_numbered_item(source: &str, number: &str) -> bool {
+    let source = bookforge_core::marker::strip_marker_tokens(source);
+    let Some(rest) = source.trim_start().strip_prefix(number) else {
+        return false;
+    };
+    rest.chars()
+        .next()
+        .is_some_and(|ch| matches!(ch, '.' | ')' | ':' | ']'))
+}
+
+fn number_adjacent_to_month(source: &str, number: &str) -> bool {
+    source.match_indices(number).any(|(start, _)| {
+        let end = start + number.len();
+        let left_boundary = source[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !ch.is_ascii_digit());
+        let right_boundary = source[end..]
+            .chars()
+            .next()
+            .is_none_or(|ch| !ch.is_ascii_digit());
+        left_boundary
+            && right_boundary
+            && (adjacent_word_before(source, start).is_some_and(is_month_name)
+                || adjacent_word_after(source, end).is_some_and(is_month_name))
+    })
+}
+
+fn adjacent_word_before(source: &str, end: usize) -> Option<&str> {
+    let prefix = &source[..end];
+    let word_end = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| ch.is_ascii_alphabetic())
+        .map(|(index, ch)| index + ch.len_utf8())?;
+    let word_start = prefix[..word_end]
+        .char_indices()
+        .rev()
+        .take_while(|(_, ch)| ch.is_ascii_alphabetic())
+        .last()
+        .map_or(word_end, |(index, _)| index);
+    Some(&prefix[word_start..word_end])
+}
+
+fn adjacent_word_after(source: &str, start: usize) -> Option<&str> {
+    let suffix = &source[start..];
+    let word_start = suffix
+        .char_indices()
+        .find(|(_, ch)| ch.is_ascii_alphabetic())
+        .map(|(index, _)| index)?;
+    let word_end = suffix[word_start..]
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_alphabetic())
+        .last()
+        .map(|(index, ch)| word_start + index + ch.len_utf8())?;
+    Some(&suffix[word_start..word_end])
+}
+
+fn is_month_name(word: &str) -> bool {
+    const MONTHS: &[&str] = &[
+        "january",
+        "jan",
+        "february",
+        "feb",
+        "march",
+        "mar",
+        "april",
+        "apr",
+        "may",
+        "june",
+        "jun",
+        "july",
+        "jul",
+        "august",
+        "aug",
+        "september",
+        "sep",
+        "sept",
+        "october",
+        "oct",
+        "november",
+        "nov",
+        "december",
+        "dec",
+    ];
+    MONTHS.iter().any(|month| word.eq_ignore_ascii_case(month))
 }
 
 fn source_copy_error(
@@ -201,32 +400,13 @@ fn parse_text_batch_response(
             .and_then(|titles| titles.get(&request_item.segment_id.0))
             .map(String::as_str);
         let validation_error = if turbo {
-            request_item
-                .protected_spans
-                .iter()
-                .find(|span| {
-                    !span.trim().is_empty()
-                        && !crate::validation::protected_span_present(span, &translation)
-                })
-                .map(|span| format!("protected span missing: {span}"))
-                .or_else(|| {
-                    source_copy_error(
-                        request_item,
-                        &translation,
-                        validate_source_copy,
-                        section_title,
-                    )
-                })
-                .or_else(|| {
-                    target_language.and_then(|target_language| {
-                        crate::validation::target_language_validation_error(
-                            target_language,
-                            &request_item.source_text,
-                            &translation,
-                            &request_item.protected_spans,
-                        )
-                    })
-                })
+            turbo_batch_item_validation_error(
+                request_item,
+                &translation,
+                validate_source_copy,
+                section_title,
+                target_language,
+            )
         } else {
             batch_item_validation_error(
                 request_item,
@@ -236,7 +416,13 @@ fn parse_text_batch_response(
                 target_language,
             )
         };
-        if let Some(error) = validation_error {
+        if validation_error
+            .as_ref()
+            .is_some_and(BatchItemValidationError::has_errors)
+        {
+            let error = validation_error
+                .expect("validation report checked as present")
+                .persistence_message();
             failures.push(BatchItemFailure {
                 item_id: item.id.clone(),
                 segment_id: request_item.segment_id.clone(),
@@ -258,6 +444,7 @@ fn parse_text_batch_response(
             item_id: item.id.clone(),
             segment_id: request_item.segment_id.clone(),
             text: translation,
+            warning: validation_error.map(|report| report.persistence_message()),
             input_tokens: None,
             input_cached_tokens: None,
             output_tokens: None,
@@ -408,13 +595,20 @@ fn parse_run_batch_response(
         let section_title = section_titles
             .and_then(|titles| titles.get(&request_item.segment_id.0))
             .map(String::as_str);
-        if let Some(error) = batch_item_validation_error(
+        let validation_error = batch_item_validation_error(
             request_item,
             &translation,
             validate_source_copy,
             section_title,
             target_language,
-        ) {
+        );
+        if validation_error
+            .as_ref()
+            .is_some_and(BatchItemValidationError::has_errors)
+        {
+            let error = validation_error
+                .expect("validation report checked as present")
+                .persistence_message();
             failures.push(BatchItemFailure {
                 item_id: item.id.clone(),
                 segment_id: request_item.segment_id.clone(),
@@ -430,6 +624,7 @@ fn parse_run_batch_response(
             item_id: item.id.clone(),
             segment_id: request_item.segment_id.clone(),
             text: translation,
+            warning: validation_error.map(|report| report.persistence_message()),
             input_tokens: None,
             input_cached_tokens: None,
             output_tokens: None,
@@ -480,7 +675,7 @@ pub(super) fn render_batch_items(
             } else {
                 item.required_markers.clone()
             };
-            let protected_spans = item.protected_spans.clone();
+            let protected_spans = protected_span_texts(item);
             let mut obj = serde_json::json!({
                 "id": item.item_id,
                 "kind": item.kind,
@@ -559,6 +754,141 @@ fn wrap_text_only_translation_with_source_markers(source: &str, translation: &st
         return translation;
     }
     format!("{prefix}{translation}")
+}
+
+#[cfg(test)]
+mod protected_span_severity_tests {
+    use super::*;
+    use bookforge_core::{
+        ir::{BlockId, ProtectedSpan, ProtectedSpanKind, SectionId},
+        segment::SegmentId,
+    };
+
+    fn item_with_span(source: &str, kind: ProtectedSpanKind, text: &str) -> TranslationBatchItem {
+        TranslationBatchItem {
+            item_id: "item".to_string(),
+            segment_id: SegmentId("segment".to_string()),
+            section_id: SectionId("section".to_string()),
+            block_id: BlockId("block".to_string()),
+            ordinal: 0,
+            kind: "paragraph".to_string(),
+            source_text: source.to_string(),
+            text_runs: Vec::new(),
+            protected_spans: vec![ProtectedSpan {
+                kind,
+                text: text.to_string(),
+            }],
+            required_markers: Vec::new(),
+            checksum: "checksum".to_string(),
+        }
+    }
+
+    fn parse_one(item: TranslationBatchItem, translation: &str) -> BatchTranslationResult {
+        let batch = TranslationBatch {
+            id: "batch".to_string(),
+            ordinal: 0,
+            mode: item.mode(),
+            kind: BatchKind::Translation,
+            items: vec![item],
+            token_estimate: 10,
+            section_id: SectionId("section".to_string()),
+        };
+        let response = serde_json::json!({
+            "items": [{"id": "item", "translation": translation}]
+        })
+        .to_string();
+        parse_batch_response(&batch, &response).expect("batch response parses")
+    }
+
+    #[test]
+    fn missing_math_is_a_successful_item_with_warning() {
+        let result = parse_one(
+            item_with_span("Einstein wrote E=mc^2", ProtectedSpanKind::Math, "E=mc^2"),
+            "Einstein scrisse la formula",
+        );
+
+        assert!(result.failures.is_empty());
+        assert_eq!(result.translations.len(), 1);
+        assert!(
+            result.translations[0]
+                .warning
+                .as_deref()
+                .is_some_and(|warning| {
+                    warning.contains("warning: protected span missing: E=mc^2")
+                })
+        );
+    }
+
+    #[test]
+    fn missing_url_remains_a_hard_item_failure() {
+        let result = parse_one(
+            item_with_span(
+                "Visit https://example.com",
+                ProtectedSpanKind::Url,
+                "https://example.com",
+            ),
+            "Visita il sito",
+        );
+
+        assert!(result.translations.is_empty());
+        assert_eq!(result.failures.len(), 1);
+        assert!(
+            result.failures[0]
+                .error
+                .contains("error: protected span missing: https://example.com")
+        );
+    }
+
+    #[test]
+    fn hard_marker_violation_is_not_masked_by_soft_math() {
+        let mut item = item_with_span("<m1>E=mc^2</m1>", ProtectedSpanKind::Math, "E=mc^2");
+        item.required_markers = vec!["m1".to_string()];
+        let validation = batch_item_validation_error(&item, "La formula", false, None, None)
+            .expect("both violations should be reported");
+
+        assert!(validation.has_errors());
+        assert_eq!(validation.violations().len(), 2);
+        assert!(validation.contains("inline marker missing: m1"));
+        assert!(validation.contains("protected span missing: E=mc^2"));
+        assert!(validation.violations().iter().any(|violation| {
+            violation.severity == QaFindingSeverity::Warning
+                && violation.protected_span_kind == Some(ProtectedSpanKind::Math)
+        }));
+    }
+
+    #[test]
+    fn number_severity_uses_substance_and_critical_context_boundary() {
+        let weak = batch_item_validation_error(
+            &item_with_span("Chapter 42 explains it", ProtectedSpanKind::Number, "42"),
+            "Il capitolo lo spiega",
+            false,
+            None,
+            None,
+        )
+        .expect("missing weak number is still surfaced");
+        assert!(!weak.has_errors());
+
+        for (source, number) in [
+            ("Published in 1987", "1987"),
+            ("The value is 0.0027", "0.0027"),
+            ("It cost $15", "$15"),
+            ("The event was December 8", "8"),
+            ("1. First item", "1"),
+        ] {
+            let substantial = batch_item_validation_error(
+                &item_with_span(source, ProtectedSpanKind::Number, number),
+                "La traduzione omette il dato",
+                false,
+                None,
+                None,
+            )
+            .expect("missing number is surfaced");
+            assert!(
+                substantial.has_errors(),
+                "{number} in {source:?} should be hard: {substantial}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/bookforge-llm/src/batch/tests.rs
+++ b/crates/bookforge-llm/src/batch/tests.rs
@@ -1,7 +1,10 @@
 use super::*;
-use bookforge_core::segment::{
-    SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata, SegmentSource,
-    SegmentTextRun,
+use bookforge_core::{
+    ir::{ProtectedSpan, ProtectedSpanKind},
+    segment::{
+        SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
+        SegmentSource, SegmentTextRun,
+    },
 };
 
 fn make_segment(id: &str, blocks: Vec<SegmentBlock>, markers: Vec<String>) -> Segment {
@@ -61,7 +64,13 @@ fn protected_block(text: &str, spans: Vec<String>) -> SegmentBlock {
             id: "r0".to_string(),
             text: text.to_string(),
         }],
-        protected_spans: spans,
+        protected_spans: spans
+            .into_iter()
+            .map(|text| ProtectedSpan {
+                kind: ProtectedSpanKind::Number,
+                text,
+            })
+            .collect(),
     }
 }
 
@@ -574,7 +583,7 @@ fn parses_valid_batch_response() {
 }
 
 #[test]
-fn missing_protected_span_fails_batch_item_instead_of_appending() {
+fn missing_short_ordinal_succeeds_with_warning_instead_of_appending() {
     let seg = make_segment(
         "seg1",
         vec![protected_block("Chapter 4th", vec!["4th".to_string()])],
@@ -599,17 +608,19 @@ fn missing_protected_span_fails_batch_item_instead_of_appending() {
     })
     .to_string();
 
-    // The dropped span must surface as an item failure feeding the
-    // repair pipeline — never be glued onto the translated text.
+    // A short ordinal is a soft Number violation: keep the model output,
+    // surface the warning, and never glue the source token onto the text.
     let result = parse_batch_response(batch, &response).expect("parse");
-    assert_eq!(result.translations.len(), 0);
-    assert_eq!(result.failures.len(), 1);
+    assert_eq!(result.translations.len(), 1);
+    assert_eq!(result.failures.len(), 0);
+    assert_eq!(result.translations[0].text, "Capitolo");
     assert!(
-        result.failures[0]
-            .error
-            .contains("protected span missing: 4th"),
-        "got: {}",
-        result.failures[0].error
+        result.translations[0]
+            .warning
+            .as_deref()
+            .is_some_and(|warning| warning.contains("protected span missing: 4th")),
+        "got: {:?}",
+        result.translations[0].warning
     );
 }
 
@@ -1230,7 +1241,10 @@ fn turbo_batches_keep_internal_markers_but_hide_them_from_the_model() {
         kind: "paragraph".to_string(),
         text: "Before <m1>bold</m1> 42".to_string(),
         text_runs: Vec::new(),
-        protected_spans: vec!["42".to_string()],
+        protected_spans: vec![ProtectedSpan {
+            kind: ProtectedSpanKind::Number,
+            text: "42".to_string(),
+        }],
     };
     let segment = make_segment("seg1", vec![block], vec!["m1".to_string()]);
     let batch_config = BatchConfig {
@@ -1250,13 +1264,21 @@ fn turbo_batches_keep_internal_markers_but_hide_them_from_the_model() {
     assert_eq!(batch.mode, BatchMode::TurboTextOnly);
     assert_eq!(batch.items[0].source_text, "Before <m1>bold</m1> 42");
     assert!(batch.items[0].required_markers.is_empty());
-    assert_eq!(batch.items[0].protected_spans, ["42"]);
+    assert_eq!(
+        batch.items[0]
+            .protected_spans
+            .iter()
+            .map(|span| (span.kind, span.text.as_str()))
+            .collect::<Vec<_>>(),
+        [(ProtectedSpanKind::Number, "42")]
+    );
 
     let rendered = render_batch_items(&batch, &test_run_config());
     assert!(!rendered.contains("<m1>"));
     assert!(!rendered.contains("</m1>"));
     assert!(rendered.contains("Before bold 42"));
     assert!(rendered.contains("\"protected\":[\"42\"]"));
+    assert!(!rendered.contains("\"kind\":\"Number\""));
 }
 
 #[test]

--- a/crates/bookforge-llm/src/double_check.rs
+++ b/crates/bookforge-llm/src/double_check.rs
@@ -147,7 +147,15 @@ where
                 required_markers: block
                     .map(|block| marker_ids_in_text(&block.text))
                     .unwrap_or_default(),
-                protected_spans: block.map(|b| b.protected_spans.clone()).unwrap_or_default(),
+                protected_spans: block
+                    .map(|block| {
+                        block
+                            .protected_spans
+                            .iter()
+                            .map(|span| span.text.clone())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
                 deterministic_warnings: Vec::new(),
             };
 

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use bookforge_core::{
     config::{BatchConfig, ContextScope, ResolvedRunSettings, TranslationProfile},
     glossary::{GlossaryFormat, GlossaryPromptTerm},
-    ir::BlockId,
+    ir::{BlockId, ProtectedSpan},
     scheduler::SchedulerConfig,
     segment::{BlockTranslation, Segment, SegmentBlock, SegmentId, SegmentStatus},
 };
@@ -1368,7 +1368,11 @@ fn segment_run_block_to_json(block: &SegmentBlock) -> Value {
                 "text": run.text,
             }))
             .collect::<Vec<_>>(),
-        "protected_spans": block.protected_spans,
+        "protected_spans": block
+            .protected_spans
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect::<Vec<_>>(),
     })
 }
 
@@ -1387,7 +1391,7 @@ fn parse_and_validate(
                     segment.id.0, parsed.segment_id
                 )));
             }
-            let expected_spans: &[String] = segment
+            let expected_spans: &[ProtectedSpan] = segment
                 .source
                 .blocks
                 .first()
@@ -1652,12 +1656,16 @@ fn validation_retry_appendix(segment: &Segment, mode: TranslationMode, error: &s
     )
 }
 
-fn validate_protected_spans(segment: &Segment, spans: &[String], translation: &str) -> Result<()> {
+fn validate_protected_spans(
+    segment: &Segment,
+    spans: &[ProtectedSpan],
+    translation: &str,
+) -> Result<()> {
     for span in spans {
-        if !crate::validation::protected_span_present(span, translation) {
+        if !crate::validation::protected_span_present(&span.text, translation) {
             return Err(LlmError::InvalidResponse(format!(
                 "protected span missing from segment '{}': {}",
-                segment.id.0, span
+                segment.id.0, span.text
             )));
         }
     }
@@ -1782,7 +1790,7 @@ mod tests {
     use std::time::Duration;
 
     use bookforge_core::{
-        ir::SectionId,
+        ir::{ProtectedSpan, ProtectedSpanKind, SectionId},
         segment::{
             Segment, SegmentBlock, SegmentConstraints, SegmentContext, SegmentMetadata,
             SegmentSource, SegmentTextRun,
@@ -2112,7 +2120,10 @@ mod tests {
         let mut segment = segment("seg_a", 0, vec![("b0", "Visit https://example.com")]);
         segment.source.blocks[0]
             .protected_spans
-            .push("https://example.com".to_string());
+            .push(protected_span(
+                ProtectedSpanKind::Url,
+                "https://example.com",
+            ));
         segment
             .constraints
             .preserve_spans
@@ -2146,7 +2157,7 @@ mod tests {
         let mut segment = segment("seg_a", 0, vec![("b0", "The 4th day")]);
         segment.source.blocks[0]
             .protected_spans
-            .push("4th".to_string());
+            .push(protected_span(ProtectedSpanKind::Number, "4th"));
         segment.constraints.preserve_spans.push("4th".to_string());
 
         let translations = translate_segments(MissingProtectedSpanProvider, &[segment], &config())
@@ -2175,8 +2186,12 @@ mod tests {
     fn localized_decimal_protected_span_passes_validation() {
         let segment = segment("seg_a", 0, vec![("b0", "diameter 0.1 to 1 mm")]);
 
-        validate_protected_spans(&segment, &["0.1".to_string()], "diametro da 0,1 a 1 mm")
-            .expect("decimal comma localization should preserve numeric value");
+        validate_protected_spans(
+            &segment,
+            &[protected_span(ProtectedSpanKind::Number, "0.1")],
+            "diametro da 0,1 a 1 mm",
+        )
+        .expect("decimal comma localization should preserve numeric value");
     }
 
     #[test]
@@ -2185,7 +2200,7 @@ mod tests {
 
         validate_protected_spans(
             &segment,
-            &["-63.5".to_string()],
+            &[protected_span(ProtectedSpanKind::Number, "-63.5")],
             "il potenziale era circa –63,5 mV",
         )
         .expect("localized minus and decimal comma should preserve numeric value");
@@ -2197,7 +2212,7 @@ mod tests {
 
         validate_protected_spans(
             &segment,
-            &["1957,1989".to_string()],
+            &[protected_span(ProtectedSpanKind::Citation, "1957,1989")],
             "Skou (1957, 1989) isolò una ATPasi",
         )
         .expect("citation spacing should not count as a dropped numeric span");
@@ -2207,8 +2222,12 @@ mod tests {
     fn dangling_numeric_protected_span_passes_validation() {
         let segment = segment("seg_a", 0, vec![("b0", "The value was 10-")]);
 
-        validate_protected_spans(&segment, &["10-".to_string()], "7,3 × 10⁻⁷ mol cm⁻²")
-            .expect("dangling numeric extraction artifacts should not force review");
+        validate_protected_spans(
+            &segment,
+            &[protected_span(ProtectedSpanKind::Number, "10-")],
+            "7,3 × 10⁻⁷ mol cm⁻²",
+        )
+        .expect("dangling numeric extraction artifacts should not force review");
     }
 
     #[test]
@@ -2217,7 +2236,7 @@ mod tests {
 
         let error = validate_protected_spans(
             &segment,
-            &["5.16".to_string()],
+            &[protected_span(ProtectedSpanKind::Number, "5.16")],
             "Si noti che questa forma di rettificazione deriva dai canali aperti.",
         )
         .expect_err("absent numeric spans still need review");
@@ -2236,7 +2255,7 @@ mod tests {
         );
         segment.source.blocks[0]
             .protected_spans
-            .push("1".to_string());
+            .push(protected_span(ProtectedSpanKind::Number, "1"));
         segment.constraints.preserve_spans.push("1".to_string());
 
         let translations = translate_segments(
@@ -2482,6 +2501,27 @@ mod tests {
         assert!(rendered.user.contains("\"Aragorn\" -> \"Aragorn\""));
     }
 
+    #[test]
+    fn run_preserving_prompt_projects_protected_spans_to_text() {
+        let mut segment = segment("seg_a", 0, vec![("b0", "Chapter 42")]);
+        segment.source.blocks[0].protected_spans =
+            vec![protected_span(ProtectedSpanKind::Number, "42")];
+        segment.constraints.preserve_spans = vec!["42".to_string()];
+
+        let rendered = render_prompt(
+            &PromptLibrary::global().run_preserving,
+            &segment,
+            &config(),
+            TranslationMode::RunPreserving,
+            &[],
+        )
+        .expect("run-preserving prompt should render");
+
+        assert!(rendered.user.contains("42"));
+        assert!(!rendered.user.contains("\"kind\": \"Number\""));
+        assert!(!rendered.user.contains("\"kind\":\"Number\""));
+    }
+
     fn config() -> TranslationRunConfig {
         TranslationRunConfig {
             source_language: Some("English".to_string()),
@@ -2556,6 +2596,13 @@ mod tests {
                 max_tokens: 100,
             },
             checksum: id.to_string(),
+        }
+    }
+
+    fn protected_span(kind: ProtectedSpanKind, text: &str) -> ProtectedSpan {
+        ProtectedSpan {
+            kind,
+            text: text.to_string(),
         }
     }
 

--- a/crates/bookforge-store/src/db/findings.rs
+++ b/crates/bookforge-store/src/db/findings.rs
@@ -2,6 +2,8 @@ use super::*;
 
 use std::collections::BTreeMap;
 
+pub use bookforge_core::ir::QaFindingSeverity;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum QaFindingKind {
     ProtectedSpanMissing,
@@ -51,26 +53,6 @@ impl QaFindingKind {
     }
 }
 
-/// `error` means the output is structurally unusable or the run could not
-/// produce output at all (protocol, transport, or an unclassified hard
-/// failure). `warning` means the output is intact and renderable but a
-/// heuristic validator judged the content suspect, or the operator stopped
-/// the run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QaFindingSeverity {
-    Error,
-    Warning,
-}
-
-impl QaFindingSeverity {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Error => "error",
-            Self::Warning => "warning",
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QaFinding {
     pub kind: QaFindingKind,
@@ -110,11 +92,19 @@ pub fn classify_segment_error(error: &str) -> Vec<QaFinding> {
     }
 
     let mut findings: Vec<QaFinding> = Vec::new();
-    for fragment in error
+    for encoded_fragment in error
         .split("; ")
         .map(str::trim)
         .filter(|part| !part.is_empty())
     {
+        let (explicit_severity, fragment) =
+            if let Some(fragment) = encoded_fragment.strip_prefix("warning: ") {
+                (Some(QaFindingSeverity::Warning), fragment)
+            } else if let Some(fragment) = encoded_fragment.strip_prefix("error: ") {
+                (Some(QaFindingSeverity::Error), fragment)
+            } else {
+                (None, encoded_fragment)
+            };
         let kind = classify_failure(fragment);
         if kind == QaFindingKind::Other
             && let Some(previous) = findings.last_mut()
@@ -128,7 +118,7 @@ pub fn classify_segment_error(error: &str) -> Vec<QaFinding> {
         }
         findings.push(QaFinding {
             kind,
-            severity: kind.severity(),
+            severity: explicit_severity.unwrap_or_else(|| kind.severity()),
             message: fragment.to_string(),
         });
     }
@@ -294,12 +284,14 @@ impl JobStore {
         Ok(())
     }
 
-    /// Drop findings for any segment in the job that no longer carries an error.
+    /// Drop stale error findings for segments that no longer carry an error.
+    /// Warnings may intentionally belong to succeeded segments.
     pub fn prune_stale_findings(&self, job_id: &str) -> Result<usize> {
         let conn = self.conn.borrow();
         Ok(conn.execute(
             "DELETE FROM qa_findings
              WHERE job_id = ?1
+               AND severity = 'error'
                AND segment_id IN (
                  SELECT id FROM segments
                  WHERE job_id = ?1 AND (error IS NULL OR TRIM(error) = '')

--- a/crates/bookforge-store/src/db/translations.rs
+++ b/crates/bookforge-store/src/db/translations.rs
@@ -35,6 +35,17 @@ impl JobStore {
     }
 
     pub fn save_translation(&self, request: SaveTranslation<'_>) -> Result<()> {
+        self.save_translation_with_findings(request, None)
+    }
+
+    /// Save a successful translation and optionally replace its durable QA
+    /// findings. The segment remains `succeeded`; warnings live in
+    /// `qa_findings`, not `segments.error`.
+    pub fn save_translation_with_findings(
+        &self,
+        request: SaveTranslation<'_>,
+        findings: Option<&str>,
+    ) -> Result<()> {
         if self.translation_is_human_corrected(request.job_id, request.segment_id)? {
             return Ok(());
         }
@@ -85,7 +96,13 @@ impl JobStore {
         }
         // Findings are instrumentation, so a failed findings write must never
         // fail the surrounding translation checkpoint.
-        let _ = self.clear_segment_findings(request.job_id, request.segment_id);
+        let findings = findings.map(str::trim).filter(|value| !value.is_empty());
+        let _ = if let Some(findings) = findings {
+            self.record_segment_findings(request.job_id, request.segment_id, findings)
+                .map(|_| ())
+        } else {
+            self.clear_segment_findings(request.job_id, request.segment_id)
+        };
         self.consume_dashboard_retry_guidance(request.job_id, request.segment_id)?;
         self.touch_job_unless_status(request.job_id, "running", &["paused", "stopped"])?;
         Ok(())


### PR DESCRIPTION
**Stacked on #63** — merge that first; this PR's base is `fix/segment-count-reconcile` so the diff stays clean.

## Why

Two independent judges adjudicated the 371 surviving `protected_span_missing` flags from 29 real jobs:

| judge | false-positive rate |
| --- | --- |
| Kimi K3 (stricter) | **82.4%** |
| deepseek-v4-pro | 97.3% |

Take 82.4% as the floor — v4-pro was caught contradicting itself and over-calling. Even at the floor, this cannot justify sending a segment to `needs_review`.

Those 371 flags by span kind:

| kind | flags | share |
| --- | --- | --- |
| Math / loose | 204 | 55.0% |
| Number (pure) | 123 | 33.2% |
| Number (ordinal) | 44 | 11.9% |
| **Url / Email / Filename / Anchor / Citation** | **0** | **0%** |

The noise is entirely Math and Number, so this is **severity-by-kind, not a blanket demotion**. And 105 of 362 false positives were the source EPUB's own OCR damage — `^` replaced spaces and letters, `^` is a strong inline math operator, so `Thei^is^ood^reason` became a Math span no translation could ever reproduce.

## What changed

- Violations carry a severity. A soft-only result leaves the segment **Succeeded** while still persisting a `warning` finding into `qa_findings`, so it stays visible in `status` and the review HTML without gating the run. Violations are now **collected rather than short-circuited**, so a soft Math miss can never mask a hard marker failure on the same item.
- Url/Email/Filename/Anchor/Citation stay **hard** — no evidence they misfire. Marker and structure violations stay **hard**, judged 75–80% true positive.
- **Number is split by substance**: hard for 3+ digits, decimals, currency, multi-component numbers, month-dates and list numbering; soft for otherwise-bare one/two-digit values and short ordinals.

  Deliberately *not* "all small numbers are soft": a source `December 8` came back as `10 dicembre`, and a segment beginning `1.` came back beginning `2.`. Both are real data corruption a reader would never catch. This is a demotion, not a weakening — the check must keep finding those.
- Tokens with 2+ math operators and no digit are no longer treated as math, so OCR wreckage stops becoming a protected span at all. `E=mc^2`, `p<0.05`, `x_12`, `3.5*2` keep working.
- `ProtectedSpanKind` is threaded through segmentation as a **typed field** — `SegmentBlock` and `TranslationBatchItem` now hold `Vec<ProtectedSpan>`.

## Two defects found while cleaning up

An earlier attempt smuggled the kind through `Vec<String>` as *a count of trailing empty strings*. Replacing it with a real type surfaced two genuine bugs, both now fixed with regression tests:

1. It bumped `SEGMENT_SCHEMA_VERSION` to 2. That constant feeds the cache-namespace hasher ([segment.rs:103](crates/bookforge-core/src/segment.rs:103)), so it would have **silently invalidated every existing translation cache**. Restored to 1.
2. The `[kind=...]` suffix on validation messages could **reach repair prompts**. Provider payloads now project spans to text explicitly and repair errors strip the metadata — guarded by `provider_validation_errors_omit_protected_span_kinds` and `run_preserving_prompt_projects_protected_spans_to_text`.

Worth noting I had reviewed that encoding and cleared it on both counts. I checked `stable_hash(&source_text)` but missed the separate namespace hasher, and I checked prompt field rendering but missed the error-message path into repair. The type refactor is what exposed them.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **813 passed / 0 failed / 3 ignored** (was 803).

The `cli_live_reconfigure_...` lifecycle test flaked once under full-workspace build load, as it has repeatedly today, then passed clean on re-run — same behaviour addressed in #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)