### PR TITLE
chore(serve): serve ElevenLabs per-model limits instead of copying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ local browser-based translation runs:
 | Generate audiobooks | [Audiobooks](docs/audiobooks.md) |
 | Understand EPUB parsing and rebuilding | [EPUB pipeline](docs/EPUB_PIPELINE.md) |
 | Understand the system design and crate boundaries | [Architecture](docs/ARCHITECTURE.md) |
+| Measure whether a validator flag is real | [Validator tooling](docs/validator-tooling.md) |
 | Contribute code or documentation | [Contributing](CONTRIBUTING.md) |
 
 ## Install And Setup

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -14,7 +14,7 @@
 //! - Binds `127.0.0.1` by default; the book text is private.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     convert::Infallible,
     ffi::OsString,
     net::SocketAddr,
@@ -2897,6 +2897,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 supports_instructions: false,
                 supports_speed: true,
                 max_chars: 40_000,
+                model_max_chars: BTreeMap::new(),
             },
             AudioProviderOption {
                 id: "openai",
@@ -2912,6 +2913,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 supports_instructions: true,
                 supports_speed: true,
                 max_chars: 4_096,
+                model_max_chars: BTreeMap::new(),
             },
             AudioProviderOption {
                 id: "gemini",
@@ -2927,6 +2929,7 @@ fn dashboard_options_payload() -> DashboardOptions {
                 supports_instructions: true,
                 supports_speed: false,
                 max_chars: 4_096,
+                model_max_chars: BTreeMap::new(),
             },
             AudioProviderOption {
                 id: "elevenlabs",
@@ -2944,6 +2947,15 @@ fn dashboard_options_payload() -> DashboardOptions {
                 max_chars: bookforge_audio::elevenlabs_model_max_input_chars(
                     "eleven_multilingual_v2",
                 ),
+                model_max_chars: AUDIO_ELEVENLABS_MODELS
+                    .iter()
+                    .map(|model| {
+                        (
+                            *model,
+                            bookforge_audio::elevenlabs_model_max_input_chars(model),
+                        )
+                    })
+                    .collect(),
             },
         ],
         ffmpeg_available: bookforge_audio::ffmpeg_available(),
@@ -3355,6 +3367,9 @@ struct AudioProviderOption {
     supports_instructions: bool,
     supports_speed: bool,
     max_chars: usize,
+    /// Per-model input ceilings, so the browser never keeps its own copy of a
+    /// provider's limits. Empty when every model shares `max_chars`.
+    model_max_chars: BTreeMap<&'static str, usize>,
 }
 
 impl JobDetail {
@@ -3658,6 +3673,43 @@ mod tests {
             audio_provider_max_chars("elevenlabs", "eleven_flash_v2_5"),
             40_000
         );
+    }
+
+    /// The browser used to carry its own table of ElevenLabs per-model limits,
+    /// which is a copy that can drift from the one synthesis actually enforces.
+    /// The options payload now serves them, so guard both halves: the payload
+    /// agrees with the canonical function, and the JS no longer hardcodes them.
+    #[test]
+    fn audio_options_serve_per_model_limits_so_the_browser_keeps_no_copy() {
+        let options = dashboard_options_payload();
+        let elevenlabs = options
+            .audio_providers
+            .iter()
+            .find(|provider| provider.id == "elevenlabs")
+            .expect("elevenlabs provider should be offered");
+
+        assert!(
+            !elevenlabs.model_max_chars.is_empty(),
+            "per-model limits must reach the browser"
+        );
+        for model in elevenlabs.models {
+            assert_eq!(
+                elevenlabs.model_max_chars.get(model).copied(),
+                Some(bookforge_audio::elevenlabs_model_max_input_chars(model)),
+                "served limit for {model} must match the synthesis path"
+            );
+        }
+
+        assert!(
+            DASHBOARD_JS.contains("provider.model_max_chars"),
+            "the browser must read limits from the payload"
+        );
+        for stale in ["eleven_flash_v2_5:40000", "eleven_v3:5000"] {
+            assert!(
+                !DASHBOARD_JS.contains(stale),
+                "dashboard.js must not reintroduce a hardcoded limit table ({stale})"
+            );
+        }
     }
 
     #[test]
@@ -4352,14 +4404,14 @@ mod tests {
     fn dashboard_assets_reassemble_byte_stably() {
         use sha2::{Digest, Sha256};
 
-        assert_eq!(DASHBOARD_HTML.len(), 113_200);
+        assert_eq!(DASHBOARD_HTML.len(), 113_292);
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_CSS}}"));
         assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_JS}}"));
         let digest = Sha256::digest(DASHBOARD_HTML.as_bytes());
         let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
         assert_eq!(
             digest_hex,
-            "440a46cbeb6a7630f488d337b5e22ecc077f69c86b7f108e8a895a309362dd3c"
+            "908c441831ab32699345eedd9157909c26c8477d7c1e893d5c176daeb351c486"
         );
 
         let crlf = |asset: &str| asset.replace("\r\n", "\n").replace('\n', "\r\n");

--- a/crates/bookforge-cli/src/commands/serve/dashboard.js
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.js
@@ -458,12 +458,13 @@ function audioProviderOption(id) {
       default_voice:"mock", formats:["wav"], default_format:"wav", requires_key:false,
       requires_voice:false, supports_auto_model:false, supports_instructions:false, supports_speed:true, max_chars:40000 };
 }
+// Per-model ceilings come from /api/options, which sources them from the same
+// Rust function the synthesis path uses. Do not reintroduce a table here: a
+// second copy of a provider's limits will drift from the first.
 function audioProviderMaxChars(provider, model) {
-  if (provider.id === "elevenlabs") {
-    const limits = { eleven_v3:5000, eleven_multilingual_v1:10000, eleven_multilingual_v2:10000,
-      eleven_flash_v2:30000, eleven_turbo_v2:30000, eleven_flash_v2_5:40000, eleven_turbo_v2_5:40000 };
-    return limits[model] || 10000;
-  }
+  const perModel = provider.model_max_chars || {};
+  const limit = Number(perModel[model]);
+  if (Number.isFinite(limit) && limit > 0) return limit;
   return Math.max(1, Number(provider.max_chars) || 4096);
 }
 function bfAudioProvider(id) {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,8 @@ the milestones below.
 > audiobook narration hierarchy, chaptered `.m4b` output by default,
 > ElevenLabs consistency controls, cost/quota estimates, WebUI parity, and OCR
 > endpoint foundations. v2.6.1 was prepared and merged to `main` on 2026-07-21
-> with security-audit remediation and two ElevenLabs fixes; its tag is pending.
+> with security-audit remediation and two ElevenLabs fixes, and was tagged and
+> released on 2026-07-22.
 > This document is kept for architectural invariants, shipped-milestone
 > context, and deferred follow-up work. For current user behavior, start
 > with `README.md`, `CHANGELOG.md`, and `docs/v2-web-dashboard-plan.md`;

--- a/docs/review-checklist.md
+++ b/docs/review-checklist.md
@@ -115,6 +115,76 @@ Batch / scheduler invariants (if the milestone touches `batch.rs`):
 - Repair batches use a sentinel value for any field they don't
   participate in.
 
+### Partial failure reported as success
+
+Three independent subsystem audits on 2026-07-27 converged on one recurring
+defect shape, found at six separate sites. It is the single most productive
+thing to look for in this codebase, so check it explicitly.
+
+The pattern: an operation partly fails, and the failure is converted into a
+success signal somewhere downstream. Real instances, all now fixed:
+
+- A batch response missing requested items returned `Ok`, and the caller — which
+  never inspected the failures it carried — told the adaptive sizer it had
+  succeeded. The sizer then **grew** the batch, so more items were dropped. A
+  compounding loop, not an edge case.
+- An empty translation for a non-empty source was marked `Succeeded`, became
+  cache-eligible, and erased the prose on rebuild.
+- `--chapters N --prune` reported "removed stale chunks" while deleting every
+  unselected chapter's paid audio.
+- ffmpeg failing mid-encode still emitted `"status": "succeeded"` with a null
+  audiobook, having already overwritten a previously good file.
+- The dashboard reported "Resume worker started" after a 150 ms check, before
+  provider construction, so a worker that died for want of an API key looked
+  fine.
+- `.m4b` assembly silently dropped chapter markers when a duration probe failed
+  and still reported the requested deliverable.
+
+Questions worth asking of any PR:
+
+- Does an `Ok`/success value here carry a failure list that nobody reads?
+- Can this report success before the thing it reports on has actually happened?
+- If this partially succeeds, is the partial state distinguishable from the
+  complete one *by a caller*, not just in a log line?
+- Does a "safe to delete" comment state the precondition it actually needs?
+
+Related: a check that cannot fail usefully is the same disease. Before adding a
+validator, ask what it would take for it to be wrong, and see
+`docs/validator-tooling.md` for how to measure that after the fact.
+
+### Test timing and ordering
+
+Four wall-clock races and one ordering race were removed on 2026-07-27. They
+are easy to reintroduce, and each shape needs a **different** fix — applying the
+wrong one makes things worse.
+
+1. **Polling a condition against a deadline.** The deadline *is* the pass/fail
+   criterion, so under load an alive-but-unscheduled process is
+   indistinguishable from a dead one. Raising the timeout is wrong; wait on a
+   real signal instead (an event the production code already emits), while
+   watching for premature exit so genuine failures still fail fast.
+2. **An assertion racing a production time window.** The window is product
+   behaviour and must not move to suit a test. Make the threshold injectable,
+   keep the production default, and let only the specific test opt out.
+3. **Awaiting a real signal with a timeout as deadlock insurance.** Here the
+   `await` is the criterion and the timeout only prevents a hang, so a tight
+   budget buys nothing and converts slow scheduling into a false failure.
+   **Raising it to something generous (30s+) is correct.**
+4. **Asserting order across an actor boundary.** The checkpoint writer runs
+   concurrently with the scheduler by design, so its events interleave
+   nondeterministically. Compare a multiset of event kinds plus the order of
+   everything outside the actor — never a total order.
+
+Some timeouts must stay tight: a test verifying that a 1 ms deadline expires is
+testing elapsed time, and lengthening it destroys the test. Judgement, not a
+blanket rule.
+
+**Verification standard:** these failures are probabilistic under load, and each
+cold run picks a different victim. Two clean runs is not evidence — that is how
+the third and fourth races survived two separate attempts. Reproduce with
+`cargo clean -p bookforge-llm -p bookforge-epub -p bookforge-cli` followed
+immediately by `cargo test --workspace`, at least three times.
+
 ### Security / privacy
 
 - API keys: `--api-key-env` is still the only key intake path. No new

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -1,0 +1,118 @@
+# Measuring validator quality
+
+BookForge flags a translated segment as `needs_review` when a deterministic,
+string-level check fires. Those checks have no model of meaning, so some
+proportion of what they flag is wrong — and until 2026-07-26 nothing measured
+which proportion.
+
+Two dev-time examples exist to answer that. Neither is wired into `translate`,
+and neither should be: a model that gated or repaired translations would violate
+the architectural invariants in `ROADMAP.md` §1.1–§1.2.
+
+```
+cargo run --release --example replay_validation -- --help
+cargo run --release --example judge_flags -- --help
+```
+
+## `replay_validation` — replay the validator offline, for free
+
+`batch_item_validation_error` is a pure function over (source block, model
+output). Everything it needs is already on disk: each job's `input.epub`
+snapshot plus the per-block translations the run stored. So validation logic can
+be re-run over real books without calling a provider.
+
+```
+cargo run --release --example replay_validation -- --target-lang Italian
+```
+
+It re-derives blocks from every snapshot, pairs them with stored translations,
+re-runs validation, and reports flags by kind — plus a delta against what the
+original run recorded in `segments.error`. **Zero API calls, zero cost.**
+
+Notes that matter when reading its output:
+
+- The store is opened through a **throwaway copy**, because `JobStore::open`
+  migrates on open. The original is never written. Verify with a hash if you
+  are nervous; the numbers below were produced that way.
+- Jobs whose run snapshot cannot be resolved are **skipped and counted**, not
+  silently defaulted. An earlier version defaulted, and the resulting figures
+  were meaningless.
+- **Preserved-source pairs are reported separately.** A `needs_review` segment
+  stores the *source* text as its translation, so replaying those compares
+  source against source and says nothing about the model. In one run that
+  artifact was 4,750 of 5,139 raw flags. Always read the
+  "excluding preserved-source pairs" figure.
+- `--emit-pairs <file.jsonl>` writes the flagged pairs for the judge below.
+
+Use it to answer "did this validator change help?" before spending anything.
+
+## `judge_flags` — ask a model whether a flag is real
+
+The question is **not** "is this translation good?" It is "is this specific
+validator complaint correct about this specific translation?" That is a much
+narrower question, and models answer it well.
+
+```
+cargo run --release --example judge_flags -- --pairs pairs.jsonl --dry-run
+cargo run --release --example judge_flags -- --pairs pairs.jsonl \
+    --provider openrouter --model moonshotai/kimi-k3 --limit 100
+```
+
+Output is a per-kind true-positive / false-positive rate. That number decides
+whether a validator is worth keeping, tightening, or demoting.
+
+Operational lessons, all learned the expensive way:
+
+- **`--dry-run` first, always.** It renders prompts and estimates cost without
+  calling anything.
+- **`--limit` truncates, it does not sample.** Shuffle your pairs first (with a
+  recorded seed) or you will judge only the earliest jobs, which is a biased
+  read on exactly the thing you are measuring.
+- **Raise `--max-output-tokens`.** The 400 default starves reasoning models:
+  Kimi K3 returned empty content on **49 of 150** calls at 400, and **4 of 100**
+  at 1200. That is a third of the spend wasted.
+- **Verdicts are cached on disk** by content hash, so re-runs of already-judged
+  units are free. Keep the cache directory between runs.
+- **Judges disagree, and the stricter one has been right.** On a shared subset,
+  deepseek-v4-pro reported 97.3% false positive against Kimi K3's 82.4%. v4-pro
+  was caught contradicting its own rationale and dismissing real defects — a
+  source `December 8` rendered as `10 dicembre`, which is silent data
+  corruption. Treat a single judge's rate as a bound, not a measurement, and
+  prefer the stricter model.
+
+## What this measured, 2026-07-26/27
+
+Recorded here so the next person does not re-derive it. Corpus: 29 real
+English→Italian jobs, deepseek-v4-flash.
+
+| | flags |
+| --- | --- |
+| protected-span flags, before any fix | 600 |
+| after marker-aware span detection (#61) | 371 |
+| after severity demotion (#64) | 348 |
+| after the OCR letter-run guard (#65) | 265 |
+
+False-positive rate over that period stayed roughly flat, **75.3% → 77.5%**.
+That is the important finding: four rounds of heuristic tuning cut *volume*
+without improving *precision*. It is why protected-span violations were demoted
+to warnings rather than tuned a fifth time, and why further heuristic work there
+is not recommended without new evidence.
+
+Two things the measurement surfaced that nobody was looking for:
+
+- **~29% of remaining false positives were OCR damage in the source**, not
+  validator logic. A `^` standing in for a misread letter is a strong inline
+  math operator, so garbled prose became a protected "math" span. When flag
+  volume spikes, suspect the scan before the validator.
+- `other` and `unknown_inline_marker` came back **100% true positive** in both
+  runs (small n). Those checks earn their keep and remain hard failures.
+
+## Cost
+
+Judging 389 flags cost about $0.07 on deepseek-v4-flash, $0.21 on
+deepseek-v4-pro, and roughly $1.72 on Kimi K3 before cache hits. The entire
+two-day measurement effort cost under $3.
+
+Add new models to `pricing/providers.json` **and** the packaged copy at
+`crates/bookforge-cli/pricing/providers.json` — a test asserts they are
+identical.


### PR DESCRIPTION
ElevenLabs input ceilings were maintained in **two** independent places: the canonical `elevenlabs_model_max_input_chars` in `bookforge-audio` that the synthesis path enforces, and a hardcoded table in `dashboard.js`.

They agree today. Nothing keeps them agreeing — and a browser believing a stale ceiling either blocks a request the provider would have accepted, or lets one through that it will reject.

*(An audit reported this as three copies. `serve.rs` was already delegating to the canonical function, so it was two.)*

## Change

Audio provider options now carry a `model_max_chars` map built from the canonical function, and the browser reads it. Providers whose models share a single ceiling send an empty map and fall back to `max_chars` exactly as before.

## The test matters more than the change

There is no JS test harness, so drift here would be invisible until a user hit it. The regression test pins **both** halves:

- the served payload must agree with `elevenlabs_model_max_input_chars` for every offered model
- `dashboard.js` must not reintroduce a literal limit table

## A note on the tripwire I had to update

`dashboard_assets_reassemble_byte_stably` pins the assembled dashboard's exact byte length and SHA-256. My edit broke it immediately, which is precisely what it is for — it is the same mechanism that would have caught the double-encoded `·` separator fixed in #71 before it ever shipped. Updated deliberately, with the new hash recomputed from the assembly logic rather than pasted from the failure message.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **845 passed / 0 failed / 3 ignored** (was 844).

🤖 Generated with [Claude Code](https://claude.com/claude-code)