### PR TITLE
Chunk glossary proposals so one truncation cannot lose the whole pass

### DIFF
--- a/crates/bookforge-cli/src/commands/glossary.rs
+++ b/crates/bookforge-cli/src/commands/glossary.rs
@@ -18,6 +18,7 @@ use clap::{Args, Subcommand};
 use serde::{Deserialize, Serialize};
 
 const MODEL_REJECTION_NOTE_PREFIX: &str = "model rejection (not terminology): ";
+const DEFAULT_PROPOSAL_MAX_OUTPUT_TOKENS: u32 = 8_192;
 
 #[derive(Debug, Args)]
 pub struct GlossaryArgs {
@@ -173,8 +174,8 @@ struct ProposeArgs {
     #[arg(long)]
     qa_api_key_env: Option<String>,
 
-    /// Output-token budget for the proposal request. Defaults to a budget
-    /// scaled to the number of pending candidates.
+    /// Output-token budget for each proposal request. Defaults to 8192;
+    /// candidates are chunked to reserve about 320 tokens apiece.
     #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
     qa_max_output_tokens: Option<u32>,
 
@@ -396,8 +397,22 @@ async fn propose_candidates(store: &JobStore, args: ProposeArgs) -> Result<()> {
             }
         }
     }
+    for failure in &run.failures {
+        println!(
+            "Proposal request failed for {} candidates (IDs {}): {}",
+            failure.candidate_ids.len(),
+            failure
+                .candidate_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+            failure.error
+        );
+    }
     println!(
-        "Tokens: estimated input {}, provider input {}, provider output {}.",
+        "Requests: {}. Tokens: estimated input {}, provider input {}, provider output {}.",
+        run.request_count,
         run.estimated_input_tokens,
         format_optional_tokens(run.input_tokens),
         format_optional_tokens(run.output_tokens)
@@ -406,20 +421,14 @@ async fn propose_candidates(store: &JobStore, args: ProposeArgs) -> Result<()> {
         "Review explicitly with: bookforge glossary review-candidates {} --language \"{}->{}\"",
         args.book_id, source_language, target_language
     );
+    if counts.failed > 0 {
+        anyhow::bail!(
+            "glossary proposal pass incomplete: {} of {} candidates failed; completed results were retained for review and failed candidates remain pending",
+            counts.failed,
+            counts.total()
+        );
+    }
     Ok(())
-}
-
-/// Output-token budget for a proposal request covering `candidates` terms.
-///
-/// One request carries every pending candidate, so a flat default is wrong at
-/// both ends. A measured run â€” Kimi K3, 40 candidates â€” used 8,277 output
-/// tokens, about 207 per candidate including reasoning. 320 per candidate
-/// leaves headroom for a more verbose model; the 8,192 floor keeps small books
-/// from being starved by a tight budget, and the 65,536 ceiling stops a
-/// pathological candidate list from requesting an unbounded completion.
-fn proposal_output_budget(candidates: usize) -> u32 {
-    let scaled = candidates.saturating_mul(320).min(u32::MAX as usize) as u32;
-    scaled.clamp(8_192, 65_536)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -427,6 +436,19 @@ struct ProposalCounts {
     rendered: usize,
     declined: usize,
     model_rejected: usize,
+    failed: usize,
+}
+
+impl ProposalCounts {
+    fn completed(self) -> usize {
+        self.rendered
+            .saturating_add(self.declined)
+            .saturating_add(self.model_rejected)
+    }
+
+    fn total(self) -> usize {
+        self.completed().saturating_add(self.failed)
+    }
 }
 
 fn proposal_counts(run: &GlossaryProposalRun) -> ProposalCounts {
@@ -438,6 +460,11 @@ fn proposal_counts(run: &GlossaryProposalRun) -> ProposalCounts {
             _ => counts.rendered += 1,
         }
     }
+    counts.failed = run
+        .failures
+        .iter()
+        .map(|failure| failure.candidate_ids.len())
+        .sum();
     counts
 }
 
@@ -447,10 +474,27 @@ fn format_proposal_summary(counts: ProposalCounts) -> String {
     } else {
         "candidates"
     };
-    format!(
-        "Saved {} proposed renderings and {} declines; model rejected {} {} as not terminology. All remain reviewable auto_candidate rows.",
-        counts.rendered, counts.declined, counts.model_rejected, rejected_candidate_label
-    )
+    if counts.failed == 0 {
+        format!(
+            "Completed all {} glossary candidates: persisted {} proposed renderings and {} model-rejected {}; the model declined {}. All remain reviewable auto_candidate rows.",
+            counts.total(),
+            counts.rendered,
+            counts.model_rejected,
+            rejected_candidate_label,
+            counts.declined
+        )
+    } else {
+        format!(
+            "INCOMPLETE glossary proposal pass: completed {} of {} candidates, persisting {} proposed renderings and {} model-rejected {}; the model declined {}. {} candidates failed and remain pending.",
+            counts.completed(),
+            counts.total(),
+            counts.rendered,
+            counts.model_rejected,
+            rejected_candidate_label,
+            counts.declined,
+            counts.failed
+        )
+    }
 }
 
 fn candidate_needs_proposal(candidate: &StoredGlossaryCandidate) -> bool {
@@ -507,7 +551,7 @@ where
         &items,
         provider_name,
         model,
-        max_output_tokens.unwrap_or_else(|| proposal_output_budget(items.len())),
+        max_output_tokens.unwrap_or(DEFAULT_PROPOSAL_MAX_OUTPUT_TOKENS),
     )
     .await
     .map_err(|error| anyhow::anyhow!("glossary proposal request failed: {error}"))?;
@@ -1059,16 +1103,14 @@ mod tests {
     use bookforge_llm::{
         CompletionRequest, CompletionResponse, FinishReason, LlmError, ProviderCapabilities,
     };
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[test]
-    fn proposal_budget_scales_with_candidates_between_a_floor_and_a_ceiling() {
-        assert_eq!(proposal_output_budget(0), 8_192);
-        assert_eq!(proposal_output_budget(20), 8_192);
-        // The measured 40-candidate run needed 8,277 output tokens, which the
-        // old flat 4,096 default could not cover.
-        assert!(proposal_output_budget(40) > 8_277);
-        assert_eq!(proposal_output_budget(100), 32_000);
-        assert_eq!(proposal_output_budget(1_000_000), 65_536);
+    fn proposal_requests_default_to_the_provider_friendly_qa_cap() {
+        assert_eq!(DEFAULT_PROPOSAL_MAX_OUTPUT_TOKENS, 8_192);
     }
 
     #[derive(Clone)]
@@ -1166,6 +1208,34 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct FailOnRequestProvider {
+        inner: MockProvider,
+        calls: Arc<AtomicUsize>,
+        fail_call: usize,
+    }
+
+    impl LlmProvider for FailOnRequestProvider {
+        async fn complete(
+            &self,
+            request: CompletionRequest,
+        ) -> std::result::Result<CompletionResponse, LlmError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == self.fail_call {
+                Err(LlmError::Provider(format!(
+                    "offline failure on request {}",
+                    call + 1
+                )))
+            } else {
+                self.inner.complete(request).await
+            }
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            self.inner.capabilities()
+        }
+    }
+
     fn stored_term(source_text: &str, target_text: &str, status: GlossaryStatus) -> GlossaryTerm {
         GlossaryTerm {
             id: None,
@@ -1182,6 +1252,23 @@ mod tests {
             target_language: "Italian".to_string(),
             source_count: 3,
         }
+    }
+
+    fn seed_proposal_candidates(store: &JobStore, count: usize) {
+        let source_texts = (0..count)
+            .map(|index| format!("candidate-{index}"))
+            .collect::<Vec<_>>();
+        let candidates = source_texts
+            .iter()
+            .map(|source_text| NewGlossaryCandidate {
+                source_text,
+                category: GlossaryCategory::Invented,
+                source_count: 3,
+            })
+            .collect::<Vec<_>>();
+        store
+            .upsert_glossary_candidates("book", "English", "Italian", candidates.as_slice())
+            .expect("candidates");
     }
 
     #[test]
@@ -1356,6 +1443,145 @@ case_sensitive = true
     }
 
     #[tokio::test]
+    async fn multi_chunk_pass_persists_the_same_results_as_one_chunk() {
+        let chunked_directory = tempfile::tempdir().expect("chunked temporary directory");
+        let chunked_store =
+            JobStore::open(chunked_directory.path().join("jobs.sqlite")).expect("chunked store");
+        seed_proposal_candidates(&chunked_store, 5);
+        let chunked_provider = MockProvider::new(bookforge_llm::MockMode::PrefixTarget, "Italian");
+
+        let chunked_run = propose_candidates_with_provider(
+            &chunked_store,
+            &[],
+            "book",
+            "English",
+            "Italian",
+            "mock",
+            "mock-prefix-target",
+            320,
+            Some(640),
+            &chunked_provider,
+        )
+        .await
+        .expect("chunked proposal pass");
+        assert_eq!(chunked_run.request_count, 3);
+        assert!(chunked_run.failures.is_empty());
+
+        let single_directory = tempfile::tempdir().expect("single temporary directory");
+        let single_store =
+            JobStore::open(single_directory.path().join("jobs.sqlite")).expect("single store");
+        seed_proposal_candidates(&single_store, 5);
+        let single_provider = MockProvider::new(bookforge_llm::MockMode::PrefixTarget, "Italian");
+
+        let single_run = propose_candidates_with_provider(
+            &single_store,
+            &[],
+            "book",
+            "English",
+            "Italian",
+            "mock",
+            "mock-prefix-target",
+            320,
+            Some(3_200),
+            &single_provider,
+        )
+        .await
+        .expect("single-chunk proposal pass");
+        assert_eq!(single_run.request_count, 1);
+        assert!(single_run.failures.is_empty());
+
+        let chunked_candidates = chunked_store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("chunked candidates");
+        let single_candidates = single_store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("single candidates");
+        assert_eq!(chunked_candidates, single_candidates);
+    }
+
+    #[tokio::test]
+    async fn failing_chunk_persists_successes_and_reports_every_unlanded_candidate() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let store = JobStore::open(directory.path().join("jobs.sqlite")).expect("store");
+        seed_proposal_candidates(&store, 6);
+        let before = store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("candidates");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = FailOnRequestProvider {
+            inner: MockProvider::new(bookforge_llm::MockMode::PrefixTarget, "Italian"),
+            calls: calls.clone(),
+            fail_call: 1,
+        };
+
+        let run = propose_candidates_with_provider(
+            &store,
+            &[],
+            "book",
+            "English",
+            "Italian",
+            "mock",
+            "fail-second-request",
+            320,
+            Some(640),
+            &provider,
+        )
+        .await
+        .expect("partial outcome should be returned for explicit reporting");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(run.request_count, 3);
+        assert_eq!(run.proposals.len(), 4);
+        assert_eq!(run.failures.len(), 1);
+        assert_eq!(run.failures[0].candidate_ids.len(), 2);
+        let accounted_ids = run
+            .proposals
+            .iter()
+            .map(|proposal| proposal.id)
+            .chain(
+                run.failures
+                    .iter()
+                    .flat_map(|failure| failure.candidate_ids.iter().copied()),
+            )
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            accounted_ids,
+            before
+                .iter()
+                .map(|candidate| candidate.id)
+                .collect::<std::collections::BTreeSet<_>>()
+        );
+
+        let after = store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("candidates");
+        assert_eq!(
+            after
+                .iter()
+                .filter(|candidate| candidate.target_text.is_some())
+                .count(),
+            4
+        );
+        assert_eq!(
+            after
+                .iter()
+                .filter(|candidate| candidate_needs_proposal(candidate))
+                .count(),
+            2
+        );
+        let counts = proposal_counts(&run);
+        assert_eq!(counts.completed(), 4);
+        assert_eq!(counts.failed, 2);
+        let summary = format_proposal_summary(counts);
+        assert!(summary.contains("INCOMPLETE"), "{summary}");
+        assert!(summary.contains("completed 4 of 6"), "{summary}");
+        assert!(
+            summary.contains("2 candidates failed and remain pending"),
+            "{summary}"
+        );
+    }
+
+    #[tokio::test]
     async fn declined_proposal_leaves_candidate_unrendered_and_pending() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let store = JobStore::open(directory.path().join("jobs.sqlite")).expect("store");
@@ -1463,10 +1689,11 @@ case_sensitive = true
                 rendered: 0,
                 declined: 0,
                 model_rejected: 1,
+                failed: 0,
             }
         );
         assert!(
-            format_proposal_summary(counts).contains("model rejected 1 candidate"),
+            format_proposal_summary(counts).contains("1 model-rejected candidate"),
             "the user-facing summary must report the rejection count"
         );
 
@@ -1543,7 +1770,7 @@ case_sensitive = true
     }
 
     #[tokio::test]
-    async fn provider_failure_does_not_modify_candidates() {
+    async fn provider_failure_is_reported_and_does_not_modify_candidates() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let store = JobStore::open(directory.path().join("jobs.sqlite")).expect("store");
         store
@@ -1562,7 +1789,7 @@ case_sensitive = true
             .list_glossary_candidates("book", "English", "Italian")
             .expect("candidate");
 
-        let error = propose_candidates_with_provider(
+        let run = propose_candidates_with_provider(
             &store,
             &[],
             "book",
@@ -1575,11 +1802,17 @@ case_sensitive = true
             &FailingProvider,
         )
         .await
-        .expect_err("provider failure should surface");
+        .expect("the partial outcome should retain candidate accounting");
 
+        let counts = proposal_counts(&run);
         assert!(
-            error.to_string().contains("offline test failure"),
-            "{error}"
+            run.failures[0].error.contains("offline test failure"),
+            "{run:?}"
+        );
+        assert_eq!(counts.failed, 1);
+        assert!(
+            format_proposal_summary(counts).contains("INCOMPLETE"),
+            "the user-facing summary must never report a partial pass as success"
         );
         let after = store
             .list_glossary_candidates("book", "English", "Italian")

--- a/crates/bookforge-llm/src/glossary_proposal.rs
+++ b/crates/bookforge-llm/src/glossary_proposal.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use bookforge_core::GlossaryCategory;
 use serde::{Deserialize, Serialize};
@@ -11,6 +11,7 @@ use crate::{
 const PROMPT_SOURCE: &str = include_str!("../prompts/glossary_propose.v2.md");
 pub const GLOSSARY_PROPOSAL_PROMPT_NAME: &str = "glossary_propose";
 pub const GLOSSARY_PROPOSAL_PROMPT_VERSION: &str = "v2";
+const OUTPUT_TOKENS_PER_CANDIDATE: u32 = 320;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct GlossaryProposalInput {
@@ -57,9 +58,17 @@ pub struct GlossaryProposal {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlossaryProposalRun {
     pub proposals: Vec<GlossaryProposal>,
+    pub failures: Vec<GlossaryProposalFailure>,
     pub estimated_input_tokens: usize,
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
+    pub request_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlossaryProposalFailure {
+    pub candidate_ids: Vec<i64>,
+    pub error: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,6 +82,58 @@ struct RawProposal {
     target_text: Option<String>,
     policy: GlossaryProposalPolicy,
     reason: String,
+}
+
+#[derive(Debug)]
+struct ProposalBatchRequestError {
+    error: LlmError,
+    usage: ProposalUsage,
+}
+
+impl ProposalBatchRequestError {
+    fn should_split(&self) -> bool {
+        matches!(self.error, LlmError::Json(_) | LlmError::InvalidResponse(_))
+    }
+}
+
+impl std::fmt::Display for ProposalBatchRequestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProposalUsage {
+    estimated_input_tokens: usize,
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    request_count: usize,
+}
+
+impl ProposalUsage {
+    fn for_request(estimated_input_tokens: usize) -> Self {
+        Self {
+            estimated_input_tokens,
+            input_tokens: None,
+            output_tokens: None,
+            request_count: 1,
+        }
+    }
+
+    fn with_response(mut self, input_tokens: Option<u64>, output_tokens: Option<u64>) -> Self {
+        self.input_tokens = input_tokens;
+        self.output_tokens = output_tokens;
+        self
+    }
+
+    fn accumulate(&mut self, usage: Self) {
+        self.estimated_input_tokens = self
+            .estimated_input_tokens
+            .saturating_add(usage.estimated_input_tokens);
+        self.input_tokens = sum_optional_tokens(self.input_tokens, usage.input_tokens);
+        self.output_tokens = sum_optional_tokens(self.output_tokens, usage.output_tokens);
+        self.request_count = self.request_count.saturating_add(usage.request_count);
+    }
 }
 
 pub async fn propose_glossary_renderings<P>(
@@ -90,9 +151,11 @@ where
     if items.is_empty() {
         return Ok(GlossaryProposalRun {
             proposals: Vec::new(),
+            failures: Vec::new(),
             estimated_input_tokens: 0,
             input_tokens: Some(0),
             output_tokens: Some(0),
+            request_count: 0,
         });
     }
 
@@ -103,15 +166,91 @@ where
         PROMPT_SOURCE,
     )
     .map_err(|error| LlmError::Provider(error.to_string()))?;
+
+    let chunk_size = proposal_chunk_size(max_output_tokens);
+    let mut queue = items
+        .chunks(chunk_size)
+        .map(<[GlossaryProposalInput]>::to_vec)
+        .collect::<VecDeque<_>>();
+    let mut proposals = Vec::with_capacity(items.len());
+    let mut failures = Vec::new();
+    let mut usage = ProposalUsage {
+        estimated_input_tokens: 0,
+        input_tokens: Some(0),
+        output_tokens: Some(0),
+        request_count: 0,
+    };
+
+    while let Some(chunk) = queue.pop_front() {
+        match request_glossary_proposal_batch(
+            provider,
+            &template,
+            source_language,
+            target_language,
+            &chunk,
+            provider_name,
+            model,
+            max_output_tokens,
+        )
+        .await
+        {
+            Ok((mut chunk_proposals, chunk_usage)) => {
+                usage.accumulate(chunk_usage);
+                proposals.append(&mut chunk_proposals);
+            }
+            Err(error) if error.should_split() && chunk.len() > 1 => {
+                usage.accumulate(error.usage);
+                let mid = chunk.len() / 2;
+                queue.push_front(chunk[mid..].to_vec());
+                queue.push_front(chunk[..mid].to_vec());
+            }
+            Err(error) => {
+                usage.accumulate(error.usage);
+                failures.push(GlossaryProposalFailure {
+                    candidate_ids: chunk.iter().map(|item| item.id).collect(),
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(GlossaryProposalRun {
+        proposals,
+        failures,
+        estimated_input_tokens: usage.estimated_input_tokens,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        request_count: usage.request_count,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn request_glossary_proposal_batch<P>(
+    provider: &P,
+    template: &PromptTemplate,
+    source_language: &str,
+    target_language: &str,
+    items: &[GlossaryProposalInput],
+    provider_name: &str,
+    model: &str,
+    max_output_tokens: u32,
+) -> Result<(Vec<GlossaryProposal>, ProposalUsage), ProposalBatchRequestError>
+where
+    P: LlmProvider,
+{
     let mut vars = Substitutions::new();
     vars.string("source_language", source_language)
         .string("target_language", target_language)
         .json_compact("items_json", &items);
     let rendered = template
         .render(&vars)
-        .map_err(|error| LlmError::Provider(error.to_string()))?;
+        .map_err(|error| ProposalBatchRequestError {
+            error: LlmError::Provider(error.to_string()),
+            usage: ProposalUsage::for_request(0),
+        })?;
     let estimated_input_tokens =
         estimate_tokens(&rendered.system).saturating_add(estimate_tokens(&rendered.user));
+    let request_usage = ProposalUsage::for_request(estimated_input_tokens);
 
     let response = provider
         .complete(CompletionRequest {
@@ -121,30 +260,49 @@ where
             temperature: 0.1,
             max_output_tokens: Some(max_output_tokens.max(1)),
             metadata: RequestMetadata {
-                prompt_template: Some(template.name),
-                prompt_version: Some(template.version),
+                prompt_template: Some(template.name.clone()),
+                prompt_version: Some(template.version.clone()),
                 provider: Some(provider_name.to_string()),
                 model: Some(model.to_string()),
                 provider_max_attempts: Some(2),
                 ..RequestMetadata::default()
             },
         })
-        .await?;
+        .await
+        .map_err(|error| ProposalBatchRequestError {
+            error,
+            usage: request_usage,
+        })?;
+    let request_usage = request_usage.with_response(response.input_tokens, response.output_tokens);
 
     if response.finish_reason == FinishReason::Length {
-        return Err(LlmError::InvalidResponse(format!(
-            "glossary proposal output was truncated at {max_output_tokens} tokens"
-        )));
+        return Err(ProposalBatchRequestError {
+            error: LlmError::InvalidResponse(format!(
+                "glossary proposal output was truncated at {max_output_tokens} tokens"
+            )),
+            usage: request_usage,
+        });
     }
 
-    let parsed: ProposalResponse = serde_json::from_str(&response.content)?;
-    let proposals = validate_proposals(items, parsed.proposals)?;
-    Ok(GlossaryProposalRun {
-        proposals,
-        estimated_input_tokens,
-        input_tokens: response.input_tokens,
-        output_tokens: response.output_tokens,
-    })
+    let parsed: ProposalResponse =
+        serde_json::from_str(&response.content).map_err(|error| ProposalBatchRequestError {
+            error: LlmError::Json(error),
+            usage: request_usage,
+        })?;
+    let proposals =
+        validate_proposals(items, parsed.proposals).map_err(|error| ProposalBatchRequestError {
+            error,
+            usage: request_usage,
+        })?;
+    Ok((proposals, request_usage))
+}
+
+fn proposal_chunk_size(max_output_tokens: u32) -> usize {
+    usize::try_from((max_output_tokens / OUTPUT_TOKENS_PER_CANDIDATE).max(1)).unwrap_or(usize::MAX)
+}
+
+fn sum_optional_tokens(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    Some(left?.saturating_add(right?))
 }
 
 fn ensure_unique_input_ids(items: &[GlossaryProposalInput]) -> Result<(), LlmError> {
@@ -286,8 +444,42 @@ mod tests {
             Some("[Italian] phantasmatron")
         );
         assert_eq!(run.proposals[0].policy, GlossaryProposalPolicy::Recreate);
+        assert!(run.failures.is_empty());
+        assert_eq!(run.request_count, 1);
         assert!(run.input_tokens.is_some());
         assert!(run.output_tokens.is_some());
+    }
+
+    #[tokio::test]
+    async fn candidate_set_larger_than_one_chunk_uses_multiple_requests() {
+        assert_eq!(proposal_chunk_size(8_192), 25);
+        let provider = MockProvider::new(MockMode::PrefixTarget, "Italian");
+        let items = (1..=26)
+            .map(|id| input(id, format!("candidate-{id}").as_str()))
+            .collect::<Vec<_>>();
+
+        let run = propose_glossary_renderings(
+            &provider,
+            "English",
+            "Italian",
+            &items,
+            "mock",
+            "mock-prefix-target",
+            8_192,
+        )
+        .await
+        .expect("chunked mock proposal should succeed");
+
+        assert_eq!(run.request_count, 2);
+        assert_eq!(run.proposals.len(), items.len());
+        assert!(run.failures.is_empty());
+        assert_eq!(
+            run.proposals
+                .iter()
+                .map(|proposal| proposal.id)
+                .collect::<Vec<_>>(),
+            items.iter().map(|item| item.id).collect::<Vec<_>>()
+        );
     }
 
     #[derive(Clone)]
@@ -317,6 +509,184 @@ mod tests {
                 supports_usage_tokens: true,
             }
         }
+    }
+
+    #[derive(Clone)]
+    struct SplitRetryProvider;
+
+    impl LlmProvider for SplitRetryProvider {
+        async fn complete(
+            &self,
+            request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            let items = extract_prompt_items(&request.user);
+            if items.len() > 1 {
+                return Ok(CompletionResponse {
+                    content: serde_json::json!({ "proposals": [] }).to_string(),
+                    input_tokens: Some(10),
+                    input_cached_tokens: Some(0),
+                    output_tokens: Some(5),
+                    finish_reason: FinishReason::Length,
+                    provider_latency_ms: 1,
+                    raw: serde_json::Value::Null,
+                });
+            }
+
+            let proposals = items
+                .iter()
+                .filter_map(|item| {
+                    let id = item.get("id")?.as_i64()?;
+                    let source_text = item.get("source_text")?.as_str()?;
+                    Some(serde_json::json!({
+                        "id": id,
+                        "target_text": format!("rendered {source_text}"),
+                        "policy": "recreate",
+                        "reason": "The isolated candidate has enough evidence."
+                    }))
+                })
+                .collect::<Vec<_>>();
+            Ok(CompletionResponse {
+                content: serde_json::json!({ "proposals": proposals }).to_string(),
+                input_tokens: Some(10),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(5),
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 1,
+                raw: serde_json::Value::Null,
+            })
+        }
+
+        fn capabilities(&self) -> crate::ProviderCapabilities {
+            crate::ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct EmptyForCandidateProvider {
+        empty_id: i64,
+    }
+
+    impl LlmProvider for EmptyForCandidateProvider {
+        async fn complete(
+            &self,
+            request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            let items = extract_prompt_items(&request.user);
+            if items.iter().any(|item| {
+                item.get("id").and_then(serde_json::Value::as_i64) == Some(self.empty_id)
+            }) {
+                return Ok(CompletionResponse {
+                    content: String::new(),
+                    input_tokens: Some(10),
+                    input_cached_tokens: Some(0),
+                    output_tokens: Some(5),
+                    finish_reason: FinishReason::Stop,
+                    provider_latency_ms: 1,
+                    raw: serde_json::Value::Null,
+                });
+            }
+
+            let proposals = items
+                .iter()
+                .filter_map(|item| {
+                    let id = item.get("id")?.as_i64()?;
+                    let source_text = item.get("source_text")?.as_str()?;
+                    Some(serde_json::json!({
+                        "id": id,
+                        "target_text": format!("rendered {source_text}"),
+                        "policy": "recreate",
+                        "reason": "The candidate has enough evidence."
+                    }))
+                })
+                .collect::<Vec<_>>();
+            Ok(CompletionResponse {
+                content: serde_json::json!({ "proposals": proposals }).to_string(),
+                input_tokens: Some(10),
+                input_cached_tokens: Some(0),
+                output_tokens: Some(5),
+                finish_reason: FinishReason::Stop,
+                provider_latency_ms: 1,
+                raw: serde_json::Value::Null,
+            })
+        }
+
+        fn capabilities(&self) -> crate::ProviderCapabilities {
+            crate::ProviderCapabilities {
+                supports_json_response_format: true,
+                supports_usage_tokens: true,
+            }
+        }
+    }
+
+    fn extract_prompt_items(user: &str) -> Vec<serde_json::Value> {
+        user.lines()
+            .find_map(|line| {
+                let line = line.trim();
+                line.starts_with('[')
+                    .then(|| serde_json::from_str(line).ok())
+                    .flatten()
+            })
+            .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn truncation_bisects_and_retries_until_every_candidate_lands() {
+        let items = (1..=4)
+            .map(|id| input(id, format!("candidate-{id}").as_str()))
+            .collect::<Vec<_>>();
+
+        let run = propose_glossary_renderings(
+            &SplitRetryProvider,
+            "English",
+            "Italian",
+            &items,
+            "test",
+            "split-retry",
+            1_280,
+        )
+        .await
+        .expect("split retries should recover");
+
+        assert_eq!(run.proposals.len(), items.len());
+        assert!(run.failures.is_empty());
+        assert_eq!(
+            run.request_count, 7,
+            "one four-item request, two two-item retries, and four single-item retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_response_is_bisected_and_only_terminal_candidate_fails() {
+        let items = (1..=4)
+            .map(|id| input(id, format!("candidate-{id}").as_str()))
+            .collect::<Vec<_>>();
+
+        let run = propose_glossary_renderings(
+            &EmptyForCandidateProvider { empty_id: 3 },
+            "English",
+            "Italian",
+            &items,
+            "test",
+            "empty-on-three",
+            1_280,
+        )
+        .await
+        .expect("empty output should produce an explicitly partial result");
+
+        assert_eq!(
+            run.proposals
+                .iter()
+                .map(|proposal| proposal.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 4]
+        );
+        assert_eq!(run.failures.len(), 1);
+        assert_eq!(run.failures[0].candidate_ids, vec![3]);
+        assert!(run.failures[0].error.contains("EOF"), "{run:?}");
+        assert_eq!(run.request_count, 5);
     }
 
     #[tokio::test]
@@ -384,7 +754,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incomplete_response_is_rejected_as_a_whole() {
+    async fn incomplete_response_is_bisected_and_terminal_omission_is_accounted_for() {
         let provider = StaticProvider {
             content: serde_json::json!({
                 "proposals": [{
@@ -397,7 +767,7 @@ mod tests {
             .to_string(),
         };
 
-        let error = propose_glossary_renderings(
+        let run = propose_glossary_renderings(
             &provider,
             "English",
             "Italian",
@@ -407,8 +777,13 @@ mod tests {
             1_024,
         )
         .await
-        .expect_err("omitted IDs must fail the batch");
+        .expect("partial result should retain exact failure accounting");
 
-        assert!(error.to_string().contains("omitted IDs: 2"), "{error}");
+        assert_eq!(run.proposals.len(), 1);
+        assert_eq!(run.proposals[0].id, 1);
+        assert_eq!(run.failures.len(), 1);
+        assert_eq!(run.failures[0].candidate_ids, vec![2]);
+        assert!(run.failures[0].error.contains("unknown ID 1"), "{run:?}");
+        assert_eq!(run.request_count, 3);
     }
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -389,11 +389,11 @@ English is poor and the proposal model must make the terminology judgment.
 
 `--min-count` defaults to 3. This deliberately recovers terms that recur three
 times while keeping one- and two-off capitalized words out of the single,
-book-sized model request. Each additional candidate reserves 320 output tokens
-by default, so lowering it further is not free. The positional rule remains as
-an inexpensive candidate-budget gate, not a semantic verdict; use
-`--min-count` and `--limit` explicitly when a book or language needs a different
-recall/cost tradeoff.
+book-sized proposal pass. Each additional candidate reserves 320 output tokens
+within bounded requests by default, so lowering it further is not free. The
+positional rule remains as an inexpensive candidate-budget gate, not a semantic
+verdict; use `--min-count` and `--limit` explicitly when a book or language
+needs a different recall/cost tradeoff.
 
 On The Cyberiad at `--limit 60`, the rule dropped eleven non-terms and freed
 those slots for nine genuine coinages the noise had been crowding out
@@ -409,12 +409,19 @@ The EPUB is required because each term is sent with one bounded source excerpt
 as the QA provider options. `--qa-model` is required so an inexpensive
 translation model is not selected silently for this judgment-heavy pass.
 
-One request carries every pending candidate, so `--qa-max-output-tokens` has no
-fixed default: it is sized at 320 tokens per candidate, with a floor of 8192 and
-a ceiling of 65536. A measured 40-candidate run on Kimi K3 spent 8277 output
-tokens, about 207 each including reasoning. Pass the flag to override. If a
-reasoning model still exhausts the budget before answering, the error says so
-and names this flag rather than surfacing a bare parse failure.
+`propose` sends bounded chunks rather than one book-sized request.
+`--qa-max-output-tokens` is the cap for each request and defaults to 8192.
+Chunks reserve 320 output tokens per candidate, so the default carries at most
+25 candidates; a measured 40-candidate run on Kimi K3 spent 8277 output tokens,
+about 207 each including reasoning. Passing the flag changes both the
+per-request cap and the derived chunk size.
+
+If a response reaches the cap, is incomplete JSON, or fails response-shape
+validation, BookForge retries by bisecting that chunk, following the QA batch
+recovery strategy. One candidate is the floor. A terminal failure remains
+pending while completed chunks are persisted. The command prints an
+`INCOMPLETE` summary with completed and failed candidate counts and exits with
+an error, so a partially completed pass cannot be mistaken for success.
 
 The model chooses `preserve`, `translate`, `calque`, `recreate`, `decline`, or
 `not_terminology` and gives a one-sentence reason. `decline` means the item is
@@ -435,7 +442,8 @@ distinguishable. The command reports the model-rejection count and prints each
 reason. Existing renderings, model rejections, and `user_seeded`, `accepted`, or
 human-`rejected` decisions are not sent again.
 
-The command reports estimated and provider-reported token counts. As an
+The command reports the request count plus aggregate estimated and
+provider-reported token counts. As an
 illustrative typical case, 50 candidates with short excerpts are about 5,000
 input and 1,500 output tokens. At $3/M input and $15/M output that is roughly
 $0.04 for the book; substitute the selected model's current prices.

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -208,8 +208,13 @@ rejection is stored with a visible `model rejection (not terminology): ...`
 note, is skipped by later proposal passes, and remains in `review-candidates`
 for human override. Human rejection uses the distinct `rejected` status. The
 command reports how many candidates the model rejected and prints each reason.
-Settled and already-proposed terms are not sent again, and a provider or
-response-validation failure occurs before any candidate write.
+Settled and already-proposed terms are not sent again. The proposal pass uses
+bounded chunks of at most 25 candidates by default (8192 output tokens,
+budgeted at 320 per candidate). Truncated or structurally invalid responses are
+bisected and retried down to a single candidate. Completed chunks are retained,
+but any terminal chunk failure makes the command print an `INCOMPLETE` summary
+with completed and failed counts and exit with an error; failed candidates
+remain pending.
 
 Candidate extraction itself is English-specific: its positional evidence models
 English capitalization and non-English input gets only a 17-word English
@@ -219,23 +224,24 @@ model as precision. The default `--min-count 3` is the recommended compromise:
 it recovers three-occurrence terms without paying the 320-output-token budget
 for the much larger one- and two-occurrence tail.
 
-This pass is deliberately book-sized rather than segment-sized. A measured run —
-The Cyberiad, 40 candidates, Kimi K3 — cost 2,355 provider input tokens and
+This pass is deliberately book-scoped rather than segment-scoped. A measured
+run — The Cyberiad, 40 candidates, Kimi K3 — cost 2,355 provider input tokens and
 **8,277 output tokens**: about 207 output tokens per candidate, most of it
 reasoning. That is cents per book, once, against paying for repeated QA after
 terminology has already drifted. The command prints both its prompt estimate and
 provider-reported usage; use the selected model's current rates for budgeting.
 
-**Size the output cap from the candidate count, not a flat number.** One request
-carries every pending candidate, so the budget has to scale. A reasoning model
-that runs out mid-thought returns HTTP 200 with *no message content at all* —
-not a truncated answer — so the failure used to surface as
+**Bound each request while keeping the per-candidate allowance honest.** A
+reasoning model that runs out mid-thought returns HTTP 200 with *no message
+content at all* — not a truncated answer — so the failure used to surface as
 `missing choices[0].message.content`, which says nothing about the cause. This
 happened three separate times in two days: `judge_flags` at its 400-token
 default, the QA pass at the provider default, and this command at a flat 4,096.
 The provider now recognises that shape — `finish_reason: length`, or reasoning
-present with content absent — and names the flag to raise. `glossary propose`
-sizes its own budget at 320 tokens per candidate (floor 8,192, ceiling 65,536).
+present with content absent — and names the relevant flag. `glossary propose`
+caps each request at 8,192 output tokens by default and sizes chunks at 320
+tokens per candidate. It also bisects a truncated or invalid chunk rather than
+discarding the entire proposal pass.
 
 ## Cost
 


### PR DESCRIPTION
**Stacked on [#84](https://github.com/JunjoSick/bookforge/pull/84)** — targets `feat/glossary-propose`, not `main`, so the diff shows only this change.

## The problem #84 created

`propose_glossary_renderings` sends every pending candidate in one request. That was sized against a 40-candidate measurement. #84 lowered the `extract-candidates` default `--min-count` from 4 to 3, which changes the scale of the *documented default flow*:

```
tests/The_Cyberiad.epub
  --min-count 4  ->  186 candidates
  --min-count 3  ->  257 candidates   (the new default)
```

At 257 candidates the budget wants 82,240 output tokens and silently clamps to the 65,536 ceiling — a figure many providers reject outright. And there was no bisection, so **one truncation lost every candidate in the pass**.

Not hypothetical. A reasoning model that exhausts its output budget returns HTTP 200 with no content at all — observed at four separate call sites today, most recently at **10 of 25** requests on a 4,096 cap.

## What changed

- Requests capped at **8,192** output tokens, chunked at **25 candidates** — sized from the measured ~207 tokens each, about 55% headroom. 257 candidates become 11 requests.
- A truncated, malformed, or invalid chunk is **bisected** rather than discarded, adapting the queue-and-bisect strategy from `qa_batch.rs`. The QA helper itself is domain-specific and private, so sharing it directly would have meant contorting both call sites — the algorithm was adapted instead, deliberately.

## Independence was verified, not assumed

Chunking is only safe if candidates don't need each other's context. Checked against `glossary_propose.v2.md` before relying on it: each decision uses only that candidate's own fields and excerpt, with no cross-candidate comparison requested. Chunking removes no context, and the prompt is unchanged.

This is the opposite of the QA pass, where cross-reference context between segments is the entire signal and chunking would destroy it.

## Partial failure is never reported as success

The recurring defect in this codebase, found at six sites across three audits. Here:

- Successful renderings and model rejections are **persisted**.
- Failed candidates stay **pending**.
- The summary is prefixed `INCOMPLETE` with completed/failed counts.
- The command **exits with an error** that states completed results were retained and failed candidates remain pending — so a non-zero exit doesn't imply the whole pass was lost.

Also corrects existing misleading wording: the old summary said declines were "saved" when a decline persists nothing at all.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **885 passed / 0 failed / 3 ignored** (was 880). New offline coverage for multi-request accounting, bisection, HTTP-200-empty-content, partial failure, and single-vs-multi-chunk persistence equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)