### PR TITLE
test: remove wall-clock races that fail under compile load

### DIFF
--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -1233,6 +1233,14 @@ mod tests {
         segments: Vec<Segment>,
     }
 
+    fn assert_future_pending<F: std::future::Future>(mut future: std::pin::Pin<&mut F>) {
+        let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+        assert!(
+            future.as_mut().poll(&mut context).is_pending(),
+            "future should wait for the test transition"
+        );
+    }
+
     #[tokio::test]
     async fn paused_resume_wait_times_out_with_force_hint() {
         let fixture = resume_fixture(TranslationProfile::V1Fast.resolve(), 1);
@@ -1264,26 +1272,21 @@ mod tests {
             .store
             .mark_job_paused(&fixture.job.id)
             .expect("job should mark paused");
-        let store_path = fixture.store.path().to_path_buf();
         let job_id = fixture.job.id.clone();
-        let wake_id = job_id.clone();
-
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(5)).await;
-            let store = JobStore::open(store_path).expect("store should reopen");
-            store
-                .mark_job_running(&wake_id)
-                .expect("job should leave paused");
-        });
 
         let resumed = wait_for_paused_job_to_leave_paused(
             &fixture.store,
             &job_id,
             Duration::from_secs(1),
             Duration::from_millis(1),
-        )
-        .await
-        .expect("paused wait should not error");
+        );
+        tokio::pin!(resumed);
+        assert_future_pending(resumed.as_mut());
+        fixture
+            .store
+            .mark_job_running(&job_id)
+            .expect("job should leave paused");
+        let resumed = resumed.await.expect("paused wait should not error");
 
         assert!(resumed, "live paused job should be observed leaving paused");
     }
@@ -1303,19 +1306,21 @@ mod tests {
             },
         );
         let args = resume_args(&fixture.job.id);
-        let store_path = fixture.store.path().to_path_buf();
         let job_id = fixture.job.id.clone();
-        let wake_id = job_id.clone();
 
-        tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(5)).await;
-            let store = JobStore::open(store_path).expect("store should reopen");
-            store
-                .mark_job_running(&wake_id)
-                .expect("live watcher should leave paused");
-        });
-
-        live_fast_resume_paused_job(&fixture.store, &args)
+        let resume = live_fast_resume_paused_job(&fixture.store, &args);
+        tokio::pin!(resume);
+        assert_future_pending(resume.as_mut());
+        assert_eq!(
+            bookforge_core::read_control_file(&bookforge_core::control_path_for_job(&job_id))
+                .expect("control file should read"),
+            ControlCommand::Resume
+        );
+        fixture
+            .store
+            .mark_job_running(&job_id)
+            .expect("live watcher should leave paused");
+        resume
             .await
             .expect("pending overrides should be applied by the live watcher");
 

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -175,6 +175,9 @@ struct AppState {
     /// resolved once at startup instead of per-request) while letting tests
     /// point a router at an isolated temp-dir store without touching CWD.
     store_path: PathBuf,
+    /// Age budget used by dashboard lease reads. Production installs the
+    /// three-second worker liveness budget; router tests can inject another.
+    runtime_lease_stale_after: Duration,
     #[cfg(test)]
     resume_launches: Option<Arc<std::sync::atomic::AtomicUsize>>,
 }
@@ -301,6 +304,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         elevenlabs_voices: Arc::new(Mutex::new(None)),
         audio_cancels: Arc::new(Mutex::new(HashMap::new())),
         store_path: default_store_path(),
+        runtime_lease_stale_after: crate::control::RUNTIME_LEASE_STALE_AFTER,
         #[cfg(test)]
         resume_launches: None,
     };
@@ -499,8 +503,11 @@ async fn job_reconfigure(
     State(state): State<AppState>,
 ) -> Result<Response, AppError> {
     let store_path = state.store_path.clone();
-    let outcome =
-        tokio::task::spawn_blocking(move || runtime_settings_view(&store_path, &id)).await?;
+    let lease_stale_after = state.runtime_lease_stale_after;
+    let outcome = tokio::task::spawn_blocking(move || {
+        runtime_settings_view(&store_path, &id, lease_stale_after)
+    })
+    .await?;
     match outcome {
         Ok(Some(view)) => Ok(Json(view).into_response()),
         Ok(None) => Ok((
@@ -525,6 +532,7 @@ async fn update_job_reconfigure(
         return Ok(bad_request("select at least one runtime setting"));
     }
     let store_path = state.store_path.clone();
+    let lease_stale_after = state.runtime_lease_stale_after;
     let outcome = tokio::task::spawn_blocking(move || -> Result<RuntimeSettingsView> {
         let store = JobStore::open(&store_path)?;
         let Some(job) = store.get_job(&id)? else {
@@ -542,7 +550,7 @@ async fn update_job_reconfigure(
         }
         let (_path, written) =
             super::reconfigure::write_merged_overrides_for_job(&id, incoming)?;
-        let mut view = runtime_settings_view(&store_path, &id)?
+        let mut view = runtime_settings_view(&store_path, &id, lease_stale_after)?
             .ok_or_else(|| anyhow::anyhow!("job disappeared after reconfiguration"))?;
         view.revision = written.revision;
         Ok(view)
@@ -787,6 +795,7 @@ async fn resume_job(
         return Ok(response);
     }
     let store_path = state.store_path.clone();
+    let lease_stale_after = state.runtime_lease_stale_after;
     let lookup = id.clone();
     let action = tokio::task::spawn_blocking(move || -> Result<Option<(bool, bool, bool)>> {
         let store = JobStore::open(&store_path)?;
@@ -794,7 +803,7 @@ async fn resume_job(
             return Ok(None);
         };
         let live = matches!(
-            crate::control::runtime_lease_state(&lookup),
+            crate::control::runtime_lease_state(&lookup, lease_stale_after),
             crate::control::RuntimeLeaseState::Fresh(_)
         );
         let resumable = !store.resumable_segment_ids(&lookup)?.is_empty()
@@ -908,13 +917,14 @@ async fn control_job(
         return Ok(response);
     }
     let store_path = state.store_path.clone();
+    let lease_stale_after = state.runtime_lease_stale_after;
     let outcome = tokio::task::spawn_blocking(move || -> Result<Option<String>> {
         let store = JobStore::open(store_path)?;
         if store.get_job(&id)?.is_none() {
             return Ok(None);
         }
         if !matches!(
-            crate::control::runtime_lease_state(&id),
+            crate::control::runtime_lease_state(&id, lease_stale_after),
             crate::control::RuntimeLeaseState::Fresh(_)
         ) {
             anyhow::bail!(
@@ -2718,6 +2728,7 @@ struct RuntimeSettingsView {
 fn runtime_settings_view(
     store_path: &std::path::Path,
     id: &str,
+    lease_stale_after: Duration,
 ) -> Result<Option<RuntimeSettingsView>> {
     let store = JobStore::open(store_path)?;
     let Some(job) = store.get_job(id)? else {
@@ -2740,7 +2751,8 @@ fn runtime_settings_view(
         .unwrap_or(snapshot.validate_output);
     let changed_fields = overrides.changed_fields();
     let next_boundary = overrides.application_boundaries();
-    let (lease, live, applied_revision) = match crate::control::runtime_lease_state(id) {
+    let lease_state = crate::control::runtime_lease_state(id, lease_stale_after);
+    let (lease, live, applied_revision) = match lease_state {
         crate::control::RuntimeLeaseState::Fresh(lease) => (
             RuntimeLeaseView {
                 state: "fresh",
@@ -2999,6 +3011,7 @@ mod tests {
     use axum::http::HeaderValue;
 
     const TEST_HOST: &str = "127.0.0.1:8765";
+    const TEST_DEADLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
     fn test_state(token: &str) -> AppState {
         AppState {
@@ -3009,6 +3022,7 @@ mod tests {
             elevenlabs_voices: Arc::new(Mutex::new(None)),
             audio_cancels: Arc::new(Mutex::new(HashMap::new())),
             store_path: default_store_path(),
+            runtime_lease_stale_after: crate::control::RUNTIME_LEASE_STALE_AFTER,
             resume_launches: None,
         }
     }
@@ -3190,11 +3204,15 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()?;
 
-        let status = child_exit_status_after(&mut child, Duration::from_secs(2))
+        let expected = tokio::time::timeout(TEST_DEADLOCK_TIMEOUT, child.wait())
+            .await
+            .expect("help child should exit before the deadlock guard")?;
+        let status = child_exit_status_after(&mut child, Duration::ZERO)
             .await?
-            .expect("help child should exit quickly");
+            .expect("completed help child should have an exit status");
 
-        assert!(status.success());
+        assert_eq!(status, expected);
+        assert!(expected.success());
         Ok(())
     }
 
@@ -4118,10 +4136,9 @@ mod tests {
         let fixture = build_mutation_fixture();
         make_stopped_fixture_resumable(&fixture);
         clean_runtime_files(&fixture.job_id);
-        let router = dashboard_router(test_state_with_store(
-            &fixture.csrf,
-            fixture.store_path.clone(),
-        ));
+        let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+        state.runtime_lease_stale_after = Duration::from_millis(u64::MAX);
+        let router = dashboard_router(state);
 
         for command in ["pause", "stop"] {
             let response = post_json(

--- a/crates/bookforge-cli/src/control.rs
+++ b/crates/bookforge-cli/src/control.rs
@@ -51,7 +51,15 @@ pub(crate) fn runtime_path_for_job(job_id: &str) -> PathBuf {
     bookforge_core::run_dir_for_job(job_id).join("runtime.json")
 }
 
-pub(crate) fn runtime_lease_state(job_id: &str) -> RuntimeLeaseState {
+pub(crate) fn runtime_lease_state(job_id: &str, stale_after: Duration) -> RuntimeLeaseState {
+    runtime_lease_state_at(job_id, stale_after, now_ms())
+}
+
+fn runtime_lease_state_at(
+    job_id: &str,
+    stale_after: Duration,
+    observed_at_ms: u64,
+) -> RuntimeLeaseState {
     let path = runtime_path_for_job(job_id);
     let contents = match fs::read_to_string(&path) {
         Ok(contents) => contents,
@@ -70,8 +78,9 @@ pub(crate) fn runtime_lease_state(job_id: &str) -> RuntimeLeaseState {
         }
         Err(error) => return RuntimeLeaseState::Invalid(error.to_string()),
     };
-    let age_ms = now_ms().saturating_sub(lease.heartbeat_at_ms);
-    if age_ms <= RUNTIME_LEASE_STALE_AFTER.as_millis() as u64 {
+    let age_ms = observed_at_ms.saturating_sub(lease.heartbeat_at_ms);
+    let stale_after_ms = u64::try_from(stale_after.as_millis()).unwrap_or(u64::MAX);
+    if age_ms <= stale_after_ms {
         RuntimeLeaseState::Fresh(lease)
     } else {
         RuntimeLeaseState::Stale(lease)
@@ -121,6 +130,10 @@ pub(crate) struct RuntimeLaunchClaim {
 
 impl RuntimeLaunchClaim {
     pub(crate) fn acquire(job_id: &str) -> Result<Option<Self>> {
+        Self::acquire_with_stale_after(job_id, RUNTIME_LAUNCH_CLAIM_STALE_AFTER)
+    }
+
+    fn acquire_with_stale_after(job_id: &str, stale_after: Duration) -> Result<Option<Self>> {
         let path = bookforge_core::run_dir_for_job(job_id).join("resume.launch");
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -140,7 +153,7 @@ impl RuntimeLaunchClaim {
                         .and_then(|metadata| metadata.modified())
                         .ok()
                         .and_then(|modified| modified.elapsed().ok())
-                        .is_some_and(|age| age >= RUNTIME_LAUNCH_CLAIM_STALE_AFTER);
+                        .is_some_and(|age| age >= stale_after);
                     if stale {
                         let _ = fs::remove_file(&path);
                         continue;
@@ -357,6 +370,8 @@ pub(crate) struct ControlFileWatcher {
     job_runtime_settings: watch::Receiver<JobRuntimeSettings>,
     lease_path: PathBuf,
     lease_instance_id: String,
+    #[cfg(test)]
+    heartbeat_updates: watch::Receiver<u64>,
 }
 
 pub(crate) struct ControlBaseline {
@@ -431,6 +446,8 @@ impl ControlFileWatcher {
             validate_output: initial_validate_output,
         });
         let process_started_at_ms = now_ms();
+        #[cfg(test)]
+        let (heartbeat_sender, heartbeat_updates) = watch::channel(process_started_at_ms);
         let lease_path = runtime_path_for_job(&job_id);
         let lease_instance_id = format!(
             "{}-{process_started_at_ms}-{}",
@@ -556,12 +573,18 @@ impl ControlFileWatcher {
                 }
                 if last_heartbeat_write.elapsed() >= RUNTIME_HEARTBEAT_INTERVAL {
                     lease.heartbeat_at_ms = now_ms();
-                    if let Err(error) = write_runtime_lease(&task_lease_path, &lease) {
-                        progress.emit(ProgressEvent::Error {
-                            kind: "runtime_lease".to_string(),
-                            message: format!("failed to refresh runtime lease: {error}"),
-                            timestamp_ms: now_ms(),
-                        });
+                    match write_runtime_lease(&task_lease_path, &lease) {
+                        Ok(()) => {
+                            #[cfg(test)]
+                            heartbeat_sender.send_replace(lease.heartbeat_at_ms);
+                        }
+                        Err(error) => {
+                            progress.emit(ProgressEvent::Error {
+                                kind: "runtime_lease".to_string(),
+                                message: format!("failed to refresh runtime lease: {error}"),
+                                timestamp_ms: now_ms(),
+                            });
+                        }
                     }
                     last_heartbeat_write = Instant::now();
                 }
@@ -579,6 +602,8 @@ impl ControlFileWatcher {
             job_runtime_settings,
             lease_path,
             lease_instance_id,
+            #[cfg(test)]
+            heartbeat_updates,
         }
     }
 
@@ -588,6 +613,11 @@ impl ControlFileWatcher {
 
     pub(crate) fn job_runtime_settings(&self) -> watch::Receiver<JobRuntimeSettings> {
         self.job_runtime_settings.clone()
+    }
+
+    #[cfg(test)]
+    fn heartbeat_updates(&self) -> watch::Receiver<u64> {
+        self.heartbeat_updates.clone()
     }
 
     #[allow(dead_code)]
@@ -608,15 +638,16 @@ impl Drop for ControlFileWatcher {
 mod tests {
     use super::*;
     use bookforge_core::{NullProgressSink, TranslationProfile};
-    use std::sync::Mutex;
+
+    const TEST_DEADLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
     struct RecordingSink {
-        events: Arc<Mutex<Vec<ProgressEvent>>>,
+        events: tokio::sync::mpsc::UnboundedSender<ProgressEvent>,
     }
 
     impl ProgressSink for RecordingSink {
         fn emit(&self, event: ProgressEvent) {
-            self.events.lock().expect("events lock").push(event);
+            let _ = self.events.send(event);
         }
     }
 
@@ -735,7 +766,7 @@ mod tests {
         );
         let mut receiver = watcher.runtime_settings();
         if receiver.borrow().revision != 7 {
-            tokio::time::timeout(Duration::from_secs(2), receiver.changed())
+            tokio::time::timeout(TEST_DEADLOCK_TIMEOUT, receiver.changed())
                 .await
                 .expect("watcher should publish the sidecar")
                 .expect("runtime channel should stay open");
@@ -789,12 +820,21 @@ mod tests {
             },
         );
 
-        let first = match runtime_lease_state(&job.id) {
+        let mut heartbeat_updates = watcher.heartbeat_updates();
+        let first = match runtime_lease_state(&job.id, Duration::from_millis(u64::MAX)) {
             RuntimeLeaseState::Fresh(lease) => lease,
             state => panic!("expected a fresh runtime lease, got {state:?}"),
         };
-        tokio::time::sleep(RUNTIME_HEARTBEAT_INTERVAL + Duration::from_millis(250)).await;
-        let refreshed = match runtime_lease_state(&job.id) {
+        loop {
+            if *heartbeat_updates.borrow_and_update() > first.heartbeat_at_ms {
+                break;
+            }
+            heartbeat_updates
+                .changed()
+                .await
+                .expect("watcher should report a newer successful heartbeat write");
+        }
+        let refreshed = match runtime_lease_state(&job.id, Duration::from_millis(u64::MAX)) {
             RuntimeLeaseState::Fresh(lease) => lease,
             state => panic!("expected a refreshed runtime lease, got {state:?}"),
         };
@@ -802,7 +842,10 @@ mod tests {
         assert!(refreshed.heartbeat_at_ms > first.heartbeat_at_ms);
 
         drop(watcher);
-        assert_eq!(runtime_lease_state(&job.id), RuntimeLeaseState::Missing);
+        assert_eq!(
+            runtime_lease_state(&job.id, RUNTIME_LEASE_STALE_AFTER),
+            RuntimeLeaseState::Missing
+        );
         let _ = std::fs::remove_dir_all(run_dir);
     }
 
@@ -843,14 +886,14 @@ mod tests {
         .unwrap();
         request_job_control(&job.id, ControlCommand::Resume).unwrap();
 
-        let events = Arc::new(Mutex::new(Vec::new()));
+        let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
         let signal = PauseSignal::new();
         signal.pause();
         let watcher = ControlFileWatcher::spawn_with_stop_cancel(
             db,
             job.id.clone(),
             Arc::new(RecordingSink {
-                events: events.clone(),
+                events: event_sender,
             }),
             signal,
             CancellationToken::new(),
@@ -861,29 +904,29 @@ mod tests {
             },
         );
 
-        tokio::time::timeout(Duration::from_secs(2), async {
+        let events = tokio::time::timeout(TEST_DEADLOCK_TIMEOUT, async {
+            let mut recorded = Vec::new();
+            let mut saw_runtime_config = false;
+            let mut saw_resume = false;
             loop {
-                let saw_both = {
-                    let events = events.lock().expect("events lock");
-                    events.iter().any(|event| {
-                        matches!(
-                            event,
-                            ProgressEvent::RuntimeConfigChanged { revision: 9, .. }
-                        )
-                    }) && events
-                        .iter()
-                        .any(|event| matches!(event, ProgressEvent::JobResumed { .. }))
-                };
-                if saw_both {
-                    break;
+                let event = event_receiver
+                    .recv()
+                    .await
+                    .expect("watcher event channel should stay open");
+                saw_runtime_config |= matches!(
+                    &event,
+                    ProgressEvent::RuntimeConfigChanged { revision: 9, .. }
+                );
+                saw_resume |= matches!(&event, ProgressEvent::JobResumed { .. });
+                recorded.push(event);
+                if saw_runtime_config && saw_resume {
+                    break recorded;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
             }
         })
         .await
         .expect("watcher should publish and resume");
 
-        let events = events.lock().expect("events lock");
         let config_index = events
             .iter()
             .position(|event| {
@@ -901,7 +944,6 @@ mod tests {
             config_index < resume_index,
             "override revision must publish before Resume releases work"
         );
-        drop(events);
         assert_eq!(watcher.runtime_settings().borrow().revision, 9);
 
         drop(watcher);
@@ -914,24 +956,25 @@ mod tests {
         let run_dir = bookforge_core::run_dir_for_job(&job_id);
         let _ = std::fs::remove_dir_all(&run_dir);
 
-        let first = RuntimeLaunchClaim::acquire(&job_id)
+        let acquire = || RuntimeLaunchClaim::acquire_with_stale_after(&job_id, Duration::MAX);
+        let first = acquire()
             .expect("first claim should succeed")
             .expect("first caller should own the claim");
         assert!(
-            RuntimeLaunchClaim::acquire(&job_id)
+            acquire()
                 .expect("second acquire should be readable")
                 .is_none(),
             "a concurrent caller must not launch another worker"
         );
 
         drop(first);
-        let mut persisted = RuntimeLaunchClaim::acquire(&job_id)
+        let mut persisted = acquire()
             .expect("claim should be reusable after an unlaunched owner drops")
             .expect("new caller should own the released claim");
         persisted.persist_until_worker();
         drop(persisted);
         assert!(
-            RuntimeLaunchClaim::acquire(&job_id)
+            acquire()
                 .expect("persisted claim should remain readable")
                 .is_none(),
             "a launched worker's claim must remain until its watcher clears it"
@@ -942,6 +985,7 @@ mod tests {
 
     #[test]
     fn runtime_lease_reader_reports_stale_and_invalid_files() {
+        const OBSERVED_AT_MS: u64 = 10_000;
         let job_id = format!("runtime-lease-state-test-{}", now_ms());
         let run_dir = bookforge_core::run_dir_for_job(&job_id);
         let path = runtime_path_for_job(&job_id);
@@ -953,20 +997,20 @@ mod tests {
             instance_id: "stale-worker".to_string(),
             pid: 123,
             process_started_at_ms: 1,
-            heartbeat_at_ms: now_ms()
+            heartbeat_at_ms: OBSERVED_AT_MS
                 .saturating_sub(RUNTIME_LEASE_STALE_AFTER.as_millis() as u64 + 1),
             last_loaded_revision: 2,
             last_applied_revision: 2,
         };
         std::fs::write(&path, serde_json::to_vec(&stale).unwrap()).unwrap();
         assert!(matches!(
-            runtime_lease_state(&job_id),
+            runtime_lease_state_at(&job_id, RUNTIME_LEASE_STALE_AFTER, OBSERVED_AT_MS),
             RuntimeLeaseState::Stale(lease) if lease.instance_id == "stale-worker"
         ));
 
         std::fs::write(&path, b"not-json").unwrap();
         assert!(matches!(
-            runtime_lease_state(&job_id),
+            runtime_lease_state_at(&job_id, RUNTIME_LEASE_STALE_AFTER, OBSERVED_AT_MS),
             RuntimeLeaseState::Invalid(_)
         ));
 

--- a/crates/bookforge-cli/tests/doctor_ocr.rs
+++ b/crates/bookforge-cli/tests/doctor_ocr.rs
@@ -8,6 +8,8 @@ use std::{
 use assert_cmd::Command;
 use predicates::str::contains;
 
+const TEST_DEADLOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
 fn bookforge() -> Command {
     Command::cargo_bin("bookforge").expect("bookforge binary should be built")
 }
@@ -20,7 +22,7 @@ fn doctor_lists_models_from_loopback_ocr_endpoint() {
     std::thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("mock OCR accept");
         stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
+            .set_read_timeout(Some(TEST_DEADLOCK_TIMEOUT))
             .expect("read timeout");
         let mut request = Vec::new();
         let mut scratch = [0u8; 2048];
@@ -54,7 +56,7 @@ fn doctor_lists_models_from_loopback_ocr_endpoint() {
         .stdout(contains("baidu/Unlimited-OCR"));
 
     let request = receiver
-        .recv_timeout(Duration::from_secs(5))
+        .recv_timeout(TEST_DEADLOCK_TIMEOUT)
         .expect("doctor request captured");
     assert!(request.starts_with("GET /v1/models HTTP/1.1"));
 }


### PR DESCRIPTION
#66 fixed one lifecycle flake. It turned out to be **one instance of a systemic pattern** — cold-rebuild contention runs surfaced **four separate races**, each visible only after the previous was fixed, because they're probabilistic under load and every cold run picks a different victim.

The cost is the false signal, not the tests themselves: a failure aborts `cargo test --workspace` and reports a partial total, which repeatedly looked like a large regression and cost real time to disprove.

## Three shapes, needing opposite fixes

**1. Awaiting a real signal, timeout as deadlock insurance.** The `await` is the pass/fail criterion; the timeout only stops a hang. A tight budget buys nothing and turns slow scheduling into a false failure — so here **raising it is correct**.

- `control.rs:715` — guard 2s → 30s
- `control.rs:853` — 10ms poll loop replaced with an unbounded event channel, 30s guard
- `serve.rs:3200` — now awaits the child's real exit under a 30s guard
- `doctor_ocr.rs` — 5s → 30s

**2. An assertion racing a production time window.** The window is product behaviour and must not move, so the threshold becomes injectable. The runtime lease keeps **3s** and the launch claim **10s**; only the relevant tests opt out.

**3. Fixed sleeps standing in for scheduler progress.** Removed at `resume.rs:1269` and `:1295` — the tests now poll the future to its first suspension, perform the transition deterministically, and resume it.

## Deliberately left alone

The **1ms timeout test at `resume.rs:1245`** stays: elapsed-time expiry is precisely what it verifies, and no competing task can produce a false result. A mechanical "raise every timeout" pass would have broken it.

Also untouched: production polling intervals, the 150ms child-startup check, override-lock waits, cache TTLs, refresh intervals. Those are product behaviour, not test deadlines.

## No production behaviour changed

`RUNTIME_HEARTBEAT_INTERVAL` 1s, `RUNTIME_LEASE_STALE_AFTER` 3s, `RUNTIME_LAUNCH_CLAIM_STALE_AFTER` 10s — all unchanged, with every production caller passing the real constant. Every `resume.rs` edit is inside `mod tests`.

## Verification

**Five separate cold-contention runs** (`cargo clean -p bookforge-llm -p bookforge-epub -p bookforge-cli`, then immediately `cargo test --workspace`) — three by Codex, two independently by me. All **815 passed / 0 failed / 3 ignored**. `fmt` and `clippy -D warnings` clean.

Two clean runs is explicitly *not* sufficient evidence here; that's how the third and fourth races survived earlier attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)