### PR TITLE
Remove UTF-8 BOMs from prompt templates and guard against their return

### DIFF
--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_marker_safe.v2.md
+# translate_batch_marker_safe.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_marker_safe_compact.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_marker_safe_compact.v2.md
+# translate_batch_marker_safe_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_plain.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_plain.v2.md
+# translate_batch_plain.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_plain_compact.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_plain_compact.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_plain_compact.v2.md
+# translate_batch_plain_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_repair.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_repair.v2.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_repair.v2.md
+# translate_batch_repair.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_repair_compact.v2.md
+++ b/crates/bookforge-llm/prompts/translate_batch_repair_compact.v2.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_repair_compact.v2.md
+# translate_batch_repair_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_run_preserving.v2.md
+# translate_batch_run_preserving.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v3.md
+++ b/crates/bookforge-llm/prompts/translate_batch_run_preserving_compact.v3.md
@@ -1,4 +1,4 @@
-﻿# translate_batch_run_preserving_compact.v2.md
+# translate_batch_run_preserving_compact.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_marker_safe.v2.md
+++ b/crates/bookforge-llm/prompts/translate_marker_safe.v2.md
@@ -1,4 +1,4 @@
-﻿# translate_marker_safe.v2.md
+# translate_marker_safe.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_run_preserving.v2.md
+++ b/crates/bookforge-llm/prompts/translate_run_preserving.v2.md
@@ -1,4 +1,4 @@
-﻿# translate_run_preserving.v2.md
+# translate_run_preserving.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/prompts/translate_segment.v2.md
+++ b/crates/bookforge-llm/prompts/translate_segment.v2.md
@@ -1,4 +1,4 @@
-﻿# translate_segment.v2.md
+# translate_segment.v2.md
 
 ## System
 

--- a/crates/bookforge-llm/src/prompt.rs
+++ b/crates/bookforge-llm/src/prompt.rs
@@ -427,6 +427,34 @@ mod tests {
     }
 
     #[test]
+    fn prompt_sources_do_not_start_with_utf8_bom() {
+        let prompt_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("prompts");
+        let mut bom_prefixed = Vec::new();
+
+        for entry in std::fs::read_dir(&prompt_dir).expect("prompt directory must be readable") {
+            let entry = entry.expect("prompt directory entry must be readable");
+            if !entry
+                .file_type()
+                .expect("prompt directory entry type must be readable")
+                .is_file()
+            {
+                continue;
+            }
+
+            let bytes = std::fs::read(entry.path()).expect("prompt file must be readable");
+            if bytes.starts_with(b"\xEF\xBB\xBF") {
+                bom_prefixed.push(entry.file_name().to_string_lossy().into_owned());
+            }
+        }
+
+        bom_prefixed.sort();
+        assert!(
+            bom_prefixed.is_empty(),
+            "prompt files must not start with a UTF-8 BOM: {bom_prefixed:?}"
+        );
+    }
+
+    #[test]
     fn batch_prompt_templates_are_versioned_v3_for_retry_guidance() {
         // The six batch translate templates (plain / marker-safe /
         // run-preserving, and their compact variants) gained a per-item


### PR DESCRIPTION
Eleven templates under `crates/bookforge-llm/prompts/` began with `EF BB BF`. Windows PowerShell 5.1 writes a BOM from `Out-File` and `Set-Content -Encoding utf8`, which is almost certainly how they arrived — one edit at a time.

## The suspicion was wrong, and that is the useful part

The reason to look was that `include_str!` does not strip a BOM, so a literal U+FEFF would lead every system prompt sent to the provider, costing a token per request.

**It doesn't.** The BOM sits ahead of the top-level title, and prompt parsing extracts and trims only the later `## System` and `## User` sections. Nothing reached a provider and no tokens were wasted.

Recorded as a source-tidiness fix rather than dressed up as a runtime one.

## Checked before changing anything

The cost of being wrong here was high enough to verify rather than assume:

- **Cache identity is unaffected.** `compute_cache_namespace` and every production caller key on fixed `v2` / `batch_v3` tags and fingerprints, never on template bytes or hashes. Had prompt bytes fed a fingerprint, stripping a BOM would have invalidated every cached translation across 30 real jobs — and this change would not have been worth making.
- **No test pinned prompt bytes.** The only length assertion compares compact against standard variants relatively. This mattered because the repo has deliberate byte-level tripwires elsewhere (`dashboard_assets_reassemble_byte_stably` pins an exact length and SHA-256 on purpose).
- **Nothing depended on the BOM.** The templates are only ever loaded through `include_str!`.

An eleventh file, `translate_segment.v2.md`, was affected beyond the ten originally spotted.

## The guard is the point

A directory-wide test now fails if any file under `prompts/` starts with a BOM. Without it they come back the next time someone edits a prompt on Windows — which is exactly how eleven accumulated.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **859 passed / 0 failed / 3 ignored** over three consecutive runs (was 858).

🤖 Generated with [Claude Code](https://claude.com/claude-code)