### PR TITLE
fix(audiobook): never lose a paid run, never misreport the deliverable

### DIFF
--- a/crates/bookforge-audio/src/builder.rs
+++ b/crates/bookforge-audio/src/builder.rs
@@ -5,9 +5,9 @@
 //! already on disk. A `manifest.json` records the plan and outcomes for the
 //! operator and for the optional stitch step.
 
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use bookforge_core::ir::Book;
 use serde::{Deserialize, Serialize};
@@ -52,6 +52,10 @@ pub struct AudiobookOptions {
     /// Group physical pdftohtml pages around explicit chapter headings.
     /// This must only be enabled from a positive source-format signal.
     pub pdf_page_grouping: bool,
+    /// Only previously failed chunks may call the provider. Successful chunks
+    /// are still validated and included in the new manifest, but a missing or
+    /// corrupt successful cache entry is reported instead of being re-paid.
+    pub retry_failed: bool,
 }
 
 impl Default for AudiobookOptions {
@@ -75,6 +79,7 @@ impl Default for AudiobookOptions {
             gap_title_ms: 800,
             gap_paragraph_ms: 0,
             pdf_page_grouping: false,
+            retry_failed: false,
         }
     }
 }
@@ -170,9 +175,21 @@ pub struct AudiobookReport {
     pub chunks_total: usize,
     pub chunks_synthesized: usize,
     pub chunks_skipped: usize,
+    pub chunks_failed: usize,
+    pub failures: Vec<ChunkFailure>,
     pub files: Vec<PathBuf>,
     pub manifest_path: PathBuf,
     pub out_dir: PathBuf,
+}
+
+/// A chunk that remained unresolved after the provider's retries.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkFailure {
+    pub chapter_index: usize,
+    pub chapter_title: String,
+    pub part: usize,
+    pub file: String,
+    pub error: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -212,6 +229,8 @@ pub struct Progress {
     pub total: usize,
     pub chapter_title: String,
     pub skipped: bool,
+    pub failed: bool,
+    pub error: Option<String>,
 }
 
 /// Internal per-chunk plan item.
@@ -226,6 +245,18 @@ struct PlannedChunk {
     synthesis_sha256: String,
     path: PathBuf,
 }
+
+struct ChunkTaskOutcome {
+    record_index: usize,
+    chapter_index: usize,
+    chapter_title: String,
+    part: usize,
+    path: PathBuf,
+    report_progress: bool,
+    result: Result<(bool, Vec<u8>)>,
+}
+
+const MANIFEST_CHECKPOINT_INTERVAL: usize = 16;
 
 /// Build the deterministic chunk plan for a book. Public so the CLI can
 /// preview counts (e.g. a cost estimate) without synthesizing.
@@ -344,9 +375,10 @@ fn context_slice(text: &str, chars: usize, from_end: bool) -> Option<String> {
     }
 }
 
-/// Synthesize an audiobook. Existing non-empty files are treated as already
-/// done (resume). `on_progress` is invoked once per chunk, in completion
-/// order.
+/// Synthesize an audiobook. Existing audio is reused only after signature
+/// validation and, when a prior manifest is available, byte-count and hash
+/// verification. `on_progress` is invoked once per attempted chunk in
+/// completion order (failed-only retries omit already successful records).
 pub async fn build_audiobook<P, F>(
     book: &Book,
     provider: Arc<P>,
@@ -370,11 +402,41 @@ where
     })?;
 
     let total = plan.len();
-    let done = Arc::new(AtomicUsize::new(0));
-    let synthesized = Arc::new(AtomicUsize::new(0));
-    let skipped = Arc::new(AtomicUsize::new(0));
     let semaphore = Arc::new(Semaphore::new(options.concurrency.max(1)));
     let on_progress = Arc::new(on_progress);
+    let manifest_path = options.out_dir.join("manifest.json");
+    let previous_manifest = load_previous_manifest(&manifest_path, options.retry_failed)?;
+    let previous_records: HashMap<String, ChunkRecord> = previous_manifest
+        .map(|manifest| {
+            manifest
+                .chunks
+                .into_iter()
+                .map(|record| (record.file.clone(), record))
+                .collect()
+        })
+        .unwrap_or_default();
+    let matching_failures = if options.retry_failed {
+        let matching_failures = plan
+            .iter()
+            .filter(|chunk| {
+                previous_records
+                    .get(&file_name_of(&chunk.path))
+                    .is_some_and(|record| {
+                        record.synthesis_sha256 == chunk.synthesis_sha256
+                            && record.status == ChunkStatus::Failed
+                    })
+            })
+            .count();
+        if matching_failures == 0 {
+            return Err(BuildError::InvalidOptions(
+                "--retry-failed found no failed chunks matching the current book and synthesis settings"
+                    .to_string(),
+            ));
+        }
+        matching_failures
+    } else {
+        total
+    };
 
     // Chunk records for the manifest, in plan order.
     let records: Vec<ChunkRecord> = plan
@@ -399,8 +461,7 @@ where
         .map(|record| record.chapter_index)
         .collect::<std::collections::BTreeSet<_>>()
         .len();
-    let manifest_path = options.out_dir.join("manifest.json");
-    let manifest = Arc::new(Mutex::new(AudiobookManifest {
+    let mut manifest = AudiobookManifest {
         schema_version: 3,
         title: book.metadata.title.clone(),
         synthesis_id: options.synthesis_id.clone(),
@@ -424,8 +485,8 @@ where
         status: AudiobookStatus::Running,
         updated_at_ms: now_ms(),
         error: None,
-    }));
-    write_manifest_checkpoint(&manifest, &manifest_path)?;
+    };
+    write_manifest_checkpoint_async(&manifest, &manifest_path).await?;
 
     let mut set = tokio::task::JoinSet::new();
     for (record_index, chunk) in plan.into_iter().enumerate() {
@@ -439,27 +500,61 @@ where
         let seed = options.seed;
         let language_code = options.language_code.clone();
         let text_normalization = options.text_normalization;
-        let done = Arc::clone(&done);
-        let synthesized = Arc::clone(&synthesized);
-        let skipped = Arc::clone(&skipped);
-        let on_progress = Arc::clone(&on_progress);
-        let manifest = Arc::clone(&manifest);
-        let manifest_path = manifest_path.clone();
+        let previous_record = previous_records.get(&file_name_of(&chunk.path)).cloned();
+        let retry_failed = options.retry_failed;
+        let report_progress = !retry_failed
+            || previous_record.as_ref().is_some_and(|record| {
+                record.synthesis_sha256 == chunk.synthesis_sha256
+                    && record.status == ChunkStatus::Failed
+            });
 
         set.spawn(async move {
             let _permit = semaphore
                 .acquire()
                 .await
                 .expect("semaphore is never closed");
-            if cancel.is_cancelled() {
-                return Err(BuildError::Tts(crate::provider::TtsError::Cancelled));
-            }
-
-            let rendered = async {
-                if let Some(bytes) = read_valid_cached_audio(&chunk.path, format) {
-                    skipped.fetch_add(1, Ordering::Relaxed);
-                    return Ok::<_, BuildError>((true, bytes));
+            let result = async {
+                if cancel.is_cancelled() {
+                    return Err(BuildError::Tts(crate::provider::TtsError::Cancelled));
                 }
+                if retry_failed {
+                    match previous_record.as_ref() {
+                        Some(record)
+                            if record.synthesis_sha256 == chunk.synthesis_sha256
+                                && record.status == ChunkStatus::Failed => {}
+                        Some(record)
+                            if record.synthesis_sha256 == chunk.synthesis_sha256
+                                && matches!(
+                                    record.status,
+                                    ChunkStatus::Synthesized | ChunkStatus::Cached
+                                ) =>
+                        {
+                            return read_valid_cached_audio(
+                                &chunk.path,
+                                format,
+                                Some(record),
+                            )
+                            .map(|bytes| (true, bytes))
+                            .ok_or_else(|| {
+                                BuildError::InvalidOptions(format!(
+                                    "--retry-failed refused to re-synthesize previously successful chunk {} because its cache file is missing or invalid; rerun without --retry-failed to repair it",
+                                    file_name_of(&chunk.path)
+                                ))
+                            });
+                        }
+                        _ => {
+                            return Err(BuildError::InvalidOptions(format!(
+                                "--retry-failed refused to synthesize chunk {} because it was not recorded as failed by the previous matching run",
+                                file_name_of(&chunk.path)
+                            )));
+                        }
+                    }
+                } else if let Some(bytes) =
+                    read_valid_cached_audio(&chunk.path, format, previous_record.as_ref())
+                {
+                    return Ok((true, bytes));
+                }
+
                 let clip = provider
                     .synthesize(SpeechRequest {
                         text: chunk.text.clone(),
@@ -482,171 +577,257 @@ where
                 }
                 crate::provider::validate_audio_payload(format, None, &clip.bytes)?;
                 write_atomic(&chunk.path, &clip.bytes)?;
-                synthesized.fetch_add(1, Ordering::Relaxed);
                 Ok((false, clip.bytes))
             }
             .await;
 
-            let (was_skipped, audio_bytes) = match rendered {
-                Ok(rendered) => rendered,
-                Err(error) => {
-                    let _ = update_chunk_checkpoint(
-                        &manifest,
-                        &manifest_path,
-                        record_index,
-                        ChunkStatus::Failed,
-                        None,
-                        None,
-                        Some(error.to_string()),
-                    );
-                    return Err(error);
-                }
-            };
-            update_chunk_checkpoint(
-                &manifest,
-                &manifest_path,
+            ChunkTaskOutcome {
                 record_index,
-                if was_skipped {
-                    ChunkStatus::Cached
-                } else {
-                    ChunkStatus::Synthesized
-                },
-                Some(audio_hash(&audio_bytes)),
-                Some(audio_bytes.len() as u64),
-                None,
-            )?;
-
-            let done_now = done.fetch_add(1, Ordering::Relaxed) + 1;
-            on_progress(Progress {
-                done: done_now,
-                total,
+                chapter_index: chunk.chapter_index,
                 chapter_title: chunk.chapter_title.clone(),
-                skipped: was_skipped,
-            });
-            Ok::<PathBuf, BuildError>(chunk.path)
+                part: chunk.part,
+                path: chunk.path,
+                report_progress,
+                result,
+            }
         });
     }
 
-    // Collect results as tasks finish; on the first error, cancel the run so
-    // in-flight provider calls stop, abort the rest, and propagate.
+    // Provider/content failures are isolated to their chunks. Checkpoint them
+    // immediately and keep collecting the paid work that can still succeed.
+    // Cancellation, panics, and checkpoint failures remain run-fatal because
+    // the builder can no longer promise a trustworthy resume point.
     let mut files = Vec::with_capacity(total);
+    let mut failures = Vec::new();
+    let mut synthesized = 0usize;
+    let mut skipped = 0usize;
+    let mut done = 0usize;
+    let mut successful_since_checkpoint = 0usize;
     while let Some(joined) = set.join_next().await {
         match joined {
-            Ok(Ok(path)) => files.push(path),
-            Ok(Err(error)) => {
-                cancel.cancel();
-                set.abort_all();
-                let status =
-                    if matches!(error, BuildError::Tts(crate::provider::TtsError::Cancelled)) {
-                        AudiobookStatus::Cancelled
+            Ok(outcome) => match outcome.result {
+                Ok((was_skipped, audio_bytes)) => {
+                    update_chunk_record(
+                        &mut manifest,
+                        outcome.record_index,
+                        if was_skipped {
+                            ChunkStatus::Cached
+                        } else {
+                            ChunkStatus::Synthesized
+                        },
+                        Some(audio_hash(&audio_bytes)),
+                        Some(audio_bytes.len() as u64),
+                        None,
+                    )?;
+                    if was_skipped {
+                        skipped += 1;
                     } else {
-                        AudiobookStatus::Failed
-                    };
-                let _ = update_manifest_status(
-                    &manifest,
-                    &manifest_path,
-                    status,
-                    Some(error.to_string()),
-                );
-                return Err(error);
-            }
+                        synthesized += 1;
+                    }
+                    files.push(outcome.path);
+                    done += usize::from(outcome.report_progress);
+                    successful_since_checkpoint += 1;
+                    if outcome.report_progress {
+                        on_progress(Progress {
+                            done,
+                            total: matching_failures,
+                            chapter_title: outcome.chapter_title,
+                            skipped: was_skipped,
+                            failed: false,
+                            error: None,
+                        });
+                    }
+                    if successful_since_checkpoint >= MANIFEST_CHECKPOINT_INTERVAL {
+                        write_manifest_checkpoint_async(&manifest, &manifest_path).await?;
+                        successful_since_checkpoint = 0;
+                    }
+                }
+                Err(error)
+                    if matches!(error, BuildError::Tts(crate::provider::TtsError::Cancelled)) =>
+                {
+                    cancel.cancel();
+                    set.abort_all();
+                    update_manifest_status(
+                        &mut manifest,
+                        AudiobookStatus::Cancelled,
+                        Some(error.to_string()),
+                    );
+                    write_manifest_checkpoint_async(&manifest, &manifest_path).await?;
+                    return Err(error);
+                }
+                Err(error) => {
+                    let error = error.to_string();
+                    update_chunk_record(
+                        &mut manifest,
+                        outcome.record_index,
+                        ChunkStatus::Failed,
+                        None,
+                        None,
+                        Some(error.clone()),
+                    )?;
+                    failures.push(ChunkFailure {
+                        chapter_index: outcome.chapter_index,
+                        chapter_title: outcome.chapter_title.clone(),
+                        part: outcome.part,
+                        file: file_name_of(&outcome.path),
+                        error: error.clone(),
+                    });
+                    done += usize::from(outcome.report_progress);
+                    if outcome.report_progress {
+                        on_progress(Progress {
+                            done,
+                            total: matching_failures,
+                            chapter_title: outcome.chapter_title,
+                            skipped: false,
+                            failed: true,
+                            error: Some(error),
+                        });
+                    }
+                    write_manifest_checkpoint_async(&manifest, &manifest_path).await?;
+                    successful_since_checkpoint = 0;
+                }
+            },
             Err(join_error) => {
                 cancel.cancel();
                 set.abort_all();
                 let error = BuildError::Tts(crate::provider::TtsError::Provider(format!(
                     "synthesis task panicked: {join_error}"
                 )));
-                let _ = update_manifest_status(
-                    &manifest,
-                    &manifest_path,
+                update_manifest_status(
+                    &mut manifest,
                     AudiobookStatus::Failed,
                     Some(error.to_string()),
                 );
+                let _ = write_manifest_checkpoint_async(&manifest, &manifest_path).await;
                 return Err(error);
             }
         }
     }
     files.sort();
 
-    update_manifest_status(&manifest, &manifest_path, AudiobookStatus::Succeeded, None)?;
+    if failures.is_empty() {
+        update_manifest_status(&mut manifest, AudiobookStatus::Succeeded, None);
+    } else {
+        update_manifest_status(
+            &mut manifest,
+            AudiobookStatus::Failed,
+            Some(format!(
+                "{} of {total} chunks failed; successful chunks were preserved and will be reused",
+                failures.len()
+            )),
+        );
+    }
+    write_manifest_checkpoint_async(&manifest, &manifest_path).await?;
 
     Ok(AudiobookReport {
         chapters,
         chunks_total: total,
-        chunks_synthesized: synthesized.load(Ordering::Relaxed),
-        chunks_skipped: skipped.load(Ordering::Relaxed),
+        chunks_synthesized: synthesized,
+        chunks_skipped: skipped,
+        chunks_failed: failures.len(),
+        failures,
         files,
         manifest_path,
         out_dir: options.out_dir.clone(),
     })
 }
 
-fn read_valid_cached_audio(path: &Path, format: AudioFormat) -> Option<Vec<u8>> {
+fn read_valid_cached_audio(
+    path: &Path,
+    format: AudioFormat,
+    expected: Option<&ChunkRecord>,
+) -> Option<Vec<u8>> {
     let bytes = std::fs::read(path).ok()?;
-    crate::provider::validate_audio_payload(format, None, &bytes)
-        .ok()
-        .map(|()| bytes)
+    crate::provider::validate_audio_payload(format, None, &bytes).ok()?;
+    if let Some(expected_bytes) = expected.and_then(|record| record.bytes)
+        && expected_bytes != bytes.len() as u64
+    {
+        return None;
+    }
+    if let Some(expected_hash) = expected.and_then(|record| record.audio_sha256.as_deref())
+        && expected_hash != audio_hash(&bytes)
+    {
+        return None;
+    }
+    Some(bytes)
 }
 
 #[allow(clippy::too_many_arguments)]
-fn update_chunk_checkpoint(
-    manifest: &Arc<Mutex<AudiobookManifest>>,
-    path: &Path,
+fn update_chunk_record(
+    manifest: &mut AudiobookManifest,
     index: usize,
     status: ChunkStatus,
     audio_sha256: Option<String>,
     bytes: Option<u64>,
     error: Option<String>,
 ) -> Result<()> {
-    {
-        let mut manifest = manifest.lock().map_err(|_| {
-            BuildError::InvalidOptions("audiobook manifest lock was poisoned".to_string())
-        })?;
-        let record = manifest.chunks.get_mut(index).ok_or_else(|| {
-            BuildError::InvalidOptions("audiobook checkpoint index was invalid".to_string())
-        })?;
-        record.status = status;
-        record.audio_sha256 = audio_sha256;
-        record.bytes = bytes;
-        record.error = error;
-        manifest.completed_chunks = manifest
-            .chunks
-            .iter()
-            .filter(|record| {
-                matches!(
-                    record.status,
-                    ChunkStatus::Synthesized | ChunkStatus::Cached
-                )
-            })
-            .count();
-        manifest.updated_at_ms = now_ms();
+    let record = manifest.chunks.get_mut(index).ok_or_else(|| {
+        BuildError::InvalidOptions("audiobook checkpoint index was invalid".to_string())
+    })?;
+    let was_complete = matches!(
+        record.status,
+        ChunkStatus::Synthesized | ChunkStatus::Cached
+    );
+    let is_complete = matches!(status, ChunkStatus::Synthesized | ChunkStatus::Cached);
+    record.status = status;
+    record.audio_sha256 = audio_sha256;
+    record.bytes = bytes;
+    record.error = error;
+    match (was_complete, is_complete) {
+        (false, true) => manifest.completed_chunks += 1,
+        (true, false) => manifest.completed_chunks = manifest.completed_chunks.saturating_sub(1),
+        _ => {}
     }
-    write_manifest_checkpoint(manifest, path)
+    manifest.updated_at_ms = now_ms();
+    Ok(())
 }
 
 fn update_manifest_status(
-    manifest: &Arc<Mutex<AudiobookManifest>>,
-    path: &Path,
+    manifest: &mut AudiobookManifest,
     status: AudiobookStatus,
     error: Option<String>,
-) -> Result<()> {
-    {
-        let mut manifest = manifest.lock().map_err(|_| {
-            BuildError::InvalidOptions("audiobook manifest lock was poisoned".to_string())
-        })?;
-        manifest.status = status;
-        manifest.error = error;
-        manifest.updated_at_ms = now_ms();
-    }
-    write_manifest_checkpoint(manifest, path)
+) {
+    manifest.status = status;
+    manifest.error = error;
+    manifest.updated_at_ms = now_ms();
 }
 
-fn write_manifest_checkpoint(manifest: &Arc<Mutex<AudiobookManifest>>, path: &Path) -> Result<()> {
-    let manifest = manifest.lock().map_err(|_| {
-        BuildError::InvalidOptions("audiobook manifest lock was poisoned".to_string())
+async fn write_manifest_checkpoint_async(manifest: &AudiobookManifest, path: &Path) -> Result<()> {
+    let json = serde_json::to_vec_pretty(manifest)?;
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || write_atomic(&path, &json))
+        .await
+        .map_err(|error| {
+            BuildError::InvalidOptions(format!("audiobook checkpoint task failed: {error}"))
+        })?
+}
+
+fn load_previous_manifest(path: &Path, required: bool) -> Result<Option<AudiobookManifest>> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(BuildError::Manifest),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && !required => Ok(None),
+        Err(error) => Err(BuildError::Io {
+            path: path.to_path_buf(),
+            source: error,
+        }),
+    }
+}
+
+/// Return the exact cache filenames recorded as failed in a prior manifest.
+/// The CLI uses this to make `--retry-failed` cost estimates honest; the
+/// builder independently enforces the same status before any provider call.
+pub fn failed_chunk_files(manifest_path: &Path) -> Result<BTreeSet<String>> {
+    let manifest = load_previous_manifest(manifest_path, true)?.ok_or_else(|| {
+        BuildError::InvalidOptions("previous audiobook manifest was not found".to_string())
     })?;
-    let json = serde_json::to_vec_pretty(&*manifest)?;
-    write_atomic(path, &json)
+    Ok(manifest
+        .chunks
+        .into_iter()
+        .filter(|record| record.status == ChunkStatus::Failed)
+        .map(|record| record.file)
+        .collect())
 }
 
 fn audio_hash(bytes: &[u8]) -> String {
@@ -796,6 +977,40 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::{AudioClip, MockTtsProvider, SpeechRequest, TtsError, TtsProvider};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct RecordingProvider {
+        fail_on: Option<&'static str>,
+        calls: AtomicUsize,
+    }
+
+    impl RecordingProvider {
+        fn new(fail_on: Option<&'static str>) -> Self {
+            Self {
+                fail_on,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl TtsProvider for RecordingProvider {
+        async fn synthesize(
+            &self,
+            request: SpeechRequest,
+        ) -> std::result::Result<AudioClip, TtsError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if self
+                .fail_on
+                .is_some_and(|needle| request.text.contains(needle))
+            {
+                return Err(TtsError::Provider(
+                    "deterministic content rejection".to_string(),
+                ));
+            }
+            MockTtsProvider::new().synthesize(request).await
+        }
+    }
 
     // These tests exercise planning and synthesis against a hand-built Book,
     // so they need no EPUB fixture and no network.
@@ -1057,7 +1272,6 @@ mod tests {
 
     #[tokio::test]
     async fn build_writes_files_and_manifest_then_resumes() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let book = book_with_sections();
         let options = AudiobookOptions {
@@ -1101,7 +1315,6 @@ mod tests {
 
     #[tokio::test]
     async fn manifest_records_the_configured_gaps_not_the_defaults() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let book = book_with_sections();
         let options = AudiobookOptions {
@@ -1138,7 +1351,6 @@ mod tests {
 
     #[tokio::test]
     async fn changing_synthesis_settings_creates_new_chunks() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let book = book_with_sections();
         let mut options = AudiobookOptions {
@@ -1188,7 +1400,6 @@ mod tests {
 
     #[tokio::test]
     async fn partial_run_only_synthesizes_missing_chunks() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let book = book_with_sections();
         let options = AudiobookOptions {
@@ -1220,7 +1431,6 @@ mod tests {
 
     #[tokio::test]
     async fn corrupt_cached_audio_is_regenerated_instead_of_reused() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let book = book_with_sections();
         let options = AudiobookOptions {
@@ -1250,6 +1460,163 @@ mod tests {
         assert_eq!(&std::fs::read(corrupt_path).unwrap()[..4], b"RIFF");
     }
 
+    #[tokio::test]
+    async fn deterministic_chunk_failure_does_not_abort_and_failed_only_retry_does_not_repay() {
+        let dir = tempfile::tempdir().unwrap();
+        let book = book_with_sections();
+        let mut options = AudiobookOptions {
+            out_dir: dir.path().join("out"),
+            max_chars: 40,
+            concurrency: 2,
+            ..AudiobookOptions::default()
+        };
+        let failing = Arc::new(RecordingProvider::new(Some("third paragraph")));
+
+        let first = build_audiobook(
+            &book,
+            Arc::clone(&failing),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .expect("isolated provider failures should return a report");
+
+        assert_eq!(first.chunks_failed, 1);
+        assert_eq!(first.chunks_synthesized, first.chunks_total - 1);
+        assert_eq!(first.files.len(), first.chunks_total - 1);
+        assert!(
+            first
+                .failures
+                .iter()
+                .any(|failure| failure.error.contains("content rejection"))
+        );
+        let manifest: AudiobookManifest =
+            serde_json::from_slice(&std::fs::read(&first.manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.status, AudiobookStatus::Failed);
+        assert_eq!(
+            manifest
+                .chunks
+                .iter()
+                .filter(|record| record.status == ChunkStatus::Failed)
+                .count(),
+            1
+        );
+
+        options.retry_failed = true;
+        let retry = Arc::new(RecordingProvider::new(None));
+        let resumed = build_audiobook(
+            &book,
+            Arc::clone(&retry),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .expect("failed-only retry should finish the manifest");
+
+        assert_eq!(retry.calls.load(Ordering::Relaxed), 1);
+        assert_eq!(resumed.chunks_failed, 0);
+        assert_eq!(resumed.chunks_synthesized, 1);
+        assert_eq!(resumed.chunks_skipped, resumed.chunks_total - 1);
+        let manifest: AudiobookManifest =
+            serde_json::from_slice(&std::fs::read(&resumed.manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.status, AudiobookStatus::Succeeded);
+        assert_eq!(manifest.completed_chunks, manifest.chunks.len());
+    }
+
+    #[tokio::test]
+    async fn manifest_hash_detects_validly_prefixed_but_changed_cached_audio() {
+        let dir = tempfile::tempdir().unwrap();
+        let book = book_with_sections();
+        let options = AudiobookOptions {
+            out_dir: dir.path().join("out"),
+            max_chars: 40,
+            concurrency: 1,
+            ..AudiobookOptions::default()
+        };
+        let first = build_audiobook(
+            &book,
+            Arc::new(MockTtsProvider::new()),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        let changed_path = &first.files[0];
+        let mut changed = std::fs::read(changed_path).unwrap();
+        let last = changed.last_mut().expect("mock wav is non-empty");
+        *last ^= 1;
+        std::fs::write(changed_path, changed).unwrap();
+
+        let provider = Arc::new(RecordingProvider::new(None));
+        let resumed = build_audiobook(
+            &book,
+            Arc::clone(&provider),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(provider.calls.load(Ordering::Relaxed), 1);
+        assert_eq!(resumed.chunks_synthesized, 1);
+        assert_eq!(resumed.chunks_skipped, resumed.chunks_total - 1);
+    }
+
+    #[tokio::test]
+    async fn stale_debounced_checkpoint_still_resumes_from_atomic_chunk_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let book = book_with_sections();
+        let options = AudiobookOptions {
+            out_dir: dir.path().join("out"),
+            max_chars: 40,
+            concurrency: 1,
+            ..AudiobookOptions::default()
+        };
+        let first = build_audiobook(
+            &book,
+            Arc::new(MockTtsProvider::new()),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        let mut stale: AudiobookManifest =
+            serde_json::from_slice(&std::fs::read(&first.manifest_path).unwrap()).unwrap();
+        stale.status = AudiobookStatus::Running;
+        stale.completed_chunks = 0;
+        for chunk in &mut stale.chunks {
+            chunk.status = ChunkStatus::Pending;
+        }
+        write_atomic(
+            &first.manifest_path,
+            &serde_json::to_vec_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+
+        let provider = Arc::new(RecordingProvider::new(None));
+        let resumed = build_audiobook(
+            &book,
+            Arc::clone(&provider),
+            &options,
+            CancellationToken::new(),
+            |_| {},
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(provider.calls.load(Ordering::Relaxed), 0);
+        assert_eq!(resumed.chunks_skipped, resumed.chunks_total);
+        let manifest: AudiobookManifest =
+            serde_json::from_slice(&std::fs::read(&resumed.manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.status, AudiobookStatus::Succeeded);
+        assert_eq!(manifest.completed_chunks, manifest.chunks.len());
+    }
+
     #[test]
     fn page_furniture_is_never_planned_for_narration() {
         let mut book = book_with_sections();
@@ -1263,7 +1630,6 @@ mod tests {
 
     #[tokio::test]
     async fn empty_book_is_an_error() {
-        use crate::provider::MockTtsProvider;
         let dir = tempfile::tempdir().unwrap();
         let mut book = book_with_sections();
         for block in &mut book.blocks {

--- a/crates/bookforge-audio/src/lib.rs
+++ b/crates/bookforge-audio/src/lib.rs
@@ -22,9 +22,9 @@ pub mod stitch;
 pub mod text;
 
 pub use builder::{
-    AudiobookManifest, AudiobookOptions, AudiobookReport, AudiobookStatus, BuildError, ChunkRecord,
-    ChunkStatus, GapSettings, Progress, build_audiobook, plan_chunks, plan_chunks_for_prune,
-    validate_options,
+    AudiobookManifest, AudiobookOptions, AudiobookReport, AudiobookStatus, BuildError,
+    ChunkFailure, ChunkRecord, ChunkStatus, GapSettings, Progress, build_audiobook,
+    failed_chunk_files, plan_chunks, plan_chunks_for_prune, validate_options,
 };
 pub use cleanup::{StaleChunk, find_stale_chunks, remove_stale_chunks};
 pub use provider::{

--- a/crates/bookforge-audio/src/stitch.rs
+++ b/crates/bookforge-audio/src/stitch.rs
@@ -1,8 +1,10 @@
 //! Optional ffmpeg-based audiobook post-processing.
 
 use std::collections::BTreeMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::builder::{AudiobookManifest, ChunkRecord};
 use crate::text::ChunkKind;
@@ -54,6 +56,9 @@ struct ConcatGaps {
     paragraph: Option<String>,
 }
 
+const FFMPEG_STDERR_LIMIT: usize = 16 * 1024;
+static STAGED_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
 pub fn ffmpeg_available() -> bool {
     tool_available("ffmpeg")
 }
@@ -74,6 +79,22 @@ fn tool_available(tool: &str) -> bool {
 
 pub fn stitch(manifest: &AudiobookManifest, options: &StitchOptions) -> StitchReport {
     let mut report = StitchReport::default();
+    let unresolved = manifest
+        .chunks
+        .iter()
+        .filter(|chunk| {
+            !matches!(
+                chunk.status,
+                crate::builder::ChunkStatus::Synthesized | crate::builder::ChunkStatus::Cached
+            )
+        })
+        .count();
+    if unresolved > 0 {
+        report.warnings.push(format!(
+            "{unresolved} chunk(s) are unresolved; skipped stitching to avoid publishing an incomplete audiobook"
+        ));
+        return report;
+    }
     if !ffmpeg_available() {
         report.warnings.push(
             "ffmpeg not found on PATH; skipped stitching (per-chunk files are intact)".into(),
@@ -240,21 +261,19 @@ fn concat_copy(dir: &Path, inputs: &[String], output: &str) -> std::result::Resu
     let list_path = dir.join(&list_name);
     std::fs::write(&list_path, concat_list_content(inputs))
         .map_err(|error| format!("writing concat list: {error}"))?;
-    let status = Command::new("ffmpeg")
+    let output_path = dir.join(output);
+    let staged = staged_output_path(&output_path);
+    let staged_name = file_name_of(&staged);
+    let mut command = Command::new("ffmpeg");
+    command
         .current_dir(dir)
         .args(["-y", "-f", "concat", "-safe", "0", "-i"])
         .arg(&list_name)
         .args(["-c", "copy"])
-        .arg(output)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|error| format!("launching ffmpeg: {error}"))?;
+        .arg(&staged_name);
+    let result = run_ffmpeg_transactional(&mut command, &staged, &output_path, "ffmpeg concat");
     let _ = std::fs::remove_file(&list_path);
-    status
-        .success()
-        .then_some(())
-        .ok_or_else(|| format!("ffmpeg concat exited with {status}"))
+    result
 }
 
 fn assemble_m4b(
@@ -266,30 +285,26 @@ fn assemble_m4b(
     if chapter_files.is_empty() {
         return Err("no chapter files were produced; cannot assemble m4b".into());
     }
-    let chapter_names: Vec<String> = chapters
-        .iter()
-        .map(|(index, parts)| {
-            parts
-                .first()
-                .map(|part| part.chapter_title.clone())
-                .unwrap_or_else(|| format!("Chapter {}", index + 1))
-        })
-        .collect();
-    let entries = build_book_concat_entries(chapter_files, gaps.chapter.as_deref());
     let list_name = "book.concat.txt";
-    std::fs::write(
-        options.out_dir.join(list_name),
-        concat_list_content(&entries),
-    )
-    .map_err(|error| format!("writing book concat list: {error}"))?;
-
-    let mut ffmeta_name = None;
-    let durations = chapter_files
-        .iter()
-        .map(|path| ffprobe_duration_ms(path))
-        .collect::<Option<Vec<_>>>();
-    if let Some(durations) = durations {
-        let meta_name = "chapters.ffmeta.txt";
+    let meta_name = "chapters.ffmeta.txt";
+    let result = (|| {
+        let chapter_names: Vec<String> = chapters
+            .iter()
+            .map(|(index, parts)| {
+                parts
+                    .first()
+                    .map(|part| part.chapter_title.clone())
+                    .unwrap_or_else(|| format!("Chapter {}", index + 1))
+            })
+            .collect();
+        let durations = chapter_files
+            .iter()
+            .map(|path| ffprobe_duration_ms(path))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| {
+                "chapter metadata was skipped because ffprobe could not determine every chapter duration; skipped m4b assembly rather than publishing an unchaptered book"
+                    .to_string()
+            })?;
         let chapter_gap_ms = gaps.chapter.as_ref().map_or(0, |_| options.gap_chapter_ms);
         let metadata = build_ffmetadata(
             options.title.as_deref(),
@@ -299,55 +314,52 @@ fn assemble_m4b(
         );
         std::fs::write(options.out_dir.join(meta_name), metadata)
             .map_err(|error| format!("writing chapter metadata: {error}"))?;
-        ffmeta_name = Some(meta_name);
-    }
 
-    let mut args = vec![
-        "-y".to_string(),
-        "-f".to_string(),
-        "concat".to_string(),
-        "-safe".to_string(),
-        "0".to_string(),
-        "-i".to_string(),
-        list_name.to_string(),
-    ];
-    if let Some(meta_name) = ffmeta_name {
-        args.extend([
+        let entries = build_book_concat_entries(chapter_files, gaps.chapter.as_deref());
+        std::fs::write(
+            options.out_dir.join(list_name),
+            concat_list_content(&entries),
+        )
+        .map_err(|error| format!("writing book concat list: {error}"))?;
+
+        let mut args = vec![
+            "-y".to_string(),
+            "-f".to_string(),
+            "concat".to_string(),
+            "-safe".to_string(),
+            "0".to_string(),
+            "-i".to_string(),
+            list_name.to_string(),
             "-i".to_string(),
             meta_name.to_string(),
             "-map_metadata".to_string(),
             "1".to_string(),
+        ];
+        if options.loudnorm {
+            args.extend(["-af".to_string(), "loudnorm=I=-18:TP=-2:LRA=11".to_string()]);
+        }
+        args.extend([
+            "-c:a".to_string(),
+            "aac".to_string(),
+            "-b:a".to_string(),
+            "128k".to_string(),
         ]);
-    }
-    if options.loudnorm {
-        args.extend(["-af".to_string(), "loudnorm=I=-18:TP=-2:LRA=11".to_string()]);
-    }
-    args.extend([
-        "-c:a".to_string(),
-        "aac".to_string(),
-        "-b:a".to_string(),
-        "128k".to_string(),
-    ]);
-    append_metadata_args(
-        &mut args,
-        options.title.as_deref(),
-        options.author.as_deref(),
-    );
-    args.push("audiobook.m4b".to_string());
-    let status = Command::new("ffmpeg")
-        .current_dir(&options.out_dir)
-        .args(&args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|error| format!("launching ffmpeg for m4b: {error}"))?;
+        append_metadata_args(
+            &mut args,
+            options.title.as_deref(),
+            options.author.as_deref(),
+        );
+        let output_path = options.out_dir.join("audiobook.m4b");
+        let staged = staged_output_path(&output_path);
+        args.push(file_name_of(&staged));
+        let mut command = Command::new("ffmpeg");
+        command.current_dir(&options.out_dir).args(&args);
+        run_ffmpeg_transactional(&mut command, &staged, &output_path, "ffmpeg m4b assembly")
+            .map(|()| output_path)
+    })();
     let _ = std::fs::remove_file(options.out_dir.join(list_name));
-    let _ = std::fs::remove_file(options.out_dir.join("chapters.ffmeta.txt"));
-    if status.success() {
-        Ok(options.out_dir.join("audiobook.m4b"))
-    } else {
-        Err(format!("ffmpeg m4b assembly exited with {status}"))
-    }
+    let _ = std::fs::remove_file(options.out_dir.join(meta_name));
+    result
 }
 
 fn assemble_single_file(
@@ -369,27 +381,26 @@ fn assemble_single_file(
     )
     .map_err(|error| format!("writing single-file concat list: {error}"))?;
     let output = format!("audiobook.{}", options.extension);
+    let output_path = options.out_dir.join(&output);
+    let staged = staged_output_path(&output_path);
     let args = single_file_ffmpeg_args(
         list_name,
         &options.extension,
         options.loudnorm,
         options.title.as_deref(),
         options.author.as_deref(),
-        &output,
+        &file_name_of(&staged),
     );
-    let status = Command::new("ffmpeg")
-        .current_dir(&options.out_dir)
-        .args(&args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|error| format!("launching ffmpeg for single file: {error}"))?;
+    let mut command = Command::new("ffmpeg");
+    command.current_dir(&options.out_dir).args(&args);
+    let result = run_ffmpeg_transactional(
+        &mut command,
+        &staged,
+        &output_path,
+        "ffmpeg single-file assembly",
+    );
     let _ = std::fs::remove_file(options.out_dir.join(list_name));
-    if status.success() {
-        Ok(options.out_dir.join(output))
-    } else {
-        Err(format!("ffmpeg single-file assembly exited with {status}"))
-    }
+    result.map(|()| output_path)
 }
 
 pub fn single_file_ffmpeg_args(
@@ -446,6 +457,142 @@ fn encoder_for_extension(extension: &str) -> Option<&'static str> {
     }
 }
 
+fn staged_output_path(final_path: &Path) -> PathBuf {
+    let sequence = STAGED_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let file_name = final_path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_default();
+    let extension = final_path
+        .extension()
+        .map(|extension| extension.to_string_lossy())
+        .unwrap_or_default();
+    final_path.with_file_name(format!(
+        ".{file_name}.{}-{sequence}.part.{extension}",
+        std::process::id()
+    ))
+}
+
+fn run_ffmpeg_transactional(
+    command: &mut Command,
+    staged: &Path,
+    final_path: &Path,
+    context: &str,
+) -> std::result::Result<(), String> {
+    let result = run_ffmpeg(command, context);
+    if let Err(error) = result {
+        let _ = std::fs::remove_file(staged);
+        return Err(error);
+    }
+    if !staged.is_file() {
+        return Err(format!(
+            "{context} exited successfully but did not create {}",
+            staged.display()
+        ));
+    }
+    if let Err(error) = publish_staged_file(staged, final_path) {
+        let _ = std::fs::remove_file(staged);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn run_ffmpeg(command: &mut Command, context: &str) -> std::result::Result<(), String> {
+    command.stdout(Stdio::null()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("launching {context}: {error}"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("capturing {context} stderr failed"))?;
+    let stderr_reader = std::thread::spawn(move || bounded_stderr_tail(stderr));
+    let status = child
+        .wait()
+        .map_err(|error| format!("waiting for {context}: {error}"))?;
+    let (stderr, truncated) = stderr_reader
+        .join()
+        .map_err(|_| format!("capturing {context} stderr failed"))?
+        .map_err(|error| format!("reading {context} stderr: {error}"))?;
+    if status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&stderr);
+    let stderr = stderr.trim();
+    let detail = if stderr.is_empty() {
+        String::new()
+    } else if truncated {
+        format!("; stderr (last {FFMPEG_STDERR_LIMIT} bytes): {stderr}")
+    } else {
+        format!("; stderr: {stderr}")
+    };
+    Err(format!("{context} exited with {status}{detail}"))
+}
+
+fn bounded_stderr_tail<R: Read>(mut reader: R) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut tail = Vec::with_capacity(FFMPEG_STDERR_LIMIT);
+    let mut buffer = [0u8; 4 * 1024];
+    let mut total = 0usize;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read);
+        if read >= FFMPEG_STDERR_LIMIT {
+            tail.clear();
+            tail.extend_from_slice(&buffer[read - FFMPEG_STDERR_LIMIT..read]);
+            continue;
+        }
+        let overflow = tail
+            .len()
+            .saturating_add(read)
+            .saturating_sub(FFMPEG_STDERR_LIMIT);
+        if overflow > 0 {
+            tail.drain(..overflow);
+        }
+        tail.extend_from_slice(&buffer[..read]);
+    }
+    Ok((tail, total > FFMPEG_STDERR_LIMIT))
+}
+
+fn publish_staged_file(staged: &Path, final_path: &Path) -> std::result::Result<(), String> {
+    if !final_path.exists() {
+        return std::fs::rename(staged, final_path).map_err(|error| {
+            format!("publishing ffmpeg output {}: {error}", final_path.display())
+        });
+    }
+
+    let sequence = STAGED_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let file_name = final_path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_default();
+    let backup = final_path.with_file_name(format!(
+        ".{file_name}.{}-{sequence}.replace.bak",
+        std::process::id()
+    ));
+    std::fs::rename(final_path, &backup).map_err(|error| {
+        format!(
+            "staging previous ffmpeg output {}: {error}",
+            final_path.display()
+        )
+    })?;
+    match std::fs::rename(staged, final_path) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(backup);
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::rename(&backup, final_path);
+            Err(format!(
+                "publishing ffmpeg output {}: {error}",
+                final_path.display()
+            ))
+        }
+    }
+}
+
 fn probe_audio_params(path: &Path) -> Option<(u32, u16)> {
     let output = Command::new("ffprobe")
         .args([
@@ -490,34 +637,46 @@ fn ensure_silence_file(
     // would feed mismatched silence into a `-c copy` concat.
     let output_name = format!("silence-{ms}-{rate}-{channels}.{extension}");
     let output_path = out_dir.join(&output_name);
-    if output_path.is_file() {
+    if output_path.is_file() && silence_file_is_valid(&output_path, ms, rate, channels) {
         return Ok(output_path);
     }
     let channel_layout = if channels == 1 { "mono" } else { "stereo" };
     let duration = format!("{:.3}", f64::from(ms) / 1_000.0);
-    let status = Command::new("ffmpeg")
-        .current_dir(out_dir)
-        .args([
-            "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            &format!("anullsrc=r={rate}:cl={channel_layout}"),
-            "-t",
-            &duration,
-            "-c:a",
-            encoder,
-            &output_name,
-        ])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|error| format!("launching ffmpeg for silence: {error}"))?;
-    if status.success() {
-        Ok(output_path)
-    } else {
-        Err(format!("ffmpeg silence generation exited with {status}"))
+    let staged = staged_output_path(&output_path);
+    let staged_name = file_name_of(&staged);
+    let mut command = Command::new("ffmpeg");
+    command.current_dir(out_dir).args([
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        &format!("anullsrc=r={rate}:cl={channel_layout}"),
+        "-t",
+        &duration,
+        "-c:a",
+        encoder,
+        &staged_name,
+    ]);
+    run_ffmpeg_transactional(
+        &mut command,
+        &staged,
+        &output_path,
+        "ffmpeg silence generation",
+    )?;
+    Ok(output_path)
+}
+
+fn silence_file_is_valid(path: &Path, expected_ms: u32, rate: u32, channels: u16) -> bool {
+    if std::fs::metadata(path).map_or(true, |metadata| metadata.len() == 0) {
+        return false;
     }
+    if probe_audio_params(path) != Some((rate, channels)) {
+        return false;
+    }
+    let Some(duration_ms) = ffprobe_duration_ms(path) else {
+        return false;
+    };
+    duration_ms.abs_diff(u64::from(expected_ms)) <= u64::from((expected_ms / 5).max(100))
 }
 
 fn ffprobe_duration_ms(path: &Path) -> Option<u64> {
@@ -540,6 +699,9 @@ fn ffprobe_duration_ms(path: &Path) -> Option<u64> {
         .trim()
         .parse()
         .ok()?;
+    if !seconds.is_finite() || seconds < 0.0 {
+        return None;
+    }
     Some((seconds * 1_000.0).round() as u64)
 }
 
@@ -764,5 +926,111 @@ mod tests {
         );
         assert_eq!(sanitize_filename("***"), "untitled");
         assert_eq!(sanitize_filename("  spaced  out  "), "spaced-out");
+    }
+
+    #[test]
+    fn failed_ffmpeg_run_removes_stage_and_preserves_prior_public_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let final_path = dir.path().join("audiobook.m4b");
+        std::fs::write(&final_path, b"previous-good-output").unwrap();
+        let staged = staged_output_path(&final_path);
+        std::fs::write(&staged, b"truncated-new-output").unwrap();
+
+        #[cfg(windows)]
+        let mut command = {
+            let mut command = Command::new("cmd");
+            command.args(["/C", "echo diagnostic-from-ffmpeg 1>&2 & exit /b 7"]);
+            command
+        };
+        #[cfg(not(windows))]
+        let mut command = {
+            let mut command = Command::new("sh");
+            command.args(["-c", "echo diagnostic-from-ffmpeg >&2; exit 7"]);
+            command
+        };
+
+        let error = run_ffmpeg_transactional(&mut command, &staged, &final_path, "test ffmpeg")
+            .unwrap_err();
+        assert!(error.contains("diagnostic-from-ffmpeg"), "{error}");
+        assert_eq!(std::fs::read(&final_path).unwrap(), b"previous-good-output");
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn failed_duration_probe_skips_unchaptered_m4b_with_warning_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let options = StitchOptions {
+            out_dir: dir.path().to_path_buf(),
+            make_m4b: true,
+            gap_chapter_ms: 0,
+            gap_title_ms: 0,
+            gap_paragraph_ms: 0,
+            ..StitchOptions::default()
+        };
+        let chapters = vec![(0, vec![chunk(0, 1, ChunkKind::Title)])];
+        let missing = dir.path().join("missing-chapter.wav");
+
+        let warning =
+            assemble_m4b(&options, &chapters, &[missing], &ConcatGaps::default()).unwrap_err();
+
+        assert!(
+            warning.contains("chapter metadata was skipped"),
+            "{warning}"
+        );
+        assert!(warning.contains("unchaptered"), "{warning}");
+        assert!(!dir.path().join("audiobook.m4b").exists());
+        assert!(!dir.path().join("book.concat.txt").exists());
+        assert!(!dir.path().join("chapters.ffmeta.txt").exists());
+    }
+
+    #[test]
+    fn partial_silence_file_is_rejected_instead_of_reused() {
+        let dir = tempfile::tempdir().unwrap();
+        let partial = dir.path().join("silence-800-8000-1.wav");
+        std::fs::write(&partial, b"RIFF\0\0\0\0WAVEaudio").unwrap();
+        assert!(!silence_file_is_valid(&partial, 800, 8_000, 1));
+
+        if !ffmpeg_available() || !ffprobe_available() {
+            return;
+        }
+        let generated = ensure_silence_file(dir.path(), 800, "wav", 8_000, 1).unwrap();
+        assert_eq!(generated, partial);
+        assert!(silence_file_is_valid(&generated, 800, 8_000, 1));
+    }
+
+    #[test]
+    fn unresolved_manifest_never_stitches_partial_book() {
+        let mut manifest = AudiobookManifest {
+            schema_version: 3,
+            title: Some("Book".to_string()),
+            synthesis_id: "mock".to_string(),
+            voice: "voice".to_string(),
+            format: "wav".to_string(),
+            speed: 1.0,
+            max_chars: 2_000,
+            instructions: None,
+            seed: None,
+            language: None,
+            text_normalization: None,
+            gaps: crate::builder::GapSettings::default(),
+            author: None,
+            chapters: 1,
+            chunks: vec![chunk(0, 1, ChunkKind::Title)],
+            completed_chunks: 0,
+            status: crate::builder::AudiobookStatus::Failed,
+            updated_at_ms: 0,
+            error: Some("one failed".to_string()),
+        };
+        manifest.chunks[0].status = ChunkStatus::Failed;
+        let report = stitch(&manifest, &StitchOptions::default());
+
+        assert!(report.chapter_files.is_empty());
+        assert!(report.book_file.is_none());
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("unresolved"))
+        );
     }
 }

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -207,6 +207,12 @@ pub struct AudiobookArgs {
     #[arg(long, default_value_t = false)]
     pub prune: bool,
 
+    /// Retry only chunks recorded as failed in the previous matching
+    /// manifest. Previously successful chunks are validated but can never
+    /// call the provider in this mode.
+    #[arg(long, default_value_t = false)]
+    pub retry_failed: bool,
+
     /// Progress output mode. `tui` opens an attached full-screen audiobook
     /// dashboard; `json` emits one JSON object per completed chunk.
     #[arg(long, value_enum, default_value_t = UiMode::Auto)]
@@ -414,18 +420,33 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
         gap_title_ms: args.gap_title_ms,
         gap_paragraph_ms: args.gap_paragraph_ms,
         pdf_page_grouping,
+        retry_failed: args.retry_failed,
     };
     validate_options(&options)?;
 
-    let plan = plan_chunks(&book, &options);
+    let mut plan = plan_chunks(&book, &options);
     if plan.is_empty() {
         anyhow::bail!(
             "no narratable text found in {} (cover-only or empty book?)",
             input.display()
         );
     }
-    let full_prune_plan = (args.prune && options.chapter_filter.is_some())
-        .then(|| plan_chunks_for_prune(&book, &options));
+    let full_prune_plan = args.prune.then(|| plan_chunks_for_prune(&book, &options));
+    if args.retry_failed {
+        let failed = bookforge_audio::failed_chunk_files(&out_dir.join("manifest.json"))
+            .with_context(|| {
+                format!(
+                    "--retry-failed requires a readable prior manifest at {}",
+                    out_dir.join("manifest.json").display()
+                )
+            })?;
+        plan.retain(|chunk| failed.contains(&chunk.file));
+        if plan.is_empty() {
+            anyhow::bail!(
+                "--retry-failed found no failed chunks matching the current book and synthesis settings"
+            );
+        }
+    }
     let chapter_count = plan
         .iter()
         .map(|chunk| chunk.chapter_index)
@@ -591,11 +612,16 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 }
             }
         };
-        app.finish(if outcome.is_ok() {
-            "succeeded"
-        } else {
-            "failed"
-        });
+        app.finish(
+            if outcome
+                .as_ref()
+                .is_ok_and(|report| report.chunks_failed == 0)
+            {
+                "succeeded"
+            } else {
+                "failed"
+            },
+        );
         app.draw().ok();
         let restore = app.restore();
         restore?;
@@ -611,6 +637,52 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     };
 
     let fallback_tui_output = args.ui == UiMode::Tui && !use_tui;
+    if report.chunks_failed > 0 {
+        if human_output || fallback_tui_output {
+            eprintln!(
+                "Incomplete: {} of {} chunks failed. Successful audio was preserved.",
+                report.chunks_failed, report.chunks_total
+            );
+            for failure in &report.failures {
+                eprintln!(
+                    "  chapter {}, part {} ({}): {}",
+                    failure.chapter_index + 1,
+                    failure.part,
+                    failure.file,
+                    failure.error
+                );
+            }
+            eprintln!(
+                "Retry: rerun the same command with --retry-failed to call the provider only for these failures."
+            );
+            eprintln!("Manifest: {}", report.manifest_path.display());
+        } else if args.ui == UiMode::Json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "event": "audiobook_finished",
+                    "status": "failed",
+                    "synthesized": report.chunks_synthesized,
+                    "cached": report.chunks_skipped,
+                    "failed": report.chunks_failed,
+                    "chunks": report.chunks_total,
+                    "manifest": report.manifest_path,
+                    "chunk_files": report.files,
+                    "chapter_files": [],
+                    "audiobook": null,
+                    "single_file": null,
+                    "failures": report.failures,
+                    "warnings": [],
+                })
+            );
+        }
+        anyhow::bail!(
+            "{} audiobook chunk(s) failed; successful chunks are resumable from {}",
+            report.chunks_failed,
+            report.manifest_path.display()
+        );
+    }
+
     let stitch_report = if postprocess {
         Some(stitch_output(StitchRequest {
             manifest_path: &report.manifest_path,
@@ -618,7 +690,6 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
             book: &book,
             format,
             make_m4b,
-            require_m4b: args.m4b,
             make_single: args.single,
             gap_chapter_ms: args.gap_chapter_ms,
             gap_title_ms: args.gap_title_ms,
@@ -629,10 +700,45 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
     } else {
         None
     };
+    if let Some(stitch_report) = &stitch_report {
+        write_stitch_warnings_to_process(&out_dir, &stitch_report.warnings)?;
+    }
+    let deliverable_errors = stitch_report.as_ref().map_or_else(Vec::new, |result| {
+        missing_requested_deliverables(result, report.chapters, args.stitch, make_m4b, args.single)
+    });
+    let strict_deliverable_errors = stitch_report.as_ref().map_or_else(Vec::new, |result| {
+        missing_requested_deliverables(result, report.chapters, false, args.m4b, args.single)
+    });
+    let legacy_missing_ffmpeg_stitch = args.stitch
+        && !make_m4b
+        && !args.single
+        && stitch_report.as_ref().is_some_and(|result| {
+            result
+                .warnings
+                .iter()
+                .any(|warning| warning.starts_with("ffmpeg not found on PATH"))
+        });
+    let final_status = if deliverable_errors.is_empty() || legacy_missing_ffmpeg_stitch {
+        "succeeded"
+    } else if strict_deliverable_errors.is_empty() {
+        "partial"
+    } else {
+        "failed"
+    };
+    let deliverable_status = if deliverable_errors.is_empty() {
+        "complete"
+    } else {
+        "partial"
+    };
 
     if human_output || fallback_tui_output {
+        let summary = if deliverable_errors.is_empty() {
+            "Done"
+        } else {
+            "Incomplete"
+        };
         println!(
-            "Done: {} synthesized, {} reused (resume), {} files total",
+            "{summary}: {} synthesized, {} reused (resume), {} files total",
             report.chunks_synthesized,
             report.chunks_skipped,
             report.files.len()
@@ -653,14 +759,19 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 .and_then(|result| result.single_file.as_ref())
                 .map_or("none".to_string(), |path| path.display().to_string()),
         );
+        for error in &deliverable_errors {
+            eprintln!("error: {error}");
+        }
     } else if args.ui == UiMode::Json {
         println!(
             "{}",
             serde_json::json!({
                 "event": "audiobook_finished",
-                "status": "succeeded",
+                "status": final_status,
+                "deliverable_status": deliverable_status,
                 "synthesized": report.chunks_synthesized,
                 "cached": report.chunks_skipped,
+                "failed": 0,
                 "chunks": report.chunks_total,
                 "manifest": report.manifest_path,
                 "chunk_files": report.files,
@@ -668,8 +779,13 @@ pub async fn run(args: AudiobookArgs, cancel: CancellationToken) -> Result<()> {
                 "audiobook": stitch_report.as_ref().and_then(|result| result.book_file.as_ref()),
                 "single_file": stitch_report.as_ref().and_then(|result| result.single_file.as_ref()),
                 "warnings": stitch_report.as_ref().map(|result| &result.warnings),
+                "deliverable_errors": deliverable_errors,
             })
         );
+    }
+
+    if !strict_deliverable_errors.is_empty() {
+        anyhow::bail!("{}", strict_deliverable_errors.join("; "));
     }
 
     if stitch_report.is_none() && human_output && args.no_book_file {
@@ -1040,6 +1156,8 @@ fn progress_callback(ui: UiMode, total: usize) -> Arc<dyn Fn(Progress) + Send + 
                     "total": event.total,
                     "chapter": event.chapter_title,
                     "cached": event.skipped,
+                    "failed": event.failed,
+                    "error": event.error,
                 })
             );
         });
@@ -1054,7 +1172,9 @@ fn progress_callback(ui: UiMode, total: usize) -> Arc<dyn Fn(Progress) + Send + 
     );
     Arc::new(move |event: Progress| {
         progress.set_position(event.done as u64);
-        let state = if event.skipped {
+        let state = if event.failed {
+            "failed"
+        } else if event.skipped {
             "cached"
         } else {
             "synthesized"
@@ -1155,17 +1275,13 @@ async fn synthesize(
 
 /// Inputs for [`stitch_output`], named at the call site.
 ///
-/// Four of these are bools, and two of them differ only in intent:
-/// `make_m4b` means "assemble an m4b if ffmpeg can", while `require_m4b` means
-/// "the user asked for one, so failing to build it is an error". As positional
-/// arguments they sat next to each other and were easy to transpose.
+/// Named inputs keep the output-policy booleans legible at the call site.
 struct StitchRequest<'a> {
     manifest_path: &'a std::path::Path,
     out_dir: &'a std::path::Path,
     book: &'a bookforge_core::ir::Book,
     format: AudioFormat,
     make_m4b: bool,
-    require_m4b: bool,
     make_single: bool,
     gap_chapter_ms: u32,
     gap_title_ms: u32,
@@ -1181,7 +1297,6 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
         book,
         format,
         make_m4b,
-        require_m4b,
         make_single,
         gap_chapter_ms,
         gap_title_ms,
@@ -1219,16 +1334,6 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
             println!("Chapter files: {}", result.chapter_files.len());
         }
     }
-    if require_m4b && result.book_file.is_none() {
-        anyhow::bail!(
-            "--m4b was requested, but audiobook.m4b could not be assembled; install ffmpeg and review the stitch warnings above"
-        );
-    }
-    if make_single && result.single_file.is_none() {
-        anyhow::bail!(
-            "--single was requested, but the flat whole-book file could not be assembled; install ffmpeg and review the stitch warnings above"
-        );
-    }
     if human_output && let Some(book_file) = &result.book_file {
         println!("Audiobook: {}", book_file.display());
     }
@@ -1236,6 +1341,71 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
         println!("Single file: {}", single_file.display());
     }
     Ok(result)
+}
+
+fn missing_requested_deliverables(
+    report: &bookforge_audio::StitchReport,
+    expected_chapters: usize,
+    require_chapters: bool,
+    require_m4b: bool,
+    require_single: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    if require_chapters && report.chapter_files.len() != expected_chapters {
+        errors.push(format!(
+            "--stitch requested {expected_chapters} chapter file(s), but only {} were produced",
+            report.chapter_files.len()
+        ));
+    }
+    if require_m4b && report.book_file.is_none() {
+        errors.push(
+            "the requested chaptered audiobook.m4b was not produced; review the stitch warnings"
+                .to_string(),
+        );
+    }
+    if require_single && report.single_file.is_none() {
+        errors.push(
+            "--single was requested, but the flat whole-book file was not produced; review the stitch warnings"
+                .to_string(),
+        );
+    }
+    errors
+}
+
+fn write_stitch_warnings_to_process(out_dir: &std::path::Path, warnings: &[String]) -> Result<()> {
+    let path = out_dir.join("process.json");
+    if !path.is_file() {
+        return Ok(());
+    }
+    let mut process: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&path)
+            .with_context(|| format!("failed to read process state {}", path.display()))?,
+    )
+    .with_context(|| format!("failed to parse process state {}", path.display()))?;
+    let object = process
+        .as_object_mut()
+        .context("audiobook process state must be a JSON object")?;
+    object.insert("warnings".to_string(), serde_json::json!(warnings));
+
+    let staged = out_dir.join("process.warnings.part.tmp");
+    std::fs::write(&staged, serde_json::to_vec_pretty(&process)?)
+        .with_context(|| format!("failed to stage process state {}", staged.display()))?;
+    let backup = out_dir.join("process.warnings.replace.bak");
+    let _ = std::fs::remove_file(&backup);
+    std::fs::rename(&path, &backup)
+        .with_context(|| format!("failed to preserve process state {}", path.display()))?;
+    match std::fs::rename(&staged, &path) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(backup);
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::rename(&backup, &path);
+            let _ = std::fs::remove_file(staged);
+            Err(error)
+                .with_context(|| format!("failed to publish process state {}", path.display()))
+        }
+    }
 }
 
 fn default_out_dir(input: &std::path::Path) -> PathBuf {
@@ -1271,9 +1441,9 @@ fn validate_audio_base_url(value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AudioProviderKind, BreakTagsArg, normalize_language_code, parse_chapter_ranges,
-        resolve_context_chars, resolve_heading_break_tag, resolve_language_code,
-        validate_audio_base_url,
+        AudioProviderKind, BreakTagsArg, missing_requested_deliverables, normalize_language_code,
+        parse_chapter_ranges, resolve_context_chars, resolve_heading_break_tag,
+        resolve_language_code, validate_audio_base_url, write_stitch_warnings_to_process,
     };
 
     #[test]
@@ -1404,5 +1574,43 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn missing_explicit_or_automatic_deliverables_are_failures() {
+        let report = bookforge_audio::StitchReport::default();
+        let errors = missing_requested_deliverables(&report, 3, true, true, true);
+        assert_eq!(errors.len(), 3);
+        assert!(errors[0].contains("--stitch"));
+        assert!(errors[1].contains("chaptered audiobook.m4b"));
+        assert!(errors[2].contains("--single"));
+
+        assert!(
+            missing_requested_deliverables(&report, 3, false, false, false).is_empty(),
+            "per-chunk-only output is successful when no stitched deliverable was requested"
+        );
+    }
+
+    #[test]
+    fn stitch_warnings_are_added_to_existing_process_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("process.json"),
+            br#"{"status":"running","pid":42,"auto_model":true}"#,
+        )
+        .unwrap();
+        let warnings = vec![
+            "ffprobe could not read chapter 2".to_string(),
+            "m4b was not produced".to_string(),
+        ];
+
+        write_stitch_warnings_to_process(dir.path(), &warnings).unwrap();
+
+        let process: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("process.json")).unwrap())
+                .unwrap();
+        assert_eq!(process["status"], "running");
+        assert_eq!(process["pid"], 42);
+        assert_eq!(process["warnings"], serde_json::json!(warnings));
     }
 }

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -35,10 +35,13 @@ local browser dashboard started by `bookforge serve`.
    time, writing `chapter-NNN-part-NNN-<hash>.<ext>` atomically (temp file then
    rename) so an interrupted write is never mistaken for a finished one.
 6. **Manifest**: a schema-3 `manifest.json` records the plan, narration kind,
-   synthesis settings, gap settings, author, and per-chunk metadata.
-7. **Assemble**: when ffmpeg is available, a normal run creates a chaptered
-   `audiobook.m4b` with chapter markers and title/artist metadata (using the
-   EPUB author as the artist). The chunks remain the resumable units on disk.
+   synthesis settings, gap settings, author, and each chunk's success or
+   failure. Provider/content failures do not cancel unrelated paid work; the
+   run finishes the remaining chunks, records every error, and exits as failed.
+7. **Assemble**: only a fully synthesized manifest is assembled. When ffmpeg is
+   available, a normal run creates a chaptered `audiobook.m4b` with chapter
+   markers and title/artist metadata (using the EPUB author as the artist). The
+   chunks remain the resumable units on disk.
 
 ## Narration hierarchy and continuity
 
@@ -154,6 +157,7 @@ aloud instead of treating them as directives.
 | `--list-voices` | off | List ElevenLabs voice IDs and metadata; no input EPUB is required. |
 | `--dry-run` | off | Print the chapter/chunk plan, cost estimate, and available quota, then exit. |
 | `--prune` | off | Delete superseded chunks not used by the current plan (report-only with `--dry-run`). |
+| `--retry-failed` | off | Call the provider only for chunks recorded as failed in the previous matching manifest. |
 | `--ui <auto\|progress\|quiet\|json\|tui>` | `auto` | Select progress output or the full-screen terminal dashboard. |
 
 Chapter numbers are the one-based numbers shown in the plan. Comma-separated
@@ -232,14 +236,43 @@ If ffmpeg is unavailable, BookForge keeps the completed chunks and warns that
 it could not create the automatic book file. An explicitly requested `--m4b`
 fails clearly while preserving those chunks for a later resumed stitch.
 
+ffmpeg writes each chapter, `.m4b`, flat book file, and reusable silence clip
+to a private sibling path first. A successful encode atomically replaces the
+public filename; a failed encode removes the staged file and leaves any older
+good artifact untouched. Failure messages include a bounded tail of ffmpeg's
+stderr. If ffprobe cannot determine every chapter duration, BookForge does not
+publish an unchaptered `.m4b` under the promised chaptered filename.
+
+Explicit whole-book requests are strict: `--m4b` and `--single` make the
+command fail if their requested artifacts are absent. The established
+best-effort contract for `--stitch` and automatic M4B assembly remains
+non-fatal (so completed synthesis is still reusable when ffmpeg is absent or
+fails). JSON adds `"deliverable_status": "partial"` plus itemized
+`deliverable_errors`; post-processing failures use overall `"status":
+"partial"` (or `"failed"` for strict outputs). For backward compatibility, the
+specific `--stitch`-with-no-ffmpeg case retains overall `"status":
+"succeeded"` to mean synthesis succeeded, while its deliverable status and
+warnings still state that no chapter files exist. Dashboard-launched runs copy
+stitch warnings into the additive `warnings` array in `process.json`.
+
 ## Resume and cache cleanup
 
 Re-run the same command and every matching hashed chunk already on disk is
-skipped. The `bookforge-audio-v2` cache key covers the text, narration kind,
+skipped. A normal resume repairs every missing or invalid cache entry. After a
+partial failure, add `--retry-failed` for the stronger paid-run guarantee: only
+records whose prior status is `failed` may call the provider. Previously
+successful records are validated against the manifest's byte count and SHA-256
+hash; if one is missing or changed, failed-only mode reports it rather than
+silently paying to regenerate it.
+
+The `bookforge-audio-v2` cache key covers the text, narration kind,
 provider/model identity, voice, format, speed, instructions, seed, language,
-normalization, and same-chapter neighbor context. An interrupted write is
-never accepted as a finished chunk. The run summary reports how many chunks
-were synthesized and reused.
+normalization, and same-chapter neighbor context. An interrupted chunk write is
+never accepted as finished. Manifest updates are serialized off the async
+synthesis workers, checkpointed in small batches, and always flushed for a
+failure, cancellation, and final outcome. The audio files remain the durable
+resume source if a process stops between a chunk rename and the next batched
+manifest checkpoint.
 
 Superseded chunks stay on disk so prior generations remain auditable. Pass
 `--prune` to remove chunk files the current run does not use and free the


### PR DESCRIPTION
Audiobook runs cost real money per character and take hours. Every item here is an instance of the pattern two independent audits found across this codebase: **partial failure reported as success.**

## A single bad chunk could make a book permanently unfinishable

Once provider retries were exhausted the builder cancelled everything — and resume retried that same chunk first. A chunk that fails *deterministically* (a provider content filter, pathological text) meant the book could never complete, with no way to skip or defer it. On a paid multi-hour run that's the most likely real-world frustration.

- **Chunk failures now continue by default.** Successful paid work is kept, the manifest ends `failed`, JSON reports failure, and the CLI exits nonzero after itemizing every failed chunk. **A run with failures cannot report plain success.**
- **New `--retry-failed`** may only call the provider for records already marked failed. Successful chunks are validated and cannot be re-synthesized, so retrying never re-pays for work already bought.

## ffmpeg could destroy a good output

Every command wrote `-y` directly to its **final public filename**, so a mid-encode failure could leave a truncated artifact *and* destroy a previously good one. All stderr went to null, making disk-full, codec, malformed-input and permission failures indistinguishable.

- Deliverables now stage to a sibling file and rename transactionally; a failed command removes the staged file and leaves the prior artifact intact.
- A bounded 16 KiB stderr tail is retained for diagnosis.
- **Silence files** were reused unvalidated, so a killed generation left a partial that the next run treated as good. They are now probed for rate, channels and duration first.

## The advertised deliverable could silently not exist

`.m4b` assembly omitted chapter metadata whenever any duration probe failed — producing a playable but **unchaptered** book reported as the requested deliverable, with *no warning at all* when gaps were zero (no preliminary probe runs in that case). It now refuses to publish an unchaptered file and says why.

Missing deliverables carry `deliverable_status` and itemized errors, and stitch warnings are atomically merged into `process.json` so the dashboard can surface them.

## Manifest I/O was quadratic

Every chunk completion re-serialized the whole manifest under a mutex with blocking I/O on an async worker. Updates are now O(1), batched every 16 successes off the workers, and always flushed on failure, cancellation and completion. Atomic chunk files remain the resume source between checkpoints, so an abrupt kill still resumes correctly — throughput was not traded for correctness.

## A judgement call worth flagging

On cache hits the prior manifest's byte count and SHA-256 are now compared where available. That was chosen **over** a minimum-length heuristic, because valid sizes vary widely across codecs and providers. No decoding dependency was added — single-binary distribution is an architectural goal.

This addresses the gap where signature-only validation (`ID3` plus two sync bytes, or a 12-byte `RIFF` prefix) could bless a truncated-but-prefixed response and cache it permanently. The signature check still does its original job of stopping a 200-with-JSON-error being stored as audio.

## Deliberately preserved

Existing integration tests require `--stitch` with ffmpeg missing to exit successfully with overall `"status":"succeeded"`. That contract is kept rather than silently broken — but `deliverable_status` is now `partial` with errors and warnings attached, so the deliverable is no longer misrepresented. Explicit `--m4b` and `--single` remain strict.

## Known follow-up across a boundary

The child now writes a warnings field into `process.json`, but the `serve.rs` monitor replaces that file after the child exits. Preserving the field through that final write belongs to #71, which owns `serve.rs`. Flagged rather than reached across the ownership fence — worth confirming end-to-end once both land.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **836 passed / 0 failed / 3 ignored** (was 827).

ffmpeg was unavailable locally, so those tests follow the existing conditional style; transactional failure behaviour was exercised with a controlled failing subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
