### PR TITLE
refactor(translate): one pipeline for both providers, and glossary rule counters

### DIFF
--- a/crates/bookforge-cli/src/commands/translate/engine.rs
+++ b/crates/bookforge-cli/src/commands/translate/engine.rs
@@ -1,8 +1,11 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
-use bookforge_core::{ResolvedRunSettings, scheduler::SchedulerConfig, segment::Segment};
-use bookforge_llm::{LlmProvider, SegmentTranslation, TranslationRunConfig};
+use bookforge_core::{
+    ResolvedRunSettings, glossary::GlossarySelectionRule, scheduler::SchedulerConfig,
+    segment::Segment,
+};
+use bookforge_llm::{LlmProvider, SegmentTranslation, TelemetryLog, TranslationRunConfig};
 use bookforge_store::JobStore;
 
 use crate::checkpoint::CheckpointWriter;
@@ -62,6 +65,68 @@ pub(crate) async fn run_checkpointed_translation<P>(
 where
     P: LlmProvider,
 {
+    run_checkpointed_translation_inner(
+        provider,
+        pending_segments,
+        run_config,
+        settings,
+        checkpoint,
+        progress,
+        batch_enabled,
+        Arc::new(TelemetryLog::new()),
+        &HashMap::new(),
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_checkpointed_translation_instrumented<P>(
+    provider: P,
+    pending_segments: &[Segment],
+    run_config: &TranslationRunConfig,
+    settings: &ResolvedRunSettings,
+    checkpoint: CheckpointRunContext<'_>,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    batch_enabled: bool,
+    telemetry: Arc<TelemetryLog>,
+    glossary_rules: &HashMap<String, Vec<GlossarySelectionRule>>,
+    print_human_output: bool,
+) -> Result<Vec<SegmentTranslation>>
+where
+    P: LlmProvider,
+{
+    run_checkpointed_translation_inner(
+        provider,
+        pending_segments,
+        run_config,
+        settings,
+        checkpoint,
+        progress,
+        batch_enabled,
+        telemetry,
+        glossary_rules,
+        print_human_output,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_checkpointed_translation_inner<P>(
+    provider: P,
+    pending_segments: &[Segment],
+    run_config: &TranslationRunConfig,
+    settings: &ResolvedRunSettings,
+    checkpoint: CheckpointRunContext<'_>,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    batch_enabled: bool,
+    telemetry: Arc<TelemetryLog>,
+    glossary_rules: &HashMap<String, Vec<GlossarySelectionRule>>,
+    print_human_output: bool,
+) -> Result<Vec<SegmentTranslation>>
+where
+    P: LlmProvider,
+{
     if pending_segments.is_empty() {
         return Ok(Vec::new());
     }
@@ -94,6 +159,8 @@ where
             checkpoint_context,
             progress,
             Some(&mut control_poller),
+            telemetry.clone(),
+            print_human_output,
         )
         .await
     } else {
@@ -106,5 +173,40 @@ where
         )
         .await
     };
-    finalize_writer(translation_result, sender, writer).await
+    let translations = finalize_writer(translation_result, sender, writer).await?;
+    record_glossary_telemetry(
+        &telemetry,
+        &run_config.glossary,
+        glossary_rules,
+        &translations,
+    );
+    Ok(translations)
+}
+
+pub(crate) fn record_glossary_telemetry(
+    telemetry: &TelemetryLog,
+    glossary: &bookforge_llm::GlossaryRunConfig,
+    rules_by_segment: &HashMap<String, Vec<GlossarySelectionRule>>,
+    translations: &[SegmentTranslation],
+) {
+    for translation in translations {
+        let Some(entries) = glossary.entries_by_segment.get(&translation.segment_id.0) else {
+            continue;
+        };
+        let Some(rules) = rules_by_segment.get(&translation.segment_id.0) else {
+            continue;
+        };
+        debug_assert_eq!(entries.len(), rules.len());
+        let output = translation.joined_text();
+        for (entry, rule) in entries.iter().zip(rules) {
+            let honored = if entry.target.is_empty() {
+                false
+            } else if entry.case_sensitive {
+                output.contains(&entry.target)
+            } else {
+                output.to_lowercase().contains(&entry.target.to_lowercase())
+            };
+            telemetry.record_glossary_entry(*rule, honored);
+        }
+    }
 }

--- a/crates/bookforge-cli/src/commands/translate/finalization.rs
+++ b/crates/bookforge-cli/src/commands/translate/finalization.rs
@@ -3,8 +3,8 @@ use super::*;
 /// Shared post-translation pipeline: QA, fallback, double-check, finish, report.
 /// Both batch and non-batch paths call this after translation completes.
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn finish_translation_pipeline(
-    provider: &OpenAiCompatibleProvider,
+pub(super) async fn finish_translation_pipeline<P>(
+    provider: &P,
     cancel_token: &tokio_util::sync::CancellationToken,
     cli_args: &TranslateArgs,
     segments: &[Segment],
@@ -21,7 +21,15 @@ pub(super) async fn finish_translation_pipeline(
     started: std::time::Instant,
     snapshot: &mut RunConfigSnapshot,
     job_runtime_settings: &tokio::sync::watch::Receiver<crate::control::JobRuntimeSettings>,
-) -> Result<()> {
+    telemetry: &TelemetryLog,
+    glossary_rules: &std::collections::HashMap<
+        String,
+        Vec<bookforge_core::glossary::GlossarySelectionRule>,
+    >,
+) -> Result<()>
+where
+    P: LlmProvider + Clone,
+{
     translations.sort_by_key(|t| t.ordinal);
 
     let pause_signal = run_config.pause_signal.clone().unwrap_or_default();
@@ -56,7 +64,7 @@ pub(super) async fn finish_translation_pipeline(
         return Ok(());
     }
     let fallback_config = FallbackPassConfig::from_snapshot(snapshot.fallback.as_ref());
-    let fallback_translations = run_fallback_pass(
+    let fallback_translations = run_fallback_pass_instrumented(
         cancel_token,
         fallback_config.as_ref(),
         segments,
@@ -68,6 +76,8 @@ pub(super) async fn finish_translation_pipeline(
         &controlled_run_config,
         Some(&mut control_poller),
         progress.clone(),
+        telemetry,
+        glossary_rules,
     )
     .await?;
     *translations = fallback_translations;
@@ -171,8 +181,8 @@ pub(super) async fn wait_for_finalize_stage_control(
     ))
 }
 
-struct DoubleCheckPass<'a> {
-    provider: &'a OpenAiCompatibleProvider,
+struct DoubleCheckPass<'a, P> {
+    provider: &'a P,
     cancel_token: &'a tokio_util::sync::CancellationToken,
     cli_args: &'a TranslateArgs,
     segments: &'a [Segment],
@@ -184,7 +194,49 @@ struct DoubleCheckPass<'a> {
     progress: Arc<dyn bookforge_core::ProgressSink>,
 }
 
-async fn run_double_check_pass(pass: DoubleCheckPass<'_>) -> Result<bool> {
+#[derive(Clone)]
+enum DoubleCheckProvider<P> {
+    Primary(P),
+    Mock(MockProvider),
+    OpenAi(OpenAiCompatibleProvider),
+}
+
+impl<P> LlmProvider for DoubleCheckProvider<P>
+where
+    P: LlmProvider,
+{
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> std::result::Result<CompletionResponse, LlmError> {
+        match self {
+            Self::Primary(provider) => provider.complete(request).await,
+            Self::Mock(provider) => provider.complete(request).await,
+            Self::OpenAi(provider) => provider.complete(request).await,
+        }
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        match self {
+            Self::Primary(provider) => provider.capabilities(),
+            Self::Mock(provider) => provider.capabilities(),
+            Self::OpenAi(provider) => provider.capabilities(),
+        }
+    }
+
+    fn is_reasoning(&self) -> bool {
+        match self {
+            Self::Primary(provider) => provider.is_reasoning(),
+            Self::Mock(provider) => provider.is_reasoning(),
+            Self::OpenAi(provider) => provider.is_reasoning(),
+        }
+    }
+}
+
+async fn run_double_check_pass<P>(pass: DoubleCheckPass<'_, P>) -> Result<bool>
+where
+    P: LlmProvider + Clone,
+{
     let DoubleCheckPass {
         provider,
         cancel_token,
@@ -201,37 +253,56 @@ async fn run_double_check_pass(pass: DoubleCheckPass<'_>) -> Result<bool> {
         return Ok(true);
     }
 
-    let (dc_provider, dc_provider_name, dc_model) = if cli_args.double_check_provider.is_some()
-        || cli_args.double_check_model.is_some()
-    {
-        let provider_str = cli_args
-            .double_check_provider
-            .as_deref()
-            .unwrap_or("openrouter");
-        let dc_config = provider_config(
-            provider_str,
-            cli_args.double_check_model.as_deref(),
-            cli_args.double_check_base_url.as_deref(),
-            cli_args.double_check_api_key_env.as_deref(),
-            settings.provider.timeout_seconds,
-            settings.provider.provider_max_attempts,
-            settings.provider.thinking_disabled,
-            settings.provider.retry_after_policy,
-            settings.provider.max_backoff_seconds,
-            settings.provider.max_idle_per_host,
-            settings.provider.json_mode,
-        )?;
-        let provider = OpenAiCompatibleProvider::new_with_cancel(dc_config, cancel_token.clone())
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let model = provider.model().to_string();
-        (provider, provider_str.to_string(), model)
-    } else {
-        (
-            provider.clone(),
-            config.provider.clone(),
-            provider.model().to_string(),
-        )
-    };
+    let (dc_provider, dc_provider_name, dc_model) =
+        if cli_args.double_check_provider.is_some() || cli_args.double_check_model.is_some() {
+            let provider_str = cli_args
+                .double_check_provider
+                .as_deref()
+                .unwrap_or("openrouter");
+            if provider_str == "mock" {
+                let model = cli_args
+                    .double_check_model
+                    .clone()
+                    .unwrap_or_else(|| config.model.clone());
+                (
+                    DoubleCheckProvider::Mock(MockProvider::new(
+                        mock_mode(&model),
+                        &config.target_language,
+                    )),
+                    provider_str.to_string(),
+                    model,
+                )
+            } else {
+                let dc_config = provider_config(
+                    provider_str,
+                    cli_args.double_check_model.as_deref(),
+                    cli_args.double_check_base_url.as_deref(),
+                    cli_args.double_check_api_key_env.as_deref(),
+                    settings.provider.timeout_seconds,
+                    settings.provider.provider_max_attempts,
+                    settings.provider.thinking_disabled,
+                    settings.provider.retry_after_policy,
+                    settings.provider.max_backoff_seconds,
+                    settings.provider.max_idle_per_host,
+                    settings.provider.json_mode,
+                )?;
+                let provider =
+                    OpenAiCompatibleProvider::new_with_cancel(dc_config, cancel_token.clone())
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                let model = provider.model().to_string();
+                (
+                    DoubleCheckProvider::OpenAi(provider),
+                    provider_str.to_string(),
+                    model,
+                )
+            }
+        } else {
+            (
+                DoubleCheckProvider::Primary(provider.clone()),
+                config.provider.clone(),
+                config.model.clone(),
+            )
+        };
     let mut double_check_config = config.clone();
     double_check_config.provider = dc_provider_name;
     double_check_config.model = dc_model;

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -60,15 +60,14 @@ pub use args::TranslateArgs;
 pub(crate) use cache::{CacheContext, apply_cached_translations, pending_segments_for_job};
 use checkpointing::finalize_writer;
 pub(crate) use engine::{CheckpointRunContext, run_checkpointed_translation};
+use engine::{record_glossary_telemetry, run_checkpointed_translation_instrumented};
 #[cfg(test)]
 use finalization::suspicious_qa_candidates;
 pub(crate) use finalization::{
     apply_double_check_corrections, job_was_stopped, mark_job_finished,
     persist_corrected_translations, print_stopped_resume_hint, qa_reviews_for_mode,
 };
-use finalization::{
-    finish_translation_pipeline, mark_unfinished_segments_failed, wait_for_finalize_stage_control,
-};
+use finalization::{finish_translation_pipeline, mark_unfinished_segments_failed};
 use orchestration::human_stdout_enabled;
 pub use orchestration::run;
 use reporting::print_summary_rebuild_and_report;
@@ -554,6 +553,7 @@ fn provider_config(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn translate_and_checkpoint_batch<P>(
     provider: P,
     segments: &[Segment],
@@ -562,6 +562,8 @@ pub(crate) async fn translate_and_checkpoint_batch<P>(
     checkpoint: CheckpointContext<'_>,
     progress: Arc<dyn bookforge_core::ProgressSink>,
     mut control: Option<&mut crate::control::ControlFilePoller<'_>>,
+    telemetry: Arc<TelemetryLog>,
+    print_human_output: bool,
 ) -> Result<Vec<SegmentTranslation>>
 where
     P: LlmProvider,
@@ -574,10 +576,9 @@ where
         return translate_and_checkpoint(provider, segments, config, checkpoint, control).await;
     }
 
-    eprintln!("Batches: {}", batches.len());
-
-    use std::sync::Arc;
-    let telemetry = Arc::new(TelemetryLog::new());
+    if print_human_output {
+        eprintln!("Batches: {}", batches.len());
+    }
 
     // Keep the adaptive controller alive even while disabled so a live
     // revision can enable it at the next request boundary without rebuilding
@@ -754,6 +755,40 @@ pub(crate) async fn run_fallback_pass(
     cancel_token: &tokio_util::sync::CancellationToken,
     fallback_config: Option<&FallbackPassConfig>,
     segments: &[Segment],
+    translations: Vec<SegmentTranslation>,
+    store: &JobStore,
+    job_id: &str,
+    prompt_version: &str,
+    settings: &ResolvedRunSettings,
+    primary_run_config: &TranslationRunConfig,
+    control: Option<&mut crate::control::ControlFilePoller<'_>>,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+) -> Result<Vec<SegmentTranslation>> {
+    let telemetry = TelemetryLog::new();
+    let glossary_rules = std::collections::HashMap::new();
+    run_fallback_pass_instrumented(
+        cancel_token,
+        fallback_config,
+        segments,
+        translations,
+        store,
+        job_id,
+        prompt_version,
+        settings,
+        primary_run_config,
+        control,
+        progress,
+        &telemetry,
+        &glossary_rules,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_fallback_pass_instrumented(
+    cancel_token: &tokio_util::sync::CancellationToken,
+    fallback_config: Option<&FallbackPassConfig>,
+    segments: &[Segment],
     mut translations: Vec<SegmentTranslation>,
     store: &JobStore,
     job_id: &str,
@@ -762,6 +797,11 @@ pub(crate) async fn run_fallback_pass(
     primary_run_config: &TranslationRunConfig,
     control: Option<&mut crate::control::ControlFilePoller<'_>>,
     progress: Arc<dyn bookforge_core::ProgressSink>,
+    telemetry: &TelemetryLog,
+    glossary_rules: &std::collections::HashMap<
+        String,
+        Vec<bookforge_core::glossary::GlossarySelectionRule>,
+    >,
 ) -> Result<Vec<SegmentTranslation>> {
     let Some(fallback_config) = fallback_config else {
         return Ok(translations);
@@ -823,6 +863,8 @@ pub(crate) async fn run_fallback_pass(
         provider: provider_str.to_string(),
         model: model_str.to_string(),
         prompt_version: prompt_version.to_string(),
+        // Recovery favors reproducibility and low provider pressure: mirror
+        // the primary pass temperature, but dispatch one segment at a time.
         temperature: 0.2,
         scheduler: SchedulerConfig {
             concurrency: 1,
@@ -894,6 +936,7 @@ pub(crate) async fn run_fallback_pass(
         provider => anyhow::bail!("unsupported fallback provider '{provider}'"),
     };
     let fresh = finalize_writer(translation_result, sender, writer).await?;
+    record_glossary_telemetry(telemetry, &run_config.glossary, glossary_rules, &fresh);
 
     for ft in &fresh {
         if let Some(existing) = translations

--- a/crates/bookforge-cli/src/commands/translate/orchestration.rs
+++ b/crates/bookforge-cli/src/commands/translate/orchestration.rs
@@ -64,6 +64,7 @@ pub async fn run(
                     &effective_provider,
                     &args,
                     &settings,
+                    &cancel_token,
                     progress_sink,
                 )
                 .await
@@ -122,353 +123,64 @@ async fn run_mock_translation(
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
-    let started = std::time::Instant::now();
-    progress.emit(bookforge_core::ProgressEvent::StageStarted {
-        stage: "read_epub".to_string(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    let book = read_epub(input)?;
-    progress.emit(bookforge_core::ProgressEvent::StageFinished {
-        stage: "read_epub".to_string(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    progress.emit(bookforge_core::ProgressEvent::StageStarted {
-        stage: "segmentation".to_string(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    let segments = build_segments(&book, &settings.segmentation)?;
-    progress.emit(bookforge_core::ProgressEvent::SegmentationFinished {
-        segment_count: segments.len(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
+    run_mock_translation_with_store(
+        input,
+        config,
+        provider_args,
+        cli_args,
+        settings,
+        cancel_token,
+        progress,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_mock_translation_with_store(
+    input: &PathBuf,
+    config: &TranslationConfig,
+    provider_args: &CliProviderArgs,
+    cli_args: &TranslateArgs,
+    settings: &ResolvedRunSettings,
+    cancel_token: &tokio_util::sync::CancellationToken,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    store: Option<JobStore>,
+) -> Result<()> {
     let model = config
         .model
         .clone()
         .unwrap_or_else(|| "mock-prefix-target".to_string());
-    let prompt_version = PromptVersion::V2.as_str();
-    let store = JobStore::open_default()?;
-    let glossary = prepare_glossary_run_config(
-        &store,
-        &cli_args.glossary,
-        config.source_language.as_deref(),
-        &config.target_language,
-        cli_args.book_id.as_deref(),
-        cli_args.series_id.as_deref(),
-        cli_args.glossary_format,
-        cli_args.glossary_budget_tokens,
-        cli_args.prompt_extra.clone(),
-        &segments,
-    )?;
-    let context_run_config = context_run_config_from_args(cli_args);
-    let context_registry: Option<Arc<ContextRegistry>> = if context_run_config.enabled() {
-        Some(Arc::new(ContextRegistry::new(&segments)))
-    } else {
-        None
-    };
-    let style = prepare_style_run_config(
-        &store,
-        &cli_args.style,
-        &config.target_language,
-        cli_args.book_id.as_deref(),
-        cli_args.series_id.as_deref(),
-    )?;
-    let entities = prepare_entities_run_config(
-        &store,
-        &cli_args.entities,
-        config.source_language.as_deref(),
-        &config.target_language,
-        cli_args.book_id.as_deref(),
-        cli_args.series_id.as_deref(),
-    )?;
-    let job = store.create_job(CreateJob {
+    let provider = MockProvider::new(mock_mode(&model), &config.target_language);
+    run_translation_with_store(
         input,
-        output: &config.output,
-        source_lang: config.source_language.as_deref(),
-        target_lang: &config.target_language,
-        provider: "mock",
-        model: &model,
-        base_url: None,
-        api_key_env: None,
-        book_id: cli_args.book_id.as_deref(),
-        series_id: cli_args.series_id.as_deref(),
-    })?;
-    if human_stdout_enabled(cli_args.ui) {
-        println!("Job: {}", job.id);
-    }
-    crate::control::clear_job_control(&job.id)?;
-    progress.emit(bookforge_core::ProgressEvent::JobCreated {
-        job_id: job.id.clone(),
-        input_path: input.display().to_string(),
-        output_path: config.output.display().to_string(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    let cache_namespace = compute_cache_namespace(
-        settings.segmentation.max_segment_tokens,
-        settings.segmentation.context_tokens,
-        settings.profile.namespace_str(),
-        settings.batch.enabled,
-        prompt_version,
-        &glossary.fingerprint,
-        if style.run_config.is_some() {
-            &style.fingerprint
-        } else {
-            ""
-        },
-        if entities.run_config.is_some() {
-            &entities.fingerprint
-        } else {
-            ""
-        },
-    );
-    let mut snapshot = persist_snapshot(
-        &store,
-        &job,
-        input,
-        &config.output,
+        config,
         provider_args,
         cli_args,
         settings,
-        prompt_version,
-        &cache_namespace,
-        &glossary.fingerprint,
-        &glossary.active_terms,
-        &style.fingerprint,
-        &style.rendered_block,
-        &entities.fingerprint,
-        &entities.rendered_block,
-        &model,
-        None,
-        None,
-    )?;
-    let rebuild_options = rebuild_options_from_snapshot(&snapshot);
-    store.insert_segments(
-        &job.id,
-        &segments,
-        prompt_version,
-        "mock",
-        &model,
-        &cache_namespace,
-    )?;
-    let pause_signal = bookforge_llm::PauseSignal::new();
-    let stop_cancel_token = tokio_util::sync::CancellationToken::new();
-    let control_watcher = crate::control::ControlFileWatcher::spawn_with_stop_cancel(
-        store.path().to_path_buf(),
-        job.id.clone(),
-        progress.clone(),
-        pause_signal.clone(),
-        stop_cancel_token.clone(),
-        crate::control::ControlBaseline {
-            settings: settings.clone(),
-            qa: cli_args.qa,
-            validate_output: cli_args.validate_output,
+        ProviderRun {
+            provider,
+            model,
+            prompt_version: if settings.batch.enabled {
+                PromptVersion::BatchV3.as_str()
+            } else {
+                PromptVersion::V2.as_str()
+            },
+            base_url: None,
+            api_key_env: None,
+            model_context_tokens: settings.provider.model_context_tokens,
+            max_output_tokens: settings.provider.max_output_tokens,
+            batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+            compact_prompts: settings.compact_prompts,
+            cancel_token: cancel_token.clone(),
         },
-    );
-    let job_runtime_settings = control_watcher.job_runtime_settings();
-    let run_config = TranslationRunConfig {
-        source_language: config.source_language.clone(),
-        target_language: config.target_language.clone(),
-        provider: "mock".to_string(),
-        model: model.clone(),
-        prompt_version: prompt_version.to_string(),
-        temperature: 0.2,
-        scheduler: settings.scheduler.clone(),
-        profile: settings.profile,
-        model_context_tokens: None,
-        max_output_tokens: None,
-        batch_max_output_tokens: None,
-        compact_prompts: false,
-        glossary: glossary.run_config.clone(),
-        context: context_run_config,
-        context_registry: context_registry.clone(),
-        style: style.run_config.clone(),
-        entities: entities.run_config.clone(),
-        pause_signal: Some(pause_signal.clone()),
-        runtime_settings: Some(control_watcher.runtime_settings()),
-    }; // mock
-    let provider = MockProvider::new(mock_mode(&model), &config.target_language);
-    let mut translations = apply_cached_translations(
-        &segments,
-        CacheContext {
-            store: &store,
-            job_id: &job.id,
-            prompt_version,
-            provider: &config.provider,
-            model: &model,
-            source_lang: config.source_language.as_deref(),
-            target_lang: &config.target_language,
-            cache_namespace: &cache_namespace,
-        },
-    )?;
-    let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
-    prepopulate_context_registry(context_registry.as_ref(), &segments, &translations);
-    progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
-        hits: translations.len(),
-        misses: pending_segments.len(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    let fresh_translations = run_checkpointed_translation(
-        provider.clone(),
-        &pending_segments,
-        &run_config,
-        settings,
-        CheckpointRunContext {
-            store: &store,
-            job_id: &job.id,
-            provider: "mock",
-            model: &model,
-            prompt_version,
-        },
-        progress.clone(),
-        settings.batch.enabled,
+        progress,
+        store,
     )
-    .await?;
-    if job_was_stopped(&store, &job.id)? {
-        print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-        return Ok(());
-    }
-    translations.extend(fresh_translations);
-    translations.sort_by_key(|translation| translation.ordinal);
-    let mut control_poller = crate::control::ControlFilePoller::new_with_stop_cancel(
-        &store,
-        &job.id,
-        progress.clone(),
-        stop_cancel_token.clone(),
-    );
-    if !wait_for_finalize_stage_control(&mut control_poller, &pause_signal).await? {
-        print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-        return Ok(());
-    }
-    let qa_runtime = job_runtime_settings.borrow().clone();
-    let qa_run_config = crate::control::freeze_run_config_for_stage(&run_config, &qa_runtime);
-    let qa_reviews = qa_reviews_for_mode(
-        ProgressRequestProvider::new(provider.clone(), progress.clone()),
-        &segments,
-        &translations,
-        &qa_run_config,
-        &qa_runtime.settings.qa,
-        qa_runtime.qa,
-    )
-    .await;
-    if !wait_for_finalize_stage_control(&mut control_poller, &pause_signal).await? {
-        print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-        return Ok(());
-    }
-    let fallback_config = FallbackPassConfig::from_snapshot(snapshot.fallback.as_ref());
-    let fallback_translations = run_fallback_pass(
-        &stop_cancel_token,
-        fallback_config.as_ref(),
-        &segments,
-        std::mem::take(&mut translations),
-        &store,
-        &job.id,
-        prompt_version,
-        settings,
-        &run_config,
-        Some(&mut control_poller),
-        progress.clone(),
-    )
-    .await?;
-    translations = fallback_translations;
-    if job_was_stopped(&store, &job.id)? {
-        print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-        return Ok(());
-    }
-    if !wait_for_finalize_stage_control(&mut control_poller, &pause_signal).await? {
-        print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-        return Ok(());
-    }
-    let double_check_runtime = job_runtime_settings.borrow().clone();
-    let double_check_run_config =
-        crate::control::freeze_run_config_for_stage(&run_config, &double_check_runtime);
-    if double_check_runtime.settings.double_check.mode != DoubleCheckMode::Off
-        && !snapshot.finalize.double_check_complete
-    {
-        println!("Double-check: auditing translations...");
-        let corrections = match run_double_check(
-            ProgressRequestProvider::new(provider.clone(), progress.clone()),
-            &segments,
-            &translations,
-            &double_check_run_config,
-            &double_check_runtime.settings.double_check,
-        )
-        .await
-        {
-            Ok(corrections) => corrections,
-            Err(_)
-                if run_config
-                    .pause_signal
-                    .as_ref()
-                    .is_some_and(bookforge_llm::PauseSignal::is_stopped) =>
-            {
-                print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-                return Ok(());
-            }
-            Err(e) => return Err(anyhow::anyhow!("double-check failed: {e}")),
-        };
-        let changed_segment_ids = apply_double_check_corrections(&mut translations, &corrections);
-        persist_corrected_translations(
-            &store,
-            &job.id,
-            &double_check_run_config,
-            &translations,
-            &changed_segment_ids,
-        )?;
-        snapshot.finalize.double_check_complete = true;
-        store.update_job_config_snapshot(&job.id, &snapshot)?;
-        if job_was_stopped(&store, &job.id)? {
-            print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-            return Ok(());
-        }
-    }
-    loop {
-        if !wait_for_finalize_stage_control(&mut control_poller, &pause_signal).await? {
-            print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-            return Ok(());
-        }
-        if mark_job_finished(&store, &job.id, &translations)? {
-            break;
-        }
-        if job_was_stopped(&store, &job.id)? {
-            print_stopped_resume_hint(&job.id, human_stdout_enabled(cli_args.ui));
-            return Ok(());
-        }
-    }
-    let validation_runtime = job_runtime_settings.borrow().clone();
-    print_summary_rebuild_and_report(
-        &store,
-        &job,
-        &book,
-        &segments,
-        &translations,
-        &qa_reviews,
-        config,
-        &rebuild_options,
-        validation_runtime.validate_output,
-        cli_args.strict_epubcheck,
-        human_stdout_enabled(cli_args.ui),
-    )?;
-    let summary = store
-        .summary(&job.id)?
-        .ok_or_else(|| anyhow::anyhow!("job '{}' summary unavailable", job.id))?;
-    reconfigure::clear_overrides_for_job(&job.id)?;
-    progress.emit(bookforge_core::ProgressEvent::ArtifactWritten {
-        path: config.output.display().to_string(),
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-    progress.emit(bookforge_core::ProgressEvent::TranslationFinished {
-        succeeded: summary.succeeded,
-        cached: summary.cached,
-        needs_review: summary.needs_review,
-        failed: summary.failed,
-        input_tokens: summary.input_tokens,
-        output_tokens: summary.output_tokens,
-        elapsed_ms: started.elapsed().as_millis() as u64,
-        timestamp_ms: bookforge_core::progress::now_ms(),
-    });
-
-    Ok(())
+    .await
 }
 
 async fn run_openai_compatible_translation(
@@ -480,7 +192,30 @@ async fn run_openai_compatible_translation(
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
-    let started = std::time::Instant::now();
+    run_openai_compatible_translation_with_store(
+        input,
+        config,
+        provider_args,
+        cli_args,
+        settings,
+        cancel_token,
+        progress,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_openai_compatible_translation_with_store(
+    input: &PathBuf,
+    config: &TranslationConfig,
+    provider_args: &CliProviderArgs,
+    cli_args: &TranslateArgs,
+    settings: &ResolvedRunSettings,
+    cancel_token: &tokio_util::sync::CancellationToken,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    store: Option<JobStore>,
+) -> Result<()> {
     let mut provider_config = provider_config(
         &config.provider,
         config.model.as_deref(),
@@ -524,6 +259,62 @@ async fn run_openai_compatible_translation(
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
 
+    run_translation_with_store(
+        input,
+        config,
+        provider_args,
+        cli_args,
+        settings,
+        ProviderRun {
+            provider,
+            model,
+            prompt_version: if settings.batch.enabled {
+                PromptVersion::BatchV3.as_str()
+            } else {
+                PromptVersion::V2.as_str()
+            },
+            base_url: Some(provider_config.base_url),
+            api_key_env: Some(provider_config.api_key_env),
+            model_context_tokens: settings.provider.model_context_tokens,
+            max_output_tokens: settings.provider.max_output_tokens,
+            batch_max_output_tokens: settings.provider.batch_max_output_tokens,
+            compact_prompts: settings.compact_prompts,
+            cancel_token: cancel_token.clone(),
+        },
+        progress,
+        store,
+    )
+    .await
+}
+
+struct ProviderRun<P> {
+    provider: P,
+    model: String,
+    prompt_version: &'static str,
+    base_url: Option<String>,
+    api_key_env: Option<String>,
+    model_context_tokens: Option<u32>,
+    max_output_tokens: Option<u32>,
+    batch_max_output_tokens: Option<u32>,
+    compact_prompts: bool,
+    cancel_token: tokio_util::sync::CancellationToken,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_translation_with_store<P>(
+    input: &PathBuf,
+    config: &TranslationConfig,
+    provider_args: &CliProviderArgs,
+    cli_args: &TranslateArgs,
+    settings: &ResolvedRunSettings,
+    provider_run: ProviderRun<P>,
+    progress: Arc<dyn bookforge_core::ProgressSink>,
+    store: Option<JobStore>,
+) -> Result<()>
+where
+    P: LlmProvider + Clone,
+{
+    let started = std::time::Instant::now();
     progress.emit(bookforge_core::ProgressEvent::StageStarted {
         stage: "read_epub".to_string(),
         timestamp_ms: bookforge_core::progress::now_ms(),
@@ -543,12 +334,10 @@ async fn run_openai_compatible_translation(
         segment_count: segments.len(),
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
-    let run_prompt_version = if settings.batch.enabled {
-        PromptVersion::BatchV3.as_str()
-    } else {
-        PromptVersion::V2.as_str()
+    let store = match store {
+        Some(store) => store,
+        None => JobStore::open_default()?,
     };
-    let store = JobStore::open_default()?;
     let glossary = prepare_glossary_run_config(
         &store,
         &cli_args.glossary,
@@ -561,6 +350,12 @@ async fn run_openai_compatible_translation(
         cli_args.prompt_extra.clone(),
         &segments,
     )?;
+    let glossary_rules = select_glossary_for_segments(
+        &segments,
+        &glossary.active_terms,
+        cli_args.glossary_budget_tokens,
+    )
+    .rules_by_segment;
     let context_run_config = context_run_config_from_args(cli_args);
     let context_registry: Option<Arc<ContextRegistry>> = if context_run_config.enabled() {
         Some(Arc::new(ContextRegistry::new(&segments)))
@@ -588,9 +383,9 @@ async fn run_openai_compatible_translation(
         source_lang: config.source_language.as_deref(),
         target_lang: &config.target_language,
         provider: &config.provider,
-        model: &model,
-        base_url: Some(&provider_config.base_url),
-        api_key_env: Some(&provider_config.api_key_env),
+        model: &provider_run.model,
+        base_url: provider_run.base_url.as_deref(),
+        api_key_env: provider_run.api_key_env.as_deref(),
         book_id: cli_args.book_id.as_deref(),
         series_id: cli_args.series_id.as_deref(),
     })?;
@@ -609,7 +404,7 @@ async fn run_openai_compatible_translation(
         settings.segmentation.context_tokens,
         settings.profile.namespace_str(),
         settings.batch.enabled,
-        run_prompt_version,
+        provider_run.prompt_version,
         &glossary.fingerprint,
         if style.run_config.is_some() {
             &style.fingerprint
@@ -630,7 +425,7 @@ async fn run_openai_compatible_translation(
         provider_args,
         cli_args,
         settings,
-        run_prompt_version,
+        provider_run.prompt_version,
         &cache_namespace,
         &glossary.fingerprint,
         &glossary.active_terms,
@@ -638,17 +433,17 @@ async fn run_openai_compatible_translation(
         &style.rendered_block,
         &entities.fingerprint,
         &entities.rendered_block,
-        &model,
-        Some(provider_config.base_url.clone()),
-        Some(provider_config.api_key_env.clone()),
+        &provider_run.model,
+        provider_run.base_url.clone(),
+        provider_run.api_key_env.clone(),
     )?;
     let rebuild_options = rebuild_options_from_snapshot(&snapshot);
     store.insert_segments(
         &job.id,
         &segments,
-        run_prompt_version,
+        provider_run.prompt_version,
         &config.provider,
-        &model,
+        &provider_run.model,
         &cache_namespace,
     )?;
     let pause_signal = bookforge_llm::PauseSignal::new();
@@ -657,7 +452,7 @@ async fn run_openai_compatible_translation(
         job.id.clone(),
         progress.clone(),
         pause_signal.clone(),
-        cancel_token.clone(),
+        provider_run.cancel_token.clone(),
         crate::control::ControlBaseline {
             settings: settings.clone(),
             qa: cli_args.qa,
@@ -669,15 +464,15 @@ async fn run_openai_compatible_translation(
         source_language: config.source_language.clone(),
         target_language: config.target_language.clone(),
         provider: config.provider.clone(),
-        model: model.clone(),
-        prompt_version: run_prompt_version.to_string(),
+        model: provider_run.model.clone(),
+        prompt_version: provider_run.prompt_version.to_string(),
         temperature: 0.2,
         scheduler: settings.scheduler.clone(),
         profile: settings.profile,
-        model_context_tokens: settings.provider.model_context_tokens,
-        max_output_tokens: settings.provider.max_output_tokens,
-        batch_max_output_tokens: settings.provider.batch_max_output_tokens,
-        compact_prompts: settings.compact_prompts,
+        model_context_tokens: provider_run.model_context_tokens,
+        max_output_tokens: provider_run.max_output_tokens,
+        batch_max_output_tokens: provider_run.batch_max_output_tokens,
+        compact_prompts: provider_run.compact_prompts,
         glossary: glossary.run_config.clone(),
         context: context_run_config,
         context_registry: context_registry.clone(),
@@ -691,25 +486,24 @@ async fn run_openai_compatible_translation(
         CacheContext {
             store: &store,
             job_id: &job.id,
-            prompt_version: run_prompt_version,
+            prompt_version: provider_run.prompt_version,
             provider: &config.provider,
-            model: &model,
+            model: &provider_run.model,
             source_lang: config.source_language.as_deref(),
             target_lang: &config.target_language,
             cache_namespace: &cache_namespace,
         },
     )?;
-    let hits = translations.len();
-    let pending_count = segments.len().saturating_sub(hits);
+    let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
     progress.emit(bookforge_core::ProgressEvent::CacheScanFinished {
-        hits,
-        misses: pending_count,
+        hits: translations.len(),
+        misses: pending_segments.len(),
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
-    let pending_segments = pending_segments_for_job(&store, &job.id, &segments)?;
     prepopulate_context_registry(context_registry.as_ref(), &segments, &translations);
-    let fresh_translations = run_checkpointed_translation(
-        provider.clone(),
+    let telemetry = Arc::new(TelemetryLog::new());
+    let fresh_translations = run_checkpointed_translation_instrumented(
+        provider_run.provider.clone(),
         &pending_segments,
         &run_config,
         settings,
@@ -717,11 +511,14 @@ async fn run_openai_compatible_translation(
             store: &store,
             job_id: &job.id,
             provider: &config.provider,
-            model: &model,
-            prompt_version: run_prompt_version,
+            model: &provider_run.model,
+            prompt_version: provider_run.prompt_version,
         },
         progress.clone(),
         settings.batch.enabled,
+        telemetry.clone(),
+        &glossary_rules,
+        human_stdout_enabled(cli_args.ui),
     )
     .await?;
     if job_was_stopped(&store, &job.id)? {
@@ -731,14 +528,14 @@ async fn run_openai_compatible_translation(
     translations.extend(fresh_translations);
 
     finish_translation_pipeline(
-        &provider,
-        cancel_token,
+        &provider_run.provider,
+        &provider_run.cancel_token,
         cli_args,
         &segments,
         &mut translations,
         &store,
         &job,
-        run_prompt_version,
+        provider_run.prompt_version,
         settings,
         &run_config,
         config,
@@ -748,10 +545,20 @@ async fn run_openai_compatible_translation(
         started,
         &mut snapshot,
         &job_runtime_settings,
+        telemetry.as_ref(),
+        &glossary_rules,
     )
     .await?;
 
-    if cancel_token.is_cancelled() && !job_was_stopped(&store, &job.id)? {
+    if telemetry.has_glossary_entries() {
+        let summary = telemetry.glossary_summary();
+        tracing::info!(target: "bookforge::telemetry", "{summary}");
+        if human_stdout_enabled(cli_args.ui) {
+            eprintln!("{summary}");
+        }
+    }
+
+    if provider_run.cancel_token.is_cancelled() && !job_was_stopped(&store, &job.id)? {
         let _ = store.mark_job_interrupted(&job.id);
         eprintln!();
         eprintln!("Interrupted by user.");

--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -6,7 +6,18 @@ use bookforge_core::{
         SegmentMetadata, SegmentSource, SegmentTextRun,
     },
 };
-use std::{fs, time::SystemTime};
+use std::{fs, io::Write, sync::Mutex, time::SystemTime};
+
+#[derive(Default)]
+struct RecordingProgressSink {
+    events: Mutex<Vec<bookforge_core::ProgressEvent>>,
+}
+
+impl bookforge_core::ProgressSink for RecordingProgressSink {
+    fn emit(&self, event: bookforge_core::ProgressEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
 
 #[test]
 fn toki_pona_text_only_retry_guidance_downgrades_only_the_targeted_batch() {
@@ -150,6 +161,121 @@ async fn scheduler_guard_preserves_completed_segments_on_run_level_error() {
 }
 
 #[tokio::test]
+async fn mock_and_openai_entry_points_share_events_and_artifacts() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = temp.path().join("input.epub");
+    build_translation_fixture(&input);
+    let mock_output = temp.path().join("mock.epub");
+    let openai_output = temp.path().join("openai.epub");
+    let mock_store_path = temp.path().join("mock.sqlite");
+    let openai_store_path = temp.path().join("openai.sqlite");
+
+    let mut settings = TranslationProfile::V1Fast.resolve();
+    settings.batch.enabled = false;
+    settings.scheduler.concurrency = 1;
+    settings.scheduler.max_attempts = 1;
+    settings.provider.provider_max_attempts = 1;
+    settings.provider.json_mode = bookforge_core::JsonMode::PromptOnly;
+
+    let mut mock_args = translate_args_with_preset(None);
+    mock_args.input = input.clone();
+    mock_args.out = Some(mock_output.clone());
+    mock_args.language.target = "English".to_string();
+    mock_args.provider.provider = "mock".to_string();
+    mock_args.provider.model = Some("mock-prefix-target".to_string());
+    let mock_config = TranslationConfig {
+        source_language: Some("English".to_string()),
+        target_language: "English".to_string(),
+        provider: "mock".to_string(),
+        model: Some("mock-prefix-target".to_string()),
+        concurrency: 1,
+        max_attempts: 1,
+        output: mock_output.clone(),
+    };
+    let mock_progress = Arc::new(RecordingProgressSink::default());
+    orchestration::run_mock_translation_with_store(
+        &input,
+        &mock_config,
+        &mock_args.provider,
+        &mock_args,
+        &settings,
+        &tokio_util::sync::CancellationToken::new(),
+        mock_progress.clone(),
+        Some(JobStore::open(&mock_store_path).unwrap()),
+    )
+    .await
+    .expect("mock entry point should finish");
+
+    let (base_url, server) = spawn_openai_prefix_server().await;
+    let mut openai_args = translate_args_with_preset(None);
+    openai_args.input = input.clone();
+    openai_args.out = Some(openai_output.clone());
+    openai_args.language.target = "English".to_string();
+    openai_args.provider.provider = "openai-compatible".to_string();
+    openai_args.provider.model = Some("test-model".to_string());
+    openai_args.provider.base_url = Some(base_url);
+    openai_args.provider.api_key_env = Some("OLLAMA_API_KEY".to_string());
+    let openai_config = TranslationConfig {
+        source_language: Some("English".to_string()),
+        target_language: "English".to_string(),
+        provider: "openai-compatible".to_string(),
+        model: Some("test-model".to_string()),
+        concurrency: 1,
+        max_attempts: 1,
+        output: openai_output.clone(),
+    };
+    let openai_progress = Arc::new(RecordingProgressSink::default());
+    orchestration::run_openai_compatible_translation_with_store(
+        &input,
+        &openai_config,
+        &openai_args.provider,
+        &openai_args,
+        &settings,
+        &tokio_util::sync::CancellationToken::new(),
+        openai_progress.clone(),
+        Some(JobStore::open(&openai_store_path).unwrap()),
+    )
+    .await
+    .expect("OpenAI-compatible entry point should finish");
+    server.abort();
+
+    let openai_job_id = openai_progress
+        .events
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|event| match event {
+            bookforge_core::ProgressEvent::JobCreated { job_id, .. } => Some(job_id.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let openai_records = JobStore::open(&openai_store_path)
+        .unwrap()
+        .segment_records(&openai_job_id)
+        .unwrap();
+    assert!(
+        openai_records.iter().all(|record| record.error.is_none()),
+        "OpenAI-compatible stub should produce valid translations: {openai_records:?}"
+    );
+
+    assert_eq!(
+        fs::read(mock_output).unwrap(),
+        fs::read(openai_output).unwrap(),
+        "provider construction must not change the rebuilt EPUB"
+    );
+
+    let mock_events = progress_event_kinds(&mock_progress.events.lock().unwrap());
+    let openai_events = progress_event_kinds(&openai_progress.events.lock().unwrap())
+        .into_iter()
+        .filter(|kind| kind != "RuntimeConfigResolved")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        mock_events, openai_events,
+        "the only intentional event difference is runtime provider resolution"
+    );
+}
+
+#[tokio::test]
 async fn fallback_pass_honors_stop_control_file() {
     let db_path = temp_path("fallback_stop.sqlite");
     let input_path = temp_path("fallback_stop_input.epub");
@@ -237,7 +363,6 @@ async fn fallback_pass_honors_stop_control_file() {
         control_path.clone(),
         Arc::new(NullProgressSink),
     );
-
     let result = run_fallback_pass(
         &tokio_util::sync::CancellationToken::new(),
         Some(&fallback_config),
@@ -649,6 +774,177 @@ fn temp_path(name: &str) -> PathBuf {
         "bookforge-cli-test-{}-{nanos}-{seq}-{name}",
         std::process::id()
     ))
+}
+
+fn build_translation_fixture(path: &std::path::Path) {
+    let file = fs::File::create(path).expect("fixture EPUB should be creatable");
+    let mut zip = zip::ZipWriter::new(file);
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let deflated = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/epub+zip").unwrap();
+    zip.start_file("META-INF/container.xml", deflated).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#,
+    )
+    .unwrap();
+    zip.start_file("content.opf", deflated).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">orchestration-fixture</dc:identifier>
+    <dc:title></dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="chapter"/></spine>
+</package>"#,
+    )
+    .unwrap();
+    zip.start_file("chapter.xhtml", deflated).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Chapter</title></head>
+<body><p>Hello world.</p></body>
+</html>"#,
+    )
+    .unwrap();
+    zip.finish().unwrap();
+}
+
+async fn spawn_openai_prefix_server() -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test server should bind");
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end = loop {
+                let Ok(read) = stream.read(&mut chunk).await else {
+                    break None;
+                };
+                if read == 0 {
+                    break None;
+                }
+                request.extend_from_slice(&chunk[..read]);
+                if let Some(index) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                    break Some(index + 4);
+                }
+            };
+            let Some(header_end) = header_end else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("Content-Length: ")
+                        .or_else(|| line.strip_prefix("content-length: "))
+                })
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            while request.len() < header_end + content_length {
+                let Ok(read) = stream.read(&mut chunk).await else {
+                    break;
+                };
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let body: serde_json::Value =
+                serde_json::from_slice(&request[header_end..header_end + content_length]).unwrap();
+            let user = body["messages"][1]["content"].as_str().unwrap();
+            let user = user.replace("\r\n", "\n");
+            let segment_id = user
+                .rsplit_once(r#""segment_id": ""#)
+                .and_then(|(_, value)| value.split('"').next())
+                .unwrap();
+            let completion =
+                if let Some((_, source_blocks)) = user.split_once("Source blocks:\n\n```json\n") {
+                    let source_blocks = source_blocks.split_once("\n```").unwrap().0;
+                    let blocks = serde_json::from_str::<Vec<serde_json::Value>>(source_blocks)
+                        .unwrap()
+                        .into_iter()
+                        .map(|block| {
+                            serde_json::json!({
+                                "block_id": block["block_id"],
+                                "translation": format!(
+                                    "[English] {}",
+                                    block["text"].as_str().unwrap()
+                                ),
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    serde_json::json!({"segment_id": segment_id, "blocks": blocks}).to_string()
+                } else {
+                    let source = user
+                        .split_once("Source segment:\n\n```txt\n")
+                        .and_then(|(_, value)| value.split_once("\n```"))
+                        .map(|(source, _)| source)
+                        .unwrap();
+                    serde_json::json!({
+                        "segment_id": segment_id,
+                        "translation": format!("[English] {source}"),
+                    })
+                    .to_string()
+                };
+            let response_body = serde_json::json!({
+                "choices": [{
+                    "message": {"content": completion},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            })
+            .to_string();
+            let response_headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                response_body.len()
+            );
+            stream.write_all(response_headers.as_bytes()).await.unwrap();
+            stream.write_all(response_body.as_bytes()).await.unwrap();
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    (format!("http://{address}"), server)
+}
+
+fn progress_event_kinds(events: &[bookforge_core::ProgressEvent]) -> Vec<String> {
+    events
+        .iter()
+        .map(|event| {
+            serde_json::to_value(event)
+                .unwrap()
+                .as_object()
+                .and_then(|object| object.keys().next())
+                .expect("progress event should serialize as a tagged object")
+                .clone()
+        })
+        .collect()
 }
 
 #[test]

--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -270,6 +270,25 @@ pub struct GlossaryPromptTerm {
     pub case_sensitive: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GlossarySelectionRule {
+    SegmentMatched,
+    AlwaysActive,
+    RecentlyActive,
+    HighFrequencyAnchor,
+}
+
+impl GlossarySelectionRule {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SegmentMatched => "segment_matched",
+            Self::AlwaysActive => "always_active",
+            Self::RecentlyActive => "recently_active",
+            Self::HighFrequencyAnchor => "high_frequency_anchor",
+        }
+    }
+}
+
 impl GlossaryPromptTerm {
     fn from_term(term: &GlossaryTerm) -> Self {
         Self {
@@ -286,6 +305,11 @@ impl GlossaryPromptTerm {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentGlossarySelections {
     pub entries_by_segment: HashMap<String, Vec<GlossaryPromptTerm>>,
+    /// Selection rules aligned by index with `entries_by_segment`.
+    ///
+    /// This metadata is intentionally kept out of `GlossaryPromptTerm` so it
+    /// never changes the serialized prompt or its cache identity.
+    pub rules_by_segment: HashMap<String, Vec<GlossarySelectionRule>>,
     pub truncated_authoritative_entries: usize,
 }
 
@@ -329,20 +353,31 @@ pub fn select_glossary_for_segments(
     let computed_counts = source_counts(segments, &terms);
     let high_frequency = high_frequency_anchors(&terms, &computed_counts, 20);
     let mut entries_by_segment = HashMap::new();
+    let mut rules_by_segment = HashMap::new();
     let mut truncated_authoritative_entries = 0usize;
 
     for (index, segment) in segments.iter().enumerate() {
-        let mut selected = Vec::<&GlossaryTerm>::new();
+        let mut selected = Vec::<(&GlossaryTerm, GlossarySelectionRule)>::new();
         let mut seen = HashSet::<i64>::new();
 
         for term in &terms {
             if term_matches(&segment.source.text, term) {
-                push_term(&mut selected, &mut seen, term);
+                push_term(
+                    &mut selected,
+                    &mut seen,
+                    term,
+                    GlossarySelectionRule::SegmentMatched,
+                );
             }
         }
 
         for term in terms.iter().filter(|term| term.always_active) {
-            push_term(&mut selected, &mut seen, term);
+            push_term(
+                &mut selected,
+                &mut seen,
+                term,
+                GlossarySelectionRule::AlwaysActive,
+            );
         }
 
         let start = index.saturating_sub(5);
@@ -352,28 +387,38 @@ pub fn select_glossary_for_segments(
             }
             for term in &terms {
                 if term_matches(&previous.source.text, term) {
-                    push_term(&mut selected, &mut seen, term);
+                    push_term(
+                        &mut selected,
+                        &mut seen,
+                        term,
+                        GlossarySelectionRule::RecentlyActive,
+                    );
                 }
             }
         }
 
         for term in &high_frequency {
-            push_term(&mut selected, &mut seen, term);
+            push_term(
+                &mut selected,
+                &mut seen,
+                term,
+                GlossarySelectionRule::HighFrequencyAnchor,
+            );
         }
 
         let (bounded, truncated) = enforce_budget(selected, budget_tokens);
         truncated_authoritative_entries += truncated;
-        entries_by_segment.insert(
-            segment.id.0.clone(),
-            bounded
-                .into_iter()
-                .map(GlossaryPromptTerm::from_term)
-                .collect(),
-        );
+        let (entries, rules) = bounded
+            .into_iter()
+            .map(|(term, rule)| (GlossaryPromptTerm::from_term(term), rule))
+            .unzip();
+        entries_by_segment.insert(segment.id.0.clone(), entries);
+        rules_by_segment.insert(segment.id.0.clone(), rules);
     }
 
     SegmentGlossarySelections {
         entries_by_segment,
+        rules_by_segment,
         truncated_authoritative_entries,
     }
 }
@@ -403,25 +448,29 @@ pub fn target_matches(text: &str, term: &GlossaryTerm) -> bool {
 }
 
 fn push_term<'a>(
-    selected: &mut Vec<&'a GlossaryTerm>,
+    selected: &mut Vec<(&'a GlossaryTerm, GlossarySelectionRule)>,
     seen: &mut HashSet<i64>,
     term: &'a GlossaryTerm,
+    rule: GlossarySelectionRule,
 ) {
     let synthetic = term.synthetic_id();
     if seen.insert(synthetic) {
-        selected.push(term);
+        selected.push((term, rule));
     }
 }
 
-fn enforce_budget(terms: Vec<&GlossaryTerm>, budget_tokens: usize) -> (Vec<&GlossaryTerm>, usize) {
+fn enforce_budget(
+    terms: Vec<(&GlossaryTerm, GlossarySelectionRule)>,
+    budget_tokens: usize,
+) -> (Vec<(&GlossaryTerm, GlossarySelectionRule)>, usize) {
     let mut used = 0usize;
     let mut kept = Vec::new();
     let mut truncated = 0usize;
-    for term in terms {
+    for (term, rule) in terms {
         let estimate = estimate_prompt_tokens(term);
         if used + estimate <= budget_tokens || kept.is_empty() {
             used += estimate;
-            kept.push(term);
+            kept.push((term, rule));
         } else if term.status == GlossaryStatus::UserSeeded || term.always_active {
             truncated += 1;
         }
@@ -842,6 +891,43 @@ mod tests {
         let second = &selected.entries_by_segment["seg_2"];
         assert!(second.iter().any(|entry| entry.source == "Ring"));
         assert!(second.iter().any(|entry| entry.source == "you"));
+    }
+
+    #[test]
+    fn selection_rules_are_credited_only_when_they_inject_an_entry() {
+        let mut matched = term("Matched", "Corrisposto", GlossaryScopeKind::Book);
+        matched.category = GlossaryCategory::Phrase;
+        let mut always = term("Always", "Sempre", GlossaryScopeKind::Book);
+        always.category = GlossaryCategory::Style;
+        always.always_active = true;
+        let mut recent = term("Recent", "Recente", GlossaryScopeKind::Book);
+        recent.category = GlossaryCategory::Phrase;
+        let mut anchor = term("Anchor", "Ancora", GlossaryScopeKind::Book);
+        anchor.category = GlossaryCategory::Person;
+        anchor.source_count = 100;
+        let segments = vec![
+            segment("seg_1", 0, "Recent appeared earlier"),
+            segment("seg_2", 1, "Matched appears now"),
+        ];
+
+        let selections =
+            select_glossary_for_segments(&segments, &[matched, always, recent, anchor], 800);
+        let entries = &selections.entries_by_segment["seg_2"];
+        let rules = &selections.rules_by_segment["seg_2"];
+        let credited = entries
+            .iter()
+            .zip(rules)
+            .map(|(entry, rule)| (entry.source.as_str(), *rule))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(credited["Matched"], GlossarySelectionRule::SegmentMatched);
+        assert_eq!(credited["Always"], GlossarySelectionRule::AlwaysActive);
+        assert_eq!(credited["Recent"], GlossarySelectionRule::RecentlyActive);
+        assert_eq!(
+            credited["Anchor"],
+            GlossarySelectionRule::HighFrequencyAnchor
+        );
+        assert_eq!(credited.len(), 4);
     }
 
     #[test]

--- a/crates/bookforge-llm/src/telemetry.rs
+++ b/crates/bookforge-llm/src/telemetry.rs
@@ -1,14 +1,23 @@
 use bookforge_core::config::ProviderRequestMetric;
-use std::sync::Mutex;
+use bookforge_core::glossary::GlossarySelectionRule;
+use std::{collections::HashMap, sync::Mutex};
 
 pub struct TelemetryLog {
     entries: Mutex<Vec<ProviderRequestMetric>>,
+    glossary_rules: Mutex<HashMap<GlossarySelectionRule, GlossaryRuleCounters>>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct GlossaryRuleCounters {
+    injected: usize,
+    honored: usize,
 }
 
 impl TelemetryLog {
     pub fn new() -> Self {
         Self {
             entries: Mutex::new(Vec::new()),
+            glossary_rules: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -28,6 +37,54 @@ impl TelemetryLog {
 
     pub fn snapshot(&self) -> Vec<ProviderRequestMetric> {
         self.entries.lock().map(|e| e.clone()).unwrap_or_default()
+    }
+
+    pub fn record_glossary_entry(&self, rule: GlossarySelectionRule, honored: bool) {
+        if let Ok(mut rules) = self.glossary_rules.lock() {
+            let counters = rules.entry(rule).or_default();
+            counters.injected += 1;
+            counters.honored += usize::from(honored);
+        }
+    }
+
+    pub fn glossary_rule_counts(&self, rule: GlossarySelectionRule) -> (usize, usize) {
+        self.glossary_rules
+            .lock()
+            .ok()
+            .and_then(|rules| rules.get(&rule).copied())
+            .map(|counters| (counters.injected, counters.honored))
+            .unwrap_or_default()
+    }
+
+    pub fn has_glossary_entries(&self) -> bool {
+        self.glossary_rules
+            .lock()
+            .is_ok_and(|rules| rules.values().any(|counters| counters.injected > 0))
+    }
+
+    pub fn glossary_summary(&self) -> String {
+        const RULES: [GlossarySelectionRule; 4] = [
+            GlossarySelectionRule::SegmentMatched,
+            GlossarySelectionRule::AlwaysActive,
+            GlossarySelectionRule::RecentlyActive,
+            GlossarySelectionRule::HighFrequencyAnchor,
+        ];
+
+        let rules = self.glossary_rules.lock().ok();
+        let rendered = RULES.map(|rule| {
+            let counters = rules
+                .as_ref()
+                .and_then(|rules| rules.get(&rule))
+                .copied()
+                .unwrap_or_default();
+            format!(
+                "{} injected={} honored={}",
+                rule.as_str(),
+                counters.injected,
+                counters.honored
+            )
+        });
+        format!("glossary rules | {}", rendered.join(" | "))
     }
 }
 
@@ -69,4 +126,32 @@ fn percentile(sorted: &[u64], pct: f64) -> u64 {
     }
     let idx = ((pct / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
     sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glossary_counters_increment_only_the_recorded_rule() {
+        let rules = [
+            GlossarySelectionRule::SegmentMatched,
+            GlossarySelectionRule::AlwaysActive,
+            GlossarySelectionRule::RecentlyActive,
+            GlossarySelectionRule::HighFrequencyAnchor,
+        ];
+
+        for rule in rules {
+            let telemetry = TelemetryLog::new();
+            telemetry.record_glossary_entry(rule, false);
+            assert_eq!(telemetry.glossary_rule_counts(rule), (1, 0));
+            for other in rules {
+                if other != rule {
+                    assert_eq!(telemetry.glossary_rule_counts(other), (0, 0));
+                }
+            }
+            telemetry.record_glossary_entry(rule, true);
+            assert_eq!(telemetry.glossary_rule_counts(rule), (2, 1));
+        }
+    }
 }


### PR DESCRIPTION
`run_mock_translation` and `run_openai_compatible_translation` each carried a ~300-line copy of the pipeline — and they had **already drifted**.

That matters more than ordinary duplication: the mock path is what the offline test suite exercises. **The tests were not testing the code a real book runs through.**

Both entry points are now thin wrappers over one generic `run_translation_with_store<P: LlmProvider>`. `orchestration.rs` went from **766 to 573 lines**.

## Four genuine divergences, none deliberate

Unifying surfaced real behavioural differences, not just structural ones:

| divergence | effect |
| --- | --- |
| Mock batch runs used **prompt V2 instead of V3** | and ignored model limits and compact-prompt settings |
| Mock runs used a **separate cancellation token** | cancellation semantics differed from production |
| Mock finalization **ignored explicit double-check provider/model selection** | and differed in correction and checkpoint behaviour |
| Cache-miss counts computed differently | equivalent under current invariants — but only by coincidence |

The **real pipeline was taken as canonical** in every case, on the grounds that it honours the runtime configuration the user actually requested.

A new equivalence test asserts both entry points produce identical artifacts and event sequences for the same input, excluding the one deliberate real-only runtime-config event. The paths cannot silently diverge again.

## Glossary rule instrumentation

`docs/ROADMAP.md` §5.8 has carried an open follow-up since 2026-07-03:

> Ranking rules 3 and 4 were specified before any usage evidence existed, and nothing instruments whether they ever fire usefully. Before extending this machinery further, add counters and check the data; if rules 3–4 contribute nothing measurable, simplify rather than extend.

Every injected entry is now attributed to exactly one of `segment_matched`, `always_active`, `recently_active` or `high_frequency_anchor` — deduplicated entries credited to the first rule that selected them — and telemetry reports **injected** and **honoured** counts per rule.

"Honoured" is the cheap textual check that the output contains the target term, respecting the entry's case-sensitivity setting. Cache hits are not counted.

**Ranking behaviour is unchanged**, and §5.8 stays open. The roadmap asks for measurement before modification, and that sequencing has already proven right once in this codebase — a protected-span heuristic survived four rounds of tuning before measurement showed the tuning wasn't improving precision.

## Smaller items

- Fallback `temperature: 0.2` and `concurrency: 1` kept as deliberate recovery policy, now with a comment saying so rather than looking like a leftover.
- `Batches: N` no longer prints unconditionally into non-human UI modes, where it could smudge the TUI.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **830 passed / 0 failed / 3 ignored** (was 827).

This is a refactor: no user-visible behaviour change was intended, and the four divergences above are cases where the mock path was brought into line with production rather than the reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
