### PR TITLE
Send the right thinking-suppression parameter per provider

### DIFF
--- a/crates/bookforge-cli/src/cost.rs
+++ b/crates/bookforge-cli/src/cost.rs
@@ -217,6 +217,43 @@ mod tests {
     }
 
     #[test]
+    fn billable_output_total_including_reasoning_is_charged_once() {
+        let catalog = parse_pricing(
+            r#"{
+  "schema_version": 1,
+  "updated_at": "2026-07-30",
+  "providers": {
+    "openrouter": {
+      "models": {
+        "reasoning-model": {
+          "input_per_million_usd": 0.0,
+          "output_per_million_usd": 15.0,
+          "input_cache_per_million_usd": null
+        }
+      }
+    }
+  }
+}"#,
+            PricingSource::Bundled,
+        )
+        .expect("test pricing should parse");
+
+        // The provider layer folds any reasoning usage into this billable
+        // output aggregate. The cost layer must price that aggregate once.
+        let cost = estimate_cost_usd_with_pricing(
+            &catalog,
+            "openrouter",
+            "reasoning-model",
+            0,
+            0,
+            182_000,
+        )
+        .expect("test model should be priced");
+
+        assert!((cost - 2.73).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn unsupported_schema_is_rejected() {
         let error = parse_pricing(
             r#"{"schema_version":2,"updated_at":"x","providers":{"x":{"models":{}}}}"#,

--- a/crates/bookforge-llm/src/provider.rs
+++ b/crates/bookforge-llm/src/provider.rs
@@ -701,6 +701,41 @@ fn cached_input_tokens(raw: &Value) -> Option<u64> {
         .or(Some(0))
 }
 
+fn reasoning_tokens(raw: &Value) -> Option<u64> {
+    raw.pointer("/usage/completion_tokens_details/reasoning_tokens")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            raw.pointer("/usage/output_tokens_details/reasoning_tokens")
+                .and_then(Value::as_u64)
+        })
+}
+
+/// Return the provider's billable output-token aggregate.
+///
+/// OpenAI, OpenRouter, and DeepSeek define reasoning tokens as a subset of
+/// `completion_tokens`, so adding the detailed count would double-count them.
+/// A few OpenAI-compatible gateways have returned visible completion tokens
+/// separately while keeping `total_tokens` correct, however. Taking the larger
+/// of `completion_tokens` and `total_tokens - prompt_tokens` handles both shapes
+/// without double-counting standards-compliant responses. The reasoning detail
+/// is a final fallback for partial usage objects.
+fn billable_output_tokens(raw: &Value) -> Option<u64> {
+    let completion_tokens = raw
+        .pointer("/usage/completion_tokens")
+        .and_then(Value::as_u64);
+    let output_from_total = raw
+        .pointer("/usage/total_tokens")
+        .and_then(Value::as_u64)
+        .zip(raw.pointer("/usage/prompt_tokens").and_then(Value::as_u64))
+        .map(|(total, prompt)| total.saturating_sub(prompt));
+
+    completion_tokens
+        .into_iter()
+        .chain(output_from_total)
+        .max()
+        .or_else(|| reasoning_tokens(raw))
+}
+
 #[derive(Debug, Clone)]
 pub struct OpenAiCompatibleConfig {
     pub base_url: String,
@@ -738,6 +773,7 @@ pub struct OpenAiCompatibleProvider {
     client: reqwest::Client,
     reasoning_detected: AtomicBool,
     response_format_supported: AtomicBool,
+    thinking_warning_emitted: AtomicBool,
     pub cancel_token: CancellationToken,
 }
 
@@ -749,6 +785,9 @@ impl Clone for OpenAiCompatibleProvider {
             reasoning_detected: AtomicBool::new(self.reasoning_detected.load(Ordering::Relaxed)),
             response_format_supported: AtomicBool::new(
                 self.response_format_supported.load(Ordering::Relaxed),
+            ),
+            thinking_warning_emitted: AtomicBool::new(
+                self.thinking_warning_emitted.load(Ordering::Relaxed),
             ),
             cancel_token: self.cancel_token.clone(),
         }
@@ -782,6 +821,7 @@ impl OpenAiCompatibleProvider {
             client,
             reasoning_detected: AtomicBool::new(is_reasoning),
             response_format_supported: AtomicBool::new(true),
+            thinking_warning_emitted: AtomicBool::new(false),
             cancel_token,
         })
     }
@@ -789,10 +829,93 @@ impl OpenAiCompatibleProvider {
     pub fn model(&self) -> &str {
         &self.config.model
     }
+
+    fn request_body(&self, request: &CompletionRequest) -> Value {
+        let mut body = json!({
+            "model": self.config.model,
+            "temperature": request.temperature,
+            "messages": [
+                {"role": "system", "content": request.system},
+                {"role": "user", "content": request.user}
+            ]
+        });
+
+        if let Some(max_tokens) = request.max_output_tokens {
+            body["max_tokens"] = json!(max_tokens);
+        }
+
+        if self.config.thinking_disabled {
+            match reasoning_control_for_config(&self.config) {
+                ReasoningControl::OpenRouter => {
+                    body["reasoning"] = json!({"enabled": false});
+                }
+                ReasoningControl::OpenAi => {
+                    body["reasoning_effort"] = json!("none");
+                }
+                ReasoningControl::DeepSeek => {
+                    body["thinking"] = json!({"type": "disabled"});
+                }
+                ReasoningControl::Unsupported => {
+                    if !self.thinking_warning_emitted.swap(true, Ordering::Relaxed) {
+                        warn!(
+                            base_url = %self.config.base_url,
+                            model = %self.config.model,
+                            "provider: thinking suppression was requested, but this \
+                             OpenAI-compatible endpoint has no recognized suppression \
+                             parameter; sending no thinking/reasoning field"
+                        );
+                    }
+                }
+            }
+        }
+
+        let use_response_format = request.response_format == ResponseFormat::Json
+            && match self.config.json_mode {
+                bookforge_core::JsonMode::PromptOnly => false,
+                bookforge_core::JsonMode::ResponseFormat => true,
+                bookforge_core::JsonMode::Auto => {
+                    self.response_format_supported.load(Ordering::Relaxed)
+                }
+            };
+
+        if use_response_format {
+            body["response_format"] = json!({"type": "json_object"});
+        }
+
+        body
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReasoningControl {
+    OpenRouter,
+    OpenAi,
+    DeepSeek,
+    Unsupported,
+}
+
+fn reasoning_control_for_config(config: &OpenAiCompatibleConfig) -> ReasoningControl {
+    let host = reqwest::Url::parse(&config.base_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase));
+
+    match host.as_deref() {
+        Some(host) if host == "openrouter.ai" || host.ends_with(".openrouter.ai") => {
+            ReasoningControl::OpenRouter
+        }
+        Some("api.openai.com") => ReasoningControl::OpenAi,
+        Some("api.deepseek.com") => ReasoningControl::DeepSeek,
+        _ => match config.api_key_env.as_str() {
+            "OPENROUTER_API_KEY" => ReasoningControl::OpenRouter,
+            "DEEPSEEK_API_KEY" => ReasoningControl::DeepSeek,
+            _ => ReasoningControl::Unsupported,
+        },
+    }
 }
 
 impl LlmProvider for OpenAiCompatibleProvider {
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse> {
+        let mut body = self.request_body(&request);
         let api_key = match std::env::var(&self.config.api_key_env) {
             Ok(value) => Some(value),
             Err(_) if local_api_key_is_optional(&self.config.api_key_env) => None,
@@ -808,22 +931,6 @@ impl LlmProvider for OpenAiCompatibleProvider {
             "{}/chat/completions",
             self.config.base_url.trim_end_matches('/')
         );
-        let mut body = json!({
-            "model": self.config.model,
-            "temperature": request.temperature,
-            "messages": [
-                {"role": "system", "content": request.system},
-                {"role": "user", "content": request.user}
-            ]
-        });
-
-        if let Some(max_tokens) = request.max_output_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
-
-        if self.config.thinking_disabled {
-            body["thinking"] = json!({"type": "disabled"});
-        }
 
         let use_response_format = request.response_format == ResponseFormat::Json
             && match self.config.json_mode {
@@ -833,10 +940,6 @@ impl LlmProvider for OpenAiCompatibleProvider {
                     self.response_format_supported.load(Ordering::Relaxed)
                 }
             };
-
-        if use_response_format {
-            body["response_format"] = json!({"type": "json_object"});
-        }
 
         let max_attempts = request
             .metadata
@@ -1065,9 +1168,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
             .to_string();
         let input_tokens = raw.pointer("/usage/prompt_tokens").and_then(Value::as_u64);
         let input_cached_tokens = cached_input_tokens(&raw);
-        let output_tokens = raw
-            .pointer("/usage/completion_tokens")
-            .and_then(Value::as_u64);
+        let output_tokens = billable_output_tokens(&raw);
 
         // Detect reasoning models from their first response so subsequent
         // requests can use a higher max_output_tokens budget.
@@ -1312,6 +1413,158 @@ mod tests {
     use super::*;
     use bookforge_core::RetryAfterPolicy;
     use tokio::time::Duration;
+
+    fn offline_provider(base_url: &str, model: &str) -> OpenAiCompatibleProvider {
+        offline_provider_with_key(base_url, "BOOKFORGE_OFFLINE_TEST_API_KEY", model)
+    }
+
+    fn offline_provider_with_key(
+        base_url: &str,
+        api_key_env: &str,
+        model: &str,
+    ) -> OpenAiCompatibleProvider {
+        OpenAiCompatibleProvider::new(OpenAiCompatibleConfig {
+            base_url: base_url.to_string(),
+            api_key_env: api_key_env.to_string(),
+            model: model.to_string(),
+            timeout_seconds: 10,
+            provider_max_attempts: 1,
+            thinking_disabled: true,
+            retry_after_policy: RetryAfterPolicy::None,
+            max_backoff_seconds: 1,
+            max_idle_per_host: 1,
+            json_mode: bookforge_core::JsonMode::PromptOnly,
+        })
+        .expect("offline provider config should be valid")
+    }
+
+    fn offline_request() -> CompletionRequest {
+        CompletionRequest {
+            system: "translate".to_string(),
+            user: "hello".to_string(),
+            response_format: ResponseFormat::Json,
+            temperature: 0.2,
+            max_output_tokens: Some(256),
+            metadata: RequestMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn openrouter_request_uses_unified_reasoning_suppression() {
+        let provider = offline_provider("https://openrouter.ai/api/v1", "anthropic/claude-opus-5");
+
+        let body = provider.request_body(&offline_request());
+
+        assert_eq!(body["reasoning"], json!({"enabled": false}));
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn openai_request_uses_chat_completions_reasoning_effort() {
+        let provider = offline_provider("https://api.openai.com/v1", "gpt-5.6-terra");
+
+        let body = provider.request_body(&offline_request());
+
+        assert_eq!(body["reasoning_effort"], json!("none"));
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn deepseek_request_uses_documented_thinking_toggle() {
+        let provider = offline_provider("https://api.deepseek.com/v1", "deepseek-v4-flash");
+
+        let body = provider.request_body(&offline_request());
+
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn deepseek_preset_identity_survives_a_base_url_proxy() {
+        let provider = offline_provider_with_key(
+            "https://gateway.example.test/deepseek/v1",
+            "DEEPSEEK_API_KEY",
+            "deepseek-v4-flash",
+        );
+
+        let body = provider.request_body(&offline_request());
+
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn recognized_base_url_wins_over_credential_identity() {
+        let provider = offline_provider_with_key(
+            "https://api.deepseek.com/v1",
+            "OPENROUTER_API_KEY",
+            "deepseek-v4-flash",
+        );
+
+        let body = provider.request_body(&offline_request());
+
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn unknown_compatible_endpoint_omits_suppression_and_marks_warning_emitted() {
+        let provider = offline_provider("https://llm.example.test/v1", "custom-model");
+
+        let body = provider.request_body(&offline_request());
+
+        assert!(body.get("reasoning").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("thinking").is_none());
+        assert!(
+            provider.thinking_warning_emitted.load(Ordering::Relaxed),
+            "the unsupported suppression path must emit its warning"
+        );
+    }
+
+    #[test]
+    fn billable_output_does_not_double_count_reasoning_breakdown() {
+        let raw = json!({
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 100,
+                "completion_tokens_details": {"reasoning_tokens": 70},
+                "total_tokens": 150
+            }
+        });
+
+        assert_eq!(billable_output_tokens(&raw), Some(100));
+    }
+
+    #[test]
+    fn billable_output_uses_total_when_gateway_reports_visible_completion_only() {
+        let raw = json!({
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 30,
+                "completion_tokens_details": {"reasoning_tokens": 70},
+                "total_tokens": 150
+            }
+        });
+
+        assert_eq!(billable_output_tokens(&raw), Some(100));
+    }
+
+    #[test]
+    fn billable_output_falls_back_to_reasoning_for_partial_usage() {
+        let raw = json!({
+            "usage": {
+                "completion_tokens_details": {"reasoning_tokens": 70}
+            }
+        });
+
+        assert_eq!(billable_output_tokens(&raw), Some(70));
+    }
 
     #[test]
     fn empty_content_from_a_truncated_response_names_the_output_cap() {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -137,6 +137,19 @@ bookforge translate book.epub \
   --out book.it.epub
 ```
 
+`--no-thinking` asks the selected endpoint to suppress reasoning. BookForge
+sends OpenRouter's `reasoning.enabled=false`, OpenAI Chat Completions'
+`reasoning_effort=none`, or DeepSeek's `thinking.type=disabled`, selected from
+the base URL or a known OpenRouter/DeepSeek preset credential identity. Other
+OpenAI-compatible endpoints receive no guessed suppression field and produce a
+warning. This includes the bundled local Ollama and llama.cpp endpoints until
+they expose a compatible, documented control.
+
+Provider-reported `completion_tokens` is the billable output aggregate and
+already includes any `completion_tokens_details.reasoning_tokens` breakdown.
+BookForge stores that aggregate as `tokens_output` and uses it for status and
+cost reporting. It does not add the reasoning breakdown a second time.
+
 `--qa` controls the optional LLM review pass. `off` skips it, `all` reviews
 every non-empty successful, cached, or `needs_review` translation, and
 `suspicious` limits those reviewable translations to segments with at least

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -11,6 +11,47 @@ The initial provider target is OpenAI-compatible chat completions, with DeepSeek
 
 All non-mock providers go through `OpenAiCompatibleProvider`. Provider settings include timeout, provider-level attempts, retry-after handling, max backoff, idle connection pool size, JSON mode, model context tokens, and output-token limits.
 
+## Thinking Suppression
+
+`--no-thinking` is dispatched from the configured base URL (or the known
+OpenRouter/DeepSeek preset credential identity when a proxy overrides that URL)
+because
+OpenAI-compatible chat-completion APIs do not share one reasoning-control
+parameter:
+
+| Endpoint | Request field |
+| --- | --- |
+| OpenRouter (`openrouter.ai`) | `"reasoning": {"enabled": false}` |
+| OpenAI (`api.openai.com`) | `"reasoning_effort": "none"` |
+| DeepSeek (`api.deepseek.com`) | `"thinking": {"type": "disabled"}` |
+
+DeepSeek V4's OpenAI-format API documents the `thinking` toggle directly.
+This is a DeepSeek extension, not an Anthropic Messages API request: BookForge
+still sends `/chat/completions`.
+
+For any other `openai-compatible` base URL, BookForge cannot safely guess a
+vendor-specific parameter. It omits all suppression fields and warns instead
+of sending an unknown field that the server may silently ignore. The local
+Ollama and llama.cpp presets currently take this warning path. A model may
+also require reasoning even when its gateway supports a suppression field;
+the provider's model-specific error remains authoritative.
+
+## Reasoning Token Accounting
+
+OpenAI-format usage reports define
+`completion_tokens_details.reasoning_tokens` as a breakdown of
+`completion_tokens`, not an additional token count. BookForge therefore stores
+the billable completion aggregate in `segments.tokens_output`; adding the
+reasoning detail again would double-count standards-compliant responses.
+
+As a defensive compatibility measure, BookForge compares `completion_tokens`
+with `total_tokens - prompt_tokens` and keeps the larger output aggregate. This
+also handles gateways that report visible completion tokens separately while
+keeping `total_tokens` correct. If only a reasoning-token detail is present,
+that count is used as the output fallback. Cost estimates price the resulting
+`tokens_output` aggregate once. There is no separate reasoning column or
+schema migration.
+
 ## Presets And Profiles
 
 Provider presets can change both endpoint/model defaults and runtime knobs such as concurrency, provider attempts, batch target size, adaptive batch sizing, and retry policy. Explicit CLI flags win over preset values.


### PR DESCRIPTION
`OpenAiCompatibleProvider::complete` emitted `thinking: {"type": "disabled"}` to every OpenAI-compatible endpoint with **no provider dispatch**. The parameter differs by vendor — OpenRouter takes a unified `reasoning` object, OpenAI takes `reasoning_effort` — and OpenAI-compatible servers ignore unknown fields silently, so `--no-thinking` failed without complaint everywhere but DeepSeek. Seven presets set `thinking_disabled`, so this was never only the CLI path.

Dispatch is now by recognised base-URL host, with OpenRouter/DeepSeek credential identity as a fallback and explicit known hosts taking precedence. Local Ollama/llama.cpp presets warn once and omit the field rather than sending something meaningless.

## Two claims in the originating report were wrong

Recorded so nobody re-derives them:

- **DeepSeek V4 *does* honour `thinking: {"type": "disabled"}`.** The existing field was correct for DeepSeek all along — it simply was never translated for other vendors. All seven preset settings are unchanged.
- **Reasoning tokens are already included in `completion_tokens`** for billing, so no reasoning column was warranted. Adding one and summing would *double-count* compliant responses. `tokens_output` remains the durable billable aggregate.

The parser is now defensive about providers that report usage inconsistently — taking the larger of `completion_tokens` and `total_tokens - prompt_tokens`, and falling back to the reasoning detail only when that is the sole output figure supplied. Cost prices that aggregate exactly once.

## What actually caused the cost discrepancy

The measurement that prompted this — opus-5 billed **$4.81** against **$1.89** reconstructed from recorded tokens — is therefore **not** explained by unrecorded reasoning tokens.

In that run the correlation was with **failed requests**:

| model | failed requests | reconciliation |
| --- | --- | --- |
| gpt-5.6-luna | 0 | exact |
| gpt-5.6-terra | 0 | exact |
| claude-opus-5 | 3 | 154% low |
| claude-fable-5 | 2 | 53% low |

A failed request is billed but records no tokens. opus-5's decode failures each generated ~9,000–11,000 output tokens that were charged and discarded, plus repeated bisection on the segment that never recovered. Only the two models with zero failures reconcile exactly.

That remains unverified against raw provider responses and is **not** addressed in this PR.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **914 passed / 0 failed / 3 ignored** over three consecutive runs. No provider was called — assertions are on the constructed request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)