### PR TITLE
Synchronise lifecycle tests on observable events instead of timing windows

### DIFF
--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -1876,6 +1876,12 @@ fn cli_live_reconfigure_updates_later_single_requests_and_cleans_runtime_files()
         ])
         .assert()
         .success();
+    // A successful reconfigure command means the sidecar is durable, not that
+    // the live watch channel has published it. Keep request 1 parked until the
+    // worker acknowledges revision 1 so later dispatch cannot race the watcher.
+    wait_for_child_events(&events, &mut child, |events| {
+        event_count(events, "RuntimeConfigChanged") >= 1
+    });
 
     assert!(
         request_finished_ids(&read_jsonl(&events)).is_empty(),
@@ -1948,6 +1954,12 @@ fn cli_live_reconfigure_repartitions_pending_batch_work() {
         ])
         .assert()
         .success();
+    // The release gate protects only the in-flight batch. Wait for the worker's
+    // acknowledgement as well, otherwise pending work can repartition under
+    // revision 0 when the watcher loses a scheduling race.
+    wait_for_child_events(&events, &mut child, |events| {
+        event_count(events, "RuntimeConfigChanged") >= 1
+    });
 
     assert_eq!(
         batch_request_finished_count(&read_jsonl(&events)),
@@ -1990,11 +2002,10 @@ fn cli_stop_preserves_runtime_overrides_and_resume_consumes_them() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let events = temp.path().join("stop-runtime-reconfigure-events.jsonl");
     let output = temp.path().join("stop-runtime-reconfigure.epub");
-    let mut child = spawn_controlled_mock_translate(&temp, &events, &output);
+    let release = temp.path().join("stop-runtime-reconfigure-release");
+    let mut child = spawn_gated_mock_translate(&temp, &events, &output, &release);
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_events(&events, |events| {
-        !request_started_payloads(events).is_empty()
-    });
+    wait_for_first_batch_request(&events, &mut child);
 
     bookforge()
         .current_dir(temp.path())
@@ -2010,13 +2021,16 @@ fn cli_stop_preserves_runtime_overrides_and_resume_consumes_them() {
         ])
         .assert()
         .success();
-    wait_for_event_count(&events, "RuntimeConfigChanged", 1);
+    wait_for_child_events(&events, &mut child, |events| {
+        event_count(events, "RuntimeConfigChanged") >= 1
+    });
     write_control_file(&control_path(&temp, &job_id), ControlCommand::Stop)
         .expect("stop control should write");
+    fs::write(&release, "release").expect("mock release file should write");
 
     let status = child.wait().expect("translate child should exit");
     assert!(status.success(), "translate child failed: {status}");
-    wait_for_job_status(&temp, &job_id, "stopped");
+    assert_eq!(job_status(&temp, &job_id), "stopped");
     let stopped_events = read_jsonl(&events);
     assert_eq!(event_count(&stopped_events, "TranslationFinished"), 0);
     let initially_finished = segment_finished_ids(&stopped_events);
@@ -2115,13 +2129,21 @@ fn cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries() {
         &temp,
         &events,
         &output,
-        &[
-            ("BOOKFORGE_MOCK_QA_DELAY_MS", "1500"),
-            ("BOOKFORGE_TEST_FINALIZE_BOUNDARY_DELAY_MS", "200"),
-        ],
+        &[("BOOKFORGE_MOCK_QA_DELAY_MS", "3000")],
     );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_request_started_prefix(&events, "qa_");
+    wait_for_child_events(&events, &mut child, |events| {
+        request_started_ids(events)
+            .iter()
+            .any(|id| id.starts_with("qa_"))
+    });
+    // Freeze the later stage boundary instead of requiring a separate
+    // reconfigure process to finish inside the QA provider's delay window.
+    // The already-started QA request keeps revision 0; the paused boundary
+    // cannot dispatch double-check until revision 1 is acknowledged below.
+    write_control_file(&control_path(&temp, &job_id), ControlCommand::Pause)
+        .expect("pause control should write");
+    wait_for_child_job_status(&temp, &job_id, "paused", &mut child);
 
     bookforge()
         .current_dir(temp.path())
@@ -2142,6 +2164,11 @@ fn cli_finalize_stages_snapshot_runtime_settings_at_stage_boundaries() {
     wait_for_child_events(&events, &mut child, |events| {
         event_count(events, "RuntimeConfigChanged") >= 1
     });
+    bookforge()
+        .current_dir(temp.path())
+        .args(["resume", &job_id, "--ui", "quiet"])
+        .assert()
+        .success();
 
     let status = child.wait().expect("translate child should exit");
     assert!(status.success(), "translate child failed: {status}");
@@ -2297,9 +2324,18 @@ fn cli_pause_during_inflight_batch_holds_finalize_passes() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let events = temp.path().join("finalize-pause-events.jsonl");
     let output = temp.path().join("finalize-pause.epub");
-    let mut child = spawn_finalize_controlled_mock_translate(&temp, &events, &output);
+    let release = temp.path().join("finalize-pause-release");
+    let mut child = spawn_finalize_stage_delay_mock_translate(
+        &temp,
+        &events,
+        &output,
+        &[(
+            "BOOKFORGE_MOCK_RELEASE_FILE",
+            release.to_str().expect("release path should be UTF-8"),
+        )],
+    );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_events(&events, |events| batch_request_started_count(events) >= 1);
+    wait_for_first_batch_request(&events, &mut child);
 
     let control_path = temp
         .path()
@@ -2307,8 +2343,11 @@ fn cli_pause_during_inflight_batch_holds_finalize_passes() {
         .join(&job_id)
         .join("control");
     write_control_file(&control_path, ControlCommand::Pause).expect("pause control should write");
-    wait_for_job_status(&temp, &job_id, "paused");
-    thread::sleep(Duration::from_millis(700));
+    wait_for_child_job_status(&temp, &job_id, "paused", &mut child);
+    fs::write(&release, "release").expect("mock release file should write");
+    wait_for_child_events(&events, &mut child, |events| {
+        batch_request_finished_count(events) >= 1
+    });
 
     let paused_events = read_jsonl(&events);
     assert!(
@@ -2350,9 +2389,18 @@ fn cli_stop_during_inflight_batch_skips_finalize_until_resume() {
     let temp = tempfile::tempdir().expect("temp dir should be created");
     let events = temp.path().join("finalize-stop-events.jsonl");
     let output = temp.path().join("finalize-stop.epub");
-    let mut child = spawn_finalize_controlled_mock_translate(&temp, &events, &output);
+    let release = temp.path().join("finalize-stop-release");
+    let mut child = spawn_finalize_stage_delay_mock_translate(
+        &temp,
+        &events,
+        &output,
+        &[(
+            "BOOKFORGE_MOCK_RELEASE_FILE",
+            release.to_str().expect("release path should be UTF-8"),
+        )],
+    );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_events(&events, |events| batch_request_started_count(events) >= 1);
+    wait_for_first_batch_request(&events, &mut child);
 
     let control_path = temp
         .path()
@@ -2360,10 +2408,11 @@ fn cli_stop_during_inflight_batch_skips_finalize_until_resume() {
         .join(&job_id)
         .join("control");
     write_control_file(&control_path, ControlCommand::Stop).expect("stop control should write");
+    fs::write(&release, "release").expect("mock release file should write");
 
     let status = child.wait().expect("translate child should exit");
     assert!(status.success(), "translate child failed: {status}");
-    wait_for_job_status(&temp, &job_id, "stopped");
+    assert_eq!(job_status(&temp, &job_id), "stopped");
     let stopped_events = read_jsonl(&events);
     assert_eq!(
         finalize_request_started_count(&stopped_events),
@@ -2421,11 +2470,18 @@ fn cli_pause_during_inflight_qa_request_parks_before_more_finalize_work() {
         &[("BOOKFORGE_MOCK_QA_DELAY_MS", "3000")],
     );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_request_started_prefix(&events, "qa_");
+    wait_for_child_events(&events, &mut child, |events| {
+        request_started_ids(events)
+            .iter()
+            .any(|id| id.starts_with("qa_"))
+    });
 
     let control_path = control_path(&temp, &job_id);
     write_control_file(&control_path, ControlCommand::Pause).expect("pause control should write");
-    wait_for_job_status(&temp, &job_id, "paused");
+    wait_for_child_job_status(&temp, &job_id, "paused", &mut child);
+    // RequestStarted precedes the provider call, so Pause may park the task
+    // before it can emit RequestFinished. Observe beyond the injected provider
+    // delay, then assert that no later finalize work escaped the paused state.
     thread::sleep(Duration::from_millis(3300));
 
     let paused_events = read_jsonl(&events);
@@ -2464,11 +2520,17 @@ fn cli_pause_during_inflight_double_check_request_parks_before_corrections() {
         &[("BOOKFORGE_MOCK_DOUBLE_CHECK_DELAY_MS", "3000")],
     );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_request_started_prefix(&events, "double_check_");
+    wait_for_child_events(&events, &mut child, |events| {
+        request_started_ids(events)
+            .iter()
+            .any(|id| id.starts_with("double_check_"))
+    });
 
     let control_path = control_path(&temp, &job_id);
     write_control_file(&control_path, ControlCommand::Pause).expect("pause control should write");
-    wait_for_job_status(&temp, &job_id, "paused");
+    wait_for_child_job_status(&temp, &job_id, "paused", &mut child);
+    // As above, the request may be parked between RequestStarted and the
+    // provider call, in which case RequestFinished correctly cannot appear.
     thread::sleep(Duration::from_millis(3300));
 
     let paused_events = read_jsonl(&events);
@@ -2558,17 +2620,25 @@ fn cli_resume_after_stop_with_persisted_corrections_is_idempotent() {
         &temp,
         &events,
         &output,
-        &[("BOOKFORGE_TEST_FINALIZE_BOUNDARY_DELAY_MS", "1200")],
+        // Correction persistence happens after RequestFinished and before the
+        // next controllable stage boundary. This existing test-only injection
+        // keeps that production-default-free window open long enough to issue
+        // Stop; child-aware waits below still fail immediately on early exit.
+        &[("BOOKFORGE_TEST_FINALIZE_BOUNDARY_DELAY_MS", "3000")],
     );
     let job_id = wait_for_job_id_in_events(&events, &mut child);
-    wait_for_request_finished_prefix(&events, "repair_");
-    wait_for_corrected_block(&temp, &job_id);
+    wait_for_child_events(&events, &mut child, |events| {
+        request_finished_ids(events)
+            .iter()
+            .any(|id| id.starts_with("repair_"))
+    });
+    wait_for_child_corrected_block(&temp, &job_id, &mut child);
 
     write_control_file(&control_path(&temp, &job_id), ControlCommand::Stop)
         .expect("stop control should write");
     let status = child.wait().expect("translate child should exit");
     assert!(status.success(), "translate child failed: {status}");
-    wait_for_job_status(&temp, &job_id, "stopped");
+    assert_eq!(job_status(&temp, &job_id), "stopped");
 
     let resume_events = temp.path().join("finalize-correction-resume-events.jsonl");
     bookforge()
@@ -3260,22 +3330,6 @@ fn spawn_gated_single_mock_translate(
     )
 }
 
-fn spawn_finalize_controlled_mock_translate(
-    temp: &TempDir,
-    events: &Path,
-    output: &Path,
-) -> ChildGuard {
-    spawn_finalize_stage_delay_mock_translate(
-        temp,
-        events,
-        output,
-        &[
-            ("BOOKFORGE_MOCK_DELAY_MS", "300"),
-            ("BOOKFORGE_TEST_FINALIZE_BOUNDARY_DELAY_MS", "600"),
-        ],
-    )
-}
-
 fn spawn_finalize_stage_delay_mock_translate(
     temp: &TempDir,
     events: &Path,
@@ -3453,22 +3507,6 @@ fn wait_for_event_count(path: &Path, key: &str, min_count: usize) -> Vec<serde_j
     wait_for_events(path, |events| event_count(events, key) >= min_count)
 }
 
-fn wait_for_request_started_prefix(path: &Path, prefix: &str) -> Vec<serde_json::Value> {
-    wait_for_events(path, |events| {
-        request_started_ids(events)
-            .iter()
-            .any(|id| id.starts_with(prefix))
-    })
-}
-
-fn wait_for_request_finished_prefix(path: &Path, prefix: &str) -> Vec<serde_json::Value> {
-    wait_for_events(path, |events| {
-        request_finished_ids(events)
-            .iter()
-            .any(|id| id.starts_with(prefix))
-    })
-}
-
 fn wait_for_events(
     path: &Path,
     ready: impl FnMut(&[serde_json::Value]) -> bool,
@@ -3506,6 +3544,55 @@ fn wait_for_child_events(
             panic!(
                 "translate child exited with {status} before expected events appeared in {}",
                 path.display()
+            );
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_child_job_status(
+    temp: &TempDir,
+    job_id: &str,
+    expected: &str,
+    child: &mut process::Child,
+) {
+    // Status is the readiness signal. A wall-clock deadline would turn a
+    // runnable-but-unscheduled worker into a false failure, so only premature
+    // child exit terminates the wait.
+    let db = temp.path().join(".bookforge/jobs.sqlite");
+    loop {
+        let mut actual = None;
+        if db.exists()
+            && let Ok(store) = JobStore::open(&db)
+            && let Ok(Some(job)) = store.get_job(job_id)
+        {
+            if job.status == expected {
+                return;
+            }
+            actual = Some(job.status);
+        }
+        if let Some(status) = child.try_wait().expect("child exit status should poll") {
+            panic!(
+                "translate child exited with {status} before job {job_id} reached status \
+                 {expected}; actual={actual:?}"
+            );
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_child_corrected_block(temp: &TempDir, job_id: &str, child: &mut process::Child) {
+    loop {
+        if stored_block_texts(temp, job_id)
+            .iter()
+            .any(|text| text.contains("[corrected]"))
+        {
+            return;
+        }
+        if let Some(status) = child.try_wait().expect("child exit status should poll") {
+            panic!(
+                "translate child exited with {status} before corrected block was stored for job \
+                 {job_id}"
             );
         }
         thread::sleep(Duration::from_millis(25));
@@ -3587,23 +3674,6 @@ fn job_status(temp: &TempDir, job_id: &str) -> String {
         .expect("job should load")
         .expect("job should exist")
         .status
-}
-
-fn wait_for_corrected_block(temp: &TempDir, job_id: &str) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        if stored_block_texts(temp, job_id)
-            .iter()
-            .any(|text| text.contains("[corrected]"))
-        {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for corrected block in job {job_id}"
-        );
-        thread::sleep(Duration::from_millis(25));
-    }
 }
 
 fn wait_for_review_or_failed_segments(temp: &TempDir, job_id: &str) {


### PR DESCRIPTION
Three lifecycle tests failed intermittently under full-suite parallel load while passing reliably in isolation.

CPU contention let short mock/provider windows close while a separate control CLI was runnable but unscheduled. Every symptom looked like a product bug and none were: reconfigure arriving after the job had already succeeded, double-check dispatching before the override watcher applied the sidecar, Stop arriving after all translatable work finished, resume finding no revision-1 work left.

## Fix: observable synchronisation, not longer sleeps

- Release-file gates hold in-flight provider work until Stop/Pause setup completes.
- Reconfigure tests wait for `RuntimeConfigChanged`, not merely for sidecar creation.
- The finalize test parks the later stage boundary with Pause, applies revision 1, then resumes.
- Status and correction waits watch for premature child exit instead of failing an alive-but-unscheduled child after ten seconds.

Production defaults unchanged. One test-only boundary injection moved 1.2s → 3s, because correction persistence has no later signal before the next boundary.

## Measured

| | before | after |
| --- | --- | --- |
| lifecycle binary, stressed | 6/20 clean | **20/20 clean** |
| the three named tests | failing | 20/20 each |
| stressed workspace, 64 threads | — | 3/3 clean |
| stressed workspace, 1 thread | — | 1/1 clean |

## Alternatives rejected with data

- **Serial grouping:** 358.9s against 59–64s at 64 threads, and serialisation cannot prevent ambient starvation anyway.
- **Blanket timeout increases:** those address deadlock; these were missed windows.
- **Port/temp changes:** no shared binding or directory collision exists.

## Two things deliberately not done

- **`dashboard_resume_accepts_and_remembers_replacement_key` was not patched.** Its failure could not be reproduced across 20 runs of the full 234-test binary, and the fixed `127.0.0.1:8765` is only a synthetic Host header with no listener bound. A speculative fix would have been worse than leaving it.
- **No `assert_partial_order` helper.** #74 needed multiset equality plus an ordered projection across two streams; #95 needed happens-before edges within one. A single helper would cover only #95 and would not have prevented #74 or any of the four wall-clock races.

## This does not close the contention class

Verified separately under six busy cores, a **sixth** test outside lifecycle — `control::tests::watcher_publishes_revisioned_runtime_overrides` — failed once in three full-suite runs on this branch. The lifecycle tests targeted here are fixed; the underlying fragility is not eliminated.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **937 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)