### PR TITLE
Drop self-refuting judge findings, and add per-category precision measurement

### DIFF
--- a/crates/bookforge-cli/examples/adjudicate_translation.rs
+++ b/crates/bookforge-cli/examples/adjudicate_translation.rs
@@ -1,0 +1,1535 @@
+//! `adjudicate_translation` — measure the precision of `judge_translation`.
+//!
+//! This is a read-only, dev-time second pass over an existing
+//! `judge_translation` JSONL file. Each enumerated finding becomes one narrow
+//! adjudication task: is this category-specific complaint supported by its
+//! exact source and translation spans?
+//!
+//! Start with a dry run. It renders every selected prompt and estimates the
+//! maximum cost without calling a provider or writing output:
+//!
+//! ```text
+//! cargo run --release --example adjudicate_translation -- \
+//!   --results judge-translation.jsonl --dry-run
+//! ```
+//!
+//! A paid run writes frozen verdict JSONL and a summary containing a
+//! true-positive rate for every category. The API key is never a CLI value:
+//! `--api-key-env` accepts only the environment-variable name read by the
+//! provider at request time.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use bookforge_core::{JsonMode, RetryAfterPolicy};
+use bookforge_llm::{
+    CompletionRequest, LlmProvider, OpenAiCompatibleConfig, OpenAiCompatibleProvider,
+    RequestMetadata, ResponseFormat,
+};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Prompt changes invalidate every cached adjudication.
+const PROMPT_VERSION: &str = "adjudicate_translation/v1";
+const OUTPUT_SCHEMA_VERSION: u32 = 1;
+const SUMMARY_SCHEMA_VERSION: u32 = 1;
+const SUPPORTED_RESULTS_SCHEMA_VERSION: u32 = 1;
+const MAX_JUDGE_RESPONSE_BYTES: usize = 8 * 1024;
+const MAX_RATIONALE_CHARS: usize = 300;
+const EMBEDDED_PRICING: &str = include_str!("../pricing/providers.json");
+
+const ALL_CATEGORIES: [DefectCategory; 6] = [
+    DefectCategory::MeaningChanged,
+    DefectCategory::ContentDropped,
+    DefectCategory::ContentAdded,
+    DefectCategory::TerminologyInconsistent,
+    DefectCategory::RegisterShift,
+    DefectCategory::TargetLanguageError,
+];
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "adjudicate_translation",
+    about = "Measure judge_translation precision per defect category (dev-time only)"
+)]
+struct Args {
+    /// Existing judge_translation passage-result JSONL.
+    #[arg(long)]
+    results: PathBuf,
+
+    /// Frozen per-finding adjudication JSONL.
+    #[arg(long, default_value = "translation-adjudication.jsonl")]
+    out: PathBuf,
+
+    /// Machine-readable precision summary. Defaults beside --out.
+    #[arg(long)]
+    summary: Option<PathBuf>,
+
+    /// Provider preset: deepseek, openrouter, or openai-compatible.
+    #[arg(long, default_value = "deepseek")]
+    provider: String,
+
+    /// Judge model override. Defaults to the provider preset's model.
+    #[arg(long)]
+    model: Option<String>,
+
+    /// Base URL override. Required for --provider openai-compatible.
+    #[arg(long)]
+    base_url: Option<String>,
+
+    /// NAME of the environment variable holding the API key, never its value.
+    #[arg(long)]
+    api_key_env: Option<String>,
+
+    /// Adjudication sampling temperature.
+    #[arg(long, default_value_t = 0.0)]
+    temperature: f32,
+
+    /// Hard judge-output cap per finding.
+    #[arg(long, default_value_t = 1_024)]
+    max_output_tokens: u32,
+
+    /// Per-request timeout in seconds.
+    #[arg(long, default_value_t = 120)]
+    timeout_seconds: u64,
+
+    /// Cap on findings in input order. 0 selects all and removes the spend cap.
+    #[arg(long, default_value_t = 25)]
+    limit: usize,
+
+    /// Render prompts and estimate maximum cost without calls or writes.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Directory for content-addressed adjudication results.
+    #[arg(long, default_value = ".bookforge/translation-adjudication-cache")]
+    cache: PathBuf,
+
+    /// Disable the on-disk adjudication cache.
+    #[arg(long)]
+    no_cache: bool,
+
+    /// Pricing catalog override. The embedded CLI catalog is used by default.
+    #[arg(long)]
+    pricing: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Input and task schema
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DefectCategory {
+    MeaningChanged,
+    ContentDropped,
+    ContentAdded,
+    TerminologyInconsistent,
+    RegisterShift,
+    TargetLanguageError,
+}
+
+impl DefectCategory {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::MeaningChanged => "meaning_changed",
+            Self::ContentDropped => "content_dropped",
+            Self::ContentAdded => "content_added",
+            Self::TerminologyInconsistent => "terminology_inconsistent",
+            Self::RegisterShift => "register_shift",
+            Self::TargetLanguageError => "target_language_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct InputDefect {
+    category: DefectCategory,
+    source_quote: String,
+    translation_quote: String,
+    explanation: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InputRecordStatus {
+    Parsed,
+    Unparseable,
+    Error,
+}
+
+/// Unknown fields are intentionally tolerated: this consumer needs only the
+/// stable identity, language, status, and defect columns from passage JSONL.
+#[derive(Debug, Deserialize)]
+struct InputPassageRecord {
+    schema_version: u32,
+    passage_id: String,
+    source_language: String,
+    target_language: String,
+    status: InputRecordStatus,
+    defects: Vec<InputDefect>,
+}
+
+#[derive(Debug, Clone)]
+struct AdjudicationTask {
+    finding_id: String,
+    passage_id: String,
+    finding_index: usize,
+    source_language: String,
+    target_language: String,
+    category: DefectCategory,
+    source_quote: String,
+    translation_quote: String,
+    explanation: String,
+}
+
+#[derive(Debug, Default)]
+struct InputStats {
+    records_read: usize,
+    parsed_records: usize,
+    skipped_unparseable_lines: usize,
+    skipped_unsupported_schema: usize,
+    skipped_nonparsed_records: usize,
+    dropped_self_refuting: usize,
+}
+
+fn read_tasks(path: &Path) -> Result<(Vec<AdjudicationTask>, InputStats)> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("opening translation results {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut tasks = Vec::new();
+    let mut stats = InputStats::default();
+
+    for (line_index, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading {}", path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        stats.records_read += 1;
+        let record = match serde_json::from_str::<InputPassageRecord>(&line) {
+            Ok(record) => record,
+            Err(error) => {
+                stats.skipped_unparseable_lines += 1;
+                warn(&format!(
+                    "{}:{}: skipping unparseable result: {error}",
+                    path.display(),
+                    line_index + 1
+                ));
+                continue;
+            }
+        };
+        if record.schema_version != SUPPORTED_RESULTS_SCHEMA_VERSION {
+            stats.skipped_unsupported_schema += 1;
+            warn(&format!(
+                "{}:{}: skipping schema_version {}; expected {}",
+                path.display(),
+                line_index + 1,
+                record.schema_version,
+                SUPPORTED_RESULTS_SCHEMA_VERSION
+            ));
+            continue;
+        }
+        if record.status != InputRecordStatus::Parsed {
+            stats.skipped_nonparsed_records += 1;
+            continue;
+        }
+        stats.parsed_records += 1;
+
+        for (finding_index, defect) in record.defects.into_iter().enumerate() {
+            // This makes old result files safe to adjudicate. New result files
+            // have already applied the same conservative deterministic filter.
+            if is_self_refuting_explanation(&defect.explanation) {
+                stats.dropped_self_refuting += 1;
+                continue;
+            }
+            let finding_index_text = finding_index.to_string();
+            let finding_id = format!(
+                "finding_{}",
+                &hash_fields([
+                    record.passage_id.as_str(),
+                    finding_index_text.as_str(),
+                    defect.category.as_str(),
+                    defect.source_quote.as_str(),
+                    defect.translation_quote.as_str(),
+                    defect.explanation.as_str(),
+                ])[..20]
+            );
+            tasks.push(AdjudicationTask {
+                finding_id,
+                passage_id: record.passage_id.clone(),
+                finding_index,
+                source_language: record.source_language.clone(),
+                target_language: record.target_language.clone(),
+                category: defect.category,
+                source_quote: defect.source_quote,
+                translation_quote: defect.translation_quote,
+                explanation: defect.explanation,
+            });
+        }
+    }
+
+    Ok((tasks, stats))
+}
+
+// Keep this rule in lockstep with judge_translation. It is duplicated because
+// examples are standalone Cargo targets and the permitted edit surface does not
+// include a shared library module.
+fn is_self_refuting_explanation(explanation: &str) -> bool {
+    let words = explanation
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+    const DISMISSALS: &[&[&str]] = &[
+        &["no", "error"],
+        &["no", "errors"],
+        &["no", "issue"],
+        &["no", "issues"],
+        &["no", "problem"],
+        &["no", "problems"],
+        &["nothing", "wrong"],
+        &["is", "correct"],
+        &["is", "accurate"],
+        &["correctly", "translated"],
+        &["translated", "correctly"],
+        &["accurately", "translated"],
+        &["translated", "accurately"],
+    ];
+    if !DISMISSALS
+        .iter()
+        .any(|phrase| contains_word_sequence(&words, phrase))
+    {
+        return false;
+    }
+    const DISMISSAL_BLOCKERS: &[&str] = &["could", "hardly", "never", "not", "should", "would"];
+    if words
+        .iter()
+        .any(|word| DISMISSAL_BLOCKERS.contains(&word.as_str()))
+    {
+        return false;
+    }
+    const CONTRAST_MARKERS: &[&str] = &[
+        "although",
+        "but",
+        "except",
+        "however",
+        "nevertheless",
+        "though",
+        "yet",
+    ];
+    if words
+        .iter()
+        .any(|word| CONTRAST_MARKERS.contains(&word.as_str()))
+    {
+        return false;
+    }
+    const DEFECT_ASSERTIONS: &[&str] = &[
+        "added",
+        "adds",
+        "changed",
+        "changes",
+        "dropped",
+        "fails",
+        "incorrect",
+        "inconsistent",
+        "missing",
+        "mistranslated",
+        "omitted",
+        "ungrammatical",
+        "unidiomatic",
+        "wrong",
+    ];
+    if words
+        .iter()
+        .any(|word| DEFECT_ASSERTIONS.contains(&word.as_str()))
+    {
+        return false;
+    }
+    !words.iter().enumerate().any(|(index, word)| {
+        matches!(
+            word.as_str(),
+            "error" | "errors" | "issue" | "issues" | "problem" | "problems"
+        ) && index
+            .checked_sub(1)
+            .is_none_or(|previous| words[previous] != "no")
+    })
+}
+
+fn contains_word_sequence(words: &[String], phrase: &[&str]) -> bool {
+    words
+        .windows(phrase.len())
+        .any(|window| window.iter().map(String::as_str).eq(phrase.iter().copied()))
+}
+
+// ---------------------------------------------------------------------------
+// Frozen output schemas
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum VerdictLabel {
+    TruePositive,
+    FalsePositive,
+    Unclear,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AdjudicationStatus {
+    Parsed,
+    Unparseable,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AdjudicationRecord {
+    schema_version: u32,
+    prompt_version: String,
+    finding_id: String,
+    passage_id: String,
+    finding_index: usize,
+    category: DefectCategory,
+    source_quote: String,
+    translation_quote: String,
+    explanation: String,
+    status: AdjudicationStatus,
+    verdict: Option<VerdictLabel>,
+    confidence: Option<f64>,
+    rationale: Option<String>,
+    cached: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CategoryPrecision {
+    category: DefectCategory,
+    findings: usize,
+    adjudicated: usize,
+    true_positive: usize,
+    false_positive: usize,
+    unclear: usize,
+    unparseable: usize,
+    request_errors: usize,
+    /// `None` is serialized as JSON null: 0/0 is unknown, not 0% precision.
+    true_positive_rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrecisionSummary {
+    schema_version: u32,
+    prompt_version: String,
+    source_results: String,
+    provider: String,
+    model: String,
+    input_records: usize,
+    parsed_input_records: usize,
+    skipped_input_lines: usize,
+    skipped_unsupported_schema: usize,
+    skipped_nonparsed_records: usize,
+    dropped_input_self_refuting: usize,
+    findings_available: usize,
+    findings_selected: usize,
+    limit: usize,
+    cache_hits: usize,
+    provider_calls: usize,
+    request_errors: usize,
+    input_tokens: u64,
+    output_tokens: u64,
+    categories: Vec<CategoryPrecision>,
+}
+
+// ---------------------------------------------------------------------------
+// Prompt and scorer seam
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct RenderedPrompt {
+    system: String,
+    user: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JudgeResponse {
+    verdict: VerdictLabel,
+    confidence: f64,
+    rationale: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CachedVerdict {
+    parsed: bool,
+    verdict: Option<VerdictLabel>,
+    confidence: Option<f64>,
+    rationale: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScoreOutcome {
+    cached: CachedVerdict,
+    input_tokens: u64,
+    output_tokens: u64,
+}
+
+#[derive(Debug)]
+struct ScoreError(String);
+
+trait AdjudicationScorer {
+    fn name(&self) -> &'static str;
+
+    fn render(&self, task: &AdjudicationTask) -> RenderedPrompt;
+
+    fn score(
+        &self,
+        task: &AdjudicationTask,
+    ) -> impl std::future::Future<Output = Result<ScoreOutcome, ScoreError>> + Send;
+}
+
+struct TextScorer {
+    provider: OpenAiCompatibleProvider,
+    endpoint: Endpoint,
+    temperature: f32,
+    max_output_tokens: u32,
+}
+
+impl AdjudicationScorer for TextScorer {
+    fn name(&self) -> &'static str {
+        "text"
+    }
+
+    fn render(&self, task: &AdjudicationTask) -> RenderedPrompt {
+        render_prompt(task)
+    }
+
+    async fn score(&self, task: &AdjudicationTask) -> Result<ScoreOutcome, ScoreError> {
+        let prompt = self.render(task);
+        let response = self
+            .provider
+            .complete(CompletionRequest {
+                system: prompt.system,
+                user: prompt.user,
+                response_format: ResponseFormat::Json,
+                temperature: self.temperature,
+                max_output_tokens: Some(self.max_output_tokens),
+                metadata: RequestMetadata {
+                    segment_id: Some(task.finding_id.clone()),
+                    prompt_template: Some("adjudicate_translation".to_string()),
+                    prompt_version: Some(PROMPT_VERSION.to_string()),
+                    provider: Some(self.endpoint.provider.clone()),
+                    model: Some(self.endpoint.model.clone()),
+                    ..RequestMetadata::default()
+                },
+            })
+            .await
+            .map_err(|error| ScoreError(error.to_string()))?;
+        Ok(interpret_response(
+            &response.content,
+            response.input_tokens.unwrap_or_default(),
+            response.output_tokens.unwrap_or_default(),
+        ))
+    }
+}
+
+const JUDGE_SYSTEM_PROMPT: &str = r#"You are measuring the precision of another translation-quality judge.
+
+Your only job is to decide whether ONE specific, category-labelled complaint is correct about the exact source and translation spans supplied.
+
+Use these verdicts:
+
+true_positive - the claimed category-specific defect is demonstrated by the spans
+false_positive - the spans are fine with respect to this exact complaint
+unclear - the claim cannot be decided from the supplied spans
+
+Category meanings:
+
+meaning_changed - the translation asserts something the source does not
+content_dropped - source content is absent from the translation
+content_added - the translation asserts content with no source basis
+terminology_inconsistent - one source term is rendered inconsistently
+register_shift - formality or voice diverges without cause
+target_language_error - the translation is ungrammatical or unidiomatic
+
+Judge only the stated complaint. Do not substitute a different defect and do not reward plausible explanations unsupported by the quoted spans. If deciding the complaint requires omitted context, use unclear.
+
+Return ONLY one JSON object, without prose or code fences:
+
+{"verdict":"true_positive"|"false_positive"|"unclear","confidence":0.0,"rationale":"one sentence, at most 200 characters"}"#;
+
+fn render_prompt(task: &AdjudicationTask) -> RenderedPrompt {
+    RenderedPrompt {
+        system: JUDGE_SYSTEM_PROMPT.to_string(),
+        user: format!(
+            "Source language: {}\n\
+             Target language: {}\n\
+             Passage: {}\n\
+             Finding: {} (index {})\n\
+             Claimed category: {}\n\
+             Exact complaint: {}\n\
+             \n\
+             Exact source span:\n\
+             <<<SOURCE\n\
+             {}\n\
+             SOURCE\n\
+             \n\
+             Exact translation span:\n\
+             <<<TRANSLATION\n\
+             {}\n\
+             TRANSLATION\n\
+             \n\
+             Is this specific complaint correct? Return the JSON object only.\n",
+            task.source_language,
+            task.target_language,
+            task.passage_id,
+            task.finding_id,
+            task.finding_index,
+            task.category.as_str(),
+            task.explanation,
+            task.source_quote,
+            task.translation_quote,
+        ),
+    }
+}
+
+fn interpret_response(content: &str, input_tokens: u64, output_tokens: u64) -> ScoreOutcome {
+    let unparseable = |reason: &str| ScoreOutcome {
+        cached: CachedVerdict {
+            parsed: false,
+            verdict: None,
+            confidence: None,
+            rationale: None,
+            error: Some(reason.to_string()),
+        },
+        input_tokens,
+        output_tokens,
+    };
+
+    if content.len() > MAX_JUDGE_RESPONSE_BYTES {
+        return unparseable("judge response exceeded the response-size bound");
+    }
+    let body = strip_json_code_fence(content.trim());
+    let Ok(response) = serde_json::from_str::<JudgeResponse>(body) else {
+        // Terminal by design: malformed output is recorded and never repaired
+        // or sent to a second prompt.
+        return unparseable("judge response was not a valid adjudication object");
+    };
+    if !(0.0..=1.0).contains(&response.confidence) {
+        return unparseable("judge returned confidence outside 0.0..=1.0");
+    }
+    let rationale = response.rationale.trim();
+    if rationale.is_empty() {
+        return unparseable("judge returned an empty rationale");
+    }
+
+    ScoreOutcome {
+        cached: CachedVerdict {
+            parsed: true,
+            verdict: Some(response.verdict),
+            confidence: Some(response.confidence),
+            rationale: Some(truncate_chars(rationale, MAX_RATIONALE_CHARS)),
+            error: None,
+        },
+        input_tokens,
+        output_tokens,
+    }
+}
+
+fn strip_json_code_fence(body: &str) -> &str {
+    let Some(inner) = body.strip_prefix("```") else {
+        return body;
+    };
+    let Some(inner) = inner.strip_suffix("```") else {
+        return body;
+    };
+    let Some((tag, payload)) = inner.split_once('\n') else {
+        return body;
+    };
+    let tag = tag.trim();
+    if tag.is_empty() || tag.eq_ignore_ascii_case("json") {
+        payload.trim()
+    } else {
+        body
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    text.chars().take(max_chars).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Provider and content-addressed cache
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Endpoint {
+    provider: String,
+    base_url: String,
+    api_key_env: String,
+    model: String,
+}
+
+fn resolve_endpoint(args: &Args) -> Result<Endpoint> {
+    let (default_url, default_key_env, default_model) = match args.provider.as_str() {
+        "deepseek" => (
+            "https://api.deepseek.com/v1",
+            "DEEPSEEK_API_KEY",
+            "deepseek-v4-flash",
+        ),
+        "openrouter" => (
+            "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY",
+            "openrouter/auto",
+        ),
+        "openai-compatible" => {
+            if args.base_url.is_none() {
+                bail!("--provider openai-compatible requires --base-url");
+            }
+            ("", "OPENAI_API_KEY", "local-model")
+        }
+        other => {
+            bail!("unsupported provider '{other}'; use deepseek, openrouter, or openai-compatible")
+        }
+    };
+    Ok(Endpoint {
+        provider: args.provider.clone(),
+        base_url: args
+            .base_url
+            .clone()
+            .unwrap_or_else(|| default_url.to_string()),
+        api_key_env: args
+            .api_key_env
+            .clone()
+            .unwrap_or_else(|| default_key_env.to_string()),
+        model: args
+            .model
+            .clone()
+            .unwrap_or_else(|| default_model.to_string()),
+    })
+}
+
+fn build_text_scorer(args: &Args, endpoint: &Endpoint) -> Result<TextScorer> {
+    let provider = OpenAiCompatibleProvider::new(OpenAiCompatibleConfig {
+        base_url: endpoint.base_url.clone(),
+        api_key_env: endpoint.api_key_env.clone(),
+        model: endpoint.model.clone(),
+        timeout_seconds: args.timeout_seconds,
+        provider_max_attempts: 3,
+        thinking_disabled: true,
+        retry_after_policy: RetryAfterPolicy::JitteredExponential,
+        max_backoff_seconds: 30,
+        max_idle_per_host: 4,
+        json_mode: JsonMode::Auto,
+    })
+    .map_err(|error| anyhow::anyhow!("building provider: {error}"))?;
+    Ok(TextScorer {
+        provider,
+        endpoint: endpoint.clone(),
+        temperature: args.temperature,
+        max_output_tokens: args.max_output_tokens,
+    })
+}
+
+struct VerdictCache {
+    dir: Option<PathBuf>,
+}
+
+impl VerdictCache {
+    fn get(&self, key: &str) -> Option<CachedVerdict> {
+        let path = self.dir.as_ref()?.join(format!("{key}.json"));
+        serde_json::from_str(&fs::read_to_string(path).ok()?).ok()
+    }
+
+    fn put(&self, key: &str, verdict: &CachedVerdict) {
+        let Some(dir) = self.dir.as_ref() else {
+            return;
+        };
+        if let Err(error) = fs::create_dir_all(dir) {
+            warn(&format!(
+                "cannot create cache directory {}: {error}",
+                dir.display()
+            ));
+            return;
+        }
+        let body = match serde_json::to_string(verdict) {
+            Ok(body) => body,
+            Err(error) => {
+                warn(&format!("cannot serialize cache entry: {error}"));
+                return;
+            }
+        };
+        let path = dir.join(format!("{key}.json"));
+        if let Err(error) = fs::write(&path, body) {
+            warn(&format!(
+                "cannot write cache entry {}: {error}",
+                path.display()
+            ));
+        }
+    }
+}
+
+fn cache_key(
+    scorer: &str,
+    endpoint: &Endpoint,
+    task: &AdjudicationTask,
+    temperature: f32,
+    max_output_tokens: u32,
+) -> String {
+    let temperature = temperature.to_string();
+    let output_tokens = max_output_tokens.to_string();
+    hash_fields([
+        PROMPT_VERSION,
+        scorer,
+        endpoint.provider.as_str(),
+        endpoint.model.as_str(),
+        temperature.as_str(),
+        output_tokens.as_str(),
+        task.source_language.as_str(),
+        task.target_language.as_str(),
+        task.category.as_str(),
+        task.source_quote.as_str(),
+        task.translation_quote.as_str(),
+        task.explanation.as_str(),
+    ])
+}
+
+fn hash_fields<'a>(fields: impl IntoIterator<Item = &'a str>) -> String {
+    const SEPARATOR: &[u8] = b"\x1f";
+    let mut hasher = Sha256::new();
+    for field in fields {
+        hasher.update(field.as_bytes());
+        hasher.update(SEPARATOR);
+    }
+    hex_digest(hasher.finalize().as_slice())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Harness and precision reporting
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct RunResult {
+    records: Vec<AdjudicationRecord>,
+    cache_hits: usize,
+    provider_calls: usize,
+    request_errors: usize,
+    input_tokens: u64,
+    output_tokens: u64,
+}
+
+async fn run_adjudication<S: AdjudicationScorer>(
+    scorer: &S,
+    endpoint: &Endpoint,
+    tasks: &[AdjudicationTask],
+    cache: &VerdictCache,
+    temperature: f32,
+    max_output_tokens: u32,
+    sink: &mut dyn Write,
+) -> Result<RunResult> {
+    let mut run = RunResult::default();
+    for task in tasks {
+        let key = cache_key(
+            scorer.name(),
+            endpoint,
+            task,
+            temperature,
+            max_output_tokens,
+        );
+        let (outcome, cached) = if let Some(verdict) = cache.get(&key) {
+            run.cache_hits += 1;
+            (
+                ScoreOutcome {
+                    cached: verdict,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
+                true,
+            )
+        } else {
+            match scorer.score(task).await {
+                Ok(outcome) => {
+                    run.provider_calls += 1;
+                    // Parsed and unparseable responses are both terminal and
+                    // cached. A re-run never re-prompts malformed output.
+                    cache.put(&key, &outcome.cached);
+                    (outcome, false)
+                }
+                Err(error) => {
+                    run.provider_calls += 1;
+                    run.request_errors += 1;
+                    warn(&format!(
+                        "{} [{}]: adjudication request failed: {}",
+                        task.finding_id,
+                        task.category.as_str(),
+                        error.0
+                    ));
+                    let record = make_record(
+                        task,
+                        AdjudicationStatus::Error,
+                        None,
+                        None,
+                        None,
+                        false,
+                        0,
+                        0,
+                        Some(error.0),
+                    );
+                    write_record(sink, &record)?;
+                    run.records.push(record);
+                    continue;
+                }
+            }
+        };
+
+        run.input_tokens += outcome.input_tokens;
+        run.output_tokens += outcome.output_tokens;
+        let status = if outcome.cached.parsed {
+            AdjudicationStatus::Parsed
+        } else {
+            AdjudicationStatus::Unparseable
+        };
+        let record = make_record(
+            task,
+            status,
+            outcome.cached.verdict,
+            outcome.cached.confidence,
+            outcome.cached.rationale,
+            cached,
+            outcome.input_tokens,
+            outcome.output_tokens,
+            outcome.cached.error,
+        );
+        write_record(sink, &record)?;
+        run.records.push(record);
+    }
+    Ok(run)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn make_record(
+    task: &AdjudicationTask,
+    status: AdjudicationStatus,
+    verdict: Option<VerdictLabel>,
+    confidence: Option<f64>,
+    rationale: Option<String>,
+    cached: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+    error: Option<String>,
+) -> AdjudicationRecord {
+    AdjudicationRecord {
+        schema_version: OUTPUT_SCHEMA_VERSION,
+        prompt_version: PROMPT_VERSION.to_string(),
+        finding_id: task.finding_id.clone(),
+        passage_id: task.passage_id.clone(),
+        finding_index: task.finding_index,
+        category: task.category,
+        source_quote: task.source_quote.clone(),
+        translation_quote: task.translation_quote.clone(),
+        explanation: task.explanation.clone(),
+        status,
+        verdict,
+        confidence,
+        rationale,
+        cached,
+        input_tokens,
+        output_tokens,
+        error,
+    }
+}
+
+fn write_record(sink: &mut dyn Write, record: &AdjudicationRecord) -> Result<()> {
+    let line = serde_json::to_string(record).context("serializing adjudication record")?;
+    writeln!(sink, "{line}").context("writing adjudication record")?;
+    Ok(())
+}
+
+fn build_summary(
+    args: &Args,
+    endpoint: &Endpoint,
+    input: &InputStats,
+    findings_available: usize,
+    tasks: &[AdjudicationTask],
+    run: &RunResult,
+) -> PrecisionSummary {
+    let categories = ALL_CATEGORIES
+        .iter()
+        .map(|category| {
+            let findings = tasks
+                .iter()
+                .filter(|task| task.category == *category)
+                .count();
+            let records = run
+                .records
+                .iter()
+                .filter(|record| record.category == *category)
+                .collect::<Vec<_>>();
+            let adjudicated = records
+                .iter()
+                .filter(|record| record.status == AdjudicationStatus::Parsed)
+                .count();
+            let count_verdict = |label| {
+                records
+                    .iter()
+                    .filter(|record| {
+                        record.status == AdjudicationStatus::Parsed && record.verdict == Some(label)
+                    })
+                    .count()
+            };
+            let true_positive = count_verdict(VerdictLabel::TruePositive);
+            CategoryPrecision {
+                category: *category,
+                findings,
+                adjudicated,
+                true_positive,
+                false_positive: count_verdict(VerdictLabel::FalsePositive),
+                unclear: count_verdict(VerdictLabel::Unclear),
+                unparseable: records
+                    .iter()
+                    .filter(|record| record.status == AdjudicationStatus::Unparseable)
+                    .count(),
+                request_errors: records
+                    .iter()
+                    .filter(|record| record.status == AdjudicationStatus::Error)
+                    .count(),
+                true_positive_rate: (adjudicated != 0)
+                    .then_some(true_positive as f64 / adjudicated as f64),
+            }
+        })
+        .collect();
+
+    PrecisionSummary {
+        schema_version: SUMMARY_SCHEMA_VERSION,
+        prompt_version: PROMPT_VERSION.to_string(),
+        source_results: args.results.display().to_string(),
+        provider: endpoint.provider.clone(),
+        model: endpoint.model.clone(),
+        input_records: input.records_read,
+        parsed_input_records: input.parsed_records,
+        skipped_input_lines: input.skipped_unparseable_lines,
+        skipped_unsupported_schema: input.skipped_unsupported_schema,
+        skipped_nonparsed_records: input.skipped_nonparsed_records,
+        dropped_input_self_refuting: input.dropped_self_refuting,
+        findings_available,
+        findings_selected: tasks.len(),
+        limit: args.limit,
+        cache_hits: run.cache_hits,
+        provider_calls: run.provider_calls,
+        request_errors: run.request_errors,
+        input_tokens: run.input_tokens,
+        output_tokens: run.output_tokens,
+        categories,
+    }
+}
+
+fn print_human_report(summary: &PrecisionSummary) {
+    println!("=== Translation finding precision ===");
+    println!("source results     : {}", summary.source_results);
+    println!(
+        "judge              : {} / {}",
+        summary.provider, summary.model
+    );
+    println!("prompt             : {}", summary.prompt_version);
+    println!(
+        "input records      : {} read, {} parsed",
+        summary.input_records, summary.parsed_input_records
+    );
+    println!(
+        "input skips        : {} malformed, {} schema, {} non-parsed",
+        summary.skipped_input_lines,
+        summary.skipped_unsupported_schema,
+        summary.skipped_nonparsed_records
+    );
+    println!(
+        "self-refuting      : {} dropped from input",
+        summary.dropped_input_self_refuting
+    );
+    println!(
+        "findings           : {} available, {} selected",
+        summary.findings_available, summary.findings_selected
+    );
+    println!(
+        "cache/calls/errors : {}/{}/{}",
+        summary.cache_hits, summary.provider_calls, summary.request_errors
+    );
+    println!(
+        "provider tokens    : {} input, {} output",
+        summary.input_tokens, summary.output_tokens
+    );
+    println!(
+        "\ncategory                    found judged    true+   false+  unclear unparsed errors"
+    );
+    println!("--------------------------------------------------------------------------------");
+    for metric in &summary.categories {
+        println!(
+            "{:<27} {:>5} {:>6} {:>8} {:>8} {:>8} {:>8} {:>6}",
+            metric.category.as_str(),
+            metric.findings,
+            metric.adjudicated,
+            percent(metric.true_positive, metric.adjudicated),
+            percent(metric.false_positive, metric.adjudicated),
+            percent(metric.unclear, metric.adjudicated),
+            metric.unparseable,
+            metric.request_errors,
+        );
+    }
+}
+
+fn percent(part: usize, whole: usize) -> String {
+    if whole == 0 {
+        "-".to_string()
+    } else {
+        format!("{:.1}%", part as f64 * 100.0 / whole as f64)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pricing and dry run
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct PricingFile {
+    schema_version: u32,
+    providers: BTreeMap<String, ProviderPricing>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderPricing {
+    models: BTreeMap<String, ModelPricing>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+struct ModelPricing {
+    input_per_million_usd: f64,
+    output_per_million_usd: f64,
+}
+
+struct PricingCatalog {
+    file: PricingFile,
+    label: String,
+}
+
+impl PricingCatalog {
+    fn model_pricing(&self, provider: &str, model: &str) -> Option<ModelPricing> {
+        self.file
+            .providers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case(provider))
+            .and_then(|(_, pricing)| {
+                pricing
+                    .models
+                    .iter()
+                    .find(|(name, _)| name.eq_ignore_ascii_case(model))
+                    .map(|(_, pricing)| *pricing)
+            })
+    }
+}
+
+fn load_pricing(path: Option<&Path>) -> Result<PricingCatalog> {
+    let (body, label) = match path {
+        Some(path) => (
+            fs::read_to_string(path)
+                .with_context(|| format!("reading pricing catalog {}", path.display()))?,
+            path.display().to_string(),
+        ),
+        None => (EMBEDDED_PRICING.to_string(), "embedded catalog".to_string()),
+    };
+    let file: PricingFile =
+        serde_json::from_str(&body).with_context(|| format!("parsing {label}"))?;
+    if file.schema_version != 1 {
+        bail!(
+            "unsupported pricing schema_version {}; expected 1",
+            file.schema_version
+        );
+    }
+    Ok(PricingCatalog { file, label })
+}
+
+fn estimate_tokens(text: &str) -> u64 {
+    text.chars().count().div_ceil(4) as u64
+}
+
+fn print_dry_run(
+    args: &Args,
+    endpoint: &Endpoint,
+    tasks: &[AdjudicationTask],
+    findings_available: usize,
+    input: &InputStats,
+) -> Result<()> {
+    let mut input_tokens = 0u64;
+    for task in tasks {
+        let prompt = render_prompt(task);
+        input_tokens += estimate_tokens(&prompt.system) + estimate_tokens(&prompt.user);
+        println!(
+            "----- {} / {} [{}] -----",
+            task.passage_id,
+            task.finding_id,
+            task.category.as_str()
+        );
+        println!("--- system prompt ---");
+        println!("{}", prompt.system);
+        println!("--- user prompt ---");
+        println!("{}", prompt.user);
+    }
+    let output_cap = tasks.len() as u64 * u64::from(args.max_output_tokens);
+    let pricing = load_pricing(args.pricing.as_deref())?;
+
+    println!("\n=== Dry run estimate ===");
+    println!("mode               : DRY RUN - no provider calls or output writes");
+    println!(
+        "provider/model     : {} / {}",
+        endpoint.provider, endpoint.model
+    );
+    println!("key env name       : {}", endpoint.api_key_env);
+    println!("input records      : {}", input.records_read);
+    println!(
+        "self-refuting      : {} dropped from input",
+        input.dropped_self_refuting
+    );
+    println!("findings available : {findings_available}");
+    println!("findings selected  : {}", tasks.len());
+    println!("estimated input    : {input_tokens} tokens");
+    println!("output token cap   : {output_cap} tokens");
+    match pricing.model_pricing(&endpoint.provider, &endpoint.model) {
+        Some(model) => {
+            let maximum_cost = input_tokens as f64 / 1_000_000.0 * model.input_per_million_usd
+                + output_cap as f64 / 1_000_000.0 * model.output_per_million_usd;
+            println!(
+                "maximum cost       : ${maximum_cost:.6} ({})",
+                pricing.label
+            );
+        }
+        None => println!(
+            "maximum cost       : unavailable; no {}/{} entry in {}",
+            endpoint.provider, endpoint.model, pricing.label
+        ),
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+fn summary_path(args: &Args) -> PathBuf {
+    args.summary
+        .clone()
+        .unwrap_or_else(|| args.out.with_extension("summary.json"))
+}
+
+fn create_parent(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if let Ok(path) = fs::canonicalize(path) {
+        return Ok(path);
+    }
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()
+            .context("resolving the current directory")?
+            .join(path))
+    }
+}
+
+fn warn(message: &str) {
+    eprintln!("warning: {message}");
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    if !args.results.exists() {
+        bail!(
+            "translation result JSONL not found: {}",
+            args.results.display()
+        );
+    }
+    let endpoint = resolve_endpoint(&args)?;
+    let (mut tasks, input) = read_tasks(&args.results)?;
+    let findings_available = tasks.len();
+    if args.limit == 0 {
+        warn(&format!(
+            "--limit 0 selects all {findings_available} findings and removes the spend cap"
+        ));
+    } else if tasks.len() > args.limit {
+        tasks.truncate(args.limit);
+    }
+
+    if args.dry_run {
+        return print_dry_run(&args, &endpoint, &tasks, findings_available, &input);
+    }
+
+    let summary_path = summary_path(&args);
+    let input_path = absolute_path(&args.results)?;
+    let output_path = absolute_path(&args.out)?;
+    let machine_summary_path = absolute_path(&summary_path)?;
+    if input_path == output_path || input_path == machine_summary_path {
+        bail!("--out and --summary must not overwrite --results");
+    }
+    if output_path == machine_summary_path {
+        bail!("--out and --summary must name different files");
+    }
+
+    create_parent(&args.out)?;
+    create_parent(&summary_path)?;
+    let mut output = BufWriter::new(
+        fs::File::create(&args.out)
+            .with_context(|| format!("creating adjudication JSONL {}", args.out.display()))?,
+    );
+    let scorer = build_text_scorer(&args, &endpoint)?;
+    let cache = VerdictCache {
+        dir: (!args.no_cache).then(|| args.cache.clone()),
+    };
+    let run = run_adjudication(
+        &scorer,
+        &endpoint,
+        &tasks,
+        &cache,
+        args.temperature,
+        args.max_output_tokens,
+        &mut output,
+    )
+    .await?;
+    output.flush().context("flushing adjudication JSONL")?;
+
+    let summary = build_summary(&args, &endpoint, &input, findings_available, &tasks, &run);
+    fs::write(
+        &summary_path,
+        serde_json::to_string_pretty(&summary).context("serializing precision summary")?,
+    )
+    .with_context(|| format!("writing precision summary {}", summary_path.display()))?;
+
+    print_human_report(&summary);
+    println!("\nadjudication JSONL : {}", args.out.display());
+    println!("precision summary  : {}", summary_path.display());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Offline tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(index: usize, category: DefectCategory) -> AdjudicationTask {
+        AdjudicationTask {
+            finding_id: format!("finding-{index}"),
+            passage_id: "passage".to_string(),
+            finding_index: index,
+            source_language: "English".to_string(),
+            target_language: "Italian".to_string(),
+            category,
+            source_quote: format!("source-{index}"),
+            translation_quote: format!("translation-{index}"),
+            explanation: format!("complaint-{index}"),
+        }
+    }
+
+    fn test_args() -> Args {
+        Args {
+            results: PathBuf::from("results.jsonl"),
+            out: PathBuf::from("out.jsonl"),
+            summary: None,
+            provider: "mock".to_string(),
+            model: Some("mock-model".to_string()),
+            base_url: Some("http://invalid".to_string()),
+            api_key_env: Some("MOCK_KEY".to_string()),
+            temperature: 0.0,
+            max_output_tokens: 1_024,
+            timeout_seconds: 1,
+            limit: 25,
+            dry_run: false,
+            cache: PathBuf::from("cache"),
+            no_cache: true,
+            pricing: None,
+        }
+    }
+
+    fn test_endpoint() -> Endpoint {
+        Endpoint {
+            provider: "mock".to_string(),
+            base_url: "http://invalid".to_string(),
+            api_key_env: "MOCK_KEY".to_string(),
+            model: "mock-model".to_string(),
+        }
+    }
+
+    struct StaticScorer;
+
+    impl AdjudicationScorer for StaticScorer {
+        fn name(&self) -> &'static str {
+            "static"
+        }
+
+        fn render(&self, task: &AdjudicationTask) -> RenderedPrompt {
+            render_prompt(task)
+        }
+
+        async fn score(&self, task: &AdjudicationTask) -> Result<ScoreOutcome, ScoreError> {
+            let response = match task.finding_index {
+                0 => {
+                    r#"{"verdict":"true_positive","confidence":0.9,"rationale":"The complaint is demonstrated."}"#
+                }
+                1 => {
+                    r#"{"verdict":"false_positive","confidence":0.8,"rationale":"The spans do not support it."}"#
+                }
+                _ => "not json",
+            };
+            Ok(interpret_response(response, 10, 2))
+        }
+    }
+
+    #[tokio::test]
+    async fn static_provider_runs_offline_and_records_unparseable_output() {
+        let tasks = vec![
+            task(0, DefectCategory::MeaningChanged),
+            task(1, DefectCategory::MeaningChanged),
+            task(2, DefectCategory::RegisterShift),
+        ];
+        let mut output = Vec::new();
+        let run = run_adjudication(
+            &StaticScorer,
+            &test_endpoint(),
+            &tasks,
+            &VerdictCache { dir: None },
+            0.0,
+            1_024,
+            &mut output,
+        )
+        .await
+        .expect("offline adjudication");
+
+        assert_eq!(run.provider_calls, 3);
+        assert_eq!(run.request_errors, 0);
+        assert_eq!(run.records.len(), 3);
+        assert_eq!(run.records[2].status, AdjudicationStatus::Unparseable);
+        assert!(run.records[2].verdict.is_none());
+        assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 3);
+    }
+
+    #[test]
+    fn per_category_rates_exclude_unparseable_and_are_null_for_zero_findings() {
+        let tasks = vec![
+            task(0, DefectCategory::MeaningChanged),
+            task(1, DefectCategory::MeaningChanged),
+            task(2, DefectCategory::RegisterShift),
+        ];
+        let run = RunResult {
+            records: vec![
+                make_record(
+                    &tasks[0],
+                    AdjudicationStatus::Parsed,
+                    Some(VerdictLabel::TruePositive),
+                    Some(0.9),
+                    Some("yes".to_string()),
+                    false,
+                    1,
+                    1,
+                    None,
+                ),
+                make_record(
+                    &tasks[1],
+                    AdjudicationStatus::Parsed,
+                    Some(VerdictLabel::FalsePositive),
+                    Some(0.9),
+                    Some("no".to_string()),
+                    false,
+                    1,
+                    1,
+                    None,
+                ),
+                make_record(
+                    &tasks[2],
+                    AdjudicationStatus::Unparseable,
+                    None,
+                    None,
+                    None,
+                    false,
+                    1,
+                    1,
+                    Some("bad json".to_string()),
+                ),
+            ],
+            ..RunResult::default()
+        };
+        let summary = build_summary(
+            &test_args(),
+            &test_endpoint(),
+            &InputStats::default(),
+            tasks.len(),
+            &tasks,
+            &run,
+        );
+        let meaning = summary
+            .categories
+            .iter()
+            .find(|metric| metric.category == DefectCategory::MeaningChanged)
+            .expect("meaning_changed metric");
+        let added = summary
+            .categories
+            .iter()
+            .find(|metric| metric.category == DefectCategory::ContentAdded)
+            .expect("content_added metric");
+        let register = summary
+            .categories
+            .iter()
+            .find(|metric| metric.category == DefectCategory::RegisterShift)
+            .expect("register_shift metric");
+
+        assert_eq!(meaning.findings, 2);
+        assert_eq!(meaning.adjudicated, 2);
+        assert_eq!(meaning.true_positive_rate, Some(0.5));
+        assert_eq!(register.findings, 1);
+        assert_eq!(register.adjudicated, 0);
+        assert_eq!(register.unparseable, 1);
+        assert_eq!(register.true_positive_rate, None);
+        assert_eq!(added.findings, 0);
+        assert_eq!(added.true_positive_rate, None);
+    }
+
+    #[test]
+    fn old_results_drop_self_refuting_but_keep_mixed_findings() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("results.jsonl");
+        let input = r#"{"schema_version":1,"passage_id":"p","source_language":"English","target_language":"Italian","status":"parsed","defects":[{"category":"target_language_error","source_quote":"Grand Seneschal","translation_quote":"Gran Siniscalco","explanation":"It is correctly translated. No error."},{"category":"meaning_changed","source_quote":"X and Y","translation_quote":"X e Z","explanation":"X is correct, but Y is wrong."}]}
+"#;
+        fs::write(&path, input).expect("write input");
+
+        let (tasks, stats) = read_tasks(&path).expect("read tasks");
+        assert_eq!(stats.dropped_self_refuting, 1);
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].category, DefectCategory::MeaningChanged);
+    }
+}

--- a/crates/bookforge-cli/examples/judge_translation.rs
+++ b/crates/bookforge-cli/examples/judge_translation.rs
@@ -270,6 +270,8 @@ struct PassageRecord {
     raw_defect_count: usize,
     dropped_missing_quote: usize,
     dropped_non_verbatim_quote: usize,
+    #[serde(default)]
+    dropped_self_refuting: usize,
     cached: bool,
     input_tokens: u64,
     output_tokens: u64,
@@ -324,6 +326,12 @@ struct QualitySummary {
     unparseable_responses: usize,
     request_errors: usize,
     dropped_defects: usize,
+    #[serde(default)]
+    dropped_missing_quote: usize,
+    #[serde(default)]
+    dropped_non_verbatim_quote: usize,
+    #[serde(default)]
+    dropped_self_refuting: usize,
     cache_hits: usize,
     provider_calls: usize,
     input_tokens: u64,
@@ -790,6 +798,8 @@ struct CachedOutcome {
     raw_defect_count: usize,
     dropped_missing_quote: usize,
     dropped_non_verbatim_quote: usize,
+    #[serde(default)]
+    dropped_self_refuting: usize,
     error: Option<String>,
 }
 
@@ -921,6 +931,7 @@ fn interpret_response(
             raw_defect_count: 0,
             dropped_missing_quote: 0,
             dropped_non_verbatim_quote: 0,
+            dropped_self_refuting: 0,
             error: Some(reason.to_string()),
         },
         input_tokens,
@@ -940,6 +951,7 @@ fn interpret_response(
     let mut defects = Vec::new();
     let mut dropped_missing_quote = 0usize;
     let mut dropped_non_verbatim_quote = 0usize;
+    let mut dropped_self_refuting = 0usize;
     for raw in response.defects {
         let Some(source_quote) = nonempty_quote(raw.source_quote) else {
             dropped_missing_quote += 1;
@@ -953,6 +965,10 @@ fn interpret_response(
             || !passage.translated_text.contains(&translation_quote)
         {
             dropped_non_verbatim_quote += 1;
+            continue;
+        }
+        if is_self_refuting_explanation(&raw.explanation) {
+            dropped_self_refuting += 1;
             continue;
         }
         defects.push(Defect {
@@ -970,6 +986,7 @@ fn interpret_response(
             raw_defect_count,
             dropped_missing_quote,
             dropped_non_verbatim_quote,
+            dropped_self_refuting,
             error: None,
         },
         input_tokens,
@@ -981,6 +998,107 @@ fn nonempty_quote(quote: Option<String>) -> Option<String> {
     let quote = quote?;
     let trimmed = quote.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Drop only explanations that unambiguously dismiss their own complaint.
+///
+/// This is intentionally lexical and conservative. Prompt-only attempts at
+/// suppressing non-issues have increased finding volume in prior measurements,
+/// while a deterministic filter is stable and auditable. Any contrast marker
+/// or separate defect assertion keeps the finding, so mixed explanations such
+/// as "X is correct, but Y is wrong" are never discarded.
+fn is_self_refuting_explanation(explanation: &str) -> bool {
+    let words = explanation
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+
+    const DISMISSALS: &[&[&str]] = &[
+        &["no", "error"],
+        &["no", "errors"],
+        &["no", "issue"],
+        &["no", "issues"],
+        &["no", "problem"],
+        &["no", "problems"],
+        &["nothing", "wrong"],
+        &["is", "correct"],
+        &["is", "accurate"],
+        &["correctly", "translated"],
+        &["translated", "correctly"],
+        &["accurately", "translated"],
+        &["translated", "accurately"],
+    ];
+    let has_dismissal = DISMISSALS
+        .iter()
+        .any(|phrase| contains_word_sequence(&words, phrase));
+    if !has_dismissal {
+        return false;
+    }
+
+    // Negated and hypothetical correctness claims are not dismissals. Keeping
+    // the entire explanation on these markers is deliberately conservative.
+    const DISMISSAL_BLOCKERS: &[&str] = &["could", "hardly", "never", "not", "should", "would"];
+    if words
+        .iter()
+        .any(|word| DISMISSAL_BLOCKERS.contains(&word.as_str()))
+    {
+        return false;
+    }
+
+    const CONTRAST_MARKERS: &[&str] = &[
+        "although",
+        "but",
+        "except",
+        "however",
+        "nevertheless",
+        "though",
+        "yet",
+    ];
+    if words
+        .iter()
+        .any(|word| CONTRAST_MARKERS.contains(&word.as_str()))
+    {
+        return false;
+    }
+
+    const DEFECT_ASSERTIONS: &[&str] = &[
+        "added",
+        "adds",
+        "changed",
+        "changes",
+        "dropped",
+        "fails",
+        "incorrect",
+        "inconsistent",
+        "missing",
+        "mistranslated",
+        "omitted",
+        "ungrammatical",
+        "unidiomatic",
+        "wrong",
+    ];
+    if words
+        .iter()
+        .any(|word| DEFECT_ASSERTIONS.contains(&word.as_str()))
+    {
+        return false;
+    }
+
+    !words.iter().enumerate().any(|(index, word)| {
+        matches!(
+            word.as_str(),
+            "error" | "errors" | "issue" | "issues" | "problem" | "problems"
+        ) && index
+            .checked_sub(1)
+            .is_none_or(|previous| words[previous] != "no")
+    })
+}
+
+fn contains_word_sequence(words: &[String], phrase: &[&str]) -> bool {
+    words
+        .windows(phrase.len())
+        .any(|window| window.iter().map(String::as_str).eq(phrase.iter().copied()))
 }
 
 /// Deterministically unwrap a whole-response JSON fence. Contents are not
@@ -1084,7 +1202,18 @@ struct OutcomeCache {
 impl OutcomeCache {
     fn get(&self, key: &str) -> Option<CachedOutcome> {
         let path = self.dir.as_ref()?.join(format!("{key}.json"));
-        serde_json::from_str(&fs::read_to_string(path).ok()?).ok()
+        let mut outcome =
+            serde_json::from_str::<CachedOutcome>(&fs::read_to_string(path).ok()?).ok()?;
+        // Cache entries written before this deterministic filter existed still
+        // receive the current filtering semantics without another paid call.
+        let before = outcome.defects.len();
+        outcome
+            .defects
+            .retain(|defect| !is_self_refuting_explanation(&defect.explanation));
+        outcome.dropped_self_refuting = outcome
+            .dropped_self_refuting
+            .saturating_add(before.saturating_sub(outcome.defects.len()));
+        Some(outcome)
     }
 
     fn put(&self, key: &str, outcome: &CachedOutcome) {
@@ -1286,6 +1415,7 @@ async fn run_scoring<S: TranslationScorer>(
                         0,
                         0,
                         0,
+                        0,
                         false,
                         0,
                         0,
@@ -1313,6 +1443,7 @@ async fn run_scoring<S: TranslationScorer>(
             outcome.cached.raw_defect_count,
             outcome.cached.dropped_missing_quote,
             outcome.cached.dropped_non_verbatim_quote,
+            outcome.cached.dropped_self_refuting,
             cached,
             outcome.input_tokens,
             outcome.output_tokens,
@@ -1333,6 +1464,7 @@ fn passage_record(
     raw_defect_count: usize,
     dropped_missing_quote: usize,
     dropped_non_verbatim_quote: usize,
+    dropped_self_refuting: usize,
     cached: bool,
     input_tokens: u64,
     output_tokens: u64,
@@ -1358,6 +1490,7 @@ fn passage_record(
         raw_defect_count,
         dropped_missing_quote,
         dropped_non_verbatim_quote,
+        dropped_self_refuting,
         cached,
         input_tokens,
         output_tokens,
@@ -1419,6 +1552,19 @@ fn build_summary(
         })
         .collect();
 
+    let dropped_missing_quote: usize = parsed
+        .iter()
+        .map(|record| record.dropped_missing_quote)
+        .sum();
+    let dropped_non_verbatim_quote: usize = parsed
+        .iter()
+        .map(|record| record.dropped_non_verbatim_quote)
+        .sum();
+    let dropped_self_refuting: usize = parsed
+        .iter()
+        .map(|record| record.dropped_self_refuting)
+        .sum();
+
     QualitySummary {
         schema_version: SUMMARY_SCHEMA_VERSION,
         prompt_version: PROMPT_VERSION.to_string(),
@@ -1436,14 +1582,12 @@ fn build_summary(
             .filter(|record| record.status == RecordStatus::Unparseable)
             .count(),
         request_errors: run.request_errors,
-        dropped_defects: parsed
-            .iter()
-            .map(|record| {
-                record
-                    .dropped_missing_quote
-                    .saturating_add(record.dropped_non_verbatim_quote)
-            })
-            .sum(),
+        dropped_defects: dropped_missing_quote
+            .saturating_add(dropped_non_verbatim_quote)
+            .saturating_add(dropped_self_refuting),
+        dropped_missing_quote,
+        dropped_non_verbatim_quote,
+        dropped_self_refuting,
         cache_hits: run.cache_hits,
         provider_calls: run.provider_calls,
         input_tokens: run.input_tokens,
@@ -1529,6 +1673,12 @@ fn print_human_report(summary: &QualitySummary, corpus: &CorpusStats, owner_db: 
         summary.unparseable_responses, summary.request_errors
     );
     println!("dropped defects    : {}", summary.dropped_defects);
+    println!("  missing quote    : {}", summary.dropped_missing_quote);
+    println!(
+        "  non-verbatim     : {}",
+        summary.dropped_non_verbatim_quote
+    );
+    println!("  self-refuting    : {}", summary.dropped_self_refuting);
     println!(
         "cache/calls        : {}/{}",
         summary.cache_hits, summary.provider_calls
@@ -1826,6 +1976,7 @@ mod tests {
             raw_defect_count: 0,
             dropped_missing_quote: 0,
             dropped_non_verbatim_quote: 0,
+            dropped_self_refuting: 0,
             cached: false,
             input_tokens: 0,
             output_tokens: 0,
@@ -1918,6 +2069,38 @@ mod tests {
         assert_eq!(outcome.cached.defects.len(), 1);
         assert_eq!(outcome.cached.dropped_missing_quote, 2);
         assert_eq!(outcome.cached.dropped_non_verbatim_quote, 1);
+        assert_eq!(outcome.cached.dropped_self_refuting, 0);
+    }
+
+    #[test]
+    fn self_refuting_findings_are_dropped_but_mixed_findings_are_kept() {
+        let passage = Passage {
+            source_text: "Grand Seneschal and the steward".to_string(),
+            translated_text: "Gran Siniscalco e l'amministratore".to_string(),
+            ..passage(1)
+        };
+        let response = r#"{"defects":[
+            {"category":"target_language_error","source_quote":"Grand Seneschal","translation_quote":"Gran Siniscalco","explanation":"'Grand Seneschal' is correctly translated as 'Gran Siniscalco'. No error."},
+            {"category":"meaning_changed","source_quote":"Grand Seneschal and the steward","translation_quote":"Gran Siniscalco e l'amministratore","explanation":"'Grand Seneschal' is correct, but 'steward' is wrong."}
+        ]}"#;
+        let outcome = interpret_response(response, &passage, 11, 12);
+
+        assert!(outcome.cached.parsed);
+        assert_eq!(outcome.cached.raw_defect_count, 2);
+        assert_eq!(outcome.cached.defects.len(), 1);
+        assert_eq!(
+            outcome.cached.defects[0].category,
+            DefectCategory::MeaningChanged
+        );
+        assert_eq!(outcome.cached.dropped_missing_quote, 0);
+        assert_eq!(outcome.cached.dropped_non_verbatim_quote, 0);
+        assert_eq!(outcome.cached.dropped_self_refuting, 1);
+        assert!(!is_self_refuting_explanation(
+            "The title is not correctly translated."
+        ));
+        assert!(!is_self_refuting_explanation(
+            "The title would be correctly translated as Gran Siniscalco."
+        ));
     }
 
     #[test]
@@ -1987,9 +2170,31 @@ mod tests {
 
         assert_eq!(summary.passages_judged, 2);
         assert_eq!(summary.source_words_judged, 150);
+        assert_eq!(summary.dropped_missing_quote, 0);
+        assert_eq!(summary.dropped_non_verbatim_quote, 0);
+        assert_eq!(summary.dropped_self_refuting, 0);
         assert_eq!(meaning.count, 3);
         assert!((meaning.per_1k_source_words - 20.0).abs() < f64::EPSILON);
         assert!((hard_group.per_1k_source_words - 20.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn summary_reports_each_drop_counter_separately() {
+        let mut record = parsed_record(10, Vec::new());
+        record.dropped_missing_quote = 2;
+        record.dropped_non_verbatim_quote = 3;
+        record.dropped_self_refuting = 5;
+        let run = RunResult {
+            records: vec![record],
+            ..RunResult::default()
+        };
+
+        let summary = build_summary(&test_args(), &test_endpoint(), 1, &run);
+
+        assert_eq!(summary.dropped_missing_quote, 2);
+        assert_eq!(summary.dropped_non_verbatim_quote, 3);
+        assert_eq!(summary.dropped_self_refuting, 5);
+        assert_eq!(summary.dropped_defects, 10);
     }
 
     #[test]

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -5,15 +5,16 @@ string-level check fires. Those checks have no model of meaning, so some
 proportion of what they flag is wrong — and until 2026-07-26 nothing measured
 which proportion.
 
-Three dev-time examples cover validator replay, flag precision, and translation
-quality. None is wired into `translate`, and none should be: a model that gated
-or repaired translations would violate the architectural invariants in
-`ROADMAP.md` §1.1–§1.2.
+Four dev-time examples cover validator replay, flag precision, translation
+quality, and quality-finding precision. None is wired into `translate`, and none
+should be: a model that gated or repaired translations would violate the
+architectural invariants in `ROADMAP.md` §1.1–§1.2.
 
 ```
 cargo run --release --example replay_validation -- --help
 cargo run --release --example judge_flags -- --help
 cargo run --release --example judge_translation -- --help
+cargo run --release --example adjudicate_translation -- --help
 ```
 
 ## `replay_validation` — replay the validator offline, for free
@@ -158,8 +159,20 @@ Important measurement rules:
   and the summary. `--sample 0` explicitly selects everything and warns that
   the spend cap is gone.
 - The judge returns enumerable defects, not a score or severity. Every finding
-  must contain exact non-empty source and translation quotes. Missing quotes
-  and non-verbatim quotes are dropped and counted.
+  must contain exact non-empty source and translation quotes. Missing quotes,
+  non-verbatim quotes, and self-refuting explanations are dropped and counted
+  separately in both passage JSONL and the summary.
+- The self-refutation filter is deterministic because all three measured
+  attempts to suppress non-issues through prompt wording made the QA reviewer
+  noisier. It recognizes explicit English dismissals such as `no error`,
+  `no issue`, `is correct`, and `correctly translated`. A finding is retained
+  if the explanation contains a contrast marker (`but`, `however`, `although`,
+  and similar), a separate defect assertion, or a negated/hypothetical
+  correctness claim. Thus `X is correct, but Y is wrong` remains a finding.
+  This conservative lexical rule can miss paraphrased or non-English
+  self-refutations, and it deliberately keeps some fully dismissive
+  explanations that happen to use a contrast word. Those are false negatives;
+  the rule is biased against silently dropping a genuine mixed complaint.
 - Counts and defects per 1,000 source words are reported for every category.
   The three hard categories and three soft categories are also reported as
   separate groups. There is intentionally no combined headline score.
@@ -220,6 +233,91 @@ v4-pro buys around 40× the coverage per dollar.
 **Kimi K3 starved even at 16,000 output tokens** on 2 of 25 passages, and on 10
 of 25 at 4,096. It can burn more than 16k reasoning tokens on a 1,500-character
 passage. Budget accordingly, and see the empty-content diagnosis note above.
+
+### Self-refuting findings, measured 2026-07-29
+
+The first glossary A/B run exposed a deterministic failure mode in the absolute
+counts. Of 587 findings, 67 dismissed their own complaint:
+
+| arm | raw findings | self-refuting | retained |
+| --- | ---: | ---: | ---: |
+| baseline | 262 | 25 (9%) | 237 |
+| glossary | 325 | 42 (12%) | 283 |
+
+For `target_language_error`, 20 of 43 findings (47%) were self-refuting.
+Leaving those rows in made the glossary arm look 116% worse on soft defects;
+removing them changed that comparison to +24%. This does not make the remaining
+findings true. It only establishes the minimum rule that a finding cannot
+simultaneously say there is no defect.
+
+Cached passage outcomes written before the filter are filtered when read, so a
+cache replay adopts the new rule without another provider call. Old result
+JSONL can also be passed directly to the adjudicator below; it defensively
+applies the same rule and reports `dropped_input_self_refuting`.
+
+## `adjudicate_translation` — measure quality-finding precision
+
+This is a separate example rather than a mode inside `judge_translation`.
+Generation reads a throwaway job-store copy and measures defect incidence;
+adjudication reads only the resulting JSONL and measures whether each claim is
+right. Keeping those phases separate makes it impossible for calibration to
+rewrite a translation or accidentally reopen the owner's store, and lets one
+paid generation be calibrated repeatedly with different adjudicators.
+
+As with `judge_flags`, each request asks one narrow question. The input is one
+finding's claimed category, exact source span, exact translation span, and
+explanation. Start offline:
+
+```
+cargo run --release --example adjudicate_translation -- \
+    --results judge-translation.jsonl \
+    --provider deepseek --model deepseek-v4-pro \
+    --limit 0 --dry-run
+```
+
+`--limit` truncates in input order; it does not sample. Use `--limit 0` only
+after inspecting the dry-run maximum, or externally shuffle with a recorded
+seed if a capped precision sample is required. The paid owner-run command is:
+
+```
+cargo run --release --example adjudicate_translation -- \
+    --results judge-translation.jsonl \
+    --provider deepseek --model deepseek-v4-pro \
+    --max-output-tokens 1024 --limit 0 \
+    --out translation-adjudication.jsonl \
+    --summary translation-adjudication.summary.json
+```
+
+The content-addressed cache key includes
+`adjudicate_translation/v1`, scorer, provider/model, temperature, output cap,
+languages, category, both spans, and the complaint. It never contains the API
+key. `--api-key-env` is an environment-variable **name**, never a key value.
+Parsed and unparseable responses are both cached; an unparseable response is a
+terminal JSONL record and is never repaired or re-prompted.
+
+The frozen adjudication JSONL schema records identity and audit text plus:
+
+```
+schema_version, prompt_version, finding_id, passage_id, finding_index,
+category, source_quote, translation_quote, explanation, status,
+verdict, confidence, rationale, cached, input_tokens, output_tokens, error
+```
+
+`status` is `parsed`, `unparseable`, or `error`; parsed `verdict` is
+`true_positive`, `false_positive`, or `unclear`. The summary emits all six
+categories with `findings`, `adjudicated`, verdict counts, `unparseable`,
+`request_errors`, and `true_positive_rate`. The rate is true positives divided
+by parsed adjudications, including parsed `unclear` verdicts. Unparseable
+responses and request errors are visible but do not become false positives. A
+category with no parsed adjudications has JSON `null` and prints `-`, because
+0/0 is not 0% precision.
+
+The hand review of eight `meaning_changed` findings suggested roughly half were
+genuine, including a negation inversion and `Unwinched Waifs` rendered as
+“unscrewed orphans”; eight is not a precision measurement. No paid adjudication
+was run while adding this tooling. The owner-run summary above is the source of
+truth for the per-category table; do not copy the 4/8 impression into a reported
+rate.
 
 ## What this measured, 2026-07-26/27
 


### PR DESCRIPTION
`judge_translation` shipped and produced a real measurement. The A/B *comparison* held up, but the **absolute numbers were not trustworthy** — in two ways I measured rather than guessed.

## 1. Self-refuting findings

The judge reports a defect, then states in its own explanation that nothing is wrong:

> *"'Grand Seneschal' is correctly translated as 'Gran Siniscalco'. **No error.**"*

Measured over 587 findings from two arms of a real A/B:

| | findings | self-refuting |
| --- | --- | --- |
| baseline | 262 | 25 (9%) |
| glossary | 325 | 42 (12%) |
| — of which `target_language_error` | 43 | **20 (47%)** |

Uncorrected, that made one arm look **116% worse** on soft defects when the honest figure was a fraction of that. It's the same pathology already recorded for the QA pass: a reviewer that reports non-issues teaches its reader to ignore it.

These are now dropped and counted. The summary had been collapsing the existing missing-quote and non-verbatim-quote drops into one `dropped_defects` number; all three are now reported separately as well as in aggregate. **Cached entries are re-filtered locally**, so applying this correction to existing results costs nothing.

### Why a filter and not a better prompt

Deliberate. `docs/validator-tooling.md` records three measured attempts to control this model class by wording — every one *increased* output while precision fell (40% → 5.6% → 17.5%). A deterministic post-filter is the mechanism that actually works here.

The rule retains findings carrying contrast markers, separate defect assertions, negation, or hypothetical wording, so **"X is correct, but Y is wrong" survives**. It is English- and phrase-based and intentionally conservative: paraphrased or non-English self-refutations will still get through. That limitation is documented rather than papered over.

## 2. Unmeasured precision

Hand-checking eight `meaning_changed` findings judged roughly half genuine. That's an anecdote, not a measurement — real catches (a negation inversion; `Unwinched Waifs` → `Orfani Non Avvitati`, "unscrewed orphans") sat next to pedantic ones (`"wasn't the cleanest"` → `"non era nemmeno pulitissima"`).

`adjudicate_translation` applies the `judge_flags` methodology to quality findings: given the source span, the translation span, and the claimed category, *is this specific complaint correct?* It reads an existing results JSONL and **never opens a store**, so calibration cannot disturb job data.

It reports a **per-category true-positive rate**, so a raw count can be discounted by measured precision instead of trusted. Parsed `unclear` verdicts stay in the denominator; unparseable responses and request errors don't, and are reported separately. An unparseable adjudication is terminal — never re-prompted, never repaired.

**No precision figure is asserted in the docs.** The eight-item check is recorded as insufficient, and the paid calibration run is left to the owner rather than a number being invented to fill the gap.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **902 passed / 0 failed / 3 ignored** over four consecutive runs (was 897). No provider was called.

One caveat worth recording: a single test run aborted early with one failure that did not reproduce across four subsequent full runs, and I was not able to identify it. Noting it rather than assuming it benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)