### PR TITLE
Render one shared glossary block per batch instead of one per block item

### DIFF
--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -357,7 +357,7 @@ fn sentence_excerpt(text: &str, term_start: usize, term_end: usize, max_chars: u
     excerpt
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GlossaryPromptTerm {
     pub source: String,
     pub target: String,
@@ -567,8 +567,8 @@ fn enforce_budget(
     let mut truncated = 0usize;
     for (term, rule) in terms {
         let estimate = estimate_prompt_tokens(term);
-        if used + estimate <= budget_tokens || kept.is_empty() {
-            used += estimate;
+        if used.saturating_add(estimate) <= budget_tokens {
+            used = used.saturating_add(estimate);
             kept.push((term, rule));
         } else if term.status == GlossaryStatus::UserSeeded || term.always_active {
             truncated += 1;
@@ -578,12 +578,22 @@ fn enforce_budget(
 }
 
 fn estimate_prompt_tokens(term: &GlossaryTerm) -> usize {
-    let note = term.notes.as_deref().unwrap_or("");
-    let chars = term.source_text.len()
-        + term.target_text.len()
-        + term.category.as_str().len()
-        + note.len()
-        + 16;
+    // The budget applies to the serialized prompt entries, not just their
+    // user-authored values. Account for field names, JSON punctuation,
+    // `term_id`, and `case_sensitive`; the old value-only estimate omitted
+    // most of that cost. Three extra characters conservatively cover this
+    // entry's comma plus the surrounding array brackets.
+    let prompt_term = GlossaryPromptTerm::from_term(term);
+    let chars = serde_json::to_string(&prompt_term)
+        .map(|rendered| rendered.chars().count().saturating_add(3))
+        .unwrap_or_else(|_| {
+            term.source_text
+                .chars()
+                .count()
+                .saturating_add(term.target_text.chars().count())
+                .saturating_add(term.notes.as_deref().unwrap_or("").chars().count())
+                .saturating_add(64)
+        });
     chars.div_ceil(3).max(1)
 }
 
@@ -1121,6 +1131,36 @@ mod tests {
             GlossarySelectionRule::HighFrequencyAnchor
         );
         assert_eq!(credited.len(), 4);
+    }
+
+    #[test]
+    fn selection_budget_bounds_the_serialized_glossary_entries() {
+        let terms = (0..80)
+            .map(|index| {
+                term(
+                    &format!("Source{index:02}"),
+                    &format!("Target{index:02}"),
+                    GlossaryScopeKind::Book,
+                )
+            })
+            .collect::<Vec<_>>();
+        let source = terms
+            .iter()
+            .map(|term| term.source_text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let segments = vec![segment("seg_budget", 0, &source)];
+        let budget_tokens = 200;
+
+        let selections = select_glossary_for_segments(&segments, &terms, budget_tokens);
+        let rendered =
+            serde_json::to_string(&selections.entries_by_segment["seg_budget"]).expect("serialize");
+        let conservative_rendered_tokens = rendered.chars().count().div_ceil(3);
+
+        assert!(
+            conservative_rendered_tokens <= budget_tokens,
+            "selected glossary rendered to {conservative_rendered_tokens} estimated tokens for a {budget_tokens}-token budget"
+        );
     }
 
     #[test]

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -51,8 +51,11 @@ use planning::{
 pub use rendering::batch_item_validation_error;
 pub use rendering::parse_batch_response;
 use rendering::{
-    batch_response_item_count, parse_batch_response_with_validation, render_batch_items,
+    batch_prompt_template, batch_response_item_count, parse_batch_response_with_validation,
+    render_batch_prompt,
 };
+#[cfg(test)]
+use rendering::{render_batch_items, render_batch_prompt_extra};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BatchMode {

--- a/crates/bookforge-llm/src/batch/execution.rs
+++ b/crates/bookforge-llm/src/batch/execution.rs
@@ -1787,54 +1787,14 @@ async fn translate_one_batch_with_evidence(
         compact_retry_attempt,
     } = request;
     let context_block = crate::scheduler::render_context_pairs(&context_pairs);
-    let items_json = render_batch_items(&batch, config);
-    let template = if config.compact_prompts {
-        match batch.mode {
-            BatchMode::Plain | BatchMode::TurboTextOnly => &library.batch_plain_compact,
-            BatchMode::MarkerSafe => &library.batch_marker_safe_compact,
-            BatchMode::RunPreserving => &library.batch_run_preserving_compact,
-        }
-    } else {
-        match batch.mode {
-            BatchMode::Plain | BatchMode::TurboTextOnly => &library.batch_plain,
-            BatchMode::MarkerSafe => &library.batch_marker_safe,
-            BatchMode::RunPreserving => &library.batch_run_preserving,
-        }
-    };
-
-    let mut vars = Substitutions::new();
-    vars.string(
-        "source_language",
-        config
-            .source_language
-            .as_deref()
-            .unwrap_or("the source language"),
-    )
-    .string("target_language", &config.target_language)
-    .raw(
-        "style_guide_block",
-        config
-            .style
-            .as_ref()
-            .map(|s| s.rendered_block.clone())
-            .unwrap_or_default(),
-    )
-    .raw(
-        "entity_agreement_block",
-        config
-            .entities
-            .as_ref()
-            .map(|e| e.rendered_block.clone())
-            .unwrap_or_default(),
-    )
-    .raw("context_translation_pairs", context_block)
-    .raw(
-        "prompt_extra",
-        config.glossary.prompt_extra.clone().unwrap_or_default(),
-    )
-    .raw("items_json", items_json);
-
-    let mut rendered = match template.render(&vars) {
+    let template = batch_prompt_template(&batch, config, &library);
+    let rendered = match render_batch_prompt(
+        &batch,
+        config,
+        &library,
+        &context_block,
+        compact_retry_attempt,
+    ) {
         Ok(rendered) => rendered,
         Err(error) => {
             return BatchRequestOutput {
@@ -1844,11 +1804,6 @@ async fn translate_one_batch_with_evidence(
             };
         }
     };
-    if compact_retry_attempt > 0 {
-        rendered.user.push_str(&format!(
-            "\n\nRECOVERY MODE {compact_retry_attempt}: Return one compact JSON object only. Translate every item exactly once. Do not repeat any word, sentence, item, or explanation. End immediately after the closing brace."
-        ));
-    }
 
     let max_tokens = max_output_tokens_override
         .unwrap_or_else(|| capped_batch_max_output_tokens(&batch, config, provider.is_reasoning()));

--- a/crates/bookforge-llm/src/batch/planning.rs
+++ b/crates/bookforge-llm/src/batch/planning.rs
@@ -573,34 +573,18 @@ fn item_token_estimate(
         return estimate;
     };
 
-    let entries = config
-        .glossary
-        .entries_by_segment
-        .get(&item.segment_id.0)
-        .map(Vec::as_slice)
-        .unwrap_or(&[]);
-    if !entries.is_empty() {
-        estimate += match config.glossary.format {
-            GlossaryFormat::Json => {
-                let rendered = serde_json::to_string(entries).unwrap_or_else(|_| "[]".to_string());
-                token_estimate("glossary") + token_estimate(&rendered)
-            }
-            GlossaryFormat::Prose => {
-                let rendered = crate::scheduler::render_glossary_prose(entries);
-                token_estimate("glossary_prose") + token_estimate(&rendered)
-            }
-        };
-    }
     if let Some(guidance) = config.glossary.guidance_by_segment.get(&item.segment_id.0) {
         estimate += token_estimate("retry_guidance") + token_estimate(guidance);
     }
     estimate
 }
 
-fn batch_fixed_token_estimate(config: Option<&TranslationRunConfig>) -> usize {
+fn batch_fixed_token_estimate(
+    items: &[TranslationBatchItem],
+    config: Option<&TranslationRunConfig>,
+) -> usize {
     config
-        .and_then(|config| config.glossary.prompt_extra.as_deref())
-        .map(token_estimate)
+        .map(|config| token_estimate(&super::rendering::render_batch_prompt_extra(items, config)))
         .unwrap_or(0)
 }
 
@@ -608,7 +592,7 @@ fn batch_token_estimate(
     items: &[TranslationBatchItem],
     config: Option<&TranslationRunConfig>,
 ) -> usize {
-    batch_fixed_token_estimate(config)
+    batch_fixed_token_estimate(items, config)
         + items
             .iter()
             .map(|item| item_token_estimate(item, config))
@@ -782,8 +766,7 @@ fn repack_batch_with_config(
     let max_items = max_items.max(1);
     let mut out = Vec::new();
     let mut current_items = Vec::new();
-    let fixed_tokens = batch_fixed_token_estimate(config);
-    let mut current_tokens = fixed_tokens;
+    let mut current_tokens = 0usize;
     let mut part = 0usize;
     let base_id = batch.id;
     let base_ordinal = batch.ordinal;
@@ -792,11 +775,14 @@ fn repack_batch_with_config(
     let section_id = batch.section_id;
 
     for item in batch.items {
-        let item_tokens = item_token_estimate(&item, config).max(1);
         let would_exceed_items = current_items.len() >= max_items;
-        let would_exceed_tokens =
-            !current_items.is_empty() && current_tokens + item_tokens > target_tokens;
+        current_items.push(item);
+        let candidate_tokens = batch_token_estimate(&current_items, config);
+        let would_exceed_tokens = current_items.len() > 1 && candidate_tokens > target_tokens;
         if would_exceed_items || would_exceed_tokens {
+            let item = current_items
+                .pop()
+                .expect("candidate batch contains the item just added");
             out.push(TranslationBatch {
                 id: format!("{base_id}_adaptive_{part}"),
                 ordinal: base_ordinal * 1000 + part,
@@ -806,11 +792,12 @@ fn repack_batch_with_config(
                 token_estimate: current_tokens,
                 section_id: section_id.clone(),
             });
-            current_tokens = fixed_tokens;
+            current_items.push(item);
+            current_tokens = batch_token_estimate(&current_items, config);
             part += 1;
+        } else {
+            current_tokens = candidate_tokens;
         }
-        current_tokens += item_tokens;
-        current_items.push(item);
     }
 
     if !current_items.is_empty() {

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -1,5 +1,6 @@
 use super::*;
 use serde::Deserialize;
+use std::collections::HashSet;
 
 pub fn batch_item_validation_error(
     item: &TranslationBatchItem,
@@ -692,6 +693,140 @@ pub(super) fn batch_response_item_count(batch: &TranslationBatch, content: &str)
     )
 }
 
+fn batch_glossary_entries<'a>(
+    items: &[TranslationBatchItem],
+    config: &'a TranslationRunConfig,
+) -> Vec<&'a bookforge_core::GlossaryPromptTerm> {
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+    for item in items {
+        let segment_entries = config
+            .glossary
+            .entries_by_segment
+            .get(&item.segment_id.0)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        for entry in segment_entries {
+            if seen.insert(entry) {
+                entries.push(entry);
+            }
+        }
+    }
+    entries
+}
+
+pub(super) fn render_batch_glossary(
+    items: &[TranslationBatchItem],
+    config: &TranslationRunConfig,
+) -> String {
+    let entries = batch_glossary_entries(items, config);
+    if entries.is_empty() {
+        return String::new();
+    }
+
+    match config.glossary.format {
+        GlossaryFormat::Json => {
+            let rendered = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
+            format!(
+                "Active batch glossary constraints (must be honored throughout this batch wherever applicable):\n{rendered}"
+            )
+        }
+        GlossaryFormat::Prose => {
+            let entries = entries.into_iter().cloned().collect::<Vec<_>>();
+            crate::scheduler::render_glossary_prose(&entries)
+        }
+    }
+}
+
+pub(super) fn render_batch_prompt_extra(
+    items: &[TranslationBatchItem],
+    config: &TranslationRunConfig,
+) -> String {
+    let mut blocks = Vec::new();
+    if let Some(extra) = config
+        .glossary
+        .prompt_extra
+        .as_deref()
+        .filter(|extra| !extra.trim().is_empty())
+    {
+        blocks.push(extra.to_string());
+    }
+    let glossary = render_batch_glossary(items, config);
+    if !glossary.is_empty() {
+        blocks.push(glossary);
+    }
+    blocks.join("\n\n")
+}
+
+pub(super) fn render_batch_prompt(
+    batch: &TranslationBatch,
+    config: &TranslationRunConfig,
+    library: &PromptLibrary,
+    context_block: &str,
+    compact_retry_attempt: usize,
+) -> crate::prompt::Result<crate::prompt::Rendered> {
+    let items_json = render_batch_items(batch, config);
+    let prompt_extra = render_batch_prompt_extra(&batch.items, config);
+    let template = batch_prompt_template(batch, config, library);
+
+    let mut vars = Substitutions::new();
+    vars.string(
+        "source_language",
+        config
+            .source_language
+            .as_deref()
+            .unwrap_or("the source language"),
+    )
+    .string("target_language", &config.target_language)
+    .raw(
+        "style_guide_block",
+        config
+            .style
+            .as_ref()
+            .map(|style| style.rendered_block.clone())
+            .unwrap_or_default(),
+    )
+    .raw(
+        "entity_agreement_block",
+        config
+            .entities
+            .as_ref()
+            .map(|entities| entities.rendered_block.clone())
+            .unwrap_or_default(),
+    )
+    .raw("context_translation_pairs", context_block)
+    .raw("prompt_extra", prompt_extra)
+    .raw("items_json", items_json);
+
+    let mut rendered = template.render(&vars)?;
+    if compact_retry_attempt > 0 {
+        rendered.user.push_str(&format!(
+            "\n\nRECOVERY MODE {compact_retry_attempt}: Return one compact JSON object only. Translate every item exactly once. Do not repeat any word, sentence, item, or explanation. End immediately after the closing brace."
+        ));
+    }
+    Ok(rendered)
+}
+
+pub(super) fn batch_prompt_template<'a>(
+    batch: &TranslationBatch,
+    config: &TranslationRunConfig,
+    library: &'a PromptLibrary,
+) -> &'a crate::prompt::PromptTemplate {
+    if config.compact_prompts {
+        match batch.mode {
+            BatchMode::Plain | BatchMode::TurboTextOnly => &library.batch_plain_compact,
+            BatchMode::MarkerSafe => &library.batch_marker_safe_compact,
+            BatchMode::RunPreserving => &library.batch_run_preserving_compact,
+        }
+    } else {
+        match batch.mode {
+            BatchMode::Plain | BatchMode::TurboTextOnly => &library.batch_plain,
+            BatchMode::MarkerSafe => &library.batch_marker_safe,
+            BatchMode::RunPreserving => &library.batch_run_preserving,
+        }
+    }
+}
+
 pub(super) fn render_batch_items(
     batch: &TranslationBatch,
     config: &TranslationRunConfig,
@@ -722,28 +857,6 @@ pub(super) fn render_batch_items(
             .as_object()
             .cloned()
             .unwrap_or_default();
-
-            let entries = config
-                .glossary
-                .entries_by_segment
-                .get(&item.segment_id.0)
-                .map(Vec::as_slice)
-                .unwrap_or(&[]);
-            match config.glossary.format {
-                GlossaryFormat::Json => {
-                    obj.insert(
-                        "glossary".to_string(),
-                        serde_json::to_value(entries)
-                            .unwrap_or_else(|_| serde_json::Value::Array(Vec::new())),
-                    );
-                }
-                GlossaryFormat::Prose => {
-                    obj.insert(
-                        "glossary_prose".to_string(),
-                        serde_json::Value::String(crate::scheduler::render_glossary_prose(entries)),
-                    );
-                }
-            }
 
             if let Some(guidance) = config.glossary.guidance_by_segment.get(&item.segment_id.0) {
                 obj.insert(

--- a/crates/bookforge-llm/src/batch/tests.rs
+++ b/crates/bookforge-llm/src/batch/tests.rs
@@ -1232,7 +1232,7 @@ fn make_two_item_batch() -> TranslationBatch {
 }
 
 #[test]
-fn batch_items_include_segment_glossary() {
+fn batch_prompt_shares_segment_glossary_and_keeps_item_guidance() {
     let batch = make_two_item_batch();
     let mut config = test_run_config();
     config.glossary.entries_by_segment.insert(
@@ -1252,12 +1252,16 @@ fn batch_items_include_segment_glossary() {
         "Translate the greeting less literally.".to_string(),
     );
 
-    let rendered = render_batch_items(&batch, &config);
-    assert!(rendered.contains("\"glossary\""));
-    assert!(rendered.contains("\"retry_guidance\""));
-    assert!(rendered.contains("Translate the greeting less literally."));
-    assert!(rendered.contains("\"source\":\"Hello\""));
-    assert!(!rendered.contains("Use informal register."));
+    let rendered_items = render_batch_items(&batch, &config);
+    let prompt_extra = render_batch_prompt_extra(&batch.items, &config);
+    assert!(!rendered_items.contains("\"glossary\""));
+    assert!(rendered_items.contains("\"retry_guidance\""));
+    assert!(rendered_items.contains("Translate the greeting less literally."));
+    assert!(!rendered_items.contains("\"target\":\"Ciao\""));
+    assert!(prompt_extra.contains("Active batch glossary constraints"));
+    assert!(prompt_extra.contains("\"source\":\"Hello\""));
+    assert!(prompt_extra.contains("\"target\":\"Ciao\""));
+    assert!(prompt_extra.contains("Use informal register."));
 }
 
 #[test]
@@ -1345,6 +1349,84 @@ fn batch_prompt_overhead_repacks_glossary_heavy_items() {
     assert_eq!(adjusted.len(), 2);
     assert!(adjusted.iter().all(|batch| batch.items.len() == 1));
     assert!(adjusted.iter().all(|batch| batch.token_estimate > 120));
+}
+
+#[test]
+fn glossary_does_not_multiply_fixed_corpus_batch_prompts() {
+    let segments = (0..8)
+        .map(|segment_index| {
+            let blocks = (0..64)
+                .map(|block_index| {
+                    plain_block(&format!(
+                        "Segment {segment_index} block {block_index}: a compact sentence for a fixed corpus."
+                    ))
+                })
+                .collect();
+            make_segment(&format!("seg{segment_index}"), blocks, vec![])
+        })
+        .collect::<Vec<_>>();
+    let batch_config = BatchConfig {
+        enabled: true,
+        target_tokens: 16_000,
+        max_items: 64,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let initial = build_translation_batches(&segments, &batch_config, TranslationProfile::Balanced);
+
+    let plain_config = test_run_config();
+    let plain_batches =
+        account_for_batch_prompt_overhead(initial.clone(), &batch_config, &plain_config);
+    let library = PromptLibrary::global();
+    let plain_chars = plain_batches
+        .iter()
+        .map(|batch| {
+            let rendered = render_batch_prompt(batch, &plain_config, library, "", 0)
+                .expect("plain prompt renders");
+            rendered.system.chars().count() + rendered.user.chars().count()
+        })
+        .sum::<usize>();
+
+    let mut glossary_config = test_run_config();
+    for segment_index in 0..segments.len() {
+        glossary_config.glossary.entries_by_segment.insert(
+            format!("seg{segment_index}"),
+            (0..24)
+                .map(|term_index| bookforge_core::GlossaryPromptTerm {
+                    source: format!("source term {segment_index}-{term_index}"),
+                    target: format!("target term {segment_index}-{term_index}"),
+                    category: bookforge_core::GlossaryCategory::Phrase,
+                    note: None,
+                    term_id: Some((segment_index * 100 + term_index) as i64),
+                    case_sensitive: false,
+                })
+                .collect(),
+        );
+    }
+    let glossary_batches =
+        account_for_batch_prompt_overhead(initial, &batch_config, &glossary_config);
+    let glossary_chars = glossary_batches
+        .iter()
+        .map(|batch| {
+            let rendered = render_batch_prompt(batch, &glossary_config, library, "", 0)
+                .expect("glossary prompt renders");
+            rendered.system.chars().count() + rendered.user.chars().count()
+        })
+        .sum::<usize>();
+
+    assert!(
+        glossary_batches.len() <= plain_batches.len() * 2,
+        "glossary expanded {} plain batches to {} and the rendered prompts from {plain_chars} to {glossary_chars} chars ({:.2}x)",
+        plain_batches.len(),
+        glossary_batches.len(),
+        glossary_chars as f64 / plain_chars as f64
+    );
+    assert!(
+        glossary_chars <= plain_chars * 2,
+        "glossary expanded the rendered prompts from {plain_chars} to {glossary_chars} chars ({:.2}x)",
+        glossary_chars as f64 / plain_chars as f64
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## The measurement

Two translations of the same book (The Cyberiad, EN→IT, deepseek-v4-flash), identical settings, same scratch store. The **only** difference was whether 120 accepted glossary terms were active:

| | no glossary | with glossary |
| --- | --- | --- |
| batches | 40 | **136** |
| input tokens | 209,254 | **1,483,434** (7.1×) |
| output tokens | 221,304 | 223,148 |
| cost | $0.091 | **$0.256** |

Output tokens are unchanged, so the translation work was identical. Only the input exploded.

## Root cause

A scheduler segment holds many blocks, and batching creates **one item per block**. The full segment glossary was serialized into *every* item — so 226 reported term/segment injections became thousands of physical copies inside the prompt.

The 800-token budget never bounded this, because it wasn't measuring what actually gets sent. `estimate_prompt_tokens` counted term values plus 16 characters, omitting JSON field names, punctuation, `term_id`, and `case_sensitive`. Measured offline, a nominal 200-token glossary renders at **426** tokens — so `--glossary-budget-tokens` has never meant what its name says.

The batch tripling was mostly *effect*, not cause: the planner priced the already-duplicated per-block glossary, and `Batches:` is printed after repacking. Runtime retries and split children then resent the bloated prompts and amplified the cost again.

## The fix

Relevant terms are deduplicated and rendered as **one shared block per batch request**; retry guidance stays item-specific; planning prices that same shared block when repacking and splitting; budgeting measures the real serialized representation.

Offline reproduction over a fixed corpus, glossary off then on:

```
before   8 -> 24 batches,  variable payload  107,880 -> 1,508,088 chars  (13.98x)
after    8 ->  8 batches,  full prompts      109,640 ->   132,294 chars  ( 1.21x)
```

A fixed-corpus rendered-prompt bound now guards the regression — a ratio rather than an exact token count, so it survives ordinary prompt edits.

## This invalidates today's glossary A/B

Earlier today a measured A/B attributed **~20% more hard defects** to the accepted-glossary pass. That conclusion does not stand: the glossary arm also carried a 14× prompt bloat and heavier batch fragmentation, meaning materially less source context per request. That is a sufficient explanation for degraded quality with nothing to do with the terms themselves.

The experiment has to be re-run on this fix before anything is concluded about glossary quality.

## Deliberately unchanged

The recently-active and high-frequency selection policies, retry behaviour, and the `injected`/`honored` telemetry definition.

On the last: `recently_active injected=23 honored=0` is **not** 23 violations. "Honored" tests whether the literal target string appears in the current output, but recently-active terms are drawn from the preceding five same-chapter segments and often don't occur in the current one at all. It's a poor compliance measure — especially for inflected Italian targets — but renaming it is a design decision this measurement doesn't settle.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **899 passed / 0 failed / 3 ignored** over three consecutive runs (was 897). No provider was called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)