### PR TITLE
revert(qa): restore the original QA prompt wording, which measured best

### DIFF
--- a/crates/bookforge-llm/prompts/qa_batch.v1.md
+++ b/crates/bookforge-llm/prompts/qa_batch.v1.md
@@ -15,27 +15,7 @@ Focus on:
 - broken numbers, URLs, citations, filenames, or markers;
 - structure or formatting corruption visible in the text.
 
-Report an issue only when the translation is actually wrong or materially worse
-than the source. Never report a comparison that concludes the translation is
-correct, equivalent, acceptable, or merely one of several valid choices. If
-your comparison confirms the translation is correct, omit it.
-
-Every issue message must briefly state what is wrong and how it affects the
-translation. Use these severity levels:
-- `high`: source meaning, factual data, or content is changed or lost; for
-  example, a negation is reversed, a number is wrong, or a sentence is omitted.
-- `medium`: a real error that a reader would notice, while the passage's core
-  meaning remains recoverable; for example, a character name or established
-  term is translated inconsistently.
-- `low`: the translation remains usable, but a specific, defensible improvement
-  would fix a minor imprecision; for example, a localized register mismatch
-  makes one line noticeably too formal.
-
-Report only issues that meet the `medium` or `high` definitions. Do not report
-`low` issues; omit them from the `issues` array.
-
-Do not nitpick harmless style choices. When there is no reportable `medium` or
-`high` issue, return a `pass` verdict with an empty `issues` array.
+Do not nitpick harmless style choices.
 
 Return JSON only:
 {"reviews":[{"id":"...","verdict":"pass|warn|fail","issues":[{"severity":"low|medium|high","kind":"...","message":"...","source_excerpt":"...","translation_excerpt":"..."}]}]}

--- a/crates/bookforge-llm/prompts/qa_segment.v1.md
+++ b/crates/bookforge-llm/prompts/qa_segment.v1.md
@@ -6,8 +6,7 @@ You are a translation QA reviewer.
 
 Review whether the translation accurately conveys the source text from {{source_language}} to {{target_language}}.
 
-You are not rewriting the translation unless explicitly asked. Your job is to
-identify actual translation issues.
+You are not rewriting the translation unless explicitly asked. Your job is to identify serious issues.
 
 Focus on:
 
@@ -21,27 +20,7 @@ Focus on:
 - unnatural translation that damages meaning;
 - marker or structure problems if visible.
 
-Report an issue only when the translation is actually wrong or materially worse
-than the source. Never report a comparison that concludes the translation is
-correct, equivalent, acceptable, or merely one of several valid choices. If
-your comparison confirms the translation is correct, omit it.
-
-Every issue message must briefly state what is wrong and how it affects the
-translation. Use these severity levels:
-- `high`: source meaning, factual data, or content is changed or lost; for
-  example, a negation is reversed, a number is wrong, or a sentence is omitted.
-- `medium`: a real error that a reader would notice, while the passage's core
-  meaning remains recoverable; for example, a character name or established
-  term is translated inconsistently.
-- `low`: the translation remains usable, but a specific, defensible improvement
-  would fix a minor imprecision; for example, a localized register mismatch
-  makes one line noticeably too formal.
-
-Report only issues that meet the `medium` or `high` definitions. Do not report
-`low` issues; omit them from the `issues` array.
-
-Do not nitpick harmless style choices. When there is no reportable `medium` or
-`high` issue, return a `pass` verdict with an empty `issues` array.
+Do not nitpick stylistic choices unless they materially damage quality.
 
 Return only valid JSON.
 
@@ -53,7 +32,7 @@ The output must match this JSON shape exactly:
   "verdict": "pass",
   "issues": [
     {
-      "severity": "medium",
+      "severity": "low",
       "kind": "...",
       "message": "...",
       "source_excerpt": "...",
@@ -63,7 +42,7 @@ The output must match this JSON shape exactly:
 }
 ```
 
-Use `"warn"` for reportable `medium` problems. Use `"fail"` only for serious problems such as omitted paragraphs, major mistranslation, broken meaning, or visibly corrupted structure.
+Use `"warn"` for minor but real problems. Use `"fail"` only for serious problems such as omitted paragraphs, major mistranslation, broken meaning, or visibly corrupted structure.
 
 ## User
 


### PR DESCRIPTION
Three prompt variants, measured on the same book, same segments, same judge — The Cyberiad, Kimi K3 reviewing nine segments, adjudicated by deepseek-v4-pro via `examples/judge_flags`:

| variant | findings | true positive |
| --- | --- | --- |
| **original** ("do not nitpick") | 15 | **40.0%** |
| #80 (defined severities) | 54 | 5.6% |
| #81 (request `medium`/`high` only) | 99 | 17.5% |

**Every attempt to constrain the model increased its output.** Volume went 15 → 54 → 99.

#80 defined `low` as *"a specific, defensible improvement would fix a minor imprecision"* — creating a sanctioned category for exactly the noise it was meant to suppress. #81 then stopped requesting `low`, and the model simply **relabelled everything `medium`**, producing 99 findings several of which state in their own text *"This is correct. No issue."*

## What this shows

Severity instructions do not control this model's output volume or precision. It reports what it notices on a linear pass and applies whichever label it is permitted to use.

That matches the observed miss: a rule stated one paragraph above its violation went unnoticed on a 15,000-character segment, while terminology drift between two nearby mentions was caught. The pass is phrase-by-phrase, not holistic.

## What this reverts, and what it keeps

Both QA prompts return to the wording that measured best. **The truncation handling from #80 is untouched and stays** — it is separately correct, and cut unrecoverable batch failures from 6 to 3 on the same run.

## Left for future work, explicitly not claimed

The productive findings were consistently **cross-reference errors**: a term translated then left untranslated, a letter dropped from an invented word, register collapsing between two mentions. Asking specifically for terminology and consistency errors, over **smaller review units**, is the hypothesis worth measuring next.

This class of prompt change has now failed twice. Measure it before believing it.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **858 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)