### PR TITLE
Collapse redundantly nested inline markers in prompts, restore them after

### DIFF
--- a/crates/bookforge-core/src/marker.rs
+++ b/crates/bookforge-core/src/marker.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PairedMarkerOpen {
@@ -23,6 +23,244 @@ pub struct MarkerClose {
 pub struct MarkerInnerText {
     pub id: String,
     pub text: String,
+}
+
+/// A reversible prompt-only view of marker-bearing prose.
+///
+/// The document IR keeps every marker. This projection removes only a directly
+/// nested marker whose opening tag immediately follows its parent's opening
+/// tag and whose closing tag immediately precedes its parent's closing tag.
+/// Such a parent and child cover the same structural range. Responses can be
+/// expanded back to the original marker tree with [`Self::restore`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerPromptProjection {
+    pub text: String,
+    omitted_ids: HashSet<String>,
+    restorations: HashMap<String, MarkerRestoration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkerRestoration {
+    opens: String,
+    closes: String,
+}
+
+impl MarkerPromptProjection {
+    pub fn is_omitted(&self, id: &str) -> bool {
+        self.omitted_ids.contains(id)
+    }
+
+    pub fn collapsed_pair_count(&self) -> usize {
+        self.omitted_ids.len()
+    }
+
+    /// Restore markers omitted from the prompt around their retained parent.
+    ///
+    /// Callers still validate the expanded text against the original marker
+    /// set. This method deliberately preserves every model-supplied byte and
+    /// only injects the source marker tokens recorded by the projection.
+    pub fn restore(&self, text: &str) -> String {
+        if self.restorations.is_empty() {
+            return text.to_string();
+        }
+
+        let mut output = String::with_capacity(
+            text.len()
+                + self
+                    .restorations
+                    .values()
+                    .map(|restoration| restoration.opens.len() + restoration.closes.len())
+                    .sum::<usize>(),
+        );
+        let mut stack = Vec::<(String, Option<&MarkerRestoration>)>::new();
+        let mut rest = text;
+
+        while let Some(index) = rest.find('<') {
+            output.push_str(&rest[..index]);
+            let tag = &rest[index..];
+
+            if let Some(open) = parse_paired_marker_open(tag) {
+                let restoration = self.restorations.get(&open.id);
+                output.push_str(&tag[..open.len]);
+                if let Some(restoration) = restoration {
+                    output.push_str(&restoration.opens);
+                }
+                stack.push((open.tag_name, restoration));
+                rest = &tag[open.len..];
+            } else if let Some(empty) = parse_empty_marker(tag) {
+                output.push_str(&tag[..empty.len]);
+                rest = &tag[empty.len..];
+            } else if let Some(close) = parse_marker_close(tag) {
+                if let Some((open_name, restoration)) = stack.pop()
+                    && open_name == close.tag_name
+                    && let Some(restoration) = restoration
+                {
+                    output.push_str(&restoration.closes);
+                }
+                output.push_str(&tag[..close.len]);
+                rest = &tag[close.len..];
+            } else {
+                output.push('<');
+                rest = &tag[1..];
+            }
+        }
+
+        output.push_str(rest);
+        output
+    }
+}
+
+#[derive(Debug)]
+struct PairedMarkerRange {
+    id: String,
+    open_start: usize,
+    open_end: usize,
+    open_token: String,
+    close_start: usize,
+    close_end: usize,
+    close_token: String,
+    parent: Option<usize>,
+}
+
+/// Collapse directly nested paired markers that cover exactly the same range.
+///
+/// Marker IDs and the IR itself are untouched. The returned text is suitable
+/// for a prompt, while [`MarkerPromptProjection::restore`] recreates the full
+/// source marker nesting before validation, persistence, and EPUB rebuild.
+pub fn collapse_nested_markers_for_prompt(text: &str) -> MarkerPromptProjection {
+    if marker_structure_error(text).is_some() {
+        return identity_projection(text);
+    }
+
+    let mut ranges = Vec::<PairedMarkerRange>::new();
+    let mut stack = Vec::<(String, usize)>::new();
+    let mut offset = 0usize;
+
+    while offset < text.len() {
+        let rest = &text[offset..];
+        let Some(index) = rest.find('<') else {
+            break;
+        };
+        let tag_start = offset + index;
+        let tag = &text[tag_start..];
+
+        if let Some(open) = parse_paired_marker_open(tag) {
+            let range_index = ranges.len();
+            ranges.push(PairedMarkerRange {
+                id: open.id,
+                open_start: tag_start,
+                open_end: tag_start + open.len,
+                open_token: tag[..open.len].to_string(),
+                close_start: 0,
+                close_end: 0,
+                close_token: String::new(),
+                parent: stack.last().map(|(_, index)| *index),
+            });
+            stack.push((open.tag_name, range_index));
+            offset = tag_start + open.len;
+        } else if let Some(empty) = parse_empty_marker(tag) {
+            offset = tag_start + empty.len;
+        } else if let Some(close) = parse_marker_close(tag) {
+            let Some((open_name, range_index)) = stack.pop() else {
+                return identity_projection(text);
+            };
+            if open_name != close.tag_name {
+                return identity_projection(text);
+            }
+            ranges[range_index].close_start = tag_start;
+            ranges[range_index].close_end = tag_start + close.len;
+            ranges[range_index].close_token = tag[..close.len].to_string();
+            offset = tag_start + close.len;
+        } else {
+            offset = tag_start + 1;
+        }
+    }
+
+    if !stack.is_empty() {
+        return identity_projection(text);
+    }
+
+    let mut unique_ids = HashSet::new();
+    if ranges.iter().any(|range| !unique_ids.insert(&range.id)) {
+        return identity_projection(text);
+    }
+
+    let mut identical_child = vec![None; ranges.len()];
+    let mut omitted_ids = HashSet::new();
+    for (child_index, child) in ranges.iter().enumerate() {
+        let Some(parent_index) = child.parent else {
+            continue;
+        };
+        let parent = &ranges[parent_index];
+        if parent.open_end == child.open_start && child.close_end == parent.close_start {
+            identical_child[parent_index] = Some(child_index);
+            omitted_ids.insert(child.id.clone());
+        }
+    }
+
+    if omitted_ids.is_empty() {
+        return identity_projection(text);
+    }
+
+    let mut restorations = HashMap::new();
+    for (root_index, root) in ranges.iter().enumerate() {
+        if omitted_ids.contains(&root.id) {
+            continue;
+        }
+
+        let mut child_index = identical_child[root_index];
+        let mut opens = String::new();
+        let mut closes = Vec::new();
+        while let Some(index) = child_index {
+            let child = &ranges[index];
+            opens.push_str(&child.open_token);
+            closes.push(child.close_token.as_str());
+            child_index = identical_child[index];
+        }
+        if !opens.is_empty() {
+            restorations.insert(
+                root.id.clone(),
+                MarkerRestoration {
+                    opens,
+                    closes: closes.into_iter().rev().collect(),
+                },
+            );
+        }
+    }
+
+    let mut omitted_ranges = ranges
+        .iter()
+        .filter(|range| omitted_ids.contains(&range.id))
+        .flat_map(|range| {
+            [
+                (range.open_start, range.open_end),
+                (range.close_start, range.close_end),
+            ]
+        })
+        .collect::<Vec<_>>();
+    omitted_ranges.sort_unstable();
+
+    let mut collapsed = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for (start, end) in omitted_ranges {
+        collapsed.push_str(&text[cursor..start]);
+        cursor = end;
+    }
+    collapsed.push_str(&text[cursor..]);
+
+    MarkerPromptProjection {
+        text: collapsed,
+        omitted_ids,
+        restorations,
+    }
+}
+
+fn identity_projection(text: &str) -> MarkerPromptProjection {
+    MarkerPromptProjection {
+        text: text.to_string(),
+        omitted_ids: HashSet::new(),
+        restorations: HashMap::new(),
+    }
 }
 
 pub fn marker_ids_in_text(text: &str) -> Vec<String> {
@@ -357,6 +595,61 @@ pub fn all_markers_present(text: &str, required: &[String]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prompt_projection_collapses_only_identical_nested_ranges() {
+        let source = "<m1><m2>eyes</m2></m1> and text";
+        let projection = collapse_nested_markers_for_prompt(source);
+
+        assert_eq!(projection.text, "<m1>eyes</m1> and text");
+        assert_eq!(projection.collapsed_pair_count(), 1);
+        assert!(projection.is_omitted("m2"));
+        assert_eq!(projection.restore(&projection.text), source);
+        assert_eq!(
+            projection.restore("<m1>occhi</m1> e testo"),
+            "<m1><m2>occhi</m2></m1> e testo"
+        );
+    }
+
+    #[test]
+    fn prompt_projection_preserves_nested_different_ranges() {
+        let source = "<m1>wide <m2>narrow</m2> range</m1>";
+        let projection = collapse_nested_markers_for_prompt(source);
+
+        assert_eq!(projection.text, source);
+        assert_eq!(projection.collapsed_pair_count(), 0);
+        assert_eq!(projection.restore(source), source);
+    }
+
+    #[test]
+    fn prompt_projection_restores_identical_marker_chains() {
+        let projection = collapse_nested_markers_for_prompt("<m1><m2><m3>eyes</m3></m2></m1>");
+
+        assert_eq!(projection.text, "<m1>eyes</m1>");
+        assert_eq!(projection.collapsed_pair_count(), 2);
+        assert_eq!(
+            projection.restore("<m1>occhi</m1>"),
+            "<m1><m2><m3>occhi</m3></m2></m1>"
+        );
+    }
+
+    #[test]
+    fn prompt_projection_restores_legacy_marker_tokens() {
+        let source = r#"<m id="outer"><m id="inner">eyes</m></m>"#;
+        let projection = collapse_nested_markers_for_prompt(source);
+
+        assert_eq!(projection.text, r#"<m id="outer">eyes</m>"#);
+        assert_eq!(projection.restore(&projection.text), source);
+    }
+
+    #[test]
+    fn prompt_projection_does_not_collapse_duplicate_source_ids() {
+        let source = "<m1><m1>eyes</m1></m1>";
+        let projection = collapse_nested_markers_for_prompt(source);
+
+        assert_eq!(projection.text, source);
+        assert_eq!(projection.collapsed_pair_count(), 0);
+    }
 
     #[test]
     fn marker_ids_include_short_and_legacy_markers() {

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -617,6 +617,27 @@ mod tests {
     }
 
     #[test]
+    fn prompt_only_marker_projection_preserves_cache_identity() {
+        let source = "<m1><m2>eyes</m2></m1>";
+        let source_checksum = stable_hash(source);
+        let projection = crate::marker::collapse_nested_markers_for_prompt(source);
+        let namespace =
+            compute_cache_namespace(1200, 160, "Balanced", true, "v1", "glossary:a", "", "");
+
+        assert_ne!(projection.text, source);
+        assert_ne!(stable_hash(&projection.text), source_checksum);
+        assert_eq!(
+            stable_hash(source),
+            source_checksum,
+            "the segment source/checksum remains the unprojected IR text"
+        );
+        assert_eq!(
+            namespace, "e85ab6443d2be31dd5eae7f5e748c69592ac92f9582d129a4fb602d4e4ad7868",
+            "a reversible render projection must not move the existing cache namespace"
+        );
+    }
+
+    #[test]
     fn legacy_cache_namespace_v1_ignores_glossary_fingerprint() {
         let current_without_terms =
             compute_cache_namespace(1200, 160, "Balanced", false, "v1", "", "", "");

--- a/crates/bookforge-epub/src/reader.rs
+++ b/crates/bookforge-epub/src/reader.rs
@@ -1737,6 +1737,28 @@ mod tests {
     }
 
     #[test]
+    fn preserves_nested_identical_span_elements_in_ir() {
+        let section_id = SectionId("sec_000000".to_string());
+        let blocks = extract_blocks(
+            r#"<html><body><p><span class="italic"><span class="calibre4">eyes</span></span></p></body></html>"#,
+            "chapter.xhtml",
+            &section_id,
+            0,
+        )
+        .expect("block extraction should succeed");
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(block_text(&blocks[0]), "<m1><m2>eyes</m2></m1>");
+        assert_eq!(blocks[0].inline_marks.len(), 2);
+        assert!(
+            blocks[0]
+                .inline_marks
+                .iter()
+                .all(|mark| mark.kind == "span")
+        );
+    }
+
+    #[test]
     fn keeps_inter_inline_whitespace_between_marker_runs() {
         let section_id = SectionId("sec_000000".to_string());
         let blocks = extract_blocks(

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -116,6 +116,50 @@ fn protected_span_texts(item: &TranslationBatchItem) -> Vec<String> {
         .collect()
 }
 
+fn prompt_projected_item(
+    item: &TranslationBatchItem,
+) -> (
+    TranslationBatchItem,
+    bookforge_core::marker::MarkerPromptProjection,
+) {
+    let projection = bookforge_core::marker::collapse_nested_markers_for_prompt(&item.source_text);
+    let mut projected = item.clone();
+    projected.source_text = projection.text.clone();
+    projected
+        .required_markers
+        .retain(|id| !projection.is_omitted(id));
+    projected.text_runs = project_marker_runs(&item.text_runs, &projection);
+    (projected, projection)
+}
+
+fn project_marker_runs(
+    runs: &[SegmentTextRun],
+    projection: &bookforge_core::marker::MarkerPromptProjection,
+) -> Vec<SegmentTextRun> {
+    let mut stack = Vec::<(String, bool)>::new();
+    runs.iter()
+        .filter_map(|run| {
+            if let Some(open) = bookforge_core::marker::parse_paired_marker_open(&run.text)
+                && open.len == run.text.len()
+            {
+                let omitted = projection.is_omitted(&open.id);
+                stack.push((open.tag_name, omitted));
+                return (!omitted).then(|| run.clone());
+            }
+            if let Some(close) = bookforge_core::marker::parse_marker_close(&run.text)
+                && close.len == run.text.len()
+            {
+                let omitted = stack
+                    .pop()
+                    .filter(|(open_name, _)| open_name == &close.tag_name)
+                    .is_some_and(|(_, omitted)| omitted);
+                return (!omitted).then(|| run.clone());
+            }
+            Some(run.clone())
+        })
+        .collect()
+}
+
 fn protected_span_severity(
     item: &TranslationBatchItem,
     kind: ProtectedSpanKind,
@@ -383,9 +427,16 @@ fn parse_text_batch_response(
             continue;
         };
 
+        let translation = if turbo {
+            item.translation.clone()
+        } else {
+            let (_, projection) = prompt_projected_item(request_item);
+            projection.restore(&item.translation)
+        };
+
         if let Some(error) = crate::validation::empty_translation_validation_error(
             &request_item.source_text,
-            &item.translation,
+            &translation,
         ) {
             failures.push(BatchItemFailure {
                 item_id: item.id.clone(),
@@ -399,7 +450,6 @@ fn parse_text_batch_response(
             continue;
         }
 
-        let translation = item.translation.clone();
         let section_title = section_titles
             .and_then(|titles| titles.get(&request_item.segment_id.0))
             .map(String::as_str);
@@ -514,8 +564,9 @@ fn parse_run_batch_response(
         let Some(request_item) = requested_ids.get(item.id.as_str()) else {
             continue;
         };
+        let (projected_item, projection) = prompt_projected_item(request_item);
 
-        let expected_run_count = request_item.text_runs.len();
+        let expected_run_count = projected_item.text_runs.len();
         if item.runs.len() != expected_run_count {
             failures.push(BatchItemFailure {
                 item_id: item.id.clone(),
@@ -532,7 +583,7 @@ fn parse_run_batch_response(
             continue;
         }
 
-        let expected_ids: HashMap<&str, &SegmentTextRun> = request_item
+        let expected_ids: HashMap<&str, &SegmentTextRun> = projected_item
             .text_runs
             .iter()
             .map(|run| (run.id.as_str(), run))
@@ -553,7 +604,7 @@ fn parse_run_batch_response(
             }
         }
         if run_error.is_none() {
-            for expected in &request_item.text_runs {
+            for expected in &projected_item.text_runs {
                 if !run_by_id.contains_key(expected.id.as_str()) {
                     run_error = Some(format!("missing run ID in response: {}", expected.id));
                     break;
@@ -579,7 +630,7 @@ fn parse_run_batch_response(
             continue;
         }
 
-        let joined: Vec<String> = request_item
+        let joined: Vec<String> = projected_item
             .text_runs
             .iter()
             .map(|run| {
@@ -591,7 +642,7 @@ fn parse_run_batch_response(
             })
             .collect();
         let joined_translation = joined.join("");
-        let translation = joined_translation;
+        let translation = projection.restore(&joined_translation);
         if let Some(error) = crate::validation::empty_translation_validation_error(
             &request_item.source_text,
             &translation,
@@ -836,15 +887,17 @@ pub(super) fn render_batch_items(
         .iter()
         .map(|item| {
             let turbo = batch.mode == BatchMode::TurboTextOnly;
+            let projected = (!turbo).then(|| prompt_projected_item(item).0);
+            let prompt_item = projected.as_ref().unwrap_or(item);
             let source_text = if turbo {
-                bookforge_core::marker::strip_marker_tokens(&item.source_text)
+                bookforge_core::marker::strip_marker_tokens(&prompt_item.source_text)
             } else {
-                item.source_text.clone()
+                prompt_item.source_text.clone()
             };
             let required_markers = if turbo {
                 Vec::new()
             } else {
-                item.required_markers.clone()
+                prompt_item.required_markers.clone()
             };
             let protected_spans = protected_span_texts(item);
             let mut obj = serde_json::json!({
@@ -866,7 +919,7 @@ pub(super) fn render_batch_items(
             }
 
             if batch.mode == BatchMode::RunPreserving {
-                let runs: Vec<serde_json::Value> = item
+                let runs: Vec<serde_json::Value> = prompt_item
                     .text_runs
                     .iter()
                     .map(|r| serde_json::json!({"id": r.id, "text": r.text}))
@@ -903,6 +956,97 @@ fn wrap_text_only_translation_with_source_markers(source: &str, translation: &st
         return translation;
     }
     format!("{prefix}{translation}")
+}
+
+#[cfg(test)]
+mod nested_marker_projection_tests {
+    use super::*;
+    use bookforge_core::{
+        ir::{BlockId, SectionId},
+        segment::SegmentId,
+    };
+
+    fn item(source: &str, runs: Vec<SegmentTextRun>) -> TranslationBatchItem {
+        TranslationBatchItem {
+            item_id: "item".to_string(),
+            segment_id: SegmentId("segment".to_string()),
+            section_id: SectionId("section".to_string()),
+            block_id: BlockId("block".to_string()),
+            ordinal: 0,
+            kind: "paragraph".to_string(),
+            source_text: source.to_string(),
+            text_runs: runs,
+            protected_spans: Vec::new(),
+            required_markers: bookforge_core::marker::marker_ids_in_text(source),
+            checksum: "checksum".to_string(),
+        }
+    }
+
+    fn batch(mode: BatchMode, item: TranslationBatchItem) -> TranslationBatch {
+        TranslationBatch {
+            id: "batch".to_string(),
+            ordinal: 0,
+            mode,
+            kind: BatchKind::Translation,
+            section_id: item.section_id.clone(),
+            items: vec![item],
+            token_estimate: 1,
+        }
+    }
+
+    #[test]
+    fn marker_safe_response_restores_full_source_nesting() {
+        let source = "<m1><m2>eyes</m2></m1>";
+        let original_item = item(source, Vec::new());
+        let (projected, _) = prompt_projected_item(&original_item);
+
+        assert_eq!(projected.source_text, "<m1>eyes</m1>");
+        assert_eq!(projected.required_markers, ["m1"]);
+        assert_eq!(original_item.source_text, source);
+        assert_eq!(original_item.required_markers, ["m1", "m2"]);
+
+        let result = parse_batch_response(
+            &batch(BatchMode::MarkerSafe, original_item),
+            r#"{"items":[{"id":"item","translation":"<m1>occhi</m1>"}]}"#,
+        )
+        .expect("collapsed response should parse");
+
+        assert!(result.failures.is_empty());
+        assert_eq!(result.translations[0].text, "<m1><m2>occhi</m2></m1>");
+    }
+
+    #[test]
+    fn run_preserving_response_can_omit_redundant_marker_runs() {
+        let source = "<m1><m2>eyes</m2></m1>";
+        let runs = ["<m1>", "<m2>", "eyes", "</m2>", "</m1>"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, text)| SegmentTextRun {
+                id: format!("r{index}"),
+                text: text.to_string(),
+            })
+            .collect::<Vec<_>>();
+        let original_item = item(source, runs);
+        let (projected, _) = prompt_projected_item(&original_item);
+
+        assert_eq!(
+            projected
+                .text_runs
+                .iter()
+                .map(|run| run.text.as_str())
+                .collect::<Vec<_>>(),
+            ["<m1>", "eyes", "</m1>"]
+        );
+
+        let result = parse_batch_response(
+            &batch(BatchMode::RunPreserving, original_item),
+            r#"{"items":[{"id":"item","runs":[{"id":"r0","text":"<m1>"},{"id":"r2","text":"occhi"},{"id":"r4","text":"</m1>"}]}]}"#,
+        )
+        .expect("projected runs should parse");
+
+        assert!(result.failures.is_empty());
+        assert_eq!(result.translations[0].text, "<m1><m2>occhi</m2></m1>");
+    }
 }
 
 #[cfg(test)]

--- a/docs/EPUB_PIPELINE.md
+++ b/docs/EPUB_PIPELINE.md
@@ -17,6 +17,10 @@ The reader suppresses `script`, `style`, `svg`, and `math`. It preserves package
 
 Inline formatting, links, anchors, and empty inline elements are represented as marker tokens inside a block's prose. New extraction emits short per-block markers such as `<m1>...</m1>` and `<r1/>`. The marker parser also accepts the older verbose marker forms so stored jobs and tests can read legacy text.
 
+The IR remains lossless even when converted EPUBs contain redundant wrappers such as `<span><span>text</span></span>`: both elements receive distinct markers because the original elements may carry different attributes. Batch prompt rendering uses a reversible projection for the narrower case where a paired marker's opening tag immediately follows its parent's opening tag and its closing tag immediately precedes the parent's closing tag. The model sees only the parent marker; BookForge restores every omitted child marker before validating or storing the translation. Nested markers with any text or marker content outside the child cover different ranges and are never collapsed.
+
+This projection does not change segment source text, checksums, inline-marker schema, or the cache namespace. Existing cached translations already contain the complete marker tree and remain valid; fresh translations are expanded to that same representation before deterministic rebuild.
+
 ## Rebuild
 
 `bookforge-epub::rebuild_epub` does not serialize a new EPUB tree from scratch. It copies the original archive entries and patches only resources that have translated block IDs. The same patcher handles XHTML, OPF, and NCX XML resources.


### PR DESCRIPTION
Calibre-converted EPUBs wrap text in two nested spans around an **identical** span:

```html
<span class="italic"><span class="calibre4">eyes</span></span>
```

The reader preserves both, so prompts and translations carry `<m1><m2>eyes</m2></m1>`. On The Cyberiad this occurs **309 times across 151 blocks**. Five different models all reproduced it correctly, so it is not a translation defect — it is waste: extra marker tokens on every request containing the block, and two nested markers for the model to preserve instead of one. `unknown_inline_marker` and `other` are the only two validator checks measured at **100% true positive**, so marker errors are real failures, not noise.

## Why this is a prompt-level projection, not an IR change

Collapsing in the IR is **not safe**, and that is the load-bearing finding. Both wrappers arrive as generic `span` marks, so dropping one would break writer template alignment and the byte-faithful rebuild that `ROADMAP.md` §1.1–§1.2 require.

So instead: one marker goes to the model, and **full nesting is restored before validation and storage**. The IR and the writer are untouched. Only immediately adjacent open/close nesting over an identical range collapses — nested marks covering different ranges carry real structure and are never touched.

## The cache namespace is unchanged

This was the condition for doing it at all. Segment source text, checksums, marker schema and prompt version are untouched, so the 30 existing real jobs keep their cached translations — those already contain the complete marker tree, and fresh translations are expanded to the same representation before rebuild. Pinned by a test in `segment.rs`.

Had it invalidated the cache, the recommendation would have been to skip this entirely.

## Measured benefit

On `tests/The_Cyberiad.epub`, serialized prompt-item payload fell from **666,521 to 654,234 characters** — a **1.84%** reduction, roughly **3,071 input tokens** under the project's `chars / 4` estimator.

The token saving is modest and worth being honest about. What justifies the change is removing 309 model-visible marker obligations at zero cache cost and with reassembly behaviour unchanged.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **913 passed / 0 failed / 3 ignored**. No provider was called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)