### PR TITLE
Estimate tokens from the script of the text, not from whitespace

### DIFF
--- a/crates/bookforge-cli/examples/judge_translation.rs
+++ b/crates/bookforge-cli/examples/judge_translation.rs
@@ -49,8 +49,8 @@ use sha2::{Digest, Sha256};
 
 /// Prompt changes must invalidate the content-addressed cache.
 const PROMPT_VERSION: &str = "judge_translation/v1";
-const OUTPUT_SCHEMA_VERSION: u32 = 1;
-const SUMMARY_SCHEMA_VERSION: u32 = 1;
+const OUTPUT_SCHEMA_VERSION: u32 = 2;
+const SUMMARY_SCHEMA_VERSION: u32 = 2;
 const DEFAULT_SEED: u64 = 0xB00F_0A6E_2026_0729;
 const MAX_JUDGE_RESPONSE_BYTES: usize = 128 * 1024;
 const EMBEDDED_PRICING: &str = include_str!("../pricing/providers.json");
@@ -74,7 +74,7 @@ const ALL_CATEGORIES: [DefectCategory; 6] = [
     about = "Measure passage-level translation defects (dev-time tooling only)",
     long_about = "Builds contiguous passage-sized units from translated blocks in a throwaway \
                   copy of the BookForge job store, asks a judge to enumerate fixed defect \
-                  categories, and reports defects per 1,000 source words. Start with --dry-run."
+                  categories, and reports defects per 1,000 source characters. Start with --dry-run."
 )]
 struct Args {
     /// Path to the owner's job store. It is copied before JobStore::open.
@@ -264,7 +264,6 @@ struct PassageRecord {
     source_language: String,
     target_language: String,
     source_chars: usize,
-    source_words: usize,
     status: RecordStatus,
     defects: Vec<Defect>,
     raw_defect_count: usize,
@@ -283,7 +282,7 @@ struct PassageRecord {
 struct CategoryMetric {
     category: DefectCategory,
     count: usize,
-    per_1k_source_words: f64,
+    per_1k_source_chars: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -291,7 +290,7 @@ struct CategoryMetric {
 struct GroupMetric {
     group: DefectGroup,
     count: usize,
-    per_1k_source_words: f64,
+    per_1k_source_chars: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -299,7 +298,7 @@ struct GroupMetric {
 struct CategoryDelta {
     category: DefectCategory,
     count_delta: i64,
-    per_1k_source_words_delta: f64,
+    per_1k_source_chars_delta: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -322,7 +321,7 @@ struct QualitySummary {
     passages_available: usize,
     passages_sampled: usize,
     passages_judged: usize,
-    source_words_judged: usize,
+    source_chars_judged: usize,
     unparseable_responses: usize,
     request_errors: usize,
     dropped_defects: usize,
@@ -374,7 +373,6 @@ struct Passage {
     source_text: String,
     translated_text: String,
     source_chars: usize,
-    source_words: usize,
 }
 
 /// Assemble a greedy contiguous run. The next block starts a new passage when
@@ -450,7 +448,6 @@ fn push_passage(passages: &mut Vec<Passage>, blocks: &[EvaluationBlock]) {
             .iter()
             .map(|block| block.source_text.chars().count())
             .sum(),
-        source_words: source_text.split_whitespace().count(),
         source_text,
         translated_text,
     });
@@ -1346,7 +1343,7 @@ fn load_pricing(path: Option<&Path>) -> Result<PricingCatalog> {
 }
 
 fn estimate_tokens(text: &str) -> u64 {
-    text.chars().count().div_ceil(4) as u64
+    bookforge_core::segment::estimate_tokens(text) as u64
 }
 
 // ---------------------------------------------------------------------------
@@ -1484,7 +1481,6 @@ fn passage_record(
         source_language: passage.source_language.clone(),
         target_language: passage.target_language.clone(),
         source_chars: passage.source_chars,
-        source_words: passage.source_words,
         status,
         defects,
         raw_defect_count,
@@ -1515,9 +1511,9 @@ fn build_summary(
         .iter()
         .filter(|record| record.status == RecordStatus::Parsed)
         .collect::<Vec<_>>();
-    let source_words_judged = parsed
+    let source_chars_judged = parsed
         .iter()
-        .map(|record| record.source_words)
+        .map(|record| record.source_chars)
         .sum::<usize>();
     let mut counts = BTreeMap::<DefectCategory, usize>::new();
     for record in &parsed {
@@ -1532,7 +1528,7 @@ fn build_summary(
             CategoryMetric {
                 category: *category,
                 count,
-                per_1k_source_words: rate_per_1k(count, source_words_judged),
+                per_1k_source_chars: rate_per_1k(count, source_chars_judged),
             }
         })
         .collect::<Vec<_>>();
@@ -1547,7 +1543,7 @@ fn build_summary(
             GroupMetric {
                 group: *group,
                 count,
-                per_1k_source_words: rate_per_1k(count, source_words_judged),
+                per_1k_source_chars: rate_per_1k(count, source_chars_judged),
             }
         })
         .collect();
@@ -1575,7 +1571,7 @@ fn build_summary(
         passages_available,
         passages_sampled: run.records.len(),
         passages_judged: parsed.len(),
-        source_words_judged,
+        source_chars_judged,
         unparseable_responses: run
             .records
             .iter()
@@ -1598,11 +1594,11 @@ fn build_summary(
     }
 }
 
-fn rate_per_1k(count: usize, source_words: usize) -> f64 {
-    if source_words == 0 {
+fn rate_per_1k(count: usize, source_chars: usize) -> f64 {
+    if source_chars == 0 {
         0.0
     } else {
-        count as f64 * 1_000.0 / source_words as f64
+        count as f64 * 1_000.0 / source_chars as f64
     }
 }
 
@@ -1621,8 +1617,8 @@ fn compute_baseline_delta(current: &QualitySummary, baseline: &QualitySummary) -
                 category: metric.category,
                 count_delta: metric.count as i64
                     - baseline_metric.map_or(0, |baseline| baseline.count as i64),
-                per_1k_source_words_delta: metric.per_1k_source_words
-                    - baseline_metric.map_or(0.0, |baseline| baseline.per_1k_source_words),
+                per_1k_source_chars_delta: metric.per_1k_source_chars
+                    - baseline_metric.map_or(0.0, |baseline| baseline.per_1k_source_chars),
             }
         })
         .collect();
@@ -1667,7 +1663,7 @@ fn print_human_report(summary: &QualitySummary, corpus: &CorpusStats, owner_db: 
         "passages           : {} available, {} sampled, {} judged",
         summary.passages_available, summary.passages_sampled, summary.passages_judged
     );
-    println!("source words (n)   : {}", summary.source_words_judged);
+    println!("source chars (n)   : {}", summary.source_chars_judged);
     println!(
         "unparseable/errors : {}/{}",
         summary.unparseable_responses, summary.request_errors
@@ -1705,24 +1701,24 @@ fn print_human_report(summary: &QualitySummary, corpus: &CorpusStats, owner_db: 
         corpus.blocks_empty_translation
     );
 
-    println!("\ncategory                    count   defects/1k source words");
+    println!("\ncategory                    count   defects/1k source chars");
     println!("----------------------------------------------------------");
     for metric in &summary.categories {
         println!(
             "{:<27} {:>5} {:>25.3}",
             metric.category.as_str(),
             metric.count,
-            metric.per_1k_source_words
+            metric.per_1k_source_chars
         );
     }
-    println!("\ngroup                       count   defects/1k source words");
+    println!("\ngroup                       count   defects/1k source chars");
     println!("----------------------------------------------------------");
     for metric in &summary.groups {
         println!(
             "{:<27} {:>5} {:>25.3}",
             metric.group.as_str(),
             metric.count,
-            metric.per_1k_source_words
+            metric.per_1k_source_chars
         );
     }
     if let Some(delta) = &summary.baseline_delta {
@@ -1737,7 +1733,7 @@ fn print_human_report(summary: &QualitySummary, corpus: &CorpusStats, owner_db: 
                 "{:<27} {:>+11} {:>+12.3}",
                 row.category.as_str(),
                 row.count_delta,
-                row.per_1k_source_words_delta
+                row.per_1k_source_chars_delta
             );
         }
     }
@@ -1755,11 +1751,11 @@ fn print_dry_run(
         let prompt = render_prompt(passage);
         input_tokens += estimate_tokens(&prompt.system) + estimate_tokens(&prompt.user);
         println!(
-            "----- {} / {} [{} blocks, {} source words] -----",
+            "----- {} / {} [{} blocks, {} source chars] -----",
             passage.job_id,
             passage.passage_id,
             passage.block_ids.len(),
-            passage.source_words
+            passage.source_chars
         );
         println!("--- system prompt ---");
         println!("{}", prompt.system);
@@ -1949,13 +1945,12 @@ mod tests {
             source_language: "English".to_string(),
             target_language: "Italian".to_string(),
             source_chars: source.chars().count(),
-            source_words: source.split_whitespace().count(),
             source_text: source,
             translated_text: format!("traduzione numero {index}"),
         }
     }
 
-    fn parsed_record(words: usize, defects: Vec<Defect>) -> PassageRecord {
+    fn parsed_record(source_chars: usize, defects: Vec<Defect>) -> PassageRecord {
         PassageRecord {
             schema_version: OUTPUT_SCHEMA_VERSION,
             prompt_version: PROMPT_VERSION.to_string(),
@@ -1969,8 +1964,7 @@ mod tests {
             block_ids: Vec::new(),
             source_language: "English".to_string(),
             target_language: "Italian".to_string(),
-            source_chars: 0,
-            source_words: words,
+            source_chars,
             status: RecordStatus::Parsed,
             defects,
             raw_defect_count: 0,
@@ -2119,7 +2113,10 @@ mod tests {
         let mut record = parsed_record(10, Vec::new());
         record.seed = 123_456;
         let json = serde_json::to_value(&record).expect("serialize record");
+        assert_eq!(json["schema_version"], 2);
         assert_eq!(json["seed"], 123_456);
+        assert_eq!(json["source_chars"], 10);
+        assert!(json.get("source_words").is_none());
 
         let mut args = test_args();
         args.seed = 123_456;
@@ -2132,11 +2129,15 @@ mod tests {
                 ..RunResult::default()
             },
         );
+        let json = serde_json::to_value(&summary).expect("serialize summary");
+        assert_eq!(json["schema_version"], 2);
+        assert_eq!(json["source_chars_judged"], 10);
+        assert!(json.get("source_words_judged").is_none());
         assert_eq!(summary.seed, 123_456);
     }
 
     #[test]
-    fn rates_use_source_words_and_report_passage_n() {
+    fn rates_use_source_chars_and_report_passage_n() {
         let hard = Defect {
             category: DefectCategory::MeaningChanged,
             source_quote: "a".to_string(),
@@ -2169,13 +2170,13 @@ mod tests {
             .expect("hard group");
 
         assert_eq!(summary.passages_judged, 2);
-        assert_eq!(summary.source_words_judged, 150);
+        assert_eq!(summary.source_chars_judged, 150);
         assert_eq!(summary.dropped_missing_quote, 0);
         assert_eq!(summary.dropped_non_verbatim_quote, 0);
         assert_eq!(summary.dropped_self_refuting, 0);
         assert_eq!(meaning.count, 3);
-        assert!((meaning.per_1k_source_words - 20.0).abs() < f64::EPSILON);
-        assert!((hard_group.per_1k_source_words - 20.0).abs() < f64::EPSILON);
+        assert!((meaning.per_1k_source_chars - 20.0).abs() < f64::EPSILON);
+        assert!((hard_group.per_1k_source_chars - 20.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -2209,7 +2210,7 @@ mod tests {
             .clone_from(&CategoryMetric {
                 category: DefectCategory::ContentDropped,
                 count: 5,
-                per_1k_source_words: 2.5,
+                per_1k_source_chars: 2.5,
             });
         let mut baseline = current.clone();
         baseline.seed = 99;
@@ -2222,7 +2223,7 @@ mod tests {
             .clone_from(&CategoryMetric {
                 category: DefectCategory::ContentDropped,
                 count: 2,
-                per_1k_source_words: 1.25,
+                per_1k_source_chars: 1.25,
             });
 
         let delta = compute_baseline_delta(&current, &baseline);
@@ -2234,7 +2235,7 @@ mod tests {
         assert_eq!(delta.baseline_seed, 99);
         assert_eq!(delta.baseline_passages_judged, 3);
         assert_eq!(dropped.count_delta, 3);
-        assert!((dropped.per_1k_source_words_delta - 1.25).abs() < f64::EPSILON);
+        assert!((dropped.per_1k_source_chars_delta - 1.25).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -24,6 +24,46 @@ pub const SEGMENT_UNIT_NAME: &str = "scheduler_segment";
 /// between marker tokens instead of moving inside the preceding marker.
 pub const INLINE_MARKER_SCHEMA_VERSION: u32 = 4;
 
+const CASED_SCRIPT_CHAR_UNITS_PER_TOKEN: usize = 9;
+const CASED_SCRIPT_CHAR_UNITS_PER_CHAR: usize = 2;
+
+/// Estimate model tokens from the dominant script in `text`.
+///
+/// Unicode case is used as a script-level signal rather than a language name:
+/// alphabetic characters with case (Latin, Cyrillic, Greek, and similar
+/// scripts) use approximately 4.5 characters per token (including spaces),
+/// while predominantly caseless text (Han, Kana, Hangul, Thai, Arabic,
+/// Hebrew, Devanagari, and scripts BookForge has never enumerated) uses one
+/// character per token. Mixed text follows its dominant alphabetic script.
+/// Text without alphabetic evidence keeps the 4.5-character fallback.
+pub fn estimate_tokens(text: &str) -> usize {
+    let mut chars = 0usize;
+    let mut cased = 0usize;
+    let mut caseless = 0usize;
+
+    for ch in text.chars() {
+        chars += 1;
+        if ch.is_alphabetic() {
+            if ch.is_lowercase() || ch.is_uppercase() {
+                cased += 1;
+            } else {
+                caseless += 1;
+            }
+        }
+    }
+
+    if chars == 0 {
+        return 0;
+    }
+    if caseless > cased {
+        chars
+    } else {
+        chars
+            .saturating_mul(CASED_SCRIPT_CHAR_UNITS_PER_CHAR)
+            .div_ceil(CASED_SCRIPT_CHAR_UNITS_PER_TOKEN)
+    }
+}
+
 /// Compute a cache namespace that scopes lookups to a single set of
 /// schema and segmentation parameters. Cached rows from a different
 /// namespace are not eligible for reuse.
@@ -261,7 +301,7 @@ pub fn build_segments(book: &Book, config: &SegmentationConfig) -> Result<Vec<Se
             if matches!(block.kind, BlockKind::Code | BlockKind::PageFurniture) {
                 continue;
             }
-            let block_tokens = block.token_estimate.max(1);
+            let block_tokens = estimate_tokens(&block_text(block)).max(1);
             let should_flush = !current.is_empty()
                 && current_tokens + block_tokens > config.max_segment_tokens
                 && !should_keep_with_previous(&current, block);
@@ -374,7 +414,7 @@ fn push_segment(
 
     let token_estimate = blocks
         .iter()
-        .map(|block| block.token_estimate.max(1))
+        .map(|block| estimate_tokens(&block_text(block)).max(1))
         .sum::<usize>();
 
     let metadata = SegmentMetadata {
@@ -432,7 +472,8 @@ fn should_keep_with_previous(current: &[&Block], next: &Block) -> bool {
         return false;
     };
 
-    matches!(previous.kind, crate::ir::BlockKind::Heading(_)) && next.token_estimate <= 80
+    matches!(previous.kind, crate::ir::BlockKind::Heading(_))
+        && estimate_tokens(&block_text(next)) <= 80
 }
 
 fn block_text(block: &Block) -> String {
@@ -474,6 +515,44 @@ mod tests {
         BlockKind, BookFormat, BookId, DomPath, Metadata, ProtectedSpanKind, Resource, Section,
         SpineItem, TextRun,
     };
+
+    #[test]
+    fn token_estimate_is_derived_from_the_dominant_script() {
+        assert_eq!(estimate_tokens("abcdefgh"), 2);
+        assert_eq!(estimate_tokens("矛盾是普遍存在的"), 8);
+        assert_eq!(
+            estimate_tokens("Project Gutenberg 矛盾是普遍存在的实践是检验真理的标准"),
+            36
+        );
+        assert_eq!(estimate_tokens("1234"), 1);
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn segmentation_recomputes_stale_block_token_estimates() {
+        let mut book = book_with_two_sections();
+        book.blocks[1].text_runs[0].text = "矛盾是普遍存在的".to_string();
+        book.blocks[1].token_estimate = 1;
+        book.blocks[2].text_runs[0].text = "实践是检验真理的标准".to_string();
+        book.blocks[2].token_estimate = 1;
+
+        let segments = build_segments(
+            &book,
+            &SegmentationConfig {
+                max_segment_tokens: 12,
+                context_tokens: 0,
+            },
+        )
+        .expect("segments should build");
+
+        let section_a = segments
+            .iter()
+            .filter(|segment| segment.section_id.0 == "sec_000000")
+            .collect::<Vec<_>>();
+        assert_eq!(section_a.len(), 2);
+        assert_eq!(section_a[0].source.token_estimate, 9);
+        assert_eq!(section_a[1].source.token_estimate, 10);
+    }
 
     #[test]
     fn builds_stable_segments_without_crossing_sections() {

--- a/crates/bookforge-llm/src/batch/planning.rs
+++ b/crates/bookforge-llm/src/batch/planning.rs
@@ -557,11 +557,7 @@ fn mode_target_tokens(base: usize) -> HashMap<BatchMode, usize> {
 }
 
 pub(super) fn token_estimate(text: &str) -> usize {
-    let chars = text.chars().count();
-    if chars == 0 {
-        return 0;
-    }
-    (chars / 4).max(1)
+    bookforge_core::segment::estimate_tokens(text)
 }
 
 fn item_token_estimate(
@@ -859,4 +855,15 @@ fn with_configured_token_estimate(
 ) -> TranslationBatch {
     batch.token_estimate = batch_token_estimate(&batch.items, config);
     batch
+}
+
+#[cfg(test)]
+mod script_estimate_tests {
+    use super::token_estimate;
+
+    #[test]
+    fn caseless_source_text_is_not_divided_by_four() {
+        assert_eq!(token_estimate("矛盾是普遍存在的"), 8);
+        assert_eq!(token_estimate("The quick brown fox."), 5);
+    }
 }

--- a/crates/bookforge-llm/src/provider.rs
+++ b/crates/bookforge-llm/src/provider.rs
@@ -680,7 +680,7 @@ fn extract_plain_source(user_prompt: &str) -> Option<String> {
 }
 
 fn estimate_tokens(text: &str) -> u64 {
-    text.split_whitespace().count().max(1) as u64
+    bookforge_core::segment::estimate_tokens(text).max(1) as u64
 }
 
 fn cached_input_tokens(raw: &Value) -> Option<u64> {
@@ -1413,6 +1413,13 @@ mod tests {
     use super::*;
     use bookforge_core::RetryAfterPolicy;
     use tokio::time::Duration;
+
+    #[test]
+    fn offline_usage_estimate_is_script_aware() {
+        assert_eq!(estimate_tokens("矛盾是普遍存在的"), 8);
+        assert_eq!(estimate_tokens("The quick brown fox."), 5);
+        assert_eq!(estimate_tokens(""), 1);
+    }
 
     fn offline_provider(base_url: &str, model: &str) -> OpenAiCompatibleProvider {
         offline_provider_with_key(base_url, "BOOKFORGE_OFFLINE_TEST_API_KEY", model)

--- a/docs/SEGMENTATION.md
+++ b/docs/SEGMENTATION.md
@@ -6,7 +6,9 @@ Segments are stable, bounded translation units derived from the document IR. A s
 
 The EPUB reader emits blocks for headings, paragraphs, list items, quotes, table cells/rows, captions, footnotes, and addressable stray text nodes. `pre` and `code` content becomes `BlockKind::Code`; those blocks remain in the rebuilt EPUB but are not sent to the model.
 
-Each block has a stable section id, block id, DOM path, ordinal, text runs, inline markers, protected spans, and token estimate. Inline EPUB structure is represented in the source prose with short per-block markers:
+Each block has a stable section id, block id, DOM path, ordinal, text runs, inline markers, protected spans, and token estimate. Before grouping, segment construction recomputes the estimate from the text instead of trusting a reader-supplied value. The estimator derives the dominant script from Unicode case evidence: cased-dominant text uses approximately 4.5 characters per token including spaces, while caseless-dominant text uses approximately one. This covers CJK and other caseless scripts without a language-name list or reliance on `--source-lang`.
+
+Inline EPUB structure is represented in the source prose with short per-block markers:
 
 ```text
 Hello <m1>formatted</m1> text <r1/> here.
@@ -16,7 +18,7 @@ Paired inline elements use `<mN>...</mN>`. Empty inline elements use `<rN/>`. Le
 
 ## Segment Construction
 
-`bookforge-core::segment::build_segments` walks blocks in book order and groups them under the configured token budget. Segments do not cross section/resource boundaries. Short headings can be grouped with the following block when they fit.
+`bookforge-core::segment::build_segments` walks blocks in book order and groups them under the configured token budget. Segments do not cross section/resource boundaries. Short headings can be grouped with the following block when they fit. The same script-derived estimate is used later for provider request batching and offline mock-provider usage, so segment and batch budgets use one unit.
 
 The translation profile supplies that token budget. `bookforge translate` and `bookforge estimate` both default to `v1-fast` (currently 12,000 maximum source tokens per scheduler segment), and explicit `--profile`, `--max-segment-tokens`, and `--context-tokens` estimate options follow translation's precedence. Provider request batching happens after segmentation: a request may contain several scheduler segments, but it does not create or remove job-store segment rows.
 

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -74,12 +74,18 @@ Two budgeting traps:
 
 ### Quality — reported, not ranked
 
+> **Legacy unit; rerun required.** These quality results were recorded with
+> `judge_translation` summary schema 1 and normalize by whitespace-delimited
+> source words. Current schema 2 reports defects per 1,000 Unicode source
+> characters so caseless scripts have a valid denominator. The rates below are
+> historical only and are not comparable with new benchmark summaries.
+
 Judged on the passages common to every arm, so exposure is equal. Under
 `deepseek-v4-pro` (38 passages, 4,253 words), ordered by residual hard defects
 after removing wordplay-handling complaints and the judge's own self-refuting
 findings:
 
-| model | residual | hard/1k | soft/1k |
+| model | residual | legacy hard/1k words | legacy soft/1k words |
 | --- | --- | --- | --- |
 | `x-ai/grok-4.5` | 35 | 12.5 | 5.4 |
 | `anthropic/claude-fable-5` | 50 | 13.4 | 1.4 |

--- a/docs/validator-tooling.md
+++ b/docs/validator-tooling.md
@@ -219,10 +219,11 @@ Important measurement rules:
   self-refutations, and it deliberately keeps some fully dismissive
   explanations that happen to use a contrast word. Those are false negatives;
   the rule is biased against silently dropping a genuine mixed complaint.
-- Counts and defects per 1,000 source words are reported for every category.
+- Counts and defects per 1,000 Unicode source characters are reported for every category.
   The three hard categories and three soft categories are also reported as
-  separate groups. There is intentionally no combined headline score.
-- Unparseable output is recorded once and excluded from the word/rate
+  separate groups. Character exposure is deterministic for both spaced and
+  caseless scripts; there is intentionally no combined headline score.
+- Unparseable output is recorded once and excluded from the character/rate
   denominator. It is never sent to a repair model. Request failures are also
   recorded rather than converted into zero-defect passages.
 - The default judge output cap is 4,096 tokens. This is intentionally generous:
@@ -238,6 +239,11 @@ Important measurement rules:
 
 ### What this measured, 2026-07-29
 
+> **Legacy unit.** The measurements in this section predate summary schema 2
+> and use whitespace-delimited source words. They are retained as historical
+> context, but their `/1k` rates cannot be compared with current
+> character-normalized output. Re-run the benchmark to establish replacement figures.
+
 First real run. Corpus: `If We Burn`, English→Italian, deepseek-v4-flash,
 133/133 segments complete — chosen deliberately over the larger Lenin jobs,
 which are PDF conversions where ~29% of validator false positives were traced
@@ -245,7 +251,7 @@ to OCR damage in the *source*. Judging those measures the scanner.
 
 25 passages, one seed, two judges:
 
-| | judged | source words | hard/1k | soft/1k |
+| | judged | legacy source words | hard/1k words | soft/1k words |
 | --- | --- | --- | --- | --- |
 | Kimi K3, 4k cap | 15/25 | 2,845 | 4.57 | 4.57 |
 | Kimi K3, 16k cap | 23/25 | 4,348 | 5.06 | 3.91 |
@@ -695,8 +701,8 @@ line, for example:
 Bulk acceptance: accepted=37 skipped-empty=1 skipped-model-rejected=2.
 ```
 
-Compare the `hard` group's `per_1k_source_words` in the two summary files.
-Also require equal `passages_judged` and `source_words_judged` before treating
+Compare the `hard` group's `per_1k_source_chars` in the two summary files.
+Also require equal `passages_judged` and `source_chars_judged` before treating
 the rates as a paired comparison. Use the same judge, output cap, passage size,
 and sample/seed for both jobs; `--sample 0` above removes sampling variance.
 


### PR DESCRIPTION
Whitespace word counting broke three separate things for languages without inter-word spaces. Measured on `tests/矛盾论_毛泽东` (*On Contradiction*, 27,412 characters).

## 1. `estimate` under-reported by 84×

`provider.rs::estimate_tokens` was `split_whitespace().count()`. It predicted **446** input tokens for a book that consumed **37,362**.

## 2. Batch planning under-counted, and the oversized requests failed

`planning.rs::token_estimate` was `chars / 4` — about right for English, roughly **4× low** for Chinese where a character is near one token. With default batching:

| model | outcome |
| --- | --- |
| `deepseek-v4-flash` | **61 of 211 blocks** — 71% of the book silently lost to decode failures |
| `gpt-5.6-luna` | output-cap truncation on 2 segments |

Re-running at `--batch-target-tokens 800 --batch-max-items 4` recovered Flash **completely** — which is what proved the planner was mis-sizing rather than the model being weak.

## 3. The quality benchmark could not measure these languages at all

It reported **796.7 hard defects per 1,000 source words** — 145 defects over "182 words" of a 27,412-character book.

## The fix

Estimation now derives from the **dominant script of the text itself**, following the precedent set by `candidate_extraction_strategy` in #97: it generalises to languages nobody enumerated and doesn't trust `--source`.

| | before | after | actual |
| --- | --- | --- | --- |
| Chinese | 446 | **28,625** | 37,362 |
| English (control) | 112,313 | 110,553 | — |

The residual Chinese gap is prompt and JSON-envelope overhead the estimate doesn't model, not script error. **The English control moved 1.6%** — this doesn't disturb the case that already worked.

## Benchmark unit changed to characters

`judge_translation` now reports **defects per 1,000 Unicode characters**. Characters are deterministic across scripts and avoid inventing synthetic word boundaries: 145 defects over 27,412 characters is **5.29 per 1,000**, not 796.7.

Passage and summary schemas move to **version 2**, and schema-1 baselines are **rejected** rather than silently compared — word rates and character rates cannot be subtracted. Historical figures in `validator-tooling.md` and `model-selection.md` are marked legacy and non-comparable pending re-runs.

## Whitespace callers deliberately left alone

`validation.rs` and `double_check.rs` keep theirs, with reasons: `source_web_words` isolates whitespace-delimited URL tokens rather than measuring prose length; protected-span remainder splitting compares exact literal fragments; and both `normalized_prose` functions canonicalise whitespace for equality rather than counting.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **941 passed / 0 failed / 3 ignored**. Estimation is offline — no provider calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)