### PR TITLE
fix(epub): reject OCR-damaged words as inline math

### DIFF
--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1428,16 +1428,13 @@ fn looks_like_inline_math_token(value: &str) -> bool {
     if chars.len() < 3 {
         return false;
     }
-    // OCR scans commonly substitute operators such as `^` for missing
-    // letters/spaces. Multiple operators without any digit are stronger
-    // evidence of mangled prose than of an inline equation.
-    if !chars.iter().any(|ch| ch.is_ascii_digit())
+    // OCR scans commonly substitute operators such as `^` for letters.
+    // A word-sized alphabetic run alongside an operator is stronger evidence
+    // of mangled prose than of a short symbolic operand.
+    if chars.iter().any(|ch| is_inline_math_operator(*ch))
         && chars
-            .iter()
-            .filter(|ch| is_inline_math_operator(**ch))
-            .take(2)
-            .count()
-            >= 2
+            .split(|ch| !ch.is_ascii_alphabetic())
+            .any(|run| run.len() >= 3)
     {
         return false;
     }
@@ -2214,6 +2211,41 @@ mod tests {
                 "{value}"
             );
         }
+    }
+
+    #[test]
+    fn inline_math_rejects_ocr_damaged_letter_runs() {
+        for value in [
+            "en^erPrises",
+            "the^ight",
+            "conspiracy/1*",
+            "receiv-lnThafUisrifibi^0way",
+        ] {
+            assert!(!looks_like_inline_math_token(value), "{value}");
+        }
+
+        for value in ["E=mc^2", "p<0.05", "x_12", "3.5*2", "mc^2"] {
+            assert!(looks_like_inline_math_token(value), "{value}");
+        }
+    }
+
+    #[test]
+    fn extract_blocks_does_not_protect_ocr_damaged_prose() {
+        let section_id = SectionId("sec_000000".to_string());
+        let xhtml = r#"<html xmlns="http://www.w3.org/1999/xhtml"><body>
+<p>The en^erPrises searched the^ight while conspiracy/1* appeared in receiv-lnThafUisrifibi^0way reports.</p>
+</body></html>"#;
+        let blocks = extract_blocks(xhtml, "chapter.xhtml", &section_id, 0)
+            .expect("block extraction should succeed");
+        let protected_spans = blocks
+            .iter()
+            .flat_map(|block| block.protected_spans.iter())
+            .collect::<Vec<_>>();
+
+        assert!(
+            protected_spans.is_empty(),
+            "OCR-damaged prose became protected spans: {protected_spans:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes the loop opened by #64. That PR added an OCR guard rejecting math candidates with **2+ operators and no digit**; measurement shows it was too narrow.

## Evidence

An LLM judge (Kimi K3) adjudicated 150 surviving validator flags on merged `main`. The protected-span false-positive rate was still **75.3%**, and **14 survivors were word+operator OCR damage — 11 with only one or two operators**, invisible to the old guard:

| span | operators | digit? |
| --- | --- | --- |
| `en^erPrises` ("enterprises") | 1 | no |
| `the^ight` | 1 | no |
| `conspiracy/1*` | 2 | yes |
| `receiv-lnThafUisrifibi^0way` | several | yes |

Several source EPUBs in the corpus are bad scans where `^` stands in for a misread letter. Since `^` is a strong inline math operator, mangled prose became a `Math` protected span — and translation was then required to reproduce a garbled English string verbatim, which it can never do.

## The rule

A candidate carrying an inline math operator **plus a run of 3+ consecutive ASCII letters** is prose, not math. Genuine inline math uses short symbolic operands.

| token | longest letter run | outcome |
| --- | --- | --- |
| `E=mc^2` | 2 (`mc`) | still math |
| `p<0.05` | 1 | still math |
| `x_12` | 1 | still math |
| `3.5*2` | 0 | still math |
| `x+y-z` | 1 | still math |
| `en^erPrises` | 8 | rejected |
| `the^ight` | 5 | rejected |
| `conspiracy/1*` | 11 | rejected |

Deliberately a letter **run**, not a letter **count** — `E=mc^2` has three letters total and would have been rejected by a count-based rule. That distinction is the whole rule.

The new guard doesn't logically subsume the old one, but covers all its existing fixtures, so the old one is removed rather than left alongside.

## Measured on real books

`cargo run --example replay_validation` over 29 real jobs:

| | before | after |
| --- | --- | --- |
| protected-span flags | 348 | **265** (−24%) |
| meaningful flagged pairs | 363 | **280** (−23%) |

Cumulatively, #61 → #64 → this: protected-span flags **600 → 265**, with every genuine-math regression test still green.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **815 passed / 0 failed / 3 ignored** (was 813). The lifecycle flake did not occur in this run.

Full judge analysis and caveats — including that 49 of 150 judge calls errored, so the 75.3% rests on n=93 — are in `tests/validator-judge-2026-07-27/FINDINGS.md` (gitignored, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)