### PR TITLE
fix(qa): recover truncated review batches, and make severity mean something

### DIFF
--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -148,6 +148,13 @@ pub struct TranslateArgs {
     #[arg(long)]
     pub qa_batch_target_tokens: Option<usize>,
 
+    #[arg(
+        long,
+        default_value_t = 8_192,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    pub qa_max_output_tokens: u32,
+
     #[arg(long)]
     pub qa_model: Option<String>,
 

--- a/crates/bookforge-cli/src/commands/translate/finalization.rs
+++ b/crates/bookforge-cli/src/commands/translate/finalization.rs
@@ -49,13 +49,14 @@ where
     let qa_runtime = job_runtime_settings.borrow().clone();
     let qa_run_config =
         crate::control::freeze_run_config_for_stage(&controlled_run_config, &qa_runtime);
-    let qa_reviews = qa_reviews_for_mode(
+    let qa_reviews = qa_reviews_for_mode_with_max_output_tokens(
         ProgressRequestProvider::new(provider.clone(), progress.clone()),
         segments,
         translations,
         &qa_run_config,
         &qa_runtime.settings.qa,
         qa_runtime.qa,
+        Some(cli_args.qa_max_output_tokens),
     )
     .await;
 
@@ -440,14 +441,54 @@ pub(crate) async fn qa_reviews_for_mode<P>(
 where
     P: LlmProvider,
 {
+    qa_reviews_for_mode_with_max_output_tokens(
+        provider,
+        segments,
+        translations,
+        config,
+        qa_config,
+        qa_mode,
+        None,
+    )
+    .await
+}
+
+async fn qa_reviews_for_mode_with_max_output_tokens<P>(
+    provider: P,
+    segments: &[Segment],
+    translations: &[SegmentTranslation],
+    config: &TranslationRunConfig,
+    qa_config: &bookforge_core::config::QaRunConfig,
+    qa_mode: QaMode,
+    max_output_tokens: Option<u32>,
+) -> Vec<QaSegmentReview>
+where
+    P: LlmProvider,
+{
     match qa_mode {
         QaMode::Off => Vec::new(),
         QaMode::All => {
-            qa_segments_parallel(provider, segments, translations, config, qa_config).await
+            qa_segments_parallel_with_max_output_tokens(
+                provider,
+                segments,
+                translations,
+                config,
+                qa_config,
+                max_output_tokens,
+            )
+            .await
         }
         QaMode::Suspicious => {
             let candidates = suspicious_qa_candidates(segments, translations);
-            qa_segments_parallel(provider, segments, &candidates, config, qa_config).await
+            qa_segments_parallel_with_max_output_tokens(
+                provider,
+                segments,
+                &candidates,
+                config,
+                qa_config,
+                max_output_tokens,
+            )
+            .await
         }
     }
 }

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -21,8 +21,8 @@ use bookforge_llm::{
     MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider, ProviderCapabilities,
     ProviderRateController, QaSegmentReview, RateControllerConfig, SegmentTranslation,
     StyleRunConfig, TelemetryLog, TranslationRunConfig, account_for_batch_prompt_overhead,
-    build_translation_batches, qa_segments_parallel, run_double_check, telemetry_summary,
-    translate_batches_with_callback, translate_batches_with_control,
+    build_translation_batches, qa_segments_parallel_with_max_output_tokens, run_double_check,
+    telemetry_summary, translate_batches_with_callback, translate_batches_with_control,
     translate_segments_with_callback, translate_segments_with_control,
 };
 use bookforge_store::{CreateJob, JobRecord, JobStore, SaveTranslation};

--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -1159,6 +1159,7 @@ fn translate_args_with_preset(
         qa: QaMode::Off,
         qa_concurrency: 8,
         qa_batch_target_tokens: None,
+        qa_max_output_tokens: 8_192,
         qa_model: None,
         qa_provider: None,
         qa_base_url: None,

--- a/crates/bookforge-llm/prompts/qa_batch.v1.md
+++ b/crates/bookforge-llm/prompts/qa_batch.v1.md
@@ -15,7 +15,24 @@ Focus on:
 - broken numbers, URLs, citations, filenames, or markers;
 - structure or formatting corruption visible in the text.
 
-Do not nitpick harmless style choices.
+Report an issue only when the translation is actually wrong or materially worse
+than the source. Never report a comparison that concludes the translation is
+correct, equivalent, acceptable, or merely one of several valid choices. If
+your comparison confirms the translation is correct, omit it.
+
+Every issue message must briefly state what is wrong and how it affects the
+translation. Use these severity levels:
+- `high`: source meaning, factual data, or content is changed or lost; for
+  example, a negation is reversed, a number is wrong, or a sentence is omitted.
+- `medium`: a real error that a reader would notice, while the passage's core
+  meaning remains recoverable; for example, a character name or established
+  term is translated inconsistently.
+- `low`: the translation remains usable, but a specific, defensible improvement
+  would fix a minor imprecision; for example, a localized register mismatch
+  makes one line noticeably too formal.
+
+Do not nitpick harmless style choices. When there is no actual issue, return a
+`pass` verdict with an empty `issues` array.
 
 Return JSON only:
 {"reviews":[{"id":"...","verdict":"pass|warn|fail","issues":[{"severity":"low|medium|high","kind":"...","message":"...","source_excerpt":"...","translation_excerpt":"..."}]}]}

--- a/crates/bookforge-llm/prompts/qa_segment.v1.md
+++ b/crates/bookforge-llm/prompts/qa_segment.v1.md
@@ -6,7 +6,8 @@ You are a translation QA reviewer.
 
 Review whether the translation accurately conveys the source text from {{source_language}} to {{target_language}}.
 
-You are not rewriting the translation unless explicitly asked. Your job is to identify serious issues.
+You are not rewriting the translation unless explicitly asked. Your job is to
+identify actual translation issues.
 
 Focus on:
 
@@ -20,7 +21,24 @@ Focus on:
 - unnatural translation that damages meaning;
 - marker or structure problems if visible.
 
-Do not nitpick stylistic choices unless they materially damage quality.
+Report an issue only when the translation is actually wrong or materially worse
+than the source. Never report a comparison that concludes the translation is
+correct, equivalent, acceptable, or merely one of several valid choices. If
+your comparison confirms the translation is correct, omit it.
+
+Every issue message must briefly state what is wrong and how it affects the
+translation. Use these severity levels:
+- `high`: source meaning, factual data, or content is changed or lost; for
+  example, a negation is reversed, a number is wrong, or a sentence is omitted.
+- `medium`: a real error that a reader would notice, while the passage's core
+  meaning remains recoverable; for example, a character name or established
+  term is translated inconsistently.
+- `low`: the translation remains usable, but a specific, defensible improvement
+  would fix a minor imprecision; for example, a localized register mismatch
+  makes one line noticeably too formal.
+
+Do not nitpick harmless style choices. When there is no actual issue, return a
+`pass` verdict with an empty `issues` array.
 
 Return only valid JSON.
 

--- a/crates/bookforge-llm/src/lib.rs
+++ b/crates/bookforge-llm/src/lib.rs
@@ -26,7 +26,7 @@ pub use provider::{
     MockProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider, ProviderCapabilities,
     RequestMetadata, ResponseFormat,
 };
-pub use qa_batch::qa_segments_parallel;
+pub use qa_batch::{qa_segments_parallel, qa_segments_parallel_with_max_output_tokens};
 pub use rate_controller::{
     ProviderRateController, RateControllerConfig, RequestObservation, RequestStatus,
 };

--- a/crates/bookforge-llm/src/qa_batch.rs
+++ b/crates/bookforge-llm/src/qa_batch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CompletionRequest, LlmError, LlmProvider, PromptLibrary, PromptTemplate, QaIssue,
+    CompletionRequest, FinishReason, LlmError, LlmProvider, PromptLibrary, PromptTemplate, QaIssue,
     QaSegmentReview, RequestMetadata, ResponseFormat, SegmentTranslation, TranslationRunConfig,
     concurrency::PauseState,
 };
@@ -14,6 +14,8 @@ use std::{
 };
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
+
+const DEFAULT_QA_MAX_OUTPUT_TOKENS: u32 = 8_192;
 
 #[derive(Debug, Deserialize)]
 struct QaBatchResponse {
@@ -47,6 +49,46 @@ struct QaPromptItem {
     protected_spans: Vec<String>,
 }
 
+#[derive(Debug)]
+struct QaBatchRequestError {
+    error: LlmError,
+    truncated: bool,
+}
+
+impl QaBatchRequestError {
+    fn other(error: LlmError) -> Self {
+        Self {
+            error,
+            truncated: false,
+        }
+    }
+
+    fn truncated(error: LlmError) -> Self {
+        Self {
+            error,
+            truncated: true,
+        }
+    }
+
+    fn from_json(error: serde_json::Error) -> Self {
+        let truncated = error.is_eof();
+        Self {
+            error: LlmError::Json(error),
+            truncated,
+        }
+    }
+
+    fn should_split(&self) -> bool {
+        self.truncated || is_json_shape_error(&self.error)
+    }
+}
+
+impl std::fmt::Display for QaBatchRequestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
 pub async fn qa_segments_parallel<P>(
     provider: P,
     segments: &[Segment],
@@ -57,9 +99,34 @@ pub async fn qa_segments_parallel<P>(
 where
     P: LlmProvider,
 {
+    qa_segments_parallel_with_max_output_tokens(
+        provider,
+        segments,
+        translations,
+        config,
+        qa_config,
+        None,
+    )
+    .await
+}
+
+pub async fn qa_segments_parallel_with_max_output_tokens<P>(
+    provider: P,
+    segments: &[Segment],
+    translations: &[SegmentTranslation],
+    config: &TranslationRunConfig,
+    qa_config: &QaRunConfig,
+    max_output_tokens: Option<u32>,
+) -> Vec<QaSegmentReview>
+where
+    P: LlmProvider,
+{
     let library = Arc::new(PromptLibrary::global().clone());
     let provider = Arc::new(provider);
     let semaphore = Arc::new(Semaphore::new(qa_config.concurrency.max(1)));
+    let max_output_tokens = max_output_tokens
+        .unwrap_or(DEFAULT_QA_MAX_OUTPUT_TOKENS)
+        .max(1);
     let mut tasks = JoinSet::new();
 
     let by_segment = segments
@@ -106,7 +173,8 @@ where
                     .map(|item| qa_error_review(item, "qa_cancelled", "QA semaphore closed"))
                     .collect::<Vec<_>>();
             };
-            request_qa_batch_resilient(&*provider, &library, &chunk, &config).await
+            request_qa_batch_resilient(&*provider, &library, &chunk, &config, max_output_tokens)
+                .await
         });
     }
 
@@ -151,6 +219,7 @@ async fn request_qa_batch_resilient<P>(
     library: &PromptLibrary,
     items: &[QaWorkItem],
     config: &TranslationRunConfig,
+    max_output_tokens: u32,
 ) -> Vec<QaSegmentReview>
 where
     P: LlmProvider,
@@ -159,9 +228,17 @@ where
     let mut reviews = Vec::new();
 
     while let Some(chunk) = queue.pop_front() {
-        match request_qa_batch(provider, &library.qa_batch, &chunk, config).await {
+        match request_qa_batch(
+            provider,
+            &library.qa_batch,
+            &chunk,
+            config,
+            max_output_tokens,
+        )
+        .await
+        {
             Ok(mut chunk_reviews) => reviews.append(&mut chunk_reviews),
-            Err(error) if is_json_shape_error(&error) && chunk.len() > 1 => {
+            Err(error) if error.should_split() && chunk.len() > 1 => {
                 let mid = chunk.len() / 2;
                 queue.push_front(chunk[mid..].to_vec());
                 queue.push_front(chunk[..mid].to_vec());
@@ -185,11 +262,14 @@ async fn request_qa_batch<P>(
     template: &PromptTemplate,
     items: &[QaWorkItem],
     config: &TranslationRunConfig,
-) -> Result<Vec<QaSegmentReview>, LlmError>
+    max_output_tokens: u32,
+) -> Result<Vec<QaSegmentReview>, QaBatchRequestError>
 where
     P: LlmProvider,
 {
-    wait_for_qa_pause(config).await?;
+    wait_for_qa_pause(config)
+        .await
+        .map_err(QaBatchRequestError::other)?;
 
     use crate::Substitutions;
 
@@ -241,7 +321,7 @@ where
 
     let rendered = template
         .render(&vars)
-        .map_err(|e| LlmError::Provider(e.to_string()))?;
+        .map_err(|e| QaBatchRequestError::other(LlmError::Provider(e.to_string())))?;
     let (runtime_config_revision, provider_max_attempts) = config.request_runtime_metadata();
     let response = provider
         .complete(CompletionRequest {
@@ -249,7 +329,7 @@ where
             user: rendered.user,
             response_format: ResponseFormat::Json,
             temperature: 0.0,
-            max_output_tokens: None,
+            max_output_tokens: Some(max_output_tokens),
             metadata: RequestMetadata {
                 segment_id: None,
                 block_ids: items
@@ -265,9 +345,19 @@ where
                 provider_max_attempts,
             },
         })
-        .await?;
+        .await
+        .map_err(QaBatchRequestError::other)?;
 
-    let parsed: QaBatchResponse = serde_json::from_str(&response.content)?;
+    if response.finish_reason == FinishReason::Length {
+        return Err(QaBatchRequestError::truncated(LlmError::InvalidResponse(
+            format!(
+                "QA output was truncated: max_output_tokens limit ({max_output_tokens}) reached"
+            ),
+        )));
+    }
+
+    let parsed: QaBatchResponse =
+        serde_json::from_str(&response.content).map_err(QaBatchRequestError::from_json)?;
     let by_id = items
         .iter()
         .map(|item| (item.segment.id.0.as_str(), item))
@@ -388,7 +478,7 @@ fn qa_error_review(item: &QaWorkItem, kind: &str, message: impl Into<String>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CompletionResponse, FinishReason, ProviderCapabilities};
+    use crate::{CompletionResponse, ProviderCapabilities};
     use bookforge_core::{
         config::TranslationProfile,
         ir::{BlockId, SectionId},
@@ -431,6 +521,84 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
 
+            Ok(CompletionResponse {
+                content: serde_json::to_string(&json!({ "reviews": reviews }))?,
+                input_tokens: None,
+                input_cached_tokens: None,
+                output_tokens: None,
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 0,
+                raw: json!({}),
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: false,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum ForcedTruncation {
+        FinishReasonLength,
+        PrematureEof,
+    }
+
+    struct SplitRetryQaProvider {
+        requests: Arc<Mutex<Vec<CompletionRequest>>>,
+        truncation: ForcedTruncation,
+        recover_single_items: bool,
+    }
+
+    impl LlmProvider for SplitRetryQaProvider {
+        async fn complete(
+            &self,
+            request: CompletionRequest,
+        ) -> crate::provider::Result<CompletionResponse> {
+            let ids = extract_ids_from_qa_prompt(&request.user);
+            let should_truncate = ids.len() > 1 || !self.recover_single_items;
+            self.requests.lock().expect("requests mutex").push(request);
+
+            if should_truncate {
+                return Ok(match self.truncation {
+                    ForcedTruncation::FinishReasonLength => CompletionResponse {
+                        // A syntactically complete body proves the finish reason itself
+                        // triggers recovery rather than relying on JSON parsing to fail.
+                        content: serde_json::to_string(&json!({ "reviews": [] }))?,
+                        input_tokens: None,
+                        input_cached_tokens: None,
+                        output_tokens: None,
+                        finish_reason: FinishReason::Length,
+                        provider_latency_ms: 0,
+                        raw: json!({}),
+                    },
+                    ForcedTruncation::PrematureEof => CompletionResponse {
+                        content: format!(
+                            r#"{{"reviews":[{{"id":"{}","verdict":"pass","issues":["#,
+                            ids.first().map(String::as_str).unwrap_or("unknown")
+                        ),
+                        input_tokens: None,
+                        input_cached_tokens: None,
+                        output_tokens: None,
+                        finish_reason: FinishReason::Stop,
+                        provider_latency_ms: 0,
+                        raw: json!({}),
+                    },
+                });
+            }
+
+            let reviews = ids
+                .into_iter()
+                .map(|id| {
+                    json!({
+                        "id": id,
+                        "verdict": "pass",
+                        "issues": [],
+                    })
+                })
+                .collect::<Vec<_>>();
             Ok(CompletionResponse {
                 content: serde_json::to_string(&json!({ "reviews": reviews }))?,
                 input_tokens: None,
@@ -619,6 +787,123 @@ mod tests {
 
         assert_eq!(reviews.len(), 2);
         assert_eq!(requests.lock().expect("requests mutex").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn finish_reason_length_splits_and_retries_qa_batch() {
+        let segments = vec![segment("seg_1", 0, "Hello"), segment("seg_2", 1, "Goodbye")];
+        let translations = segments
+            .iter()
+            .map(|segment| translation(segment, "Ciao"))
+            .collect::<Vec<_>>();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = SplitRetryQaProvider {
+            requests: requests.clone(),
+            truncation: ForcedTruncation::FinishReasonLength,
+            recover_single_items: true,
+        };
+
+        let reviews = qa_segments_parallel(
+            provider,
+            &segments,
+            &translations,
+            &run_config(),
+            &qa_config(10_000),
+        )
+        .await;
+
+        assert_eq!(reviews.len(), 2);
+        assert!(reviews.iter().all(|review| review.verdict == "pass"));
+        let request_item_counts = requests
+            .lock()
+            .expect("requests mutex")
+            .iter()
+            .map(|request| extract_ids_from_qa_prompt(&request.user).len())
+            .collect::<Vec<_>>();
+        assert_eq!(request_item_counts, vec![2, 1, 1]);
+    }
+
+    #[tokio::test]
+    async fn premature_eof_splits_and_retries_qa_batch() {
+        let segments = vec![segment("seg_1", 0, "Hello"), segment("seg_2", 1, "Goodbye")];
+        let translations = segments
+            .iter()
+            .map(|segment| translation(segment, "Ciao"))
+            .collect::<Vec<_>>();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = SplitRetryQaProvider {
+            requests: requests.clone(),
+            truncation: ForcedTruncation::PrematureEof,
+            recover_single_items: true,
+        };
+
+        let reviews = qa_segments_parallel(
+            provider,
+            &segments,
+            &translations,
+            &run_config(),
+            &qa_config(10_000),
+        )
+        .await;
+
+        assert_eq!(reviews.len(), 2);
+        assert!(reviews.iter().all(|review| review.verdict == "pass"));
+        assert_eq!(requests.lock().expect("requests mutex").len(), 3);
+    }
+
+    #[tokio::test]
+    async fn unrecoverable_truncation_surfaces_qa_request_failed_findings() {
+        let segments = vec![segment("seg_1", 0, "Hello"), segment("seg_2", 1, "Goodbye")];
+        let translations = segments
+            .iter()
+            .map(|segment| translation(segment, "Ciao"))
+            .collect::<Vec<_>>();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = SplitRetryQaProvider {
+            requests: requests.clone(),
+            truncation: ForcedTruncation::FinishReasonLength,
+            recover_single_items: false,
+        };
+
+        let reviews = qa_segments_parallel(
+            provider,
+            &segments,
+            &translations,
+            &run_config(),
+            &qa_config(10_000),
+        )
+        .await;
+
+        assert_eq!(reviews.len(), 2);
+        assert_eq!(requests.lock().expect("requests mutex").len(), 3);
+        for review in reviews {
+            assert_eq!(review.verdict, "warn");
+            assert_eq!(review.issues[0].kind, "qa_request_failed");
+            assert!(review.issues[0].message.contains("QA output was truncated"));
+        }
+    }
+
+    #[tokio::test]
+    async fn configurable_qa_output_cap_reaches_request() {
+        let segments = vec![segment("seg_1", 0, "Hello")];
+        let translations = vec![translation(&segments[0], "Ciao")];
+        let provider = CaptureQaProvider::default();
+        let requests = provider.requests.clone();
+
+        let reviews = qa_segments_parallel_with_max_output_tokens(
+            provider,
+            &segments,
+            &translations,
+            &run_config(),
+            &qa_config(10_000),
+            Some(12_345),
+        )
+        .await;
+
+        assert_eq!(reviews.len(), 1);
+        let requests = requests.lock().expect("requests mutex");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].max_output_tokens, Some(12_345));
     }
 
     #[tokio::test]

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -157,6 +157,12 @@ text, so use that fraction to size the review pass against an `all` estimate.
 Failed, queued, and retry-pending segments are not sent to the reviewer, and an
 empty translation is never submitted even if its status is otherwise eligible.
 
+`--qa-max-output-tokens <TOKENS>` caps each QA response and defaults to `8192`.
+The value must be at least `1`. If a batched response reaches that limit or ends
+as incomplete JSON, BookForge retries by bisecting the batch. One segment is the
+floor: if that request is still truncated, QA records a `qa_request_failed`
+warning for the segment instead of splitting again.
+
 LLM issues are also persisted in the job's `qa_findings` data. Their kinds use
 the reserved `llm_` prefix so `status` and the review page keep model judgments
 distinct from deterministic validator failures. LLM severity maps as follows:


### PR DESCRIPTION
Two defects measured on a real run — The Cyberiad, EN→IT, flash translating, **Kimi K3 reviewing**, `--qa suspicious`, nine segments selected.

## 1. A truncated response discarded every review in its batch

Two of nine segments failed with `JSON error: EOF while parsing a string`. **22% of the pass silently lost.**

QA sent `max_output_tokens: None`, so whatever the provider defaulted to applied — and a batch asking for a JSON array of reviews *with excerpts* is exactly the shape that hits an output ceiling. The translation path already escalates on `FinishReason::Length`; QA had no equivalent.

- QA requests now carry an explicit **8,192-token cap**, configurable via `--qa-max-output-tokens`.
- Truncation — signalled by `finish_reason: length` **or** detected as a premature JSON EOF — **bisects the batch and retries**.
- The floor is a single segment, so a perpetually truncating batch makes at most **`2n - 1`** requests, then records a `qa_request_failed` finding rather than splitting forever.
- A QA failure still never fails the translation.

## 2. Every finding came back `low` — including ones the model refuted itself

On one segment all 15 findings were `low`, and several narrated a comparison before concluding the translation was fine:

> *"'chargers' (warhorses) is translated as 'destrieri', **which is correct**"*

Two genuine issues sat in that list at the same severity as the noise. A signal where everything is `low` carries no information, and a reviewer that reports non-issues teaches the reader to ignore it.

Both QA prompts now require a message to state **what is wrong and how it affects the translation**, and define severities by example rather than adjective:

| level | meaning |
| --- | --- |
| `high` | source meaning, factual data or content changed or lost — a negation reversed, a wrong number, an omitted sentence |
| `medium` | a real error a reader would notice, core meaning still recoverable — a character name or established term translated inconsistently |
| `low` | usable, but a specific defensible improvement would fix a minor imprecision |

**Deliberately not fixed by filtering out `low` findings.** That hides the calibration problem rather than fixing it, and would have discarded one of the two real catches.

## Why this is worth calibrating rather than removing

The LLM pass was independently judged at **40% true positive**, against **3.2%** for the deterministic protected-span check — same book, same judge, and that 40% is a floor since the judge is the one known to over-call false positives.

The split is informative: its true positives were **consistency and register errors spanning distance** (`Incursione`/`sortita` for the same word, a letter dropped from `CYPHROEROTICON`, `Wanna buy any, mister?` collapsing to formal `Ne vuole comprare, signore?`). Its false positives were all **isolated single-phrase judgements**.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **858 passed / 0 failed / 3 ignored** (was 854).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
