### PR TITLE
Make accepting glossary proposals scriptable, and document the A/B protocol

### DIFF
--- a/crates/bookforge-cli/src/commands/glossary.rs
+++ b/crates/bookforge-cli/src/commands/glossary.rs
@@ -44,6 +44,8 @@ enum GlossaryCommand {
     ExtractCandidates(ExtractCandidatesArgs),
     /// Ask a review model for target renderings of pending candidates.
     Propose(ProposeArgs),
+    /// Accept every rendered candidate without starting an interactive review.
+    AcceptCandidates(AcceptCandidatesArgs),
     /// Interactively accept, translate, or reject extracted candidates.
     ReviewCandidates(ReviewCandidatesArgs),
 }
@@ -152,6 +154,14 @@ struct ReviewCandidatesArgs {
 }
 
 #[derive(Debug, Args)]
+struct AcceptCandidatesArgs {
+    book_id: String,
+
+    #[arg(long)]
+    language: Option<String>,
+}
+
+#[derive(Debug, Args)]
 struct ProposeArgs {
     input: PathBuf,
 
@@ -234,6 +244,7 @@ pub async fn run(args: GlossaryArgs) -> Result<()> {
         GlossaryCommand::Export(args) => export_terms(&store, args),
         GlossaryCommand::ExtractCandidates(args) => extract_candidates(&store, args),
         GlossaryCommand::Propose(args) => propose_candidates(&store, args).await,
+        GlossaryCommand::AcceptCandidates(args) => accept_candidates(&store, args),
         GlossaryCommand::ReviewCandidates(args) => review_candidates(&store, args),
     }
 }
@@ -502,10 +513,14 @@ fn candidate_needs_proposal(candidate: &StoredGlossaryCandidate) -> bool {
         .target_text
         .as_deref()
         .is_none_or(|target| target.trim().is_empty())
-        && !candidate
-            .notes
-            .as_deref()
-            .is_some_and(|notes| notes.starts_with(MODEL_REJECTION_NOTE_PREFIX))
+        && !candidate_is_model_rejected(candidate)
+}
+
+fn candidate_is_model_rejected(candidate: &StoredGlossaryCandidate) -> bool {
+    candidate
+        .notes
+        .as_deref()
+        .is_some_and(|notes| notes.starts_with(MODEL_REJECTION_NOTE_PREFIX))
 }
 
 fn model_rejection_note(reason: &str) -> String {
@@ -650,6 +665,67 @@ fn format_optional_tokens(tokens: Option<u64>) -> String {
         .unwrap_or_else(|| "unreported".to_string())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct BulkAcceptanceCounts {
+    accepted: usize,
+    skipped_empty: usize,
+    skipped_model_rejected: usize,
+}
+
+fn accept_candidates(store: &JobStore, args: AcceptCandidatesArgs) -> Result<()> {
+    let Some((source_language, target_language)) =
+        resolve_candidate_language_pair(store, &args.book_id, args.language.as_deref())?
+    else {
+        println!(
+            "{}",
+            format_bulk_acceptance_summary(BulkAcceptanceCounts::default())
+        );
+        return Ok(());
+    };
+    let candidates =
+        store.list_glossary_candidates(&args.book_id, &source_language, &target_language)?;
+    let counts = bulk_accept_candidates(store, &candidates)?;
+    println!("{}", format_bulk_acceptance_summary(counts));
+    Ok(())
+}
+
+fn bulk_accept_candidates(
+    store: &JobStore,
+    candidates: &[StoredGlossaryCandidate],
+) -> Result<BulkAcceptanceCounts> {
+    let mut counts = BulkAcceptanceCounts::default();
+    for candidate in candidates {
+        if candidate_is_model_rejected(candidate) {
+            counts.skipped_model_rejected += 1;
+            continue;
+        }
+        if candidate
+            .target_text
+            .as_deref()
+            .is_none_or(|target| target.trim().is_empty())
+        {
+            counts.skipped_empty += 1;
+            continue;
+        }
+        if !store.accept_glossary_candidate(candidate.id, None)? {
+            anyhow::bail!(
+                "candidate {} was no longer pending; accepted {} candidates before stopping",
+                candidate.id,
+                counts.accepted
+            );
+        }
+        counts.accepted += 1;
+    }
+    Ok(counts)
+}
+
+fn format_bulk_acceptance_summary(counts: BulkAcceptanceCounts) -> String {
+    format!(
+        "Bulk acceptance: accepted={} skipped-empty={} skipped-model-rejected={}.",
+        counts.accepted, counts.skipped_empty, counts.skipped_model_rejected
+    )
+}
+
 fn review_candidates(store: &JobStore, args: ReviewCandidatesArgs) -> Result<()> {
     let Some((source_language, target_language)) =
         resolve_candidate_language_pair(store, &args.book_id, args.language.as_deref())?
@@ -699,24 +775,8 @@ fn review_candidates(store: &JobStore, args: ReviewCandidatesArgs) -> Result<()>
                 }
             }
             Ok(ReviewCommand::AcceptAll) => {
-                let proposed = candidates
-                    .iter()
-                    .filter(|candidate| {
-                        candidate
-                            .target_text
-                            .as_deref()
-                            .is_some_and(|target| !target.trim().is_empty())
-                    })
-                    .collect::<Vec<_>>();
-                let mut accepted = 0usize;
-                for candidate in proposed {
-                    if store.accept_glossary_candidate(candidate.id, None)? {
-                        accepted += 1;
-                    }
-                }
-                println!(
-                    "Accepted {accepted} proposed renderings; candidates without a rendering remain pending."
-                );
+                let counts = bulk_accept_candidates(store, &candidates)?;
+                println!("{}", format_bulk_acceptance_summary(counts));
             }
             Ok(ReviewCommand::Set(number, target)) => {
                 let candidate = match candidate_by_number(&candidates, number) {
@@ -1337,6 +1397,108 @@ case_sensitive = true
         assert_eq!(
             parse_review_command("quit").expect("quit command"),
             ReviewCommand::Quit
+        );
+    }
+
+    #[test]
+    fn bulk_acceptance_promotes_rendered_candidates_and_preserves_other_decisions() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let store = JobStore::open(directory.path().join("jobs.sqlite")).expect("store");
+        store
+            .upsert_glossary_terms(&[
+                stored_term("rendered one", "reso uno", GlossaryStatus::AutoCandidate),
+                stored_term("rendered two", "reso due", GlossaryStatus::AutoCandidate),
+                stored_term("empty", "", GlossaryStatus::AutoCandidate),
+                stored_term("whitespace", "   ", GlossaryStatus::AutoCandidate),
+                stored_term("accepted", "preesistente", GlossaryStatus::Accepted),
+                stored_term("seeded", "manuale", GlossaryStatus::UserSeeded),
+                stored_term("human rejected", "", GlossaryStatus::Rejected),
+            ])
+            .expect("terms");
+        let candidates = store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("candidates");
+
+        let counts = bulk_accept_candidates(&store, &candidates).expect("bulk acceptance");
+
+        assert_eq!(
+            counts,
+            BulkAcceptanceCounts {
+                accepted: 2,
+                skipped_empty: 2,
+                skipped_model_rejected: 0,
+            }
+        );
+        let terms = store
+            .list_glossary_terms(GlossaryFilter {
+                scope_kind: Some(GlossaryScopeKind::Book),
+                scope_id: Some("book"),
+                source_language: Some("English"),
+                target_language: Some("Italian"),
+                active_only: false,
+            })
+            .expect("terms");
+        let term = |source: &str| {
+            terms
+                .iter()
+                .find(|term| term.source_text == source)
+                .expect("term")
+        };
+        assert_eq!(term("rendered one").status, GlossaryStatus::Accepted);
+        assert_eq!(term("rendered two").status, GlossaryStatus::Accepted);
+        assert_eq!(term("empty").status, GlossaryStatus::AutoCandidate);
+        assert_eq!(term("whitespace").status, GlossaryStatus::AutoCandidate);
+        assert_eq!(term("accepted").status, GlossaryStatus::Accepted);
+        assert_eq!(term("accepted").target_text, "preesistente");
+        assert_eq!(term("seeded").status, GlossaryStatus::UserSeeded);
+        assert_eq!(term("seeded").target_text, "manuale");
+        assert_eq!(term("human rejected").status, GlossaryStatus::Rejected);
+    }
+
+    #[test]
+    fn bulk_acceptance_skips_model_rejections_even_with_a_rendering() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let store = JobStore::open(directory.path().join("jobs.sqlite")).expect("store");
+        let mut model_rejected =
+            stored_term("ordinary word", "parola", GlossaryStatus::AutoCandidate);
+        model_rejected.notes = Some(model_rejection_note("It is not terminology."));
+        store
+            .upsert_glossary_terms(&[
+                stored_term("real term", "termine", GlossaryStatus::AutoCandidate),
+                model_rejected,
+            ])
+            .expect("terms");
+        let candidates = store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("candidates");
+
+        let counts = bulk_accept_candidates(&store, &candidates).expect("bulk acceptance");
+
+        assert_eq!(
+            counts,
+            BulkAcceptanceCounts {
+                accepted: 1,
+                skipped_empty: 0,
+                skipped_model_rejected: 1,
+            }
+        );
+        let remaining = store
+            .list_glossary_candidates("book", "English", "Italian")
+            .expect("remaining candidates");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].source_text, "ordinary word");
+        assert!(candidate_is_model_rejected(&remaining[0]));
+    }
+
+    #[test]
+    fn bulk_acceptance_summary_reports_every_outcome_count() {
+        assert_eq!(
+            format_bulk_acceptance_summary(BulkAcceptanceCounts {
+                accepted: 7,
+                skipped_empty: 3,
+                skipped_model_rejected: 2,
+            }),
+            "Bulk acceptance: accepted=7 skipped-empty=3 skipped-model-rejected=2."
         );
     }
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -365,6 +365,10 @@ bookforge glossary propose book.epub \
   --qa-provider openrouter \
   --qa-model moonshotai/kimi-k3
 
+# Non-interactive: explicitly accept every usable proposal.
+bookforge glossary accept-candidates cyberiad --language "English->Italian"
+
+# Interactive: inspect, edit, or reject individual rows.
 bookforge glossary review-candidates cyberiad --language "English->Italian"
 ```
 
@@ -430,17 +434,35 @@ rendering; `not_terminology` means it is ordinary language or extraction noise.
 Both are targetless, but they are not interchangeable.
 
 A rendering fills `target_text` but remains `auto_candidate`; it is inactive
-until a human runs `accept N`, edits it with `set N "..."`, or explicitly runs
-`accept-all`. `accept-all` only promotes candidates that have a non-empty
-rendering. A decline writes no target and remains pending for manual treatment.
+until a human explicitly accepts it. For a script or batch experiment, run
+`accept-candidates BOOK_ID`; for row-by-row review, use `accept N`, edit with
+`set N "..."`, or run the REPL's `accept-all`. Both bulk surfaces only promote
+candidates with a non-empty rendering and print stable outcome counts:
+
+```text
+Bulk acceptance: accepted=37 skipped-empty=1 skipped-model-rejected=2.
+```
+
+Model rejections are always skipped by bulk acceptance, even if a malformed or
+future row happens to contain a rendering. A broad opt-in would make it too easy
+to erase the distinction between "the model proposed this rendering" and "the
+model said this is not terminology." Override one deliberately in
+`review-candidates` instead. A decline writes no target and remains pending for
+manual treatment.
+
 A model rejection stays visible in `review-candidates` as an inactive
 `auto_candidate` with a `model rejection (not terminology): ...` note. That note
 both preserves the model's reason and prevents automatic re-proposal. A reviewer
 can override it with `accept N` or `set N "..."`; a human `reject N` instead
 changes the status to `rejected`, so machine and human decisions remain
-distinguishable. The command reports the model-rejection count and prints each
-reason. Existing renderings, model rejections, and `user_seeded`, `accepted`, or
-human-`rejected` decisions are not sent again.
+distinguishable. Existing renderings, model rejections, and `user_seeded`,
+`accepted`, or human-`rejected` decisions are not sent again. Bulk acceptance
+also leaves all three settled statuses untouched.
+
+`accept-candidates` intentionally has no category or `source_count` filters.
+`extract-candidates --min-count/--limit` already controls the batch, while an
+acceptance filter would make partially activated proposal sets easier to mistake
+for complete experiments. Add filters only when a measured workflow needs them.
 
 The command reports the request count plus aggregate estimated and
 provider-reported token counts. As an

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -370,6 +370,122 @@ reasoning. That is cents per book, once, against paying for repeated QA after
 terminology has already drifted. The command prints both its prompt estimate and
 provider-reported usage; use the selected model's current rates for budgeting.
 
+### Reproducible accepted-glossary A/B
+
+This experiment asks whether an accepted glossary reduces translation defects,
+not merely whether the glossary machinery runs. **Never run it against the
+owner's real store.** That store contains 30 irreplaceable jobs. BookForge opens
+`.bookforge/jobs.sqlite` relative to the process working directory, so every
+command below runs from one newly created scratch directory and every resulting
+store, run snapshot, output, judge result, and cache stays under that directory.
+
+The final commands require the `judge_translation` example from the quality
+benchmark work. Use a checkout containing both that example and the glossary
+batch-accept command. In PowerShell, edit only `$Repo` and `$Book`, then run the
+commands in order:
+
+```powershell
+$Repo = (Resolve-Path "C:\path\to\bookforge").Path
+$Book = (Resolve-Path "C:\path\to\book.epub").Path
+$Scratch = Join-Path ([IO.Path]::GetTempPath()) ("bookforge-glossary-ab-" + [guid]::NewGuid())
+$Manifest = Join-Path $Repo "Cargo.toml"
+$BookId = "glossary-ab-book"
+$env:Path = "$env:USERPROFILE\.cargo\bin;$env:LOCALAPPDATA\mingw64\bin;$env:Path"
+New-Item -ItemType Directory -Path $Scratch | Out-Null
+Set-Location $Scratch
+
+# Offline preflight: estimate one translation before spending anything.
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  estimate $Book --source English --target Italian `
+  --provider deepseek --model deepseek-v4-flash
+
+# Paid run A: no accepted glossary exists in this new store.
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  translate $Book --source English --target Italian `
+  --provider deepseek --model deepseek-v4-flash --no-thinking `
+  --book-id $BookId --out (Join-Path $Scratch "baseline.it.epub")
+
+# Copy the value printed after "Job:" before continuing.
+$BaselineJob = "<baseline-job-id>"
+
+# Extraction is offline. Proposal is paid and remains inactive.
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  glossary extract-candidates $Book --book-id $BookId `
+  --source-lang English --target-lang Italian
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  glossary propose $Book --book-id $BookId --language "English->Italian" `
+  --qa-provider deepseek --qa-model deepseek-v4-pro
+
+# Explicit, non-interactive human decision. Require accepted > 0.
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  glossary accept-candidates $BookId --language "English->Italian"
+
+# Paid run B: identical translation settings, now with accepted book terms.
+cargo run --manifest-path $Manifest --package bookforge-cli --release --bin bookforge -- `
+  translate $Book --source English --target Italian `
+  --provider deepseek --model deepseek-v4-flash --no-thinking `
+  --book-id $BookId --out (Join-Path $Scratch "glossary.it.epub")
+
+# Copy the second value printed after "Job:".
+$GlossaryJob = "<glossary-job-id>"
+
+# Offline judge preflights: all passages, identical judge and settings.
+cargo run --manifest-path $Manifest --package bookforge-cli --release `
+  --example judge_translation -- --db (Join-Path $Scratch ".bookforge\jobs.sqlite") `
+  --job $BaselineJob --sample 0 --dry-run `
+  --provider deepseek --model deepseek-v4-pro --max-output-tokens 16000
+cargo run --manifest-path $Manifest --package bookforge-cli --release `
+  --example judge_translation -- --db (Join-Path $Scratch ".bookforge\jobs.sqlite") `
+  --job $GlossaryJob --sample 0 --dry-run `
+  --provider deepseek --model deepseek-v4-pro --max-output-tokens 16000
+
+# Paid judging. The second summary also prints per-category baseline deltas.
+cargo run --manifest-path $Manifest --package bookforge-cli --release `
+  --example judge_translation -- --db (Join-Path $Scratch ".bookforge\jobs.sqlite") `
+  --job $BaselineJob --sample 0 `
+  --provider deepseek --model deepseek-v4-pro --max-output-tokens 16000 `
+  --cache (Join-Path $Scratch ".bookforge\translation-judge-cache") `
+  --out (Join-Path $Scratch "judge-baseline.jsonl") `
+  --summary (Join-Path $Scratch "judge-baseline.summary.json")
+cargo run --manifest-path $Manifest --package bookforge-cli --release `
+  --example judge_translation -- --db (Join-Path $Scratch ".bookforge\jobs.sqlite") `
+  --job $GlossaryJob --sample 0 `
+  --provider deepseek --model deepseek-v4-pro --max-output-tokens 16000 `
+  --cache (Join-Path $Scratch ".bookforge\translation-judge-cache") `
+  --baseline (Join-Path $Scratch "judge-baseline.summary.json") `
+  --out (Join-Path $Scratch "judge-glossary.jsonl") `
+  --summary (Join-Path $Scratch "judge-glossary.summary.json")
+```
+
+Do not continue if batch acceptance prints `accepted=0`; there would be no
+glossary treatment to measure. It always reports all outcomes in one stable
+line, for example:
+
+```text
+Bulk acceptance: accepted=37 skipped-empty=1 skipped-model-rejected=2.
+```
+
+Compare the `hard` group's `per_1k_source_words` in the two summary files.
+Also require equal `passages_judged` and `source_words_judged` before treating
+the rates as a paired comparison. Use the same judge, output cap, passage size,
+and sample/seed for both jobs; `--sample 0` above removes sampling variance.
+
+The second translation gets **no translation-cache hits by design** once at
+least one term is accepted. Active glossary content changes its fingerprint,
+and that fingerprint changes the cache namespace. Run B therefore costs full
+price rather than being a nearly free cache replay.
+
+For a realistic translation budget, start with the offline `estimate` command
+above and double its one-run figure. As a concrete scale, 100,000 estimated
+input tokens and BookForge's 1.15× Italian output assumption produce 115,000
+output tokens. At the bundled and current
+[DeepSeek V4 Flash rates](https://api-docs.deepseek.com/quick_start/pricing/)
+of $0.14/M uncached input and $0.28/M output, that is about **$0.046 per run or
+$0.092 for the two translations**. Prompt/context overhead, retries, and the
+second run's glossary block make **$0.10–$0.15 for the translation pair** a
+more practical one-book budget. Proposal and judge calls are separate; both
+commands report usage or a dry-run maximum before the owner approves payment.
+
 **Bound each request while keeping the per-candidate allowance honest.** A
 reasoning model that runs out mid-thought returns HTTP 200 with *no message
 content at all* — not a truncated answer — so the failure used to surface as


### PR DESCRIPTION
A quality benchmark now exists ([#86](https://github.com/JunjoSick/bookforge/pull/86)). The first question it should answer is the one the glossary pass was built for:

> Does supplying an accepted glossary measurably reduce defects in the translation?

**That experiment could not be run.** Accepting proposals was only possible by typing `accept-all` into an interactive stdin REPL — not scriptable, not reproducible, not testable.

That is the same friction behind **zero corrections across 30 real jobs** (`docs/design-feedback-loop.md`). The machinery was never the problem; the manual step is.

## `glossary accept-candidates`

```bash
bookforge glossary accept-candidates cyberiad --language "English->Italian"
```

A separate subcommand rather than a flag on `propose`, so acceptance stays an **explicit act** and can never happen as a side effect of proposing or translating. It promotes only `auto_candidate` rows that carry a rendering, and reports what it did:

```
Bulk acceptance: accepted=N skipped-empty=N skipped-model-rejected=N.
```

**Model rejections are always skipped**, even if one unexpectedly carries a rendering. #84 stores them as `auto_candidate` with a `model rejection (not terminology): …` note precisely so a machine verdict stays distinguishable from a human one — a bulk accept that swept them up would quietly undo that. Overriding a rejection stays a row-specific decision.

Existing `accepted`, `user_seeded`, and human-`rejected` rows are untouched.

Category and `source_count` filters were considered and **rejected**: extraction already offers `--min-count` and `--limit`, and acceptance-time filters would make an incomplete experimental batch easier to overlook.

## The documented protocol

`docs/validator-tooling.md` now carries the full recipe — a GUID-named scratch working directory, offline preflights, baseline translation, proposal, explicit acceptance, glossary translation, and paired judging with `judge_translation`.

Two things it states plainly, because both are easy to get wrong:

- **Never run it against the real store.** It holds 30 irreplaceable jobs. Every step uses an isolated scratch `.bookforge`.
- **The second translation gets no cache hits, by design.** `compute_cache_namespace` takes a glossary fingerprint, so run B cannot hit run A's cache — which is exactly what makes the comparison valid, and also means it costs full price rather than being nearly free.

Budget is roughly **$0.10–$0.15 for the translation pair** on deepseek-v4-flash, derived from BookForge's own 100k-input/115k-output example at current published rates. Proposal and judging are separate, and both report usage or a dry-run maximum before anything is spent.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **897 passed / 0 failed / 3 ignored**. No provider was called and no translation was run in producing this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)