### PR TITLE
Stop asserting a total order over two concurrent actors' events

### DIFF
--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -2139,6 +2139,9 @@ fn cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries() {
         ])
         .assert()
         .success();
+    wait_for_child_events(&events, &mut child, |events| {
+        event_count(events, "RuntimeConfigChanged") >= 1
+    });
 
     let status = child.wait().expect("translate child should exit");
     assert!(status.success(), "translate child failed: {status}");
@@ -2151,6 +2154,17 @@ fn cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries() {
                 .is_some_and(|id| id.starts_with("qa_"))
         })
         .expect("QA request should start under the baseline stage snapshot");
+    let qa_request = &final_events[qa_started]["RequestStarted"];
+    assert_eq!(
+        qa_request["runtime_config_revision"].as_u64(),
+        Some(0),
+        "the already-started QA stage must retain the baseline revision"
+    );
+    assert_eq!(
+        qa_request["provider_max_attempts"].as_u64(),
+        Some(1),
+        "the already-started QA stage must retain the v1-fast attempt budget"
+    );
     let changed = final_events
         .iter()
         .position(|event| event.get("RuntimeConfigChanged").is_some())
@@ -2165,9 +2179,17 @@ fn cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries() {
                 .is_some_and(|id| id.starts_with("qa_"))
         })
         .expect("in-flight QA request should finish");
+    // The override watcher and the in-flight provider request are concurrent
+    // actors. The durable edit follows RequestStarted, but the watcher is not
+    // required to emit RuntimeConfigChanged before RequestFinished. Assert only
+    // the causal order plus the stage snapshots that production guarantees.
     assert!(
-        qa_started < changed && changed < qa_finished,
-        "the runtime edit should land while the frozen QA stage is in flight"
+        qa_started < changed,
+        "the runtime change cannot precede the request that triggered the edit"
+    );
+    assert!(
+        qa_started < qa_finished,
+        "the QA request must finish after it starts"
     );
     assert!(
         request_started_ids(&final_events)


### PR DESCRIPTION
Two full-suite runs today aborted with a single unexplained failure, and neither reproduced in the 3–4 repeats I gave them.

The culprit is `cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries`, **reproduced on the 11th run containing it** — ten clean first, which is exactly why short repeat counts kept clearing it. The lifecycle binary reporting `46 passed / 1 failed` accounts for the cumulative 387 seen in the first abort.

## Mechanism

The test asserted:

```rust
qa_started < changed && changed < qa_finished
```

over events emitted by **two concurrent actors** — the runtime override watcher and the in-flight provider request. Production guarantees the durable edit follows `RequestStarted`, but nothing requires the watcher to emit `RuntimeConfigChanged` before `RequestFinished`. Under load it doesn't, and the test failed while the code behaved correctly.

It now waits for the real configuration-change signal and asserts only the causal ordering production actually guarantees, plus the stage snapshots that are the point of the test. **Production code and behaviour are unchanged.**

## Third instance of this shape

After four wall-clock races and the checkpoint-actor ordering race fixed in #74. Asserting a total order over concurrent event streams keeps *looking* like a correct test and keeps being a flake. `docs/review-checklist.md` already warns about it under "Test timing and ordering" — this is evidence the warning needs to be louder, or that a helper should exist for "assert partial order over concurrent events".

## What was deliberately not touched

- **`dashboard_assets_reassemble_byte_stably`** — the exact byte-length and SHA-256 tripwire. It passed throughout and has caught a real regression before, so relaxing it to chase a flake would have been the wrong trade.
- Ruled out as candidates: the dashboard lock-order test (500 isolated and 1,280 contended repetitions) and the audiobook fixed-port preflight path (serial and full-suite).

## Left open honestly

The second abort, at a cumulative 317, is consistent with different binary ordering but **cannot be attributed** without its test name, which I failed to capture. Not assumed to be the same cause.

## Baseline correction

`main` is **904 passed / 0 failed / 3 ignored**, not the 902 that several recent PR descriptions quoted.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, 904 passed. Lifecycle binary passed 8 consecutive runs here, plus 10/10 at 64 threads during the hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)