### PR TITLE
fix(qa): stop requesting low-severity findings — measured at 2% real

### DIFF
--- a/crates/bookforge-llm/prompts/qa_batch.v1.md
+++ b/crates/bookforge-llm/prompts/qa_batch.v1.md
@@ -31,8 +31,11 @@ translation. Use these severity levels:
   would fix a minor imprecision; for example, a localized register mismatch
   makes one line noticeably too formal.
 
-Do not nitpick harmless style choices. When there is no actual issue, return a
-`pass` verdict with an empty `issues` array.
+Report only issues that meet the `medium` or `high` definitions. Do not report
+`low` issues; omit them from the `issues` array.
+
+Do not nitpick harmless style choices. When there is no reportable `medium` or
+`high` issue, return a `pass` verdict with an empty `issues` array.
 
 Return JSON only:
 {"reviews":[{"id":"...","verdict":"pass|warn|fail","issues":[{"severity":"low|medium|high","kind":"...","message":"...","source_excerpt":"...","translation_excerpt":"..."}]}]}

--- a/crates/bookforge-llm/prompts/qa_segment.v1.md
+++ b/crates/bookforge-llm/prompts/qa_segment.v1.md
@@ -37,8 +37,11 @@ translation. Use these severity levels:
   would fix a minor imprecision; for example, a localized register mismatch
   makes one line noticeably too formal.
 
-Do not nitpick harmless style choices. When there is no actual issue, return a
-`pass` verdict with an empty `issues` array.
+Report only issues that meet the `medium` or `high` definitions. Do not report
+`low` issues; omit them from the `issues` array.
+
+Do not nitpick harmless style choices. When there is no reportable `medium` or
+`high` issue, return a `pass` verdict with an empty `issues` array.
 
 Return only valid JSON.
 
@@ -50,7 +53,7 @@ The output must match this JSON shape exactly:
   "verdict": "pass",
   "issues": [
     {
-      "severity": "low",
+      "severity": "medium",
       "kind": "...",
       "message": "...",
       "source_excerpt": "...",
@@ -60,7 +63,7 @@ The output must match this JSON shape exactly:
 }
 ```
 
-Use `"warn"` for minor but real problems. Use `"fail"` only for serious problems such as omitted paragraphs, major mistranslation, broken meaning, or visibly corrupted structure.
+Use `"warn"` for reportable `medium` problems. Use `"fail"` only for serious problems such as omitted paragraphs, major mistranslation, broken meaning, or visibly corrupted structure.
 
 ## User
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -165,8 +165,11 @@ warning for the segment instead of splitting again.
 
 LLM issues are also persisted in the job's `qa_findings` data. Their kinds use
 the reserved `llm_` prefix so `status` and the review page keep model judgments
-distinct from deterministic validator failures. LLM severity maps as follows:
-`high` becomes a stored `error`; `medium` and `low` become `warning`.
+distinct from deterministic validator failures. The reviewer is instructed to
+report only `medium` and `high` issues and omit anything matching the `low`
+boundary. `low` remains accepted in model responses for compatibility. LLM
+severity maps as follows: `high` becomes a stored `error`; `medium` and `low`
+become `warning`.
 
 Repeated LLM issues are reported and stored once when both their normalized
 kind and normalized source excerpt match. Source-excerpt normalization ignores


### PR DESCRIPTION
PR #79 made the LLM QA pass usable. PR #80 then made it noticeably worse, and this fixes that.

## The regression

Measured on a real re-run — The Cyberiad, Kimi K3 reviewing, nine segments, adjudicated by deepseek-v4-pro via `examples/judge_flags`:

| | findings | true positive |
| --- | --- | --- |
| before #80 | 15 | **40.0%** |
| after #80 | 54 | **5.6%** |

Same book, same segments, same judge. **Precision collapsed 7x.**

The cause was a single line #80 introduced:

> `low`: the translation remains usable, but a specific, defensible improvement would fix a minor imprecision

The previous prompt merely *prohibited* nitpicking. That line **created a sanctioned category for it**, and the model filled it — 50 of 54 findings came back `low`.

## The definitions are good; requesting low was the error

Broken down by the severity the model itself assigned:

| severity | n | true positive |
| --- | --- | --- |
| `medium` | 4 | **50%** |
| `low` | 50 | **2%** |

They discriminate well — `medium` is **25x** more precise. So the fix requests only `medium` and `high`, keeping the `low` definition as the description of what *not* to report, where it works as a boundary.

Everything else from #80 is kept: never reporting a comparison that concludes the translation is correct, stating what is wrong and how it affects the translation, and returning `pass` with an empty issues array. `low` stays legal in the response schema so a model emitting one anyway does not fail the parse.

## Not post-hoc filtering, deliberately

Dropping `low` findings in Rust after the model returns them would have been wrong under the pre-#80 prompt, where the model labelled *everything* `low` — including six genuine catches. Not requesting them redirects the model's attention rather than discarding its work.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **858 passed / 0 failed / 3 ignored**.

Expected effect: roughly 4 findings per nine segments at ~50% precision instead of 54 at 5.6%. Fewer findings is the goal. I will re-run and re-judge to confirm rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)