### PR TITLE
Route glossary extraction by whether the source script has case

### DIFF
--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -220,25 +220,40 @@ struct CandidateStats {
     forms: BTreeMap<String, usize>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct RecurrentTokenStats {
+    source_count: usize,
+    document_count: usize,
+    prose_count: usize,
+    forms: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandidateExtractionStrategy {
+    Capitalization,
+    Recurrence,
+}
+
 pub fn extract_glossary_candidates(
     blocks: &[Block],
     source_language: &str,
     min_count: usize,
     limit: Option<usize>,
 ) -> Vec<GlossaryCandidate> {
-    let stopwords = common_words(source_language);
     let mut candidates = BTreeMap::<String, CandidateStats>::new();
+    let strategy = candidate_extraction_strategy(blocks);
 
-    for block in blocks {
-        let quoted_italic_sources = collect_quoted_italic_candidates(block, &mut candidates);
-        let visible_text = block_visible_text(block);
-        collect_capitalized_candidates(
-            &visible_text,
-            stopwords,
-            &quoted_italic_sources,
-            matches!(block.kind, BlockKind::Heading(_)),
-            &mut candidates,
-        );
+    match strategy {
+        CandidateExtractionStrategy::Capitalization => {
+            collect_capitalization_candidates(
+                blocks,
+                common_words(source_language),
+                &mut candidates,
+            );
+        }
+        CandidateExtractionStrategy::Recurrence => {
+            collect_recurrent_candidates(blocks, min_count.max(1), &mut candidates);
+        }
     }
 
     let min_count = min_count.max(1);
@@ -250,11 +265,12 @@ pub fn extract_glossary_candidates(
     let mut candidates = candidates
         .into_iter()
         .filter(|(key, stats)| {
-            // An author's own italics or quotes are an explicit signal, so
+            // An author's own quoted italics are an explicit signal, so
             // `Invented` bypasses both frequency and positional evidence.
             stats.category == GlossaryCategory::Invented
                 || (stats.source_count >= min_count
-                    && has_positional_evidence(key, stats, &word_evidence))
+                    && (strategy == CandidateExtractionStrategy::Recurrence
+                        || has_positional_evidence(key, stats, &word_evidence)))
         })
         .map(|(_, stats)| stats)
         .map(|stats| GlossaryCandidate {
@@ -275,6 +291,164 @@ pub fn extract_glossary_candidates(
         candidates.truncate(limit);
     }
     candidates
+}
+
+/// Choose extraction by whether the dominant script in the source text has
+/// case.
+///
+/// Unicode exposes case directly on characters, so routing can generalize to
+/// languages that BookForge has never enumerated. A source whose alphabetic
+/// characters are predominantly cased uses capitalization; a predominantly
+/// caseless source uses recurrence.
+///
+/// Ties and text without alphabetic evidence default to recurrence. That
+/// preserves recall when the script cannot be inferred, whereas capitalization
+/// cannot emit ordinary candidates from a caseless script. Counting the
+/// dominant kind rather than testing for any cased character prevents an
+/// occasional Latin word from rerouting a Han, Kana, Hangul, Thai, Arabic,
+/// Hebrew, or Devanagari source.
+fn candidate_extraction_strategy(blocks: &[Block]) -> CandidateExtractionStrategy {
+    let (cased, caseless) = blocks.iter().fold((0usize, 0usize), |counts, block| {
+        block_visible_text(block)
+            .chars()
+            .filter(|ch| ch.is_alphabetic())
+            .fold(counts, |(cased, caseless), ch| {
+                if ch.is_lowercase() || ch.is_uppercase() {
+                    (cased + 1, caseless)
+                } else {
+                    (cased, caseless + 1)
+                }
+            })
+    });
+
+    if cased > caseless {
+        CandidateExtractionStrategy::Capitalization
+    } else {
+        CandidateExtractionStrategy::Recurrence
+    }
+}
+
+fn collect_capitalization_candidates(
+    blocks: &[Block],
+    stopwords: &[&str],
+    candidates: &mut BTreeMap<String, CandidateStats>,
+) {
+    for block in blocks {
+        let quoted_italic_sources = collect_quoted_italic_candidates(block, candidates);
+        let visible_text = block_visible_text(block);
+        collect_capitalized_candidates(
+            &visible_text,
+            stopwords,
+            &quoted_italic_sources,
+            matches!(block.kind, BlockKind::Heading(_)),
+            candidates,
+        );
+    }
+}
+
+/// Collect recurrent words without using capitalization, sentence position,
+/// or a language-specific stoplist.
+///
+/// Blocks act as the documents in a small in-document TF-IDF calculation.
+/// Sublinear term frequency rewards repetition without letting ubiquitous
+/// function words dominate, while inverse block frequency rewards vocabulary
+/// concentrated in the parts of the book where a term is discussed. The
+/// square-root sweep size keeps the proposal batch sublinear in book length;
+/// callers can impose a tighter `--limit`.
+fn collect_recurrent_candidates(
+    blocks: &[Block],
+    min_count: usize,
+    candidates: &mut BTreeMap<String, CandidateStats>,
+) {
+    let mut recurrent = BTreeMap::<String, RecurrentTokenStats>::new();
+    let mut document_count = 0usize;
+    let mut token_count = 0usize;
+
+    for block in blocks {
+        let quoted_italic_sources = collect_quoted_italic_candidates(block, candidates);
+        let visible_text = block_visible_text(block);
+        let words = tokenize_words(&visible_text);
+        if words.is_empty() {
+            continue;
+        }
+
+        document_count += 1;
+        token_count += words.len();
+        let in_heading = matches!(block.kind, BlockKind::Heading(_));
+        let mut seen_in_document = HashSet::new();
+        for word in words {
+            if word.text.chars().filter(|ch| ch.is_alphabetic()).count() < 2 {
+                continue;
+            }
+            let key = word.text.to_lowercase();
+            if quoted_italic_sources.contains(&key) {
+                continue;
+            }
+
+            let stats = recurrent.entry(key.clone()).or_default();
+            stats.source_count += 1;
+            if !in_heading {
+                stats.prose_count += 1;
+            }
+            *stats.forms.entry(word.text).or_insert(0) += 1;
+            seen_in_document.insert(key);
+        }
+        for key in seen_in_document {
+            if let Some(stats) = recurrent.get_mut(&key) {
+                stats.document_count += 1;
+            }
+        }
+    }
+
+    let sweep_size = recurrent_sweep_size(token_count);
+    let mut recurrent = recurrent
+        .into_iter()
+        .filter(|(_, stats)| stats.source_count >= min_count && stats.prose_count > 0)
+        .map(|(key, stats)| {
+            let score = in_document_tfidf(stats.source_count, stats.document_count, document_count);
+            (key, stats, score)
+        })
+        .collect::<Vec<_>>();
+    recurrent.sort_by(|left, right| {
+        right
+            .2
+            .total_cmp(&left.2)
+            .then_with(|| right.1.source_count.cmp(&left.1.source_count))
+            .then_with(|| left.0.cmp(&right.0))
+    });
+
+    for (key, stats, _) in recurrent.into_iter().take(sweep_size) {
+        merge_recurrent_candidate(candidates, key, stats);
+    }
+}
+
+fn recurrent_sweep_size(token_count: usize) -> usize {
+    (token_count as f64).sqrt().ceil() as usize
+}
+
+fn in_document_tfidf(source_count: usize, document_count: usize, total_documents: usize) -> f64 {
+    let term_frequency = (source_count as f64).ln_1p();
+    let inverse_document_frequency = ((total_documents.saturating_add(1)) as f64
+        / (document_count.saturating_add(1)) as f64)
+        .ln();
+    term_frequency * inverse_document_frequency
+}
+
+fn merge_recurrent_candidate(
+    candidates: &mut BTreeMap<String, CandidateStats>,
+    key: String,
+    stats: RecurrentTokenStats,
+) {
+    let entry = candidates.entry(key).or_insert_with(|| CandidateStats {
+        category: GlossaryCategory::Other,
+        source_count: 0,
+        evidence_count: 0,
+        forms: BTreeMap::new(),
+    });
+    entry.source_count += stats.source_count;
+    for (form, count) in stats.forms {
+        *entry.forms.entry(form).or_insert(0) += count;
+    }
 }
 
 /// Return one short source excerpt containing a glossary candidate.
@@ -1181,6 +1355,154 @@ mod tests {
             candidates.iter().any(|candidate| {
                 candidate.source_text == "Ivan Ilych" && candidate.source_count == 2
             }),
+            "{candidates:?}"
+        );
+    }
+
+    #[test]
+    fn extraction_strategy_is_derived_from_the_dominant_script() {
+        for text in [
+            "German: Zarathustra sprach mit den Menschen.",
+            "Russian: Раскольников встретил Катерину Ивановну.",
+            "Italian: Questo Mondo è al Contrario.",
+        ] {
+            assert_eq!(
+                candidate_extraction_strategy(&[block(text)]),
+                CandidateExtractionStrategy::Capitalization,
+                "{text}"
+            );
+        }
+        for text in [
+            "中国经典名著 西游记",
+            "日本語の仮名と漢字",
+            "한국어 한글 문장",
+            "ภาษาไทยไม่มีตัวพิมพ์ใหญ่",
+            "العربية بلا حالة أحرف",
+            "עברית ללא אותיות גדולות",
+            "देवनागरी में अक्षर",
+        ] {
+            assert_eq!(
+                candidate_extraction_strategy(&[block(text)]),
+                CandidateExtractionStrategy::Recurrence,
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn occasional_cased_text_does_not_reroute_a_caseless_book() {
+        assert_eq!(
+            candidate_extraction_strategy(&[block(
+                "中国经典名著西游记。話說天下大勢，分久必合，合久必分。Project Gutenberg",
+            )]),
+            CandidateExtractionStrategy::Recurrence
+        );
+    }
+
+    #[test]
+    fn ambiguous_script_defaults_to_recurrence() {
+        assert_eq!(
+            candidate_extraction_strategy(&[block("1234 — !?")]),
+            CandidateExtractionStrategy::Recurrence
+        );
+        assert_eq!(
+            candidate_extraction_strategy(&[block("Ab 中国")]),
+            CandidateExtractionStrategy::Recurrence
+        );
+    }
+
+    #[test]
+    fn general_extraction_ranks_concentrated_vocabulary_above_ubiquitous_words() {
+        let concentrated = in_document_tfidf(4, 2, 20);
+        let ubiquitous = in_document_tfidf(40, 20, 20);
+
+        assert!(concentrated > ubiquitous);
+    }
+
+    #[test]
+    fn general_extraction_sweep_size_grows_with_the_square_root_of_tokens() {
+        assert_eq!(recurrent_sweep_size(0), 0);
+        assert_eq!(recurrent_sweep_size(1), 1);
+        assert_eq!(recurrent_sweep_size(16), 4);
+        assert_eq!(recurrent_sweep_size(17), 5);
+        assert_eq!(recurrent_sweep_size(10_000), 100);
+    }
+
+    #[test]
+    fn recurrence_extraction_finds_uncased_chinese_terminology() {
+        let blocks = vec![
+            block("光合作用 供养 花园。"),
+            block("我们 研究 光合作用。"),
+            block("光合作用 需要 阳光。"),
+            block("花园 今天 关闭。"),
+        ];
+
+        let candidates = extract_glossary_candidates(&blocks, "Chinese", 3, None);
+
+        assert!(
+            candidates.iter().any(|candidate| {
+                candidate.source_text == "光合作用" && candidate.source_count == 3
+            }),
+            "{candidates:?}"
+        );
+    }
+
+    #[test]
+    fn german_extraction_uses_noun_capitalization() {
+        let blocks = vec![
+            block("Das Quantenfeld verändert sich."),
+            block("Wir messen das Quantenfeld genau."),
+            block("Dieses Quantenfeld bleibt stabil."),
+            block("Die Messung endet heute."),
+        ];
+
+        let candidates = extract_glossary_candidates(&blocks, "German", 3, None);
+
+        assert!(
+            candidates.iter().any(|candidate| {
+                candidate.source_text == "Quantenfeld" && candidate.source_count == 3
+            }),
+            "{candidates:?}"
+        );
+    }
+
+    #[test]
+    fn russian_extraction_retains_capitalized_phrases_and_rejects_lowercase_noise() {
+        let blocks = vec![
+            block("Авдотья Романовна встретила Петра."),
+            block("Вчера Авдотья Романовна говорила."),
+            block("Авдотья ответила Петру."),
+        ];
+
+        let candidates = extract_glossary_candidates(&blocks, "Russian", 2, None);
+
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.source_text == "Авдотья Романовна"),
+            "{candidates:?}"
+        );
+        assert!(
+            !candidates
+                .iter()
+                .any(|candidate| candidate.source_text == "встретила"),
+            "{candidates:?}"
+        );
+    }
+
+    #[test]
+    fn english_extraction_remains_capitalization_gated() {
+        let blocks = vec![block(
+            "The photosynthesis changed. We measured photosynthesis twice. \
+             Later photosynthesis stopped.",
+        )];
+
+        let candidates = extract_glossary_candidates(&blocks, "English", 3, None);
+
+        assert!(
+            !candidates
+                .iter()
+                .any(|candidate| candidate.source_text == "photosynthesis"),
             "{candidates:?}"
         );
     }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -372,32 +372,45 @@ bookforge glossary accept-candidates cyberiad --language "English->Italian"
 bookforge glossary review-candidates cyberiad --language "English->Italian"
 ```
 
-`extract-candidates` is precision-tuned for English, not language-general. It
-counts a capitalized word only when it is capitalized for some reason other than
-where it sits. English capitalises the first word of every sentence, quotation,
-and parenthetical, and headings are title-cased by convention, so a word
-attested *only* in those positions is grammar rather than terminology —
-`Finally`, `Meanwhile`, `Oh`, `Yes` and `Thus` all reached the glossary that way
-before this rule existed. A multi-word phrase gets a second chance: `Ivan Ilych`
-may open every sentence it appears in, yet both its words are attested
-mid-sentence, which is what distinguishes it from `Finally Klapaucius`.
-Contractions inherit their stem, so `I'll` and `It's` are filtered as the
-pronouns they are built from while `Trurl's` survives. Author italics and quoted
-coinages bypass all of this, since they are an explicit signal.
+`extract-candidates` chooses between two extraction strategies by measuring the
+scripts in the source text itself, not by looking up the language name. If most
+alphabetic characters have Unicode case, the source uses the measured
+capitalization heuristic. This includes German: capitalized nouns are useful
+terminology candidates even though case does not distinguish them from proper
+nouns. The heuristic counts a capitalized word only when it is capitalized for
+some reason other than where it sits. English capitalises the first word of
+every sentence, quotation, and parenthetical, and headings are title-cased by
+convention, so a word attested *only* in those positions is grammar rather than
+terminology — `Finally`, `Meanwhile`, `Oh`, `Yes` and `Thus` all reached the
+glossary that way before this rule existed. A multi-word phrase gets a second
+chance: `Ivan Ilych` may open every sentence it appears in, yet both its words
+are attested mid-sentence, which is what distinguishes it from `Finally
+Klapaucius`. Contractions inherit their stem, so `I'll` and `It's` are filtered
+as the pronouns they are built from while `Trurl's` survives.
 
-For non-English input the stoplist falls back to 17 English function words. In
-German, where common nouns are capitalized mid-sentence, the positional rule
-therefore accepts every repeated noun that clears the frequency threshold. The
-extractor remains useful as a mechanical recall pass, but its precision outside
-English is poor and the proposal model must make the terminology judgment.
+Predominantly caseless sources — Han, Kana, Hangul, Thai, Arabic, Hebrew, and
+Devanagari — use an orthography-neutral recurrence sweep instead. Counting the
+dominant character kind keeps an occasional Latin word from rerouting such a
+book. The sweep considers words without relying on case and uses blocks as the
+documents in an in-book TF-IDF ranking: repetition raises a token's score,
+while vocabulary concentrated in a few blocks outranks function words spread
+throughout the book. No language stoplist or sentence-capitalization rule is
+used. Repeated headings cannot qualify without prose attestation. Unknown
+language labels need no default because routing is script-derived; if the text
+has no alphabetic evidence or the measurement ties, recurrence preserves recall
+without assuming case. Phrases that the author marks with both italics and
+enclosing quotation marks remain an explicit signal in either strategy and
+bypass the frequency floor.
 
-`--min-count` defaults to 3. This deliberately recovers terms that recur three
-times while keeping one- and two-off capitalized words out of the single,
-book-sized proposal pass. Each additional candidate reserves 320 output tokens
-within bounded requests by default, so lowering it further is not free. The
-positional rule remains as an inexpensive candidate-budget gate, not a semantic
-verdict; use `--min-count` and `--limit` explicitly when a book or language
-needs a different recall/cost tradeoff.
+`--min-count` defaults to 3. On the recurrence path it is applied before the
+TF-IDF ranking, and the automatic sweep admits at most the square root of the
+book's word-token count (rounded up), plus explicitly author-marked phrases.
+This keeps the default proposal batch sublinear in book length while making
+lowercase terminology reachable. `--limit` can impose a tighter cap on the
+frequency-ordered result. Each additional candidate reserves 320 output tokens
+within bounded proposal requests by default, so lowering `--min-count` or
+widening `--limit` is not free. The proposal model remains responsible for
+rejecting ordinary language as `not_terminology`.
 
 On The Cyberiad at `--limit 60`, the rule dropped eleven non-terms and freed
 those slots for nine genuine coinages the noise had been crowding out

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -528,13 +528,23 @@ but any terminal chunk failure makes the command print an `INCOMPLETE` summary
 with completed and failed counts and exit with an error; failed candidates
 remain pending.
 
-Candidate extraction itself is English-specific: its positional evidence models
-English capitalization and non-English input gets only a 17-word English
-fallback stoplist. German common nouns are capitalized mid-sentence, so every
-repeated noun can clear that filter. Treat extraction as recall and the strong
-model as precision. The default `--min-count 3` is the recommended compromise:
-it recovers three-occurrence terms without paying the 320-output-token budget
-for the much larger one- and two-occurrence tail.
+Candidate extraction derives its routing from the scripts in the source text
+rather than a language-name list. Sources whose alphabetic characters are
+predominantly cased — including English, Russian, Italian, and German — use the
+measured positional-capitalization, phrase, and contraction rules. Capitalized
+German nouns are useful terminology candidates. Predominantly caseless Han,
+Kana, Hangul, Thai, Arabic, Hebrew, and Devanagari sources use a
+capitalization-blind recurrence sweep. Counting the dominant character kind
+keeps an occasional Latin word from rerouting a caseless book. Repeated tokens
+are ranked with block-level, in-book TF-IDF and the sweep is capped at the square
+root of the book's word-token count, plus phrases marked with both italics and
+quotes. The final `--limit` applies to the frequency-ordered result. Unknown
+language labels need no default; when the text has no alphabetic evidence or
+the measurement ties, recurrence preserves recall without assuming case. Treat
+extraction as recall and the strong model as precision. The default
+`--min-count 3` is the recommended compromise: it recovers three-occurrence
+terms without paying the 320-output-token budget for the much larger one- and
+two-occurrence tail.
 
 This pass is deliberately book-scoped rather than segment-scoped. A measured
 run — The Cyberiad, 40 candidates, Kimi K3 — cost 2,355 provider input tokens and


### PR DESCRIPTION
Candidate extraction assumed English orthography twice over: the positional rule encoded English capitalisation, and `common_words` returned a full English stoplist for English and a **17-word** fallback for every other language.

Measured on five real books, the consequences ranged from noisy to total failure.

## Chinese extraction was impossible, not merely degraded

Two independent mechanisms blocked it:

- `tokenize_words` accumulates on `char::is_alphabetic()`, which is **true for Han**, and Chinese has no inter-word spaces — so an entire clause became one token.
- `is_capitalized_candidate_word` requires `first.is_uppercase()`, **false for every Han character**.

《西游记》 yielded **zero** candidates. That's a stronger statement than "the heuristic is noisy on non-English" and it needed a real book to establish.

## The fix routes on the script of the text itself

Predominantly **cased** characters → capitalisation path. Predominantly **caseless** → recurrence sweep ranked by block-level TF-IDF.

Deriving this from Unicode case rather than a language-name list means it generalises to languages never enumerated here, and it doesn't depend on `--source-lang` being accurate. Counting the *dominant* kind rather than testing for any cased character stops an occasional Latin word from rerouting a Han, Kana, Hangul, Thai, Arabic, Hebrew or Devanagari source. Ties and text with no alphabetic evidence default to recurrence, because capitalisation can emit nothing at all from a caseless script.

## Measured, `--limit 40`, clean main vs this branch

| book | result |
| --- | --- |
| Chinese 《西游记》 | **0 → 40** — `八戒 · 三藏 · 悟空 · 沙僧 · 師父 · 大聖` |
| English (Cyberiad) | exact ordered match |
| Italian (Vannacci) | exact ordered match |
| Russian (Dostoevsky) | exact ordered match |
| German (Zarathustra) | exact ordered match |

## Two designs were tried and rejected by measurement

This is why the final shape looks the way it does:

**"English versus everything else" regressed Russian badly.** Russian capitalises proper nouns much as English does, so the existing path already returned nothing but character names and patronymic pairs — `Раскольников`, `Свидригайлов`, `Катерина Ивановна`, `Пульхерия Александровна`. Routing it to a frequency sweep added function-word noise (`без`, `более`, `были`, `вчера`) and **lost the multi-word forms**, which are disproportionately valuable for a glossary.

**"Treat German as caseless-equivalent" also regressed**, on the theory that capitalising every noun makes case uninformative. But in German the nouns *are* the terminology: the capitalisation path yields `Zarathustra`, `Seele`, `Liebe`, `Tugend`, `Geist`, `Wille`, `Wahrheit`, `Weisheit`, where the sweep returned mostly `war`, `man`, `für`, `wir`.

## Known limitation, stated plainly

Chinese candidates are **clause-shaped rather than word-shaped** (`三藏道` — "Sanzang said") because there is no word segmentation. Without a segmenter these are the smallest recurring units available. They still surface every major character, so this is useful rather than correct.

No German stoplist was added: per-language lists don't scale, the downstream model filter already rejects non-terminology (135 of 257 candidates on one English book), and clean-main quality is matched without one. Worth revisiting only if measurement shows function words crowding terminology out of the candidate budget.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **937 passed / 0 failed / 3 ignored**. Extraction is entirely offline — no provider calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)