### PR TITLE
fix(batch): treat an incomplete batch response as a request failure

### DIFF
--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -50,7 +50,9 @@ use planning::{
 };
 pub use rendering::batch_item_validation_error;
 pub use rendering::parse_batch_response;
-use rendering::{parse_batch_response_with_validation, render_batch_items};
+use rendering::{
+    batch_response_item_count, parse_batch_response_with_validation, render_batch_items,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BatchMode {

--- a/crates/bookforge-llm/src/batch/execution.rs
+++ b/crates/bookforge-llm/src/batch/execution.rs
@@ -17,6 +17,8 @@ struct BatchWorkerOutput {
     batch: TranslationBatch,
     result: BatchWorkerResult,
     request_status: RequestStatus,
+    finish_reason: Option<FinishReason>,
+    returned_items: Option<usize>,
     latency_ms: u64,
     max_output_tokens: u32,
     output_escalated: bool,
@@ -27,8 +29,16 @@ struct BatchWorkerOutput {
 struct RepairWorkerOutput {
     batch: TranslationBatch,
     result: Result<BatchTranslationResult, LlmError>,
+    finish_reason: Option<FinishReason>,
+    returned_items: Option<usize>,
     latency_ms: u64,
     max_output_tokens: u32,
+}
+
+struct BatchRequestOutput {
+    result: Result<BatchTranslationResult, LlmError>,
+    finish_reason: Option<FinishReason>,
+    returned_items: Option<usize>,
 }
 
 struct InFlightRequestGuard(Arc<AtomicUsize>);
@@ -355,6 +365,8 @@ where
                             batch,
                             result: BatchWorkerResult::StoppedUnfinished,
                             request_status: RequestStatus::OtherError,
+                            finish_reason: None,
+                            returned_items: None,
                             latency_ms: 0,
                             max_output_tokens: 0,
                             output_escalated,
@@ -376,6 +388,8 @@ where
                                 batch,
                                 result: BatchWorkerResult::StoppedUnfinished,
                                 request_status: RequestStatus::OtherError,
+                                finish_reason: None,
+                                returned_items: None,
                                 latency_ms: 0,
                                 max_output_tokens: 0,
                                 output_escalated,
@@ -395,6 +409,8 @@ where
                                         "batch request semaphore closed".to_string(),
                                     ))),
                                     request_status: RequestStatus::OtherError,
+                                    finish_reason: None,
+                                    returned_items: None,
                                     latency_ms: 0,
                                     max_output_tokens: 0,
                                     output_escalated,
@@ -421,6 +437,8 @@ where
                                         "adaptive concurrency limiter closed".to_string(),
                                     ))),
                                     request_status: RequestStatus::OtherError,
+                                    finish_reason: None,
+                                    returned_items: None,
                                     latency_ms: 0,
                                     max_output_tokens: 0,
                                     output_escalated,
@@ -484,7 +502,7 @@ where
                         timestamp_ms: bookforge_core::progress::now_ms(),
                     });
 
-                    let result = translate_one_batch(
+                    let attempt = translate_one_batch_with_evidence(
                         provider.clone(),
                         library.clone(),
                         batch.clone(),
@@ -500,13 +518,15 @@ where
                     .await;
                     let latency_ms = started.elapsed().as_millis() as u64;
 
-                    let request_status = request_status_for_controller(&result);
+                    let request_status = request_status_for_controller(&attempt.result);
 
                     drop(permit);
                     BatchWorkerOutput {
                         batch,
-                        result: BatchWorkerResult::Provider(result),
+                        result: BatchWorkerResult::Provider(attempt.result),
                         request_status,
+                        finish_reason: attempt.finish_reason,
+                        returned_items: attempt.returned_items,
                         latency_ms,
                         max_output_tokens,
                         output_escalated,
@@ -551,6 +571,8 @@ where
                 batch,
                 result,
                 request_status,
+                finish_reason,
+                returned_items,
                 latency_ms,
                 max_output_tokens,
                 output_escalated,
@@ -579,18 +601,19 @@ where
                     continue;
                 }
             };
+            let recorded_status =
+                batch_request_metric_status(&result, batch.items.len(), returned_items);
+            let recorded_finish_reason =
+                finish_reason.map(|reason| finish_reason_label(reason).to_string());
 
             progress.emit(bookforge_core::ProgressEvent::RequestFinished {
                 request_id: format!("batch_{}", batch.id),
                 batch_id: Some(batch.id.clone()),
                 segment_id: None,
-                status: result
-                    .as_ref()
-                    .map_or_else(|e| request_status_from_error(e), |_| "ok")
-                    .to_string(),
+                status: recorded_status.clone(),
                 latency_ms,
                 status_code: None,
-                finish_reason: None,
+                finish_reason: recorded_finish_reason.clone(),
                 retry_count: 0,
                 input_tokens: result.as_ref().ok().and_then(|r| r.input_tokens),
                 output_tokens: result.as_ref().ok().and_then(|r| r.output_tokens),
@@ -610,12 +633,8 @@ where
                 input_tokens: result.as_ref().ok().and_then(|r| r.input_tokens),
                 output_tokens: result.as_ref().ok().and_then(|r| r.output_tokens),
                 latency_ms,
-                finish_reason: None,
-                status: if result.is_ok() {
-                    "ok".into()
-                } else {
-                    "error".into()
-                },
+                finish_reason: recorded_finish_reason,
+                status: recorded_status,
                 status_code: None,
                 retry_count: 0,
                 backoff_ms: 0,
@@ -806,8 +825,12 @@ where
                     );
                     pending_queue.push_back(batch);
                 }
-                Err(LlmError::InvalidResponse(_)) if batch.kind == BatchKind::Repair => {
-                    truncation_alert.observe_resolved();
+                Err(error @ LlmError::InvalidResponse(_)) if batch.kind == BatchKind::Repair => {
+                    if !is_incomplete_response_error(&error)
+                        && request_status != RequestStatus::Truncated
+                    {
+                        truncation_alert.observe_resolved();
+                    }
                     progress.emit(bookforge_core::ProgressEvent::Warning {
                         kind: "repair_batch_invalid_response".to_string(),
                         message: format!(
@@ -890,7 +913,9 @@ where
                     });
                 }
                 Err(error @ LlmError::InvalidResponse(_)) if batch.items.len() == 1 => {
-                    truncation_alert.observe_resolved();
+                    if !is_incomplete_response_error(&error) {
+                        truncation_alert.observe_resolved();
+                    }
                     let attempts =
                         increment_batch_item_attempts(&mut single_invalid_attempts_by_item, &batch);
                     let compact_retry_limit =
@@ -958,7 +983,8 @@ where
                         });
                     }
                 }
-                Err(LlmError::InvalidResponse(_)) if batch.items.len() > 1 => {
+                Err(error @ LlmError::InvalidResponse(_)) if batch.items.len() > 1 => {
+                    let incomplete = is_incomplete_response_error(&error);
                     if let Some(sizer) =
                         adaptive_sizer_mut(&mut runtime_sizer, batch_sizer.as_deref_mut())
                     {
@@ -970,7 +996,7 @@ where
                     }
                     if request_status == RequestStatus::Truncated {
                         truncation_alert.observe_unresolved(&progress);
-                    } else {
+                    } else if !incomplete {
                         truncation_alert.observe_resolved();
                     }
                     let split = split_batch_with_config(&batch, Some(config.as_ref()));
@@ -985,6 +1011,8 @@ where
                     progress.emit(bookforge_core::ProgressEvent::Warning {
                         kind: if request_status == RequestStatus::Truncated {
                             "batch_truncated_split"
+                        } else if incomplete {
+                            "batch_incomplete_response_split"
                         } else {
                             "batch_invalid_response_split"
                         }
@@ -994,6 +1022,8 @@ where
                             batch.id,
                             if request_status == RequestStatus::Truncated {
                                 "truncated output"
+                            } else if incomplete {
+                                "incomplete output"
                             } else {
                                 "invalid response"
                             }
@@ -1270,6 +1300,7 @@ where
             .collect();
 
         let mut repaired_count = 0usize;
+        let mut repair_attempts_by_batch: HashMap<String, usize> = HashMap::new();
         let mut repair_tasks = JoinSet::<RepairWorkerOutput>::new();
 
         while !repair_batches.is_empty() || !repair_tasks.is_empty() {
@@ -1421,6 +1452,8 @@ where
                         &library.batch_repair
                     };
 
+                    let mut finish_reason = None;
+                    let mut returned_items = None;
                     let result = match repair_template.render(&vars) {
                         Ok(rendered) => {
                             match provider
@@ -1449,20 +1482,32 @@ where
                                 .await
                             {
                                 Ok(response) => {
-                                    match parse_batch_response_with_validation(
-                                        &repair_batch,
-                                        &response.content,
-                                        validate_source_copy,
-                                        Some(&section_titles),
-                                        (!config.provider.eq_ignore_ascii_case("mock"))
-                                            .then_some(config.target_language.as_str()),
-                                    ) {
-                                        Ok(mut repaired) => {
-                                            repaired.input_tokens = response.input_tokens;
-                                            repaired.output_tokens = response.output_tokens;
-                                            Ok(repaired)
+                                    finish_reason = Some(response.finish_reason);
+                                    returned_items =
+                                        batch_response_item_count(&repair_batch, &response.content);
+                                    if response.finish_reason == FinishReason::Length {
+                                        Err(LlmError::InvalidResponse(
+                                            "repair batch output was truncated: max_output_tokens limit reached"
+                                                .to_string(),
+                                        ))
+                                    } else {
+                                        match parse_batch_response_with_validation(
+                                            &repair_batch,
+                                            &response.content,
+                                            validate_source_copy,
+                                            Some(&section_titles),
+                                            (!config.provider.eq_ignore_ascii_case("mock"))
+                                                .then_some(config.target_language.as_str()),
+                                        ) {
+                                            Ok(mut repaired) => {
+                                                repaired.input_tokens = response.input_tokens;
+                                                repaired.input_cached_tokens =
+                                                    response.input_cached_tokens;
+                                                repaired.output_tokens = response.output_tokens;
+                                                Ok(repaired)
+                                            }
+                                            Err(error) => Err(LlmError::InvalidResponse(error)),
                                         }
-                                        Err(error) => Err(LlmError::InvalidResponse(error)),
                                     }
                                 }
                                 Err(error) => Err(error),
@@ -1476,6 +1521,8 @@ where
                     RepairWorkerOutput {
                         batch: repair_batch,
                         result,
+                        finish_reason,
+                        returned_items,
                         latency_ms: started.elapsed().as_millis() as u64,
                         max_output_tokens,
                     }
@@ -1488,23 +1535,31 @@ where
             let RepairWorkerOutput {
                 batch,
                 result,
+                finish_reason,
+                returned_items,
                 latency_ms,
                 max_output_tokens,
             } = joined
                 .map_err(|err| LlmError::Provider(format!("repair worker task failed: {err}")))?;
 
+            let recorded_status =
+                batch_request_metric_status(&result, batch.items.len(), returned_items);
+            let recorded_finish_reason =
+                finish_reason.map(|reason| finish_reason_label(reason).to_string());
+            let repair_retry_count = repair_attempts_by_batch
+                .get(&batch.id)
+                .copied()
+                .unwrap_or(0);
+
             progress.emit(bookforge_core::ProgressEvent::RequestFinished {
                 request_id: format!("batch_{}", batch.id),
                 batch_id: Some(batch.id.clone()),
                 segment_id: None,
-                status: result
-                    .as_ref()
-                    .map_or_else(|e| request_status_from_error(e), |_| "ok")
-                    .to_string(),
+                status: recorded_status.clone(),
                 latency_ms,
                 status_code: None,
-                finish_reason: None,
-                retry_count: 0,
+                finish_reason: recorded_finish_reason.clone(),
+                retry_count: repair_retry_count,
                 input_tokens: result.as_ref().ok().and_then(|r| r.input_tokens),
                 output_tokens: result.as_ref().ok().and_then(|r| r.output_tokens),
                 error_kind: result.as_ref().err().map(|e| format!("{e:?}")),
@@ -1523,20 +1578,27 @@ where
                 input_tokens: result.as_ref().ok().and_then(|r| r.input_tokens),
                 output_tokens: result.as_ref().ok().and_then(|r| r.output_tokens),
                 latency_ms,
-                finish_reason: None,
-                status: if result.is_ok() {
-                    "ok".into()
-                } else {
-                    "error".into()
-                },
+                finish_reason: recorded_finish_reason,
+                status: recorded_status,
                 status_code: None,
-                retry_count: 0,
+                retry_count: repair_retry_count,
                 backoff_ms: 0,
                 error_kind: None,
             });
 
             match result {
                 Ok(repaired) => {
+                    if !repaired.failures.is_empty() {
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "repair_batch_item_failures".to_string(),
+                            message: format!(
+                                "repair batch {} returned {} present-but-invalid items; keeping them NeedsReview",
+                                batch.id,
+                                repaired.failures.len()
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                    }
                     for translation in repaired.translations {
                         let Some(source_item) = all_items.get(&translation.item_id) else {
                             continue;
@@ -1593,6 +1655,19 @@ where
                                 .insert(completed.segment_id.0.clone());
                         }
                     }
+                }
+                Err(error @ LlmError::InvalidResponse(_)) if repair_retry_count < 1 => {
+                    repair_attempts_by_batch.insert(batch.id.clone(), repair_retry_count + 1);
+                    progress.emit(bookforge_core::ProgressEvent::Warning {
+                        kind: "repair_batch_invalid_response_retry".to_string(),
+                        message: format!(
+                            "repair batch {} returned an invalid or incomplete response; retrying once for {} items: {error}",
+                            batch.id,
+                            batch.items.len()
+                        ),
+                        timestamp_ms: bookforge_core::progress::now_ms(),
+                    });
+                    repair_batches.push_back(batch);
                 }
                 Err(error) => {
                     progress.emit(bookforge_core::ProgressEvent::Warning {
@@ -1685,12 +1760,24 @@ pub(super) struct BatchTranslationRequest<'a> {
     pub compact_retry_attempt: usize,
 }
 
+#[cfg(test)]
 pub(super) async fn translate_one_batch(
     provider: Arc<impl LlmProvider>,
     library: Arc<PromptLibrary>,
     batch: TranslationBatch,
     request: BatchTranslationRequest<'_>,
 ) -> Result<BatchTranslationResult, LlmError> {
+    translate_one_batch_with_evidence(provider, library, batch, request)
+        .await
+        .result
+}
+
+async fn translate_one_batch_with_evidence(
+    provider: Arc<impl LlmProvider>,
+    library: Arc<PromptLibrary>,
+    batch: TranslationBatch,
+    request: BatchTranslationRequest<'_>,
+) -> BatchRequestOutput {
     let BatchTranslationRequest {
         config,
         max_output_tokens_override,
@@ -1747,9 +1834,16 @@ pub(super) async fn translate_one_batch(
     )
     .raw("items_json", items_json);
 
-    let mut rendered = template
-        .render(&vars)
-        .map_err(|e| LlmError::Provider(e.to_string()))?;
+    let mut rendered = match template.render(&vars) {
+        Ok(rendered) => rendered,
+        Err(error) => {
+            return BatchRequestOutput {
+                result: Err(LlmError::Provider(error.to_string())),
+                finish_reason: None,
+                returned_items: None,
+            };
+        }
+    };
     if compact_retry_attempt > 0 {
         rendered.user.push_str(&format!(
             "\n\nRECOVERY MODE {compact_retry_attempt}: Return one compact JSON object only. Translate every item exactly once. Do not repeat any word, sentence, item, or explanation. End immediately after the closing brace."
@@ -1788,13 +1882,19 @@ pub(super) async fn translate_one_batch(
 
     match response {
         Ok(resp) => {
+            let finish_reason = Some(resp.finish_reason);
+            let returned_items = batch_response_item_count(&batch, &resp.content);
             if resp.finish_reason == FinishReason::Length {
-                return Err(LlmError::InvalidResponse(
-                    "batch output was truncated: max_output_tokens limit reached".to_string(),
-                ));
+                return BatchRequestOutput {
+                    result: Err(LlmError::InvalidResponse(
+                        "batch output was truncated: max_output_tokens limit reached".to_string(),
+                    )),
+                    finish_reason,
+                    returned_items,
+                };
             }
 
-            let mut result = parse_batch_response_with_validation(
+            let result = parse_batch_response_with_validation(
                 &batch,
                 &resp.content,
                 validate_source_copy,
@@ -1802,14 +1902,25 @@ pub(super) async fn translate_one_batch(
                 (!config.provider.eq_ignore_ascii_case("mock"))
                     .then_some(config.target_language.as_str()),
             )
-            .map_err(LlmError::InvalidResponse)?;
-            result.input_tokens = resp.input_tokens;
-            result.input_cached_tokens = resp.input_cached_tokens;
-            result.output_tokens = resp.output_tokens;
-            apportion_batch_usage(&batch, &mut result);
-            Ok(result)
+            .map_err(LlmError::InvalidResponse)
+            .map(|mut result| {
+                result.input_tokens = resp.input_tokens;
+                result.input_cached_tokens = resp.input_cached_tokens;
+                result.output_tokens = resp.output_tokens;
+                apportion_batch_usage(&batch, &mut result);
+                result
+            });
+            BatchRequestOutput {
+                result,
+                finish_reason,
+                returned_items,
+            }
         }
-        Err(e) => Err(e),
+        Err(error) => BatchRequestOutput {
+            result: Err(error),
+            finish_reason: None,
+            returned_items: None,
+        },
     }
 }
 
@@ -2029,6 +2140,38 @@ fn request_status_from_error(error: &LlmError) -> &'static str {
         LlmError::InvalidResponse(_) => "invalid_response",
         LlmError::Json(_) => "json_error",
         _ => "error",
+    }
+}
+
+fn batch_request_metric_status<T>(
+    result: &Result<T, LlmError>,
+    requested_items: usize,
+    returned_items: Option<usize>,
+) -> String {
+    match result {
+        Ok(_) => "ok".to_string(),
+        Err(error) if is_incomplete_response_error(error) => returned_items.map_or_else(
+            || "incomplete".to_string(),
+            |returned| format!("incomplete:{returned}/{requested_items}"),
+        ),
+        Err(error) => request_status_from_error(error).to_string(),
+    }
+}
+
+fn is_incomplete_response_error(error: &LlmError) -> bool {
+    matches!(
+        error,
+        LlmError::InvalidResponse(message) if message.starts_with("batch response incomplete:")
+    )
+}
+
+fn finish_reason_label(reason: FinishReason) -> &'static str {
+    match reason {
+        FinishReason::Stop => "stop",
+        FinishReason::Length => "length",
+        FinishReason::ContentFilter => "content_filter",
+        FinishReason::ToolCalls => "tool_calls",
+        FinishReason::Unknown => "unknown",
     }
 }
 

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -382,11 +382,14 @@ fn parse_text_batch_response(
             continue;
         };
 
-        if item.translation.is_empty() && !request_item.source_text.is_empty() {
+        if let Some(error) = crate::validation::empty_translation_validation_error(
+            &request_item.source_text,
+            &item.translation,
+        ) {
             failures.push(BatchItemFailure {
                 item_id: item.id.clone(),
                 segment_id: request_item.segment_id.clone(),
-                error: "empty translation for non-empty source".to_string(),
+                error: error.to_string(),
                 input_tokens: None,
                 input_cached_tokens: None,
                 output_tokens: None,
@@ -452,18 +455,14 @@ fn parse_text_batch_response(
         });
     }
 
-    for item in &batch.items {
-        if !seen.contains_key(item.item_id.as_str()) {
-            failures.push(BatchItemFailure {
-                item_id: item.item_id.clone(),
-                segment_id: item.segment_id.clone(),
-                error: "item missing from batch response".to_string(),
-                input_tokens: None,
-                input_cached_tokens: None,
-                output_tokens: None,
-                tokens_estimated: false,
-            });
-        }
+    let missing = batch
+        .items
+        .iter()
+        .filter(|item| !seen.contains_key(item.item_id.as_str()))
+        .map(|item| item.item_id.as_str())
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(incomplete_batch_response_error(batch.items.len(), &missing));
     }
 
     Ok(BatchTranslationResult {
@@ -592,6 +591,21 @@ fn parse_run_batch_response(
             .collect();
         let joined_translation = joined.join("");
         let translation = joined_translation;
+        if let Some(error) = crate::validation::empty_translation_validation_error(
+            &request_item.source_text,
+            &translation,
+        ) {
+            failures.push(BatchItemFailure {
+                item_id: item.id.clone(),
+                segment_id: request_item.segment_id.clone(),
+                error: error.to_string(),
+                input_tokens: None,
+                input_cached_tokens: None,
+                output_tokens: None,
+                tokens_estimated: false,
+            });
+            continue;
+        }
         let section_title = section_titles
             .and_then(|titles| titles.get(&request_item.segment_id.0))
             .map(String::as_str);
@@ -632,18 +646,14 @@ fn parse_run_batch_response(
         });
     }
 
-    for item in &batch.items {
-        if !seen.contains_key(item.item_id.as_str()) {
-            failures.push(BatchItemFailure {
-                item_id: item.item_id.clone(),
-                segment_id: item.segment_id.clone(),
-                error: "item missing from batch response".to_string(),
-                input_tokens: None,
-                input_cached_tokens: None,
-                output_tokens: None,
-                tokens_estimated: false,
-            });
-        }
+    let missing = batch
+        .items
+        .iter()
+        .filter(|item| !seen.contains_key(item.item_id.as_str()))
+        .map(|item| item.item_id.as_str())
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(incomplete_batch_response_error(batch.items.len(), &missing));
     }
 
     Ok(BatchTranslationResult {
@@ -654,6 +664,32 @@ fn parse_run_batch_response(
         input_cached_tokens: None,
         output_tokens: None,
     })
+}
+
+fn incomplete_batch_response_error(requested: usize, missing: &[&str]) -> String {
+    let returned = requested.saturating_sub(missing.len());
+    format!(
+        "batch response incomplete: requested {requested} items, returned {returned}; missing item IDs: {}",
+        missing.join(", ")
+    )
+}
+
+pub(super) fn batch_response_item_count(batch: &TranslationBatch, content: &str) -> Option<usize> {
+    let parsed = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    let items = parsed.get("items")?.as_array()?;
+    let requested = batch
+        .items
+        .iter()
+        .map(|item| item.item_id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    Some(
+        items
+            .iter()
+            .filter_map(|item| item.get("id")?.as_str())
+            .filter(|item_id| requested.contains(item_id))
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+    )
 }
 
 pub(super) fn render_batch_items(

--- a/crates/bookforge-llm/src/batch/tests.rs
+++ b/crates/bookforge-llm/src/batch/tests.rs
@@ -911,10 +911,36 @@ fn detects_missing_items_in_batch_response() {
     })
     .to_string();
 
-    let result = parse_batch_response(batch, &response).expect("parse");
+    let error = parse_batch_response(batch, &response)
+        .expect_err("missing requested items must fail the whole response");
+    assert!(error.contains("batch response incomplete"));
+    assert!(error.contains("requested 2 items, returned 1"));
+}
+
+#[test]
+fn present_empty_batch_item_remains_a_per_item_failure() {
+    let batch = make_two_item_batch();
+    let first_id = batch.items[0].item_id.clone();
+    let second_id = batch.items[1].item_id.clone();
+    let response = serde_json::json!({
+        "items": [
+            {"id": first_id, "translation": "Ciao"},
+            {"id": second_id, "translation": " \n\t"},
+        ]
+    })
+    .to_string();
+
+    let result = parse_batch_response(&batch, &response)
+        .expect("a complete envelope with a bad item stays on the per-item path");
+
     assert_eq!(result.translations.len(), 1);
     assert_eq!(result.failures.len(), 1);
-    assert!(result.failures[0].error.contains("missing"));
+    assert_eq!(result.failures[0].item_id, second_id);
+    assert!(
+        result.failures[0]
+            .error
+            .contains("empty translation for non-empty source")
+    );
 }
 
 #[test]
@@ -1844,6 +1870,65 @@ impl LlmProviderTrait for FirstInvalidThenPromptEchoProvider {
     }
 }
 
+struct FirstPartialThenPromptEchoProvider {
+    calls: Mutex<usize>,
+    requested_item_counts: Arc<Mutex<Vec<usize>>>,
+}
+
+impl FirstPartialThenPromptEchoProvider {
+    fn new(requested_item_counts: Arc<Mutex<Vec<usize>>>) -> Self {
+        Self {
+            calls: Mutex::new(0),
+            requested_item_counts,
+        }
+    }
+}
+
+impl LlmProviderTrait for FirstPartialThenPromptEchoProvider {
+    async fn complete(&self, request: CompletionRequest) -> ProviderResult<CompletionResponse> {
+        let mut calls = self.calls.lock().unwrap();
+        let call = *calls;
+        *calls += 1;
+        drop(calls);
+
+        let item_ids = item_ids_from_batch_prompt(&request.user);
+        self.requested_item_counts
+            .lock()
+            .unwrap()
+            .push(item_ids.len());
+        let returned_ids = if call == 0 {
+            item_ids.into_iter().take(1).collect::<Vec<_>>()
+        } else {
+            item_ids
+        };
+        Ok(CompletionResponse {
+            content: serde_json::json!({
+                "items": returned_ids
+                    .into_iter()
+                    .map(|id| serde_json::json!({
+                        "translation": format!("[it] {id}"),
+                        "id": id,
+                    }))
+                    .collect::<Vec<_>>(),
+            })
+            .to_string(),
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            finish_reason: FinishReason::Stop,
+            provider_latency_ms: 0,
+            raw: serde_json::json!({}),
+        })
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            supports_json_response_format: true,
+            supports_usage_tokens: true,
+        }
+    }
+}
+
 struct AlwaysTransientProvider {
     calls: AtomicUsize,
 }
@@ -1997,21 +2082,8 @@ fn item_ids_from_batch_prompt(user_prompt: &str) -> Vec<String> {
         .collect()
 }
 
-struct RepairOrderingSink(Arc<std::sync::Mutex<Vec<&'static str>>>);
-
-impl bookforge_core::ProgressSink for RepairOrderingSink {
-    fn emit(&self, event: bookforge_core::ProgressEvent) {
-        if matches!(
-            event,
-            bookforge_core::ProgressEvent::BatchRepairFinished { .. }
-        ) {
-            self.0.lock().unwrap().push("repair_finished");
-        }
-    }
-}
-
 #[tokio::test]
-async fn completed_repair_publishes_segment_before_repair_phase_finishes() {
+async fn partial_batch_response_splits_smaller_without_recording_success() {
     let segment = make_segment(
         "seg1",
         vec![plain_block("Hello"), plain_block("World")],
@@ -2027,53 +2099,65 @@ async fn completed_repair_publishes_segment_before_repair_phase_finishes() {
         repair_invalid_items: true,
     };
     let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
-    let first_item_id = batches[0].items[0].item_id.clone();
-    let second_item_id = batches[0].items[1].item_id.clone();
-    let provider = SequenceProvider::new(vec![
-        serde_json::json!({
-            "items": [{"id": first_item_id, "translation": "[it] Hello"}],
-        })
-        .to_string(),
-        serde_json::json!({
-            "items": [{"id": second_item_id, "translation": "[it] World"}],
-        })
-        .to_string(),
-    ]);
-    let ordering = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let sink = Arc::new(RepairOrderingSink(ordering.clone()));
-    let callback_ordering = ordering.clone();
+    let requested_item_counts = Arc::new(Mutex::new(Vec::new()));
+    let provider = FirstPartialThenPromptEchoProvider::new(requested_item_counts.clone());
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let telemetry = Arc::new(TelemetryLog::new());
+    let mut sizer = BatchSizer::new(16_000, 128);
 
     let translations = translate_batches_with_callback(
         provider,
         batches,
         &segments,
         &test_run_config(),
-        Arc::new(TelemetryLog::new()),
+        telemetry.clone(),
         None,
+        Some(&mut sizer),
+        Arc::new(RecordingProgress {
+            events: events.clone(),
+        }),
         None,
-        sink,
-        None,
-        move |translation| {
-            assert_eq!(translation.status, SegmentStatus::Succeeded);
-            callback_ordering.lock().unwrap().push("callback");
-            Ok(())
-        },
+        |_| Ok(()),
     )
     .await
-    .expect("repair should complete");
+    .expect("split retries should complete");
 
+    assert_eq!(*requested_item_counts.lock().unwrap(), [2, 1, 1]);
     assert_eq!(translations[0].status, SegmentStatus::Succeeded);
-    assert_eq!(*ordering.lock().unwrap(), ["callback", "repair_finished"]);
+    let observations = &sizer.modes[&BatchMode::Plain].recent;
+    assert!(matches!(
+        observations.front(),
+        Some(BatchSizingObservation::InvalidJson)
+    ));
+    assert_eq!(
+        observations
+            .iter()
+            .filter(|observation| matches!(observation, BatchSizingObservation::Success { .. }))
+            .count(),
+        2,
+        "only the two complete split retries should be recorded as successes"
+    );
+    let metrics = telemetry.snapshot();
+    assert_eq!(metrics[0].status, "incomplete:1/2");
+    assert_eq!(metrics[0].items, 2);
+    assert_eq!(metrics[0].finish_reason.as_deref(), Some("stop"));
+    assert!(events.lock().unwrap().iter().any(|event| {
+        matches!(
+            event,
+            bookforge_core::ProgressEvent::Warning { kind, .. }
+                if kind == "batch_incomplete_response_split"
+        )
+    }));
 }
 
 #[tokio::test]
-async fn partial_batch_failure_without_successful_repair_marks_segment_needs_review() {
-    let seg = make_segment(
+async fn partial_repair_response_is_retried_and_present_bad_item_stays_per_item() {
+    let segment = make_segment(
         "seg1",
         vec![plain_block("Hello"), plain_block("World")],
         vec![],
     );
-    let segments = vec![seg.clone()];
+    let segments = vec![segment];
     let cfg = BatchConfig {
         enabled: true,
         target_tokens: 1000,
@@ -2085,21 +2169,26 @@ async fn partial_batch_failure_without_successful_repair_marks_segment_needs_rev
     let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
     assert_eq!(batches.len(), 1);
     let first_item_id = batches[0].items[0].item_id.clone();
-    let missing_block_id = batches[0].items[1].block_id.0.clone();
-
-    let initial_response = serde_json::json!({
-        "items": [
-            {"id": first_item_id, "translation": "[it] Hello"},
-        ]
-    })
-    .to_string();
-    // Repair returns malformed JSON so parse_batch_response fails
-    // and the missing block stays unrepaired.
-    let repair_response = "{not valid json".to_string();
-
-    let provider = SequenceProvider::new(vec![initial_response, repair_response]);
+    let second_item_id = batches[0].items[1].item_id.clone();
+    let provider = SequenceProvider::new(vec![
+        serde_json::json!({
+            "items": [
+                {"id": first_item_id, "translation": "[it] Hello"},
+                {"id": second_item_id, "translation": " \n"},
+            ]
+        })
+        .to_string(),
+        serde_json::json!({"items": []}).to_string(),
+        serde_json::json!({
+            "items": [
+                {"id": second_item_id, "translation": "[it] World"},
+            ]
+        })
+        .to_string(),
+    ]);
     let telemetry = Arc::new(TelemetryLog::new());
     let config = test_run_config();
+    let events = Arc::new(Mutex::new(Vec::new()));
     let translations = translate_batches_with_callback(
         provider,
         batches,
@@ -2108,7 +2197,9 @@ async fn partial_batch_failure_without_successful_repair_marks_segment_needs_rev
         telemetry,
         None,
         None,
-        Arc::new(bookforge_core::NullProgressSink),
+        Arc::new(RecordingProgress {
+            events: events.clone(),
+        }),
         None,
         |_| Ok(()),
     )
@@ -2116,20 +2207,70 @@ async fn partial_batch_failure_without_successful_repair_marks_segment_needs_rev
     .expect("translate");
 
     assert_eq!(translations.len(), 1);
-    let translation = &translations[0];
-    assert_eq!(
-        translation.status,
-        SegmentStatus::NeedsReview,
-        "segment with missing block translation must not be saved as Succeeded",
-    );
-    let error = translation
-        .error
-        .as_ref()
-        .expect("missing-block segment must carry an error");
+    assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+    assert_eq!(translations[0].joined_text(), "[it] Hello\n\n[it] World");
+    let events = events.lock().unwrap();
     assert!(
-        error.contains(&missing_block_id),
-        "error must name missing block id {missing_block_id}, got: {error}",
+        !events
+            .iter()
+            .any(|event| matches!(event, bookforge_core::ProgressEvent::BatchSplit { .. })),
+        "a present-but-invalid item must not split the complete initial envelope"
     );
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            bookforge_core::ProgressEvent::Warning { kind, .. }
+                if kind == "repair_batch_invalid_response_retry"
+        )
+    }));
+}
+
+#[tokio::test]
+async fn length_finished_repair_response_is_retried() {
+    let segment = make_segment("seg1", vec![plain_block("Hello")], vec![]);
+    let segments = vec![segment];
+    let cfg = BatchConfig {
+        enabled: true,
+        target_tokens: 1000,
+        max_items: 64,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+    let item_id = batches[0].items[0].item_id.clone();
+    let max_output_tokens = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingSequenceProvider::new(
+        vec![
+            RecordedResponse::ItemsFromBatch(vec![(item_id.clone(), " \t".to_string())]),
+            RecordedResponse::FinishLength,
+            RecordedResponse::ItemsFromBatch(vec![(item_id, "[it] Hello".to_string())]),
+        ],
+        max_output_tokens.clone(),
+    );
+    let telemetry = Arc::new(TelemetryLog::new());
+
+    let translations = translate_batches_with_callback(
+        provider,
+        batches,
+        &segments,
+        &test_run_config(),
+        telemetry.clone(),
+        None,
+        None,
+        Arc::new(bookforge_core::NullProgressSink),
+        None,
+        |_| Ok(()),
+    )
+    .await
+    .expect("length-finished repair should retry");
+
+    assert_eq!(max_output_tokens.lock().unwrap().len(), 3);
+    assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+    let metrics = telemetry.snapshot();
+    assert_eq!(metrics[1].finish_reason.as_deref(), Some("length"));
+    assert_eq!(metrics[1].status, "truncated");
+    assert_eq!(metrics[2].retry_count, 1);
 }
 
 #[tokio::test]

--- a/crates/bookforge-llm/src/scheduler.rs
+++ b/crates/bookforge-llm/src/scheduler.rs
@@ -1398,6 +1398,12 @@ fn parse_and_validate(
                 .map(|block| block.protected_spans.as_slice())
                 .unwrap_or(&[]);
             let translation = parsed.translation;
+            if let Some(error) = crate::validation::empty_translation_validation_error(
+                &segment.source.text,
+                &translation,
+            ) {
+                return Err(LlmError::InvalidResponse(error.to_string()));
+            }
             validate_protected_spans(segment, expected_spans, &translation)?;
             if validate_source_copy
                 && let Some(error) = crate::validation::source_copy_validation_error(
@@ -1462,6 +1468,15 @@ fn parse_and_validate(
                                 segment.id.0, source_block.block_id.0
                             ))
                         })?;
+                if let Some(error) = crate::validation::empty_translation_validation_error(
+                    &source_block.text,
+                    &translation,
+                ) {
+                    return Err(LlmError::InvalidResponse(format!(
+                        "segment '{}' block '{}': {error}",
+                        segment.id.0, source_block.block_id.0
+                    )));
+                }
                 let expected_markers = marker_ids_in_text(&source_block.text);
                 validate_markers(segment, &expected_markers, &translation)?;
                 validate_protected_spans(segment, &source_block.protected_spans, &translation)?;
@@ -1525,6 +1540,14 @@ fn parse_and_validate(
                         ))
                     })?;
                 let text = validate_and_join_runs(segment, source_block, block.translated_runs)?;
+                if let Some(error) =
+                    crate::validation::empty_translation_validation_error(&source_block.text, &text)
+                {
+                    return Err(LlmError::InvalidResponse(format!(
+                        "segment '{}' block '{}': {error}",
+                        segment.id.0, source_block.block_id.0
+                    )));
+                }
                 let expected_markers = marker_ids_in_text(&source_block.text);
                 validate_markers(segment, &expected_markers, &text)?;
                 validate_protected_spans(segment, &source_block.protected_spans, &text)?;
@@ -1865,6 +1888,89 @@ mod tests {
             .expect_err("long unchanged source prose should fail");
 
         assert!(error.to_string().contains("source-language prose"));
+    }
+
+    #[test]
+    fn non_batch_plain_rejects_whitespace_translation_for_non_empty_source() {
+        let segment = segment("seg_a", 0, vec![("b0", "Visible prose")]);
+        let response = serde_json::json!({
+            "segment_id": "seg_a",
+            "translation": " \n\t",
+        })
+        .to_string();
+
+        let error = parse_and_validate(&response, &segment, TranslationMode::Plain, false)
+            .expect_err("whitespace-only translation must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("empty translation for non-empty source")
+        );
+    }
+
+    #[test]
+    fn non_batch_marker_safe_rejects_empty_translation_for_non_empty_source() {
+        let segment = segment(
+            "seg_a",
+            0,
+            vec![("b0", "First paragraph."), ("b1", "Second paragraph.")],
+        );
+        let response = serde_json::json!({
+            "segment_id": "seg_a",
+            "blocks": [
+                {"block_id": "b0", "translation": "Primo paragrafo."},
+                {"block_id": "b1", "translation": ""},
+            ],
+        })
+        .to_string();
+
+        let error = parse_and_validate(&response, &segment, TranslationMode::MarkerSafe, false)
+            .expect_err("empty non-empty block translation must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("empty translation for non-empty source")
+        );
+    }
+
+    #[test]
+    fn non_batch_marker_safe_allows_genuinely_empty_source_block() {
+        let segment = segment("seg_a", 0, vec![("b0", ""), ("b1", "Second paragraph.")]);
+        let response = serde_json::json!({
+            "segment_id": "seg_a",
+            "blocks": [
+                {"block_id": "b0", "translation": " \n"},
+                {"block_id": "b1", "translation": "Secondo paragrafo."},
+            ],
+        })
+        .to_string();
+
+        let blocks = parse_and_validate(&response, &segment, TranslationMode::MarkerSafe, false)
+            .expect("an empty source block may have an empty translation");
+
+        assert_eq!(blocks[0].text, " \n");
+        assert_eq!(blocks[1].text, "Secondo paragrafo.");
+    }
+
+    #[tokio::test]
+    async fn empty_plain_translation_never_returns_cache_eligible_success() {
+        let segments = vec![segment("seg_a", 0, vec![("b0", "Visible prose")])];
+
+        let translations = translate_segments(WhitespaceTranslationProvider, &segments, &config())
+            .await
+            .expect("validation failure should become NeedsReview");
+
+        assert_eq!(translations.len(), 1);
+        assert_eq!(translations[0].status, SegmentStatus::NeedsReview);
+        assert!(
+            translations[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("empty translation for non-empty source"))
+        );
+        assert_eq!(translations[0].blocks[0].text, "Visible prose");
     }
 
     #[tokio::test]
@@ -2618,6 +2724,34 @@ mod tests {
             ProviderCapabilities {
                 supports_json_response_format: true,
                 supports_usage_tokens: false,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct WhitespaceTranslationProvider;
+
+    impl LlmProvider for WhitespaceTranslationProvider {
+        async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse> {
+            Ok(CompletionResponse {
+                content: serde_json::json!({
+                    "segment_id": request.metadata.segment_id.unwrap_or_default(),
+                    "translation": " \n\t",
+                })
+                .to_string(),
+                input_tokens: Some(1),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(1),
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 0,
+                raw: serde_json::json!({}),
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
             }
         }
     }

--- a/crates/bookforge-llm/src/validation.rs
+++ b/crates/bookforge-llm/src/validation.rs
@@ -219,6 +219,14 @@ pub(crate) fn source_copy_validation_error(
     None
 }
 
+pub(crate) fn empty_translation_validation_error(
+    source: &str,
+    translation: &str,
+) -> Option<&'static str> {
+    (!source.trim().is_empty() && translation.trim().is_empty())
+        .then_some("empty translation for non-empty source")
+}
+
 /// Conservative hard gates for the built-in Toki Pona style. These checks
 /// deliberately cover failures that can be detected without judging the
 /// translation's politics or semantic choices: source-language leakage,


### PR DESCRIPTION
`batch_block_mismatch` was the largest real failure mode in the product — 8 of 8 flagged segments on a fresh test book. It turned out to be a **compounding feedback loop**, not an edge case.

## Mechanism

The parser recorded every requested item absent from a response as a per-item failure and **still returned `Ok`**. Orchestration took that `Ok` as full request success without ever inspecting the failures: it cleared compact retry state, called `truncation_alert.observe_resolved()`, and called the adaptive sizer's **success** path.

So a batch returning 127 of 128 items told the sizer it succeeded → the sizer **grew** the batch → larger batches dropped more items → each drop was another reported success. That loop is why this was 8/8 rather than occasional.

Repair repeated the weakness one-shot: same lenient parser, no `FinishReason::Length` check, repair omissions never retried. An item omitted twice reached the coverage check as `NeedsReview`.

## Changes

- **Missing requested IDs now fail the whole response** and enter the same split/retry escalation malformed responses already used — so a multi-item batch **shrinks** instead of growing. Present-but-invalid items keep the per-item path: the distinction that matters is *absent* vs *present-but-bad*.
- An incomplete response no longer clears retry/truncation state and no longer records sizer success.
- Repair honours `FinishReason::Length`, retries an invalid or incomplete repair once, and still surfaces present-but-invalid repair items as `NeedsReview`.
- **Telemetry** records the finish reason and an `incomplete:<returned>/<requested>` status. Previously the stored evidence couldn't distinguish a provider stop from an output cap from model noncompliance — which is why diagnosing this needed source reading rather than a query.

## Second instance of the same disease

Batch parsing already rejected an empty target for a non-empty source. **The single-segment paths did not.** Plain and MarkerSafe checked ids, markers and spans but never non-emptiness, and the source-copy validator returns no error for empty text because its equality and overlap tests cannot match it.

The segment was marked `Succeeded`, became **cache-eligible**, and replace-mode rebuild then removed the visible text. A successful provider envelope containing valid JSON with an empty translation could silently erase prose and seed the cache for future runs.

Plain, MarkerSafe, RunPreserving and batch validation now reject whitespace-only translations for a non-empty source. Genuinely empty source blocks remain valid. A real provider failure was never affected — missing content already becomes `InvalidResponse`.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **821 passed / 0 failed / 3 ignored** (was 815). Existing tests that locked in the old partial-response behaviour were updated to the new contract rather than left asserting the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)