### PR TITLE
Price the models the comparison actually used, at current rates

### DIFF
--- a/crates/bookforge-cli/pricing/providers.json
+++ b/crates/bookforge-cli/pricing/providers.json
@@ -14,6 +14,46 @@
           "output_per_million_usd": 15.00,
           "input_cache_per_million_usd": 0.30
         },
+        "x-ai/grok-4.20": {
+          "input_per_million_usd": 1.25,
+          "output_per_million_usd": 2.50,
+          "input_cache_per_million_usd": 0.20
+        },
+        "x-ai/grok-4.5": {
+          "input_per_million_usd": 2.00,
+          "output_per_million_usd": 6.00,
+          "input_cache_per_million_usd": 0.30
+        },
+        "openai/gpt-5.1": {
+          "input_per_million_usd": 1.25,
+          "output_per_million_usd": 10.00,
+          "input_cache_per_million_usd": 0.125
+        },
+        "openai/gpt-5.6-luna": {
+          "input_per_million_usd": 0.10,
+          "output_per_million_usd": 0.60,
+          "input_cache_per_million_usd": 0.01
+        },
+        "openai/gpt-5.6-terra": {
+          "input_per_million_usd": 1.00,
+          "output_per_million_usd": 6.00,
+          "input_cache_per_million_usd": 0.10
+        },
+        "anthropic/claude-opus-5": {
+          "input_per_million_usd": 5.00,
+          "output_per_million_usd": 25.00,
+          "input_cache_per_million_usd": 0.50
+        },
+        "anthropic/claude-sonnet-5": {
+          "input_per_million_usd": 2.00,
+          "output_per_million_usd": 10.00,
+          "input_cache_per_million_usd": 0.20
+        },
+        "anthropic/claude-fable-5": {
+          "input_per_million_usd": 10.00,
+          "output_per_million_usd": 50.00,
+          "input_cache_per_million_usd": 1.00
+        },
         "google/gemini-2.5-flash-lite": {
           "input_per_million_usd": 0.075,
           "output_per_million_usd": 0.30,

--- a/pricing/providers.json
+++ b/pricing/providers.json
@@ -14,6 +14,46 @@
           "output_per_million_usd": 15.00,
           "input_cache_per_million_usd": 0.30
         },
+        "x-ai/grok-4.20": {
+          "input_per_million_usd": 1.25,
+          "output_per_million_usd": 2.50,
+          "input_cache_per_million_usd": 0.20
+        },
+        "x-ai/grok-4.5": {
+          "input_per_million_usd": 2.00,
+          "output_per_million_usd": 6.00,
+          "input_cache_per_million_usd": 0.30
+        },
+        "openai/gpt-5.1": {
+          "input_per_million_usd": 1.25,
+          "output_per_million_usd": 10.00,
+          "input_cache_per_million_usd": 0.125
+        },
+        "openai/gpt-5.6-luna": {
+          "input_per_million_usd": 0.10,
+          "output_per_million_usd": 0.60,
+          "input_cache_per_million_usd": 0.01
+        },
+        "openai/gpt-5.6-terra": {
+          "input_per_million_usd": 1.00,
+          "output_per_million_usd": 6.00,
+          "input_cache_per_million_usd": 0.10
+        },
+        "anthropic/claude-opus-5": {
+          "input_per_million_usd": 5.00,
+          "output_per_million_usd": 25.00,
+          "input_cache_per_million_usd": 0.50
+        },
+        "anthropic/claude-sonnet-5": {
+          "input_per_million_usd": 2.00,
+          "output_per_million_usd": 10.00,
+          "input_cache_per_million_usd": 0.20
+        },
+        "anthropic/claude-fable-5": {
+          "input_per_million_usd": 10.00,
+          "output_per_million_usd": 50.00,
+          "input_cache_per_million_usd": 1.00
+        },
         "google/gemini-2.5-flash-lite": {
           "input_per_million_usd": 0.075,
           "output_per_million_usd": 0.30,


### PR DESCRIPTION
The five-way model comparison and the judge calibration both ran against models **absent from the bundled catalog**, so `estimate` and the per-run cost line reported `unavailable for this provider/model` — for exactly the expensive models where a budget matters.

Adds `grok-4.20`, `grok-4.5`, `gpt-5.1`, `gpt-5.6-luna`, `gpt-5.6-terra`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`.

## Two rates moved sharply since the comparison ran

```
gpt-5.6-luna    0.50 / 3.00  ->  0.10 / 0.60   (5x cheaper)
gpt-5.6-terra   1.25 / 7.50  ->  1.00 / 6.00
```

This has a real consequence for guidance. **Luna is now cheaper than `deepseek-v4-flash` on input** (0.10 against 0.14) and only ~2× on output.

`docs/model-selection.md` currently recommends Flash for bulk work on the strength of a **25× price gap that no longer exists** — the gap is now roughly 5×, while Luna measured *significantly better* on hard defects (p=0.012, and notably 5 `content_dropped` findings against Flash's 17). That doc needs revisiting against these rates, tracked separately.

## Notes

Both catalog copies are updated together, since a test asserts they are byte-identical.

A catalog price is a **ceiling, not the charge**. One model billed at 41% of its listed rate during the comparison, because OpenRouter routes to several upstream providers at different prices. Verify against the provider dashboard before trusting an estimate.

## Verification

`fmt` clean, **937 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)