### PR TITLE
Stop requiring English number suffixes and month names verbatim

### DIFF
--- a/crates/bookforge-core/src/marker.rs
+++ b/crates/bookforge-core/src/marker.rs
@@ -99,14 +99,14 @@ pub fn marker_reference_token(text: &str) -> Option<&str> {
     }
     if !token
         .chars()
-        .any(|ch| ch.is_ascii_digit() || is_reference_symbol(ch))
+        .any(|ch| ch.is_numeric() || is_reference_symbol(ch))
     {
         return None;
     }
     token
         .chars()
         .all(|ch| {
-            ch.is_ascii_digit()
+            ch.is_numeric()
                 || ch.is_ascii_whitespace()
                 || is_reference_symbol(ch)
                 || matches!(
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn marker_reference_tokens_are_narrowly_classified() {
-        for token in ["1", "*2", "† 3", "[12]", "12–14"] {
+        for token in ["1", "*2", "† 3", "[12]", "12–14", "١٢", "१२"] {
             assert_eq!(marker_reference_token(token), Some(token), "{token}");
         }
         for prose_or_data in ["", "beautiful", "E=mc^2", "42%", "123456789"] {

--- a/crates/bookforge-llm/src/batch/rendering.rs
+++ b/crates/bookforge-llm/src/batch/rendering.rs
@@ -189,43 +189,37 @@ fn number_adjacent_to_month(source: &str, number: &str) -> bool {
             .is_none_or(|ch| !ch.is_ascii_digit());
         left_boundary
             && right_boundary
-            && (adjacent_word_before(source, start).is_some_and(is_month_name)
-                || adjacent_word_after(source, end).is_some_and(is_month_name))
+            && (alphabetic_words(&source[..start])
+                .into_iter()
+                .rev()
+                .take(2)
+                .any(is_month_name)
+                || alphabetic_words(&source[end..])
+                    .into_iter()
+                    .take(2)
+                    .any(is_month_name))
     })
 }
 
-fn adjacent_word_before(source: &str, end: usize) -> Option<&str> {
-    let prefix = &source[..end];
-    let word_end = prefix
-        .char_indices()
-        .rev()
-        .find(|(_, ch)| ch.is_ascii_alphabetic())
-        .map(|(index, ch)| index + ch.len_utf8())?;
-    let word_start = prefix[..word_end]
-        .char_indices()
-        .rev()
-        .take_while(|(_, ch)| ch.is_ascii_alphabetic())
-        .last()
-        .map_or(word_end, |(index, _)| index);
-    Some(&prefix[word_start..word_end])
-}
-
-fn adjacent_word_after(source: &str, start: usize) -> Option<&str> {
-    let suffix = &source[start..];
-    let word_start = suffix
-        .char_indices()
-        .find(|(_, ch)| ch.is_ascii_alphabetic())
-        .map(|(index, _)| index)?;
-    let word_end = suffix[word_start..]
-        .char_indices()
-        .take_while(|(_, ch)| ch.is_ascii_alphabetic())
-        .last()
-        .map(|(index, ch)| word_start + index + ch.len_utf8())?;
-    Some(&suffix[word_start..word_end])
+fn alphabetic_words(text: &str) -> Vec<&str> {
+    let mut words = Vec::new();
+    let mut start = None;
+    for (index, ch) in text.char_indices() {
+        if ch.is_alphabetic() {
+            start.get_or_insert(index);
+        } else if let Some(word_start) = start.take() {
+            words.push(&text[word_start..index]);
+        }
+    }
+    if let Some(word_start) = start {
+        words.push(&text[word_start..]);
+    }
+    words
 }
 
 fn is_month_name(word: &str) -> bool {
     const MONTHS: &[&str] = &[
+        // English
         "january",
         "jan",
         "february",
@@ -250,8 +244,84 @@ fn is_month_name(word: &str) -> bool {
         "nov",
         "december",
         "dec",
+        // Italian
+        "gennaio",
+        "gen",
+        "febbraio",
+        "marzo",
+        "aprile",
+        "maggio",
+        "mag",
+        "giugno",
+        "giu",
+        "luglio",
+        "lug",
+        "agosto",
+        "ago",
+        "settembre",
+        "set",
+        "ottobre",
+        "ott",
+        "novembre",
+        "dicembre",
+        "dic",
+        // Spanish
+        "enero",
+        "ene",
+        "febrero",
+        "abril",
+        "abr",
+        "mayo",
+        "junio",
+        "julio",
+        "septiembre",
+        "setiembre",
+        "octubre",
+        "diciembre",
+        // Portuguese
+        "janeiro",
+        "fevereiro",
+        "fev",
+        "março",
+        "maio",
+        "mai",
+        "junho",
+        "julho",
+        "outubro",
+        "out",
+        "dezembro",
+        "dez",
+        // Danish and Norwegian
+        "januar",
+        "februar",
+        "marts",
+        "mars",
+        "maj",
+        "juni",
+        "juli",
+        "oktober",
+        "okt",
+        "desember",
+        "des",
+        // French
+        "janvier",
+        "février",
+        "fevrier",
+        "avril",
+        "juin",
+        "juillet",
+        "août",
+        "aout",
+        "octobre",
+        "décembre",
+        "decembre",
+        // German
+        "jänner",
+        "märz",
+        "dezember",
     ];
-    MONTHS.iter().any(|month| word.eq_ignore_ascii_case(month))
+    let folded = word.to_lowercase();
+    MONTHS.contains(&folded.as_str())
 }
 
 fn source_copy_error(
@@ -1022,6 +1092,11 @@ mod protected_span_severity_tests {
             ("The value is 0.0027", "0.0027"),
             ("It cost $15", "$15"),
             ("The event was December 8", "8"),
+            ("L'evento era l'8 dicembre", "8"),
+            ("El evento fue el 8 de diciembre", "8"),
+            ("O evento foi em 8 de dezembro", "8"),
+            ("Begivenheden var den 8. december", "8"),
+            ("Arrangementet var 8. desember", "8"),
             ("1. First item", "1"),
         ] {
             let substantial = batch_item_validation_error(
@@ -1037,6 +1112,18 @@ mod protected_span_severity_tests {
                 "{number} in {source:?} should be hard: {substantial}"
             );
         }
+
+        assert!(
+            batch_item_validation_error(
+                &item_with_span("The event was December 8", ProtectedSpanKind::Number, "8"),
+                "L'evento era l'8 dicembre",
+                false,
+                None,
+                None,
+            )
+            .is_none(),
+            "a localized date that preserves the day must pass"
+        );
     }
 }
 

--- a/crates/bookforge-llm/src/validation.rs
+++ b/crates/bookforge-llm/src/validation.rs
@@ -884,10 +884,15 @@ fn numeric_candidates(text: &str) -> Vec<String> {
 
 /// Locale-insensitive presence check for spans that contain numbers.
 fn numeric_span_present(span: &str, translation: &str) -> bool {
-    let span_numbers = numeric_candidates(span);
+    let span_ranges = numeric_candidate_ranges(span);
+    let span_numbers = span_ranges
+        .iter()
+        .map(|(_, _, candidate)| candidate.clone())
+        .collect::<Vec<_>>();
     if span_numbers.is_empty() {
         return false;
     }
+    let starts_with_number = span_ranges.first().is_some_and(|(start, _, _)| *start == 0);
 
     let mut translated_number_forms = numeric_candidates(translation)
         .iter()
@@ -910,7 +915,7 @@ fn numeric_span_present(span: &str, translation: &str) -> bool {
 
     let mut literal_remainder = String::with_capacity(span.len());
     let mut copied_until = 0;
-    for (start, end, _) in numeric_candidate_ranges(span) {
+    for (start, end, _) in span_ranges {
         literal_remainder.push_str(&span[copied_until..start]);
         literal_remainder.push(' ');
         copied_until = end;
@@ -918,6 +923,7 @@ fn numeric_span_present(span: &str, translation: &str) -> bool {
     literal_remainder.push_str(&span[copied_until..]);
     literal_remainder
         .split_whitespace()
+        .filter(|token| !starts_with_number || !token.chars().any(char::is_alphabetic))
         .all(|token| exact_protected_span_present(token, translation))
 }
 
@@ -1206,6 +1212,28 @@ mod tests {
             "Skou (1957, 1989) isolò una ATPasi"
         ));
         assert!(protected_span_present("10-", "7,3 × 10⁻⁷ mol cm⁻²"));
+        assert!(protected_span_present(
+            "1,000.50",
+            "Il totale era 1.000,50."
+        ));
+        assert!(protected_span_present("4th", "il 4º tentativo"));
+        assert!(protected_span_present(
+            "19-August",
+            "dal 19 luglio al 7 agosto"
+        ));
+        assert!(protected_span_present(
+            "1857-1918)—tsarist",
+            "(1857-1918)—generale zarista"
+        ));
+        assert!(!protected_span_present("4th", "il 5º tentativo"));
+        assert!(!protected_span_present(
+            "19-August",
+            "dal 20 luglio al 7 agosto"
+        ));
+        assert!(!protected_span_present(
+            "1857-1918)—tsarist",
+            "(1857-1919)—generale zarista"
+        ));
     }
 
     #[test]
@@ -1246,6 +1274,10 @@ mod tests {
             "p < 0.05",
             "Il risultato era p < 0,06."
         ));
+        assert!(!protected_span_present(
+            "p < 0.05",
+            "Il risultato era 0,05."
+        ));
     }
 
     #[test]
@@ -1273,6 +1305,19 @@ mod tests {
         let translation = "Parola.<m0><m1>*2</m1></m0> Continua.";
 
         assert_eq!(marker_reference_text_error(source, translation), None);
+    }
+
+    #[test]
+    fn marker_reference_text_supports_non_ascii_numbering() {
+        let source = "Parola.<m1>١٢</m1> Segue.";
+        let preserved = "Parola.<m1>١٢</m1> Continua.";
+        let dropped = "Parola.<m1></m1> Continua.";
+
+        assert_eq!(marker_reference_text_error(source, preserved), None);
+        assert!(
+            marker_reference_text_error(source, dropped)
+                .is_some_and(|error| error.contains("lost its reference text"))
+        );
     }
 
     #[test]

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -169,6 +169,20 @@ bookforge resume <job-id>
 For a known correct translation, use `bookforge correct` instead of spending
 another provider request. See [CLI_REFERENCE.md](CLI_REFERENCE.md#review-flag-and-correct).
 
+When the finding is deterministic, read the exact message before retrying:
+
+- `translation is unchanged...` and `translation retains N%...` are both
+  source-copy checks. The latter may appear as `other` in
+  `replay_validation`; it is not the Toki Pona target-language gate.
+- Number protection compares numeric value across comma/point decimals,
+  comma/point/space grouping, numeric date reordering, and translated word
+  suffixes. Thus `1,000.50` to `1.000,50`, `4th` to `4º`, and `December 8` to
+  `8 dicembre` are valid. A different digit value is still a defect.
+- A missing small number is a hard error in a list marker or recognized month
+  context and a warning otherwise. Inspect OCR-derived source text before
+  retrying: malformed scans remain the dominant source of protected-number and
+  math false positives in the measured corpus.
+
 ## Validation cannot find EPUBCheck
 
 BookForge's built-in structural validation still runs. Missing EPUBCheck is

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -45,17 +45,63 @@ Notes that matter when reading its output:
   source against source and says nothing about the model. In one run that
   artifact was 4,750 of 5,139 raw flags. Always read the
   "excluding preserved-source pairs" figure.
+- Replay currently calls only the exact-equality message
+  `translation_unchanged`. The 92%-overlap message (`translation retains N% of
+  the source-language words`) appears under `other`, although the durable
+  finding classifier correctly stores both as `source_copy_unchanged`. Inspect
+  the `other` messages before concluding that they came from the target-language
+  gate.
 - `--emit-pairs <file.jsonl>` writes the flagged pairs for the judge below.
 
 Use it to answer "did this validator change help?" before spending anything.
 
+### Language assumptions in deterministic validation
+
+Audited 2026-07-30 against the corpus below:
+
+- Inline marker identity, multiplicity, shape, nesting, and marker-aware prose
+  splitting are structural and language-neutral. Reference text inside a marker
+  is a separate data check; decimal reference glyphs from non-Latin scripts are
+  recognized as references.
+- URL, email, filename, internal-anchor, citation, code, and footnote-reference
+  protected spans are exact data-identity checks. Math is also identity-based
+  but is reported as a warning.
+- Number matching accepts localized comma/point decimals, comma/point/space
+  grouping, and reordered numeric date components. A leading numeric value may
+  keep its value while its word suffix changes, for example `4th` to `4º` or
+  `19-August` to `19 luglio`. The value parser still recognizes ASCII digits;
+  changing the digit script itself is not treated as numeric equivalence. On
+  the real Italian-target replay, this removed 93 flagged pairs (99 individual
+  number complaints): all retained the numeric values while translating ordinal
+  suffixes, date words, or prose fused to biographical year ranges.
+- The small-date severity rule recognizes month context in English, Italian,
+  Spanish, Portuguese, Danish, Norwegian, French, and German, including a
+  linking word such as `de`. A missing one- or two-digit number outside known
+  critical contexts remains a warning.
+- Source-copy validation is intentionally cross-language, but its thresholds
+  are language-pair-blind: exact equality always fires, while near-copy requires
+  at least 120 source characters, 30 source words, 30 overlapping words, and 92%
+  multiset overlap. The corpus has no close-pair translation with which to
+  calibrate that threshold. The Italian-to-Italian identity job is not such a
+  probe: source and target language are equal and its provider is `mock`, either
+  of which disables source-copy validation.
+- `target_language_gate` is not a generic language detector. It is the strict
+  closed-vocabulary and grammar gate for the built-in Toki Pona style and
+  returns immediately for every other target language.
+- Source-copy content exceptions are not language-neutral. Reference-section
+  titles, `p.` page-note syntax, and explicit “in English” glosses are recognized
+  with English phrases. Treat results from differently titled reference
+  sections with care.
+
 ## The corpus these tools run against
 
 Measured 2026-07-29 against the owner's store, so the next person does not
-re-derive it: **30 jobs**, all 30 snapshots resolvable, 27 with stored
-translated blocks, **40,303 replayable pairs** across 8 books. Four independent
-translations of *Calling Bullshit* and five of *If We Burn* exist, which is
-free A/B material.
+re-derive it: **30 jobs** (28 English-to-Italian, one Italian-to-Italian mock
+identity run, and one English-to-Toki Pona), all 30 snapshots resolvable, 27 with
+stored translated blocks, **40,576 replayable pairs** across 8 books. The 29
+Italian-target jobs account for 40,303 of those pairs. Four independent
+translations of *Calling Bullshit* and five of *If We Burn* exist, which is free
+A/B material.
 
 `items with no translation` and `block rows with no item` in the thousands are
 expected rather than a defect: several jobs are `needs_review` or `stopped`
@@ -405,6 +451,7 @@ English→Italian jobs, deepseek-v4-flash.
 | after marker-aware span detection (#61) | 371 |
 | after severity demotion (#64) | 348 |
 | after the OCR letter-run guard (#65) | 265 |
+| after localized numeric word-suffix handling | 172 |
 
 False-positive rate over that period stayed roughly flat, **75.3% → 77.5%**.
 That is the important finding: four rounds of heuristic tuning cut *volume*


### PR DESCRIPTION
An audit of the deterministic validators for language assumptions, prompted by the discovery that glossary extraction is English-only. Three of five validator families turned out language-neutral; two did not.

## Measured result

Replayed over the real store, **protected-span flags fall 265 → 172** — 93 fewer flagged pairs.

All 93 are cases where the numeric *value* was preserved and only the English suffix or surrounding prose was translated: `4th` → `4°`, `19-August` → `19 agosto`. Those were false positives.

That continues the recorded series **600 → 371 → 348 → 265 → 172**. Unlike the earlier rounds — which `validator-tooling.md` notes cut *volume* without improving precision — this one removes genuine false positives. Source-copy and marker counts are unchanged.

## Verdicts

| validator family | verdict |
| --- | --- |
| protected identity spans (URL, email, filename, anchor, citation, code) | language-neutral |
| inline marker structure | language-neutral |
| `target_language_gate` | language-dependent **and correct** |
| **protected numbers** | **broken — fixed** |
| source-copy / `translation_unchanged` | broken at boundaries — see below |

Month recognition now covers English, Italian, Spanish, Portuguese, Danish, Norwegian, French and German. Numeric *value* equivalence still requires ASCII digits; that limitation is now documented rather than silent. A reference-text classifier that assumed ASCII numerals is also fixed.

## Two suppositions in the brief were wrong

Recorded so nobody re-derives them:

- **`target_language_gate` is not a general language gate.** It is exclusively the closed-vocabulary Toki Pona check. The `translation retains 99% of the source-language words` messages seen in replay output actually come from source-copy overlap, and **`replay_validation` misclassifies them as `other`** — a taxonomy bug in the example, left alone because examples were out of scope for this branch.
- **The Italian→Italian identity job is not close-pair evidence.** Its source and target languages match *and* its provider is `mock`, either of which disables source-copy validation entirely. The probe I suggested would have measured nothing.

## Deliberately unchanged

- **The 92% source-copy near-copy threshold.** Exact equality has no size threshold and near-copy detection is pair-blind, so a close pair (IT–ES, PT–ES, DA–NO) could plausibly misfire — but no such corpus exists here, and guessing a new threshold would be worse than the current behaviour. Documented as a known boundary instead.
- The Toki Pona gate, and the structural marker checks.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **919 passed / 0 failed / 3 ignored** over two runs. Replay is free — zero API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)