### PR TITLE
test(translate): stop asserting an order the checkpoint actor does not guarantee

### DIFF
--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -269,9 +269,40 @@ async fn mock_and_openai_entry_points_share_events_and_artifacts() {
         .into_iter()
         .filter(|kind| kind != "RuntimeConfigResolved")
         .collect::<Vec<_>>();
+
+    // The checkpoint writer is a separate actor so the hot path never blocks on
+    // SQLite, which means `CheckpointQueued` and `CheckpointFlushed` interleave
+    // nondeterministically with the scheduler's own events. Asserting a total
+    // order over them encodes an invariant the system deliberately does not
+    // have, and fails intermittently under different scheduling. Compare the
+    // full multiset — so no event can be silently lost or duplicated — and the
+    // order of everything else.
+    fn kind_counts(kinds: &[String]) -> std::collections::BTreeMap<&str, usize> {
+        let mut counts = std::collections::BTreeMap::new();
+        for kind in kinds {
+            *counts.entry(kind.as_str()).or_insert(0) += 1;
+        }
+        counts
+    }
     assert_eq!(
-        mock_events, openai_events,
-        "the only intentional event difference is runtime provider resolution"
+        kind_counts(&mock_events),
+        kind_counts(&openai_events),
+        "both entry points must emit the same events; the only intentional \
+         difference is runtime provider resolution"
+    );
+
+    const CHECKPOINT_ACTOR_EVENTS: [&str; 2] = ["CheckpointQueued", "CheckpointFlushed"];
+    let ordered = |kinds: &[String]| {
+        kinds
+            .iter()
+            .filter(|kind| !CHECKPOINT_ACTOR_EVENTS.contains(&kind.as_str()))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        ordered(&mock_events),
+        ordered(&openai_events),
+        "the deterministic event sequence must match between entry points"
     );
 }
 


### PR DESCRIPTION
Follow-up to #73, which I merged after verifying locally — the flake only appears under CI's scheduling. `main` currently has an intermittently-failing test; this fixes it.

## The failure

```
left:  ... RequestFinished, CheckpointQueued, SegmentFinished, CheckpointFlushed ...
right: ... RequestFinished, SegmentFinished, CheckpointFlushed, CheckpointQueued ...
```

Identical event kinds, different interleaving. Passed **8/8 locally on Windows**, failed on CI's Ubuntu runner.

`CheckpointQueued` and `CheckpointFlushed` come from the checkpoint-writer actor, which runs concurrently with the scheduler **precisely so the hot path never blocks on SQLite**. Their position relative to `SegmentFinished` is nondeterministic by design — so a total order over them asserts an invariant the system deliberately does not have.

## Fix

Keeps both halves of what the test is genuinely for:

- **Full multiset of event kinds must match** — no event can be silently lost or duplicated between the two paths.
- **Order of everything outside the checkpoint actor must match** — a regression that scrambled `JobCreated` → `RequestStarted` → `ArtifactWritten` → `TranslationFinished` still fails.

A comment records why those two events are exempt, so it doesn't get "fixed" back into a total order later.

This is the same family as the four wall-clock races in #67, with a different shape: not a timeout that starves under load, but an **ordering assumption over concurrent producers**. Worth noting for future test review — the tell is asserting sequence across an actor boundary.

## Verification

20/20 in isolation, plus a cold-rebuild contention run of the full workspace. `fmt` and `clippy -D warnings` clean, **830 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)