### PR TITLE
fix(audiobook): stop --prune deleting paid audio outside a --chapters filter

### DIFF
--- a/crates/bookforge-audio/src/builder.rs
+++ b/crates/bookforge-audio/src/builder.rs
@@ -252,6 +252,16 @@ pub fn plan_chunks(book: &Book, options: &AudiobookOptions) -> Vec<ChunkRecord> 
         .collect()
 }
 
+/// Build the complete deterministic chunk plan used to identify stale cache
+/// files. Unlike [`plan_chunks`], this deliberately ignores
+/// [`AudiobookOptions::chapter_filter`] so a partial run does not treat chunks
+/// from unselected chapters as stale.
+pub fn plan_chunks_for_prune(book: &Book, options: &AudiobookOptions) -> Vec<ChunkRecord> {
+    let mut full_book_options = options.clone();
+    full_book_options.chapter_filter = None;
+    plan_chunks(book, &full_book_options)
+}
+
 fn build_plan(book: &Book, options: &AudiobookOptions) -> Vec<PlannedChunk> {
     let ext = options.format.extension();
     let mut planned = Vec::new();
@@ -878,6 +888,33 @@ mod tests {
                 ChunkKind::Title
             );
         }
+    }
+
+    #[test]
+    fn prune_plan_ignores_chapter_filter_and_preserves_selected_chunk_names() {
+        let book = book_with_sections();
+        let options = AudiobookOptions {
+            max_chars: 40,
+            chapter_filter: Some([2].into_iter().collect()),
+            ..AudiobookOptions::default()
+        };
+
+        let filtered = plan_chunks(&book, &options);
+        assert!(
+            filtered.iter().all(|chunk| chunk.chapter_index == 1),
+            "the ordinary plan should contain only the selected chapter"
+        );
+
+        let prune_plan = plan_chunks_for_prune(&book, &options);
+        let planned_chapters: std::collections::BTreeSet<_> =
+            prune_plan.iter().map(|chunk| chunk.chapter_index).collect();
+        assert_eq!(planned_chapters, [0, 1].into_iter().collect());
+        assert!(
+            filtered
+                .iter()
+                .all(|selected| prune_plan.iter().any(|chunk| chunk.file == selected.file)),
+            "removing the filter must not change selected chapters' cache names"
+        );
     }
 
     #[test]

--- a/crates/bookforge-audio/src/cleanup.rs
+++ b/crates/bookforge-audio/src/cleanup.rs
@@ -19,8 +19,8 @@ use crate::builder::ChunkRecord;
 /// files this crate actually manages.
 const MANAGED_EXTENSIONS: &[&str] = &["mp3", "opus", "aac", "flac", "wav", "pcm"];
 
-/// A managed chunk file in the output directory that the current plan will not
-/// use — safe to delete.
+/// A managed chunk file in the output directory that the complete current
+/// book plan will not use and is therefore safe to delete.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaleChunk {
     pub path: PathBuf,
@@ -56,7 +56,13 @@ fn is_managed_chunk_name(name: &str) -> bool {
 }
 
 /// List managed chunk files in `out_dir` that the current `plan` does not
-/// reference. A resume never uses these, so they are safe to remove.
+/// reference.
+///
+/// The caller must provide a complete plan covering every narratable chapter
+/// under the current synthesis settings. A chapter-filtered plan is not
+/// sufficient: existing chunks for omitted chapters may still be reusable.
+/// Given a complete plan, a resume never uses the returned files, so they are
+/// safe to remove.
 ///
 /// Returns an empty list if `out_dir` does not exist. Results are sorted by
 /// path for stable reporting.
@@ -183,6 +189,52 @@ mod tests {
         assert!(out.join(keep).exists());
         assert!(out.join("chapter-001.mp3").exists());
         assert!(out.join("audiobook.m4b").exists());
+    }
+
+    #[test]
+    fn complete_plan_keeps_unselected_chapters_and_finds_superseded_chunk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path();
+        let chapter_one = "chapter-001-part-001-1111111111111111.wav";
+        let chapter_two = "chapter-002-part-001-2222222222222222.wav";
+        let chapter_three = "chapter-003-part-001-3333333333333333.wav";
+        let superseded = "chapter-002-part-001-aaaaaaaaaaaaaaaa.wav";
+        for name in [chapter_one, chapter_two, chapter_three, superseded] {
+            fs::write(out.join(name), b"paid audio").expect("write fixture");
+        }
+
+        // This is the full-book reference plan used even when the synthesis
+        // run itself selects only chapter 2.
+        let plan = vec![
+            record(chapter_one),
+            record(chapter_two),
+            record(chapter_three),
+        ];
+        let found = find_stale_chunks(out, &plan).expect("scan");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path, out.join(superseded));
+
+        remove_stale_chunks(&found).expect("remove");
+        assert!(!out.join(superseded).exists());
+        assert!(out.join(chapter_one).exists());
+        assert!(out.join(chapter_two).exists());
+        assert!(out.join(chapter_three).exists());
+    }
+
+    #[test]
+    fn dry_run_listing_does_not_delete_stale_chunks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path();
+        let current = "chapter-001-part-001-0123456789abcdef.mp3";
+        let superseded = "chapter-001-part-001-fedcba9876543210.mp3";
+        fs::write(out.join(current), b"current").expect("write fixture");
+        fs::write(out.join(superseded), b"superseded").expect("write fixture");
+
+        // The CLI's dry-run path stops after this read-only listing.
+        let found = find_stale_chunks(out, &[record(current)]).expect("scan");
+        assert_eq!(found.len(), 1);
+        assert!(out.join(current).exists());
+        assert!(out.join(superseded).exists());
     }
 
     #[test]

--- a/crates/bookforge-audio/src/lib.rs
+++ b/crates/bookforge-audio/src/lib.rs
@@ -23,7 +23,8 @@ pub mod text;
 
 pub use builder::{
     AudiobookManifest, AudiobookOptions, AudiobookReport, AudiobookStatus, BuildError, ChunkRecord,
-    ChunkStatus, GapSettings, Progress, build_audiobook, plan_chunks, validate_options,
+    ChunkStatus, GapSettings, Progress, build_audiobook, plan_chunks, plan_chunks_for_prune,
+    validate_options,
 };
 pub use cleanup::{StaleChunk, find_stale_chunks, remove_stale_chunks};
 pub use provider::{

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -9,7 +9,7 @@ use bookforge_audio::{
     AudioFormat, AudiobookOptions, ElevenLabsTtsConfig, ElevenLabsTtsProvider, GeminiTtsConfig,
     GeminiTtsProvider, MockTtsProvider, OpenAiTtsConfig, OpenAiTtsProvider, Progress,
     StitchOptions, TextNormalization, build_audiobook, elevenlabs_model_max_input_chars,
-    fetch_elevenlabs_subscription, list_elevenlabs_voices, plan_chunks,
+    fetch_elevenlabs_subscription, list_elevenlabs_voices, plan_chunks, plan_chunks_for_prune,
     resolve_preferred_elevenlabs_model, stitch, validate_options,
 };
 use bookforge_epub::{ReflowOptions, read_epub, reflow_epub};
@@ -200,10 +200,10 @@ pub struct AudiobookArgs {
     #[arg(long, default_value_t = false)]
     pub dry_run: bool,
 
-    /// Remove audio chunk files in the output directory left over from earlier
-    /// runs (a different voice, model, speed, format, or edited source text).
-    /// The current run's chunks are always kept. With `--dry-run` the stale
-    /// files are only reported, never deleted.
+    /// Remove managed audio chunks superseded by the current full-book
+    /// settings (voice, model, speed, format, or source text). With
+    /// `--chapters`, reusable chunks for unselected chapters are kept. With
+    /// `--dry-run`, stale files are only reported, never deleted.
     #[arg(long, default_value_t = false)]
     pub prune: bool,
 
@@ -424,6 +424,8 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             input.display()
         );
     }
+    let full_prune_plan = (args.prune && options.chapter_filter.is_some())
+        .then(|| plan_chunks_for_prune(&book, &options));
     let chapter_count = plan
         .iter()
         .map(|chunk| chunk.chapter_index)
@@ -478,8 +480,11 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
 
     if args.dry_run {
         let stale = if args.prune {
-            bookforge_audio::find_stale_chunks(&out_dir, &plan)
-                .with_context(|| format!("scanning {} for stale chunks", out_dir.display()))?
+            bookforge_audio::find_stale_chunks(
+                &out_dir,
+                full_prune_plan.as_deref().unwrap_or(plan.as_slice()),
+            )
+            .with_context(|| format!("scanning {} for stale chunks", out_dir.display()))?
         } else {
             Vec::new()
         };
@@ -507,7 +512,7 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         } else if human_output {
             println!("Dry run: no audio synthesized.");
             if args.prune {
-                report_stale_chunks(&stale, false);
+                report_stale_chunks(&stale, true);
             }
         }
         return Ok(());
@@ -674,8 +679,14 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     }
 
     if args.prune {
-        let stale = bookforge_audio::find_stale_chunks(&out_dir, &plan)
-            .with_context(|| format!("scanning {} for stale chunks", out_dir.display()))?;
+        let stale = bookforge_audio::find_stale_chunks(
+            &out_dir,
+            full_prune_plan.as_deref().unwrap_or(plan.as_slice()),
+        )
+        .with_context(|| format!("scanning {} for stale chunks", out_dir.display()))?;
+        if (human_output || fallback_tui_output) && !stale.is_empty() {
+            report_stale_chunks(&stale, false);
+        }
         let (removed, freed) = bookforge_audio::remove_stale_chunks(&stale)
             .with_context(|| format!("removing stale chunks in {}", out_dir.display()))?;
         if args.ui == UiMode::Json {
@@ -702,15 +713,15 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     Ok(())
 }
 
-/// Print a human-readable list of stale chunk files. When `deleted` is false
-/// the files were only reported (dry run).
-fn report_stale_chunks(stale: &[bookforge_audio::StaleChunk], deleted: bool) {
+/// Print a human-readable list of stale chunk files. A dry run previews the
+/// deletion; a live run calls this immediately before removing the files.
+fn report_stale_chunks(stale: &[bookforge_audio::StaleChunk], dry_run: bool) {
     if stale.is_empty() {
         println!("Prune: no stale chunks from earlier runs.");
         return;
     }
     let freed: u64 = stale.iter().map(|chunk| chunk.bytes).sum();
-    let verb = if deleted { "Removed" } else { "Would remove" };
+    let verb = if dry_run { "Would remove" } else { "Removing" };
     println!(
         "{verb} {} stale chunk file(s) ({}):",
         stale.len(),


### PR DESCRIPTION
`bookforge audiobook <book> --chapters 2 --prune` **deleted the cached audio of every unselected chapter.** Recovering it means paying the TTS provider again. No guard, no confirmation.

## The chain

1. `build_plan` applies `chapter_filter` and skips unselected chapters **before chunks exist**, so the plan holds only selected ones.
2. `find_stale_chunks` defines stale as any managed chunk absent from that plan. Its doc comment read *"A resume never uses these, so they are safe to remove"* — true for a whole-book plan, false for a filtered one.
3. The CLI called it unconditionally whenever `--prune` was set.

The help text made it worse by being *technically* accurate: it promised to remove leftovers from a changed voice/model/speed/format/source, and that **"The current run's chunks are always kept."** With `--chapters 2`, the current run *is* only chapter 2.

## Fix

Prune now compares against a **full-book plan** via `plan_chunks_for_prune`, which clears only `chapter_filter`. Superseded generations stay removable; unselected chapters survive. Pruning after a partial run is a legitimate thing to want, so this keeps the feature rather than refusing it under a filter.

**Why the comparison is valid:** chunk identity doesn't depend on the filter. `chapter.index` comes from the book's own enumeration and the filter merely skips entries, while the part index restarts per chapter — so selected chapters hash to identical filenames either way. I verified this structurally, since if it were false, prune would have deleted *everything*.

Also:
- Human output lists the files immediately before deleting them.
- Help text now states that unselected chapters' reusable chunks are kept.
- The `find_stale_chunks` doc comment states the whole-book precondition it actually requires, instead of implying there is none.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **818 passed / 0 failed / 3 ignored** (was 815) — including a regression test that chapters 1 and 3 survive `--chapters 2 --prune` while a genuinely superseded chunk is still found.

Found by a subsystem audit; the misleading doc comment is the bug in miniature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)