### PR TITLE
Retry and bisect batch responses that fail to decode, and bound response size

### DIFF
--- a/crates/bookforge-llm/src/batch/execution.rs
+++ b/crates/bookforge-llm/src/batch/execution.rs
@@ -60,8 +60,33 @@ fn is_transient(err: &LlmError) -> bool {
     match err {
         LlmError::HttpStatus { status, .. } => *status == 429 || *status >= 500,
         LlmError::Http(e) => e.is_timeout() || e.is_connect() || e.is_decode() || e.is_body(),
+        LlmError::InvalidResponse(message) => is_empty_content_error(message),
         _ => false,
     }
+}
+
+fn is_response_transport_error(err: &LlmError) -> bool {
+    matches!(err, LlmError::Http(error) if error.is_decode() || error.is_body())
+}
+
+fn is_empty_content_error(message: &str) -> bool {
+    message.starts_with("the model produced no content")
+}
+
+fn transient_batch_attempt_limit(configured_limit: usize, error: &LlmError) -> usize {
+    let configured_limit = configured_limit.max(1);
+    if is_response_transport_error(error)
+        || matches!(error, LlmError::InvalidResponse(message) if is_empty_content_error(message))
+    {
+        configured_limit.max(2)
+    } else {
+        configured_limit
+    }
+}
+
+fn should_bisect_transient_batch(error: &LlmError) -> bool {
+    is_response_transport_error(error)
+        || matches!(error, LlmError::InvalidResponse(message) if is_empty_content_error(message))
 }
 
 pub fn collect_repair_items(result: &BatchTranslationResult) -> Vec<TranslationBatchItem> {
@@ -761,6 +786,85 @@ where
                     }
                     all_results.push(batch_result);
                 }
+                Err(ref error) if is_transient(error) && batch.kind == BatchKind::Translation => {
+                    truncation_alert.observe_resolved();
+                    let attempts =
+                        increment_batch_item_attempts(&mut transient_attempts_by_item, &batch);
+                    let attempt_limit =
+                        transient_batch_attempt_limit(config.scheduler.max_attempts, error);
+                    if attempts < attempt_limit {
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "batch_transient_retry".to_string(),
+                            message: format!(
+                                "batch {} transient error on attempt {}; retrying: {error}",
+                                batch.id, attempts
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                        pending_queue.push_back(batch);
+                    } else if batch.items.len() > 1 && should_bisect_transient_batch(error) {
+                        if let Some(sizer) =
+                            adaptive_sizer_mut(&mut runtime_sizer, batch_sizer.as_deref_mut())
+                        {
+                            sizer.on_invalid_json_for_mode(batch.mode);
+                        }
+                        for item in &batch.items {
+                            transient_attempts_by_item.remove(&item.item_id);
+                        }
+                        let split = split_batch_with_config(&batch, Some(config.as_ref()));
+                        if split.len() == 2 {
+                            progress.emit(bookforge_core::ProgressEvent::BatchSplit {
+                                batch_id: batch.id.clone(),
+                                left_items: split[0].items.len(),
+                                right_items: split[1].items.len(),
+                                timestamp_ms: bookforge_core::progress::now_ms(),
+                            });
+                        }
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "batch_transient_split".to_string(),
+                            message: format!(
+                                "batch {} still failed after {} transient attempts; splitting: {error}",
+                                batch.id, attempts
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                        pending_queue.extend(split);
+                    } else {
+                        progress.emit(bookforge_core::ProgressEvent::Warning {
+                            kind: "batch_transient_exhausted".to_string(),
+                            message: format!(
+                                "batch {} failed after {} transient attempts: {error}",
+                                batch.id, attempts
+                            ),
+                            timestamp_ms: bookforge_core::progress::now_ms(),
+                        });
+                        unblock_fence_for_batch_failure(
+                            config.context_registry.as_deref(),
+                            &segments_by_id,
+                            &batch.items,
+                        );
+                        all_results.push(BatchTranslationResult {
+                            batch_id: batch.id.clone(),
+                            translations: Vec::new(),
+                            failures: batch
+                                .items
+                                .iter()
+                                .map(|item| BatchItemFailure {
+                                    item_id: item.item_id.clone(),
+                                    segment_id: item.segment_id.clone(),
+                                    error: format!("{error}"),
+                                    input_tokens: None,
+                                    input_cached_tokens: None,
+                                    output_tokens: None,
+                                    tokens_estimated: false,
+                                })
+                                .collect(),
+                            input_tokens: None,
+                            input_cached_tokens: None,
+                            output_tokens: None,
+                        });
+                    }
+                }
                 Err(LlmError::InvalidResponse(_))
                     if batch.kind == BatchKind::Translation
                         && request_status == RequestStatus::Truncated
@@ -1031,56 +1135,6 @@ where
                         timestamp_ms: bookforge_core::progress::now_ms(),
                     });
                     pending_queue.extend(split);
-                }
-                Err(ref error) if is_transient(error) && batch.kind == BatchKind::Translation => {
-                    truncation_alert.observe_resolved();
-                    let attempts =
-                        increment_batch_item_attempts(&mut transient_attempts_by_item, &batch);
-                    if attempts < config.scheduler.max_attempts.max(1) {
-                        progress.emit(bookforge_core::ProgressEvent::Warning {
-                            kind: "batch_transient_retry".to_string(),
-                            message: format!(
-                                "batch {} transient error on attempt {}; retrying: {error}",
-                                batch.id, attempts
-                            ),
-                            timestamp_ms: bookforge_core::progress::now_ms(),
-                        });
-                        pending_queue.push_back(batch);
-                    } else {
-                        progress.emit(bookforge_core::ProgressEvent::Warning {
-                            kind: "batch_transient_exhausted".to_string(),
-                            message: format!(
-                                "batch {} failed after {} transient attempts: {error}",
-                                batch.id, attempts
-                            ),
-                            timestamp_ms: bookforge_core::progress::now_ms(),
-                        });
-                        unblock_fence_for_batch_failure(
-                            config.context_registry.as_deref(),
-                            &segments_by_id,
-                            &batch.items,
-                        );
-                        all_results.push(BatchTranslationResult {
-                            batch_id: batch.id.clone(),
-                            translations: Vec::new(),
-                            failures: batch
-                                .items
-                                .iter()
-                                .map(|item| BatchItemFailure {
-                                    item_id: item.item_id.clone(),
-                                    segment_id: item.segment_id.clone(),
-                                    error: format!("{error}"),
-                                    input_tokens: None,
-                                    input_cached_tokens: None,
-                                    output_tokens: None,
-                                    tokens_estimated: false,
-                                })
-                                .collect(),
-                            input_tokens: None,
-                            input_cached_tokens: None,
-                            output_tokens: None,
-                        });
-                    }
                 }
                 Err(error) => {
                     truncation_alert.observe_resolved();

--- a/crates/bookforge-llm/src/batch/planning.rs
+++ b/crates/bookforge-llm/src/batch/planning.rs
@@ -599,6 +599,42 @@ fn batch_token_estimate(
             .sum::<usize>()
 }
 
+fn expected_batch_output_tokens(mode: BatchMode, items: &[TranslationBatchItem]) -> usize {
+    let translated_text = items
+        .iter()
+        .map(|item| token_estimate(&item.source_text).max(1))
+        .sum::<usize>();
+    let json_envelope = 128usize.saturating_add(items.len().saturating_mul(64));
+    let run_envelope = if mode == BatchMode::RunPreserving {
+        items
+            .iter()
+            .map(|item| item.text_runs.len().saturating_mul(16))
+            .sum::<usize>()
+    } else {
+        0
+    };
+    translated_text
+        .saturating_add(json_envelope)
+        .saturating_add(run_envelope)
+}
+
+fn configured_batch_output_limit(config: Option<&TranslationRunConfig>) -> Option<usize> {
+    config
+        .and_then(|config| config.batch_max_output_tokens.or(config.max_output_tokens))
+        .map(|limit| limit as usize)
+}
+
+fn batch_fits_limits(
+    batch: &TranslationBatch,
+    target_tokens: usize,
+    max_items: usize,
+    config: Option<&TranslationRunConfig>,
+) -> bool {
+    let fits_output = configured_batch_output_limit(config)
+        .is_none_or(|limit| expected_batch_output_tokens(batch.mode, &batch.items) <= limit);
+    batch.token_estimate <= target_tokens && batch.items.len() <= max_items && fits_output
+}
+
 /// Deterministic per-item validation for text-mode batch responses. The
 /// markers that must survive are the ones present in THIS block's source;
 /// protected spans are already block-scoped.
@@ -701,7 +737,7 @@ pub(super) fn normalize_batch_for_current_sizer(
     let target_tokens = sizer.target_tokens_for_mode(batch.mode);
     let max_items = sizer.max_items_for_mode(batch.mode);
     let batch = with_configured_token_estimate(batch, config);
-    if batch.token_estimate <= target_tokens && batch.items.len() <= max_items {
+    if batch_fits_limits(&batch, target_tokens, max_items, config) {
         return vec![batch];
     }
     repack_batch_with_config(batch, target_tokens, max_items, config)
@@ -779,7 +815,10 @@ fn repack_batch_with_config(
         current_items.push(item);
         let candidate_tokens = batch_token_estimate(&current_items, config);
         let would_exceed_tokens = current_items.len() > 1 && candidate_tokens > target_tokens;
-        if would_exceed_items || would_exceed_tokens {
+        let would_exceed_output = current_items.len() > 1
+            && configured_batch_output_limit(config)
+                .is_some_and(|limit| expected_batch_output_tokens(mode, &current_items) > limit);
+        if would_exceed_items || would_exceed_tokens || would_exceed_output {
             let item = current_items
                 .pop()
                 .expect("candidate batch contains the item just added");

--- a/crates/bookforge-llm/src/batch/tests.rs
+++ b/crates/bookforge-llm/src/batch/tests.rs
@@ -149,6 +149,78 @@ fn plain_blocks_batch_together() {
 }
 
 #[test]
+fn expected_output_bound_is_opt_in_and_only_splits_the_oversized_batch() {
+    let oversized = make_segment_in_section(
+        "oversized",
+        "sec_oversized",
+        0,
+        (0..45)
+            .map(|index| plain_block(&format!("{index:02}:{}", "x".repeat(768))))
+            .collect(),
+        vec![],
+    );
+    let ordinary = make_segment_in_section(
+        "ordinary",
+        "sec_ordinary",
+        1,
+        (0..19)
+            .map(|index| plain_block(&format!("{index:02}: small")))
+            .collect(),
+        vec![],
+    );
+    let config = BatchConfig {
+        enabled: true,
+        target_tokens: 16_000,
+        max_items: 64,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let initial = build_translation_batches(
+        &[oversized, ordinary],
+        &config,
+        TranslationProfile::Balanced,
+    );
+    assert_eq!(initial.len(), 2);
+
+    let without_bound =
+        account_for_batch_prompt_overhead(initial.clone(), &config, &test_run_config());
+    assert_eq!(
+        without_bound
+            .iter()
+            .filter(|batch| batch.section_id.0 == "sec_oversized")
+            .count(),
+        1,
+        "no expected-output bound is enabled by default"
+    );
+
+    let mut bounded_config = test_run_config();
+    bounded_config.batch_max_output_tokens = Some(8_000);
+    let bounded = account_for_batch_prompt_overhead(initial, &config, &bounded_config);
+    assert!(
+        bounded
+            .iter()
+            .filter(|batch| batch.section_id.0 == "sec_oversized")
+            .count()
+            > 1,
+        "the measured 45-block response shape should be repacked"
+    );
+    assert_eq!(
+        bounded
+            .iter()
+            .filter(|batch| batch.section_id.0 == "sec_ordinary")
+            .count(),
+        1,
+        "ordinary small batches must not be shrunk by the output bound"
+    );
+    assert_eq!(
+        bounded.iter().map(|batch| batch.items.len()).sum::<usize>(),
+        64,
+        "repacking must preserve every item"
+    );
+}
+
+#[test]
 fn batch_construction_uses_only_block_local_markers() {
     let seg = make_segment(
         "seg1",
@@ -2044,6 +2116,152 @@ impl LlmProviderTrait for Arc<AlwaysTransientProvider> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum DecodeFailureMode {
+    FirstRequest,
+    MultiItemRequests,
+}
+
+struct DecodeThenPromptEchoProvider {
+    calls: AtomicUsize,
+    decode_url: String,
+    mode: DecodeFailureMode,
+    requested_item_counts: Arc<Mutex<Vec<usize>>>,
+}
+
+impl DecodeThenPromptEchoProvider {
+    fn new(
+        decode_url: String,
+        mode: DecodeFailureMode,
+        requested_item_counts: Arc<Mutex<Vec<usize>>>,
+    ) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            decode_url,
+            mode,
+            requested_item_counts,
+        }
+    }
+}
+
+impl LlmProviderTrait for DecodeThenPromptEchoProvider {
+    async fn complete(&self, request: CompletionRequest) -> ProviderResult<CompletionResponse> {
+        let item_ids = item_ids_from_batch_prompt(&request.user);
+        self.requested_item_counts
+            .lock()
+            .unwrap()
+            .push(item_ids.len());
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        let should_decode = match self.mode {
+            DecodeFailureMode::FirstRequest => call == 0,
+            DecodeFailureMode::MultiItemRequests => item_ids.len() > 1,
+        };
+        if should_decode {
+            let response = reqwest::get(&self.decode_url).await?;
+            let _: serde_json::Value = response.json().await?;
+            unreachable!("invalid JSON endpoint unexpectedly decoded")
+        }
+
+        Ok(CompletionResponse {
+            content: serde_json::json!({
+                "items": item_ids
+                    .into_iter()
+                    .map(|id| serde_json::json!({
+                        "translation": format!("[it] {id}"),
+                        "id": id,
+                    }))
+                    .collect::<Vec<_>>(),
+            })
+            .to_string(),
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            finish_reason: FinishReason::Stop,
+            provider_latency_ms: 0,
+            raw: serde_json::json!({}),
+        })
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            supports_json_response_format: true,
+            supports_usage_tokens: true,
+        }
+    }
+}
+
+struct FirstEmptyThenPromptEchoProvider {
+    calls: AtomicUsize,
+}
+
+impl LlmProviderTrait for Arc<FirstEmptyThenPromptEchoProvider> {
+    async fn complete(&self, request: CompletionRequest) -> ProviderResult<CompletionResponse> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(LlmError::InvalidResponse(
+                "the model produced no content".to_string(),
+            ));
+        }
+        let item_ids = item_ids_from_batch_prompt(&request.user);
+        Ok(CompletionResponse {
+            content: serde_json::json!({
+                "items": item_ids
+                    .into_iter()
+                    .map(|id| serde_json::json!({
+                        "translation": format!("[it] {id}"),
+                        "id": id,
+                    }))
+                    .collect::<Vec<_>>(),
+            })
+            .to_string(),
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            finish_reason: FinishReason::Stop,
+            provider_latency_ms: 0,
+            raw: serde_json::json!({}),
+        })
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            supports_json_response_format: true,
+            supports_usage_tokens: true,
+        }
+    }
+}
+
+async fn invalid_json_endpoint(
+    expected_requests: usize,
+) -> Option<(String, tokio::task::JoinHandle<()>)> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = match TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return None,
+        Err(error) => panic!("test listener should bind: {error}"),
+    };
+    let address = listener.local_addr().expect("listener address");
+    let handle = tokio::spawn(async move {
+        for _ in 0..expected_requests {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut request = vec![0_u8; 8_192];
+            let _ = stream.read(&mut request).await;
+            let body = b"{not-json";
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(header.as_bytes()).await;
+            let _ = stream.write_all(body).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+    Some((format!("http://{address}"), handle))
+}
+
 struct DelayedPromptEchoProvider;
 
 impl LlmProviderTrait for DelayedPromptEchoProvider {
@@ -2451,6 +2669,154 @@ async fn transient_batch_errors_stop_after_max_attempts() {
         "got: {:?}",
         translations[0].error
     );
+}
+
+#[tokio::test]
+async fn decode_error_retries_the_same_batch_before_response_validation() {
+    let Some((decode_url, server)) = invalid_json_endpoint(1).await else {
+        return;
+    };
+    let segment = make_segment(
+        "seg1",
+        vec![plain_block("Hello"), plain_block("World")],
+        vec![],
+    );
+    let segments = vec![segment];
+    let cfg = BatchConfig {
+        enabled: true,
+        target_tokens: 1_000,
+        max_items: 64,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+    let requested_item_counts = Arc::new(Mutex::new(Vec::new()));
+    let provider = DecodeThenPromptEchoProvider::new(
+        decode_url,
+        DecodeFailureMode::FirstRequest,
+        requested_item_counts.clone(),
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let mut config = test_run_config();
+    config.scheduler.max_attempts = 1;
+
+    let translations = translate_batches_with_callback(
+        provider,
+        batches,
+        &segments,
+        &config,
+        Arc::new(TelemetryLog::new()),
+        None,
+        None,
+        Arc::new(RecordingProgress {
+            events: events.clone(),
+        }),
+        None,
+        |_| Ok(()),
+    )
+    .await
+    .expect("decode retry should recover");
+
+    server.await.expect("invalid JSON server should finish");
+    assert_eq!(*requested_item_counts.lock().unwrap(), [2, 2]);
+    assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+    assert!(
+        !events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, bookforge_core::ProgressEvent::BatchSplit { .. })),
+        "a transport decode error must not be parsed as an empty or partial batch response"
+    );
+}
+
+#[tokio::test]
+async fn persistent_decode_error_bisects_an_oversized_batch_after_retry() {
+    let Some((decode_url, server)) = invalid_json_endpoint(2).await else {
+        return;
+    };
+    let segment = make_segment(
+        "seg1",
+        vec![plain_block("Hello"), plain_block("World")],
+        vec![],
+    );
+    let segments = vec![segment];
+    let cfg = BatchConfig {
+        enabled: true,
+        target_tokens: 1_000,
+        max_items: 64,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+    let requested_item_counts = Arc::new(Mutex::new(Vec::new()));
+    let provider = DecodeThenPromptEchoProvider::new(
+        decode_url,
+        DecodeFailureMode::MultiItemRequests,
+        requested_item_counts.clone(),
+    );
+    let mut config = test_run_config();
+    config.scheduler.max_attempts = 1;
+
+    let translations = translate_batches_with_callback(
+        provider,
+        batches,
+        &segments,
+        &config,
+        Arc::new(TelemetryLog::new()),
+        None,
+        None,
+        Arc::new(bookforge_core::NullProgressSink),
+        None,
+        |_| Ok(()),
+    )
+    .await
+    .expect("decode bisection should recover");
+
+    server.await.expect("invalid JSON server should finish");
+    assert_eq!(*requested_item_counts.lock().unwrap(), [2, 2, 1, 1]);
+    assert_eq!(translations[0].status, SegmentStatus::Succeeded);
+    assert_eq!(translations[0].blocks.len(), 2);
+}
+
+#[tokio::test]
+async fn empty_http_200_content_is_retried_for_a_single_item_batch() {
+    let segment = make_segment("seg1", vec![plain_block("Hello")], vec![]);
+    let segments = vec![segment];
+    let cfg = BatchConfig {
+        enabled: true,
+        target_tokens: 1_000,
+        max_items: 1,
+        adaptive_sizing: false,
+        split_on_json_failure: true,
+        repair_invalid_items: true,
+    };
+    let batches = build_translation_batches(&segments, &cfg, TranslationProfile::Balanced);
+    let provider = Arc::new(FirstEmptyThenPromptEchoProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let mut config = test_run_config();
+    config.scheduler.max_attempts = 1;
+
+    let translations = translate_batches_with_callback(
+        provider.clone(),
+        batches,
+        &segments,
+        &config,
+        Arc::new(TelemetryLog::new()),
+        None,
+        None,
+        Arc::new(bookforge_core::NullProgressSink),
+        None,
+        |_| Ok(()),
+    )
+    .await
+    .expect("empty-content retry should recover");
+
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(translations[0].status, SegmentStatus::Succeeded);
 }
 
 #[tokio::test]

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -137,6 +137,14 @@ bookforge translate book.epub \
   --out book.it.epub
 ```
 
+`--batch-target-tokens` bounds estimated request size. An explicit
+`--batch-max-output-tokens` also bounds the estimated JSON response while
+packing batches, in addition to capping each provider response. The response
+bound is opt-in: leaving the flag unset preserves the profile's normal batch
+packing and avoids paying prompt overhead for extra requests. If a response
+body still fails to decode after a retry, BookForge bisects a multi-item batch;
+a single item remains the recovery floor.
+
 `--qa` controls the optional LLM review pass. `off` skips it, `all` reviews
 every non-empty successful, cached, or `needs_review` translation, and
 `suspicious` limits those reviewable translations to segments with at least


### PR DESCRIPTION
## The measurement

One 47,705-character EPUB slice, translated five times with identical settings — only the model differing. The **same two segments** failed on three of five models, from three different vendors:

| model | segments |
| --- | --- |
| openai/gpt-5.6-luna | 24/24 |
| openai/gpt-5.6-terra | 24/24 |
| x-ai/grok-4.5 | 22/24 |
| anthropic/claude-opus-5 | 22/24 |
| anthropic/claude-fable-5 | 22/24 |

All six failures: `HTTP error: error decoding response body`.

The two segments need roughly **11,184 and 9,102 output tokens** in a single response. Every other segment in the book is tiny — third largest is 19 blocks against 62. A cliff, not a gradient. It silently cost **73% of the book's translated text** on the affected models.

## Three things the original report got wrong

Recorded so nobody re-derives them:

- **No layer swallowed or reclassified the error.** Provider body/decode retries were already correct; both the provider and the batch scheduler simply obeyed their configured attempt limits.
- **Decode errors are not converted into validation failures.** Parsing happens only after `provider.complete` succeeds. The two-part error string is assembled later — the HTTP error is stored, then final segment aggregation appends the missing-block mismatch.
- **`segments.attempts` cannot reveal provider-internal retries.** It is incremented when the final result is checkpointed, not per request. `attempts = 1` says nothing about how many times the provider tried.

## Changes

- Body/decode failures get **at least one batch-layer retry**, even when a speed profile configures a single attempt.
- Persistent body/decode failures **bisect** a multi-item batch once retries are exhausted; a single item is the recovery floor.
- The provider's `the model produced no content` diagnosis is treated as **transient in the batch path** and gets the same retry/bisection. Other call sites deliberately unchanged — that pattern has now been seen five times across four sites, but expanding scope here would be silent.
- An explicit `--batch-max-output-tokens` now also bounds the **estimated JSON response size** during packing, counting translated text plus item-envelope overhead.

## The output bound is opt-in, on purpose

Re-running the affected models at `--batch-max-items 12 --batch-target-tokens 3000` recovered everything — but cost **2.7× more** (fable-5 went $1.08 → $2.92), because per-request prompt overhead is re-paid on every batch.

Shrinking batches by default would triple cost for every user to fix a failure most never hit. Default planning is therefore unchanged, and unconfigured runs recover through retry and bisection instead. For this specific vendor cliff, an explicit cap near 8,000 tokens splits only the oversized shapes and leaves small batches intact.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **908 passed / 0 failed / 3 ignored**. New tests cover one-off decode retry without validation splitting, persistent-decode bisection, HTTP-200 empty content, opt-in output packing, and unchanged planning for ordinary batches. No provider was called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)