### PR TITLE
Let `translate --plan` apply the enabler's recommendations

### DIFF
--- a/crates/bookforge-cli/src/commands/plan.rs
+++ b/crates/bookforge-cli/src/commands/plan.rs
@@ -12,7 +12,7 @@ use bookforge_llm::{BatchMode, TranslationBatch, build_translation_batches};
 use clap::Args;
 use serde::Serialize;
 
-const PLAN_SCHEMA_VERSION: u32 = 1;
+pub(crate) const PLAN_SCHEMA_VERSION: u32 = 1;
 // The smallest measured oversized-response failures needed about 9,000 output
 // tokens. Use the power-of-two boundary immediately below that observed cliff.
 const SAFE_RESPONSE_TOKENS: u32 = 8_192;
@@ -212,7 +212,10 @@ fn create_plan(
     )?)
 }
 
-fn plan_book(
+/// Build the same deterministic, offline plan used by the `plan` command from
+/// an EPUB that has already been parsed. Integrated callers can therefore
+/// reuse the in-memory book instead of parsing the archive a second time.
+pub(crate) fn plan_book(
     book: &Book,
     input: &Path,
     declared_source: Option<&str>,

--- a/crates/bookforge-cli/src/commands/translate/args.rs
+++ b/crates/bookforge-cli/src/commands/translate/args.rs
@@ -15,6 +15,10 @@ use crate::{LanguageArgs, ProviderArgs as CliProviderArgs, QaMode, progress::UiM
 pub struct TranslateArgs {
     pub input: PathBuf,
 
+    /// Inspect the EPUB and fill unset translation settings from the offline plan.
+    #[arg(long, default_value_t = false)]
+    pub plan: bool,
+
     #[command(flatten)]
     pub language: LanguageArgs,
 

--- a/crates/bookforge-cli/src/commands/translate/mod.rs
+++ b/crates/bookforge-cli/src/commands/translate/mod.rs
@@ -72,7 +72,10 @@ use orchestration::human_stdout_enabled;
 pub use orchestration::run;
 use reporting::print_summary_rebuild_and_report;
 pub(crate) use reporting::{rebuild_options_from_snapshot, regenerate_report_after_correction};
-use settings::{apply_provider_preset, resolve_settings, retry_amplification_warning};
+use settings::{
+    apply_plan_recommendations, apply_provider_preset, resolve_settings,
+    retry_amplification_warning,
+};
 use snapshot::persist_snapshot;
 
 #[derive(Debug, Clone)]

--- a/crates/bookforge-cli/src/commands/translate/orchestration.rs
+++ b/crates/bookforge-cli/src/commands/translate/orchestration.rs
@@ -4,10 +4,9 @@ pub async fn run(
     args: TranslateArgs,
     cancel_token: tokio_util::sync::CancellationToken,
 ) -> Result<()> {
-    let settings = resolve_settings(&args);
-
     // Apply provider preset if specified (before explicit CLI overrides)
     let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
+    let (settings, plan_application) = resolve_settings_and_plan(&args, &effective_provider)?;
 
     let output = args
         .out
@@ -64,6 +63,7 @@ pub async fn run(
                     &effective_provider,
                     &args,
                     &settings,
+                    plan_application,
                     &cancel_token,
                     progress_sink,
                 )
@@ -76,6 +76,7 @@ pub async fn run(
                     &effective_provider,
                     &args,
                     &settings,
+                    plan_application,
                     &cancel_token,
                     progress_sink,
                 )
@@ -89,6 +90,33 @@ pub async fn run(
     .await;
 
     finalize_reporter(run_result, reporter).await
+}
+
+pub(super) struct PlanApplication {
+    pub(super) book: bookforge_core::ir::Book,
+    pub(super) applied_plan: bookforge_core::run_snapshot::AppliedPlanSnapshot,
+}
+
+pub(super) fn resolve_settings_and_plan(
+    args: &TranslateArgs,
+    effective_provider: &CliProviderArgs,
+) -> Result<(ResolvedRunSettings, Option<PlanApplication>)> {
+    let mut settings = resolve_settings(args);
+    if !args.plan {
+        return Ok((settings, None));
+    }
+
+    let book = read_epub(&args.input)?;
+    let plan = crate::commands::plan::plan_book(
+        &book,
+        &args.input,
+        args.language.source.as_deref(),
+        &args.language.target,
+        &effective_provider.provider,
+        effective_provider.model.as_deref(),
+    )?;
+    let applied_plan = apply_plan_recommendations(args, &mut settings, &plan);
+    Ok((settings, Some(PlanApplication { book, applied_plan })))
 }
 
 pub(super) fn human_stdout_enabled(ui: crate::progress::UiMode) -> bool {
@@ -117,12 +145,14 @@ async fn finalize_reporter<T>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_mock_translation(
     input: &PathBuf,
     config: &TranslationConfig,
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    plan_application: Option<PlanApplication>,
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
@@ -132,6 +162,7 @@ async fn run_mock_translation(
         provider_args,
         cli_args,
         settings,
+        plan_application,
         cancel_token,
         progress,
         None,
@@ -146,6 +177,7 @@ pub(super) async fn run_mock_translation_with_store(
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    plan_application: Option<PlanApplication>,
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
     store: Option<JobStore>,
@@ -161,6 +193,7 @@ pub(super) async fn run_mock_translation_with_store(
         provider_args,
         cli_args,
         settings,
+        plan_application,
         ProviderRun {
             provider,
             model,
@@ -183,12 +216,14 @@ pub(super) async fn run_mock_translation_with_store(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_openai_compatible_translation(
     input: &PathBuf,
     config: &TranslationConfig,
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    plan_application: Option<PlanApplication>,
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
 ) -> Result<()> {
@@ -198,6 +233,7 @@ async fn run_openai_compatible_translation(
         provider_args,
         cli_args,
         settings,
+        plan_application,
         cancel_token,
         progress,
         None,
@@ -212,6 +248,7 @@ pub(super) async fn run_openai_compatible_translation_with_store(
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    plan_application: Option<PlanApplication>,
     cancel_token: &tokio_util::sync::CancellationToken,
     progress: Arc<dyn bookforge_core::ProgressSink>,
     store: Option<JobStore>,
@@ -265,6 +302,7 @@ pub(super) async fn run_openai_compatible_translation_with_store(
         provider_args,
         cli_args,
         settings,
+        plan_application,
         ProviderRun {
             provider,
             model,
@@ -307,6 +345,7 @@ async fn run_translation_with_store<P>(
     provider_args: &CliProviderArgs,
     cli_args: &TranslateArgs,
     settings: &ResolvedRunSettings,
+    plan_application: Option<PlanApplication>,
     provider_run: ProviderRun<P>,
     progress: Arc<dyn bookforge_core::ProgressSink>,
     store: Option<JobStore>,
@@ -319,7 +358,10 @@ where
         stage: "read_epub".to_string(),
         timestamp_ms: bookforge_core::progress::now_ms(),
     });
-    let book = read_epub(input)?;
+    let (book, applied_plan) = match plan_application {
+        Some(application) => (application.book, Some(application.applied_plan)),
+        None => (read_epub(input)?, None),
+    };
     progress.emit(bookforge_core::ProgressEvent::StageFinished {
         stage: "read_epub".to_string(),
         timestamp_ms: bookforge_core::progress::now_ms(),
@@ -436,6 +478,7 @@ where
         &provider_run.model,
         provider_run.base_url.clone(),
         provider_run.api_key_env.clone(),
+        applied_plan.as_ref(),
     )?;
     let rebuild_options = rebuild_options_from_snapshot(&snapshot);
     store.insert_segments(

--- a/crates/bookforge-cli/src/commands/translate/settings.rs
+++ b/crates/bookforge-cli/src/commands/translate/settings.rs
@@ -1,8 +1,12 @@
-use bookforge_core::config::{DoubleCheckMode, ResolvedRunSettings, TranslationProfile};
+use bookforge_core::{
+    config::{DoubleCheckMode, ResolvedRunSettings, TranslationProfile},
+    run_snapshot::{AppliedPlanDecisionSnapshot, AppliedPlanSnapshot},
+};
 
 use crate::ProviderArgs as CliProviderArgs;
 
 use super::TranslateArgs;
+use crate::commands::plan::{Disposition, Plan};
 
 pub fn apply_provider_preset(
     explicit: &CliProviderArgs,
@@ -131,6 +135,96 @@ pub fn resolve_settings(args: &TranslateArgs) -> ResolvedRunSettings {
     }
 
     settings
+}
+
+/// Apply the actionable parts of an offline plan after profile, target-policy,
+/// and provider-preset defaults have resolved. Direct setting flags are tested
+/// field by field and always retain precedence.
+pub fn apply_plan_recommendations(
+    args: &TranslateArgs,
+    settings: &mut ResolvedRunSettings,
+    plan: &Plan,
+) -> AppliedPlanSnapshot {
+    let recommendations = &plan.recommendations;
+    let mut decisions = Vec::new();
+
+    if args.batch_target_tokens.is_none()
+        && recommendations.batch_target_tokens.disposition == Disposition::Set
+        && settings.batch.target_tokens != recommendations.batch_target_tokens.value
+    {
+        settings.batch.target_tokens = recommendations.batch_target_tokens.value;
+        push_plan_decision(
+            &mut decisions,
+            "batch_target_tokens",
+            recommendations.batch_target_tokens.value,
+            &recommendations.batch_target_tokens.reason,
+        );
+    }
+    if args.batch_max_items.is_none()
+        && recommendations.batch_max_items.disposition == Disposition::Set
+        && settings.batch.max_items != recommendations.batch_max_items.value
+    {
+        settings.batch.max_items = recommendations.batch_max_items.value;
+        push_plan_decision(
+            &mut decisions,
+            "batch_max_items",
+            recommendations.batch_max_items.value,
+            &recommendations.batch_max_items.reason,
+        );
+    }
+    if args.batch_max_output_tokens.is_none()
+        && let Some(value) = recommendations.batch_max_output_tokens.value
+        && settings.provider.batch_max_output_tokens != Some(value)
+    {
+        settings.provider.batch_max_output_tokens = Some(value);
+        push_plan_decision(
+            &mut decisions,
+            "batch_max_output_tokens",
+            value,
+            &recommendations.batch_max_output_tokens.reason,
+        );
+    }
+    if args.max_output_tokens.is_none()
+        && settings.provider.max_output_tokens != Some(recommendations.max_output_tokens.value)
+    {
+        settings.provider.max_output_tokens = Some(recommendations.max_output_tokens.value);
+        push_plan_decision(
+            &mut decisions,
+            "max_output_tokens",
+            recommendations.max_output_tokens.value,
+            &recommendations.max_output_tokens.reason,
+        );
+    }
+    if !args.no_thinking
+        && recommendations.no_thinking.value
+        && !settings.provider.thinking_disabled
+    {
+        settings.provider.thinking_disabled = true;
+        push_plan_decision(
+            &mut decisions,
+            "thinking_disabled",
+            true,
+            &recommendations.no_thinking.reason,
+        );
+    }
+
+    AppliedPlanSnapshot {
+        schema_version: plan.schema_version,
+        decisions,
+    }
+}
+
+fn push_plan_decision<T: serde::Serialize>(
+    decisions: &mut Vec<AppliedPlanDecisionSnapshot>,
+    setting: &str,
+    value: T,
+    reason: &str,
+) {
+    decisions.push(AppliedPlanDecisionSnapshot {
+        setting: setting.to_string(),
+        value: serde_json::to_value(value).expect("plan setting values always serialize"),
+        reason: reason.to_string(),
+    });
 }
 
 pub fn retry_amplification_warning(settings: &ResolvedRunSettings) -> Option<String> {

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bookforge_core::{
     FallbackRunConfigSnapshot, FinalizeCheckpointSnapshot, GlossaryTerm, ResolvedRunSettings,
-    ResolvedRunSettingsSnapshot, RunConfigSnapshot,
+    ResolvedRunSettingsSnapshot, RunConfigSnapshot, run_snapshot::AppliedPlanSnapshot,
 };
 use bookforge_store::{JobRecord, JobStore};
 use sha2::{Digest, Sha256};
@@ -41,6 +41,7 @@ pub(crate) fn persist_snapshot(
     model: &str,
     base_url: Option<String>,
     api_key_env: Option<String>,
+    applied_plan: Option<&AppliedPlanSnapshot>,
 ) -> anyhow::Result<RunConfigSnapshot> {
     let reports = report_paths(output);
     let events_path = cli_args
@@ -87,7 +88,10 @@ pub(crate) fn persist_snapshot(
         bilingual_style: cli_args.bilingual_style,
         bilingual_css,
         fallback: fallback_snapshot(cli_args, model),
-        finalize: FinalizeCheckpointSnapshot::default(),
+        finalize: FinalizeCheckpointSnapshot {
+            applied_plan: applied_plan.cloned(),
+            ..FinalizeCheckpointSnapshot::default()
+        },
         qa_mode: cli_args.qa.as_str().to_string(),
         validate_output: cli_args.validate_output,
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),

--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -810,6 +810,20 @@ fn temp_path(name: &str) -> PathBuf {
 }
 
 fn build_translation_fixture(path: &std::path::Path) {
+    build_epub_fixture(path, "en", &["Hello world.".to_string()]);
+}
+
+/// Writes a minimal single-chapter EPUB whose body is `paragraphs`.
+///
+/// The preflight tests need real books rather than in-memory `Book` values,
+/// because the point is to exercise parse -> segmentation -> plan. They must not
+/// reach into `tests/`: that directory is gitignored (it holds the owner's real
+/// books), so anything reading from it passes locally and fails in CI.
+fn build_epub_fixture(path: &std::path::Path, language: &str, paragraphs: &[String]) {
+    let body = paragraphs
+        .iter()
+        .map(|paragraph| format!("<p>{paragraph}</p>"))
+        .collect::<String>();
     let file = fs::File::create(path).expect("fixture EPUB should be creatable");
     let mut zip = zip::ZipWriter::new(file);
     let stored =
@@ -831,27 +845,33 @@ fn build_translation_fixture(path: &std::path::Path) {
     .unwrap();
     zip.start_file("content.opf", deflated).unwrap();
     zip.write_all(
-        br#"<?xml version="1.0" encoding="UTF-8"?>
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:identifier id="uid">orchestration-fixture</dc:identifier>
     <dc:title></dc:title>
-    <dc:language>en</dc:language>
+    <dc:language>{language}</dc:language>
   </metadata>
   <manifest>
     <item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>
   </manifest>
   <spine><itemref idref="chapter"/></spine>
-</package>"#,
+</package>"#
+        )
+        .as_bytes(),
     )
     .unwrap();
     zip.start_file("chapter.xhtml", deflated).unwrap();
     zip.write_all(
-        br#"<?xml version="1.0" encoding="UTF-8"?>
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head><title>Chapter</title></head>
-<body><p>Hello world.</p></body>
-</html>"#,
+<body>{body}</body>
+</html>"#
+        )
+        .as_bytes(),
     )
     .unwrap();
     zip.finish().unwrap();
@@ -1192,27 +1212,51 @@ fn translate_args_with_preset(
     }
 }
 
-fn translation_fixture_path(cyberiad: bool) -> PathBuf {
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .join("tests");
-    if cyberiad {
-        return fixtures.join("The_Cyberiad.epub");
-    }
-    fs::read_dir(&fixtures)
-        .expect("translation fixtures should be readable")
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .find(|path| {
-            path.extension().and_then(|extension| extension.to_str()) == Some("epub")
-                && path.file_name().and_then(|name| name.to_str()) != Some("The_Cyberiad.epub")
+/// A book-shaped EPUB in one of two scripts, for the preflight tests.
+///
+/// Both scripts get the same paragraph count and the same character count per
+/// paragraph, so the only thing that differs between them is the script itself.
+/// That is the variable the plan routes on, and holding the rest equal is what
+/// makes a difference in the resulting settings attributable to it.
+///
+/// The returned `TempDir` owns the file and must stay alive while it is read.
+fn scripted_book_fixture(caseless: bool) -> (tempfile::TempDir, PathBuf) {
+    // Long enough that the plan sees a distribution rather than a single point,
+    // and that the per-paragraph token estimate lands in the range where the
+    // batch bounds actually move.
+    const PARAGRAPHS: usize = 60;
+    const CHARACTERS_PER_PARAGRAPH: usize = 600;
+
+    let (language, sentence) = if caseless {
+        ("zh", "矛盾的普遍性和特殊性的关系是矛盾问题的精髓。")
+    } else {
+        ("en", "The universal and the particular in contradiction. ")
+    };
+    let paragraphs = (0..PARAGRAPHS)
+        .map(|_| {
+            sentence
+                .chars()
+                .cycle()
+                .take(CHARACTERS_PER_PARAGRAPH)
+                .collect::<String>()
         })
-        .expect("CJK EPUB fixture should exist")
+        .collect::<Vec<_>>();
+
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let path = temp.path().join(if caseless {
+        "caseless.epub"
+    } else {
+        "cased.epub"
+    });
+    build_epub_fixture(&path, language, &paragraphs);
+    (temp, path)
 }
 
 #[test]
 fn explicit_batch_flag_beats_plan_while_unset_fields_are_filled() {
+    let (_fixture, input) = scripted_book_fixture(true);
     let mut args = translate_args_with_preset(None);
-    args.input = translation_fixture_path(false);
+    args.input = input;
     args.plan = true;
     args.provider.provider = "mock".to_string();
     args.provider.model = Some("mock-prefix-target".to_string());
@@ -1270,26 +1314,31 @@ fn translate_without_plan_preserves_resolved_settings_bytes() {
 }
 
 #[test]
-fn real_cjk_and_latin_translate_preflights_apply_different_settings() {
-    let planned_settings = |input: PathBuf| {
+fn caseless_and_cased_translate_preflights_apply_different_settings() {
+    let planned_settings = |input: &std::path::Path| {
         let mut args = translate_args_with_preset(None);
-        args.input = input;
+        args.input = input.to_path_buf();
         args.plan = true;
         args.provider.provider = "mock".to_string();
         args.provider.model = Some("mock-prefix-target".to_string());
         let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
         let (settings, application) =
             orchestration::resolve_settings_and_plan(&args, &effective_provider)
-                .expect("real EPUB preflight should succeed");
+                .expect("EPUB preflight should succeed");
         assert!(application.is_some());
         settings
     };
 
-    let cjk = planned_settings(translation_fixture_path(false));
-    let latin = planned_settings(translation_fixture_path(true));
+    // `plan.rs` pins the rule itself against in-memory books. This asserts the
+    // same divergence survives the real path: EPUB parse, segmentation, then
+    // settings resolution.
+    let (_caseless_fixture, caseless_input) = scripted_book_fixture(true);
+    let (_cased_fixture, cased_input) = scripted_book_fixture(false);
+    let caseless = planned_settings(&caseless_input);
+    let cased = planned_settings(&cased_input);
 
-    assert!(cjk.batch.target_tokens < latin.batch.target_tokens);
-    assert!(cjk.batch.max_items < latin.batch.max_items);
+    assert!(caseless.batch.target_tokens < cased.batch.target_tokens);
+    assert!(caseless.batch.max_items < cased.batch.max_items);
 }
 
 #[tokio::test]

--- a/crates/bookforge-cli/src/commands/translate/tests.rs
+++ b/crates/bookforge-cli/src/commands/translate/tests.rs
@@ -199,6 +199,7 @@ async fn mock_and_openai_entry_points_share_events_and_artifacts() {
         &mock_args.provider,
         &mock_args,
         &settings,
+        None,
         &tokio_util::sync::CancellationToken::new(),
         mock_progress.clone(),
         Some(JobStore::open(&mock_store_path).unwrap()),
@@ -231,6 +232,7 @@ async fn mock_and_openai_entry_points_share_events_and_artifacts() {
         &openai_args.provider,
         &openai_args,
         &settings,
+        None,
         &tokio_util::sync::CancellationToken::new(),
         openai_progress.clone(),
         Some(JobStore::open(&openai_store_path).unwrap()),
@@ -1112,6 +1114,7 @@ fn translate_args_with_preset(
 ) -> TranslateArgs {
     TranslateArgs {
         input: temp_path("input.epub"),
+        plan: false,
         language: LanguageArgs {
             source: Some("English".to_string()),
             target: "Italian".to_string(),
@@ -1187,6 +1190,181 @@ fn translate_args_with_preset(
         progress_jsonl: None,
         provider_preset,
     }
+}
+
+fn translation_fixture_path(cyberiad: bool) -> PathBuf {
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("tests");
+    if cyberiad {
+        return fixtures.join("The_Cyberiad.epub");
+    }
+    fs::read_dir(&fixtures)
+        .expect("translation fixtures should be readable")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .find(|path| {
+            path.extension().and_then(|extension| extension.to_str()) == Some("epub")
+                && path.file_name().and_then(|name| name.to_str()) != Some("The_Cyberiad.epub")
+        })
+        .expect("CJK EPUB fixture should exist")
+}
+
+#[test]
+fn explicit_batch_flag_beats_plan_while_unset_fields_are_filled() {
+    let mut args = translate_args_with_preset(None);
+    args.input = translation_fixture_path(false);
+    args.plan = true;
+    args.provider.provider = "mock".to_string();
+    args.provider.model = Some("mock-prefix-target".to_string());
+    args.batch_max_items = Some(64);
+
+    let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
+    let (settings, application) =
+        orchestration::resolve_settings_and_plan(&args, &effective_provider)
+            .expect("planned settings should resolve");
+    let applied = application.expect("--plan should produce an application");
+
+    assert_eq!(settings.batch.max_items, 64, "explicit flag must win");
+    assert!(
+        settings.batch.target_tokens < TranslationProfile::V1Fast.resolve().batch.target_tokens,
+        "the unset CJK token target should be filled by the plan"
+    );
+    assert!(
+        applied
+            .applied_plan
+            .decisions
+            .iter()
+            .any(|decision| decision.setting == "batch_target_tokens")
+    );
+    assert!(
+        applied
+            .applied_plan
+            .decisions
+            .iter()
+            .all(|decision| decision.setting != "batch_max_items"),
+        "an explicit field must not be attributed to the plan"
+    );
+}
+
+#[test]
+fn translate_without_plan_preserves_resolved_settings_bytes() {
+    let args = translate_args_with_preset(None);
+    let expected =
+        bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&resolve_settings(&args));
+    let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
+    let (actual, application) =
+        orchestration::resolve_settings_and_plan(&args, &effective_provider)
+            .expect("ordinary settings should resolve");
+    let actual = bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&actual);
+
+    assert!(application.is_none());
+    assert_eq!(
+        serde_json::to_vec(&actual).unwrap(),
+        serde_json::to_vec(&expected).unwrap()
+    );
+    assert_eq!(
+        serde_json::to_vec(&bookforge_core::FinalizeCheckpointSnapshot::default()).unwrap(),
+        br#"{"double_check_complete":false}"#,
+        "an absent plan must not change legacy snapshot bytes"
+    );
+}
+
+#[test]
+fn real_cjk_and_latin_translate_preflights_apply_different_settings() {
+    let planned_settings = |input: PathBuf| {
+        let mut args = translate_args_with_preset(None);
+        args.input = input;
+        args.plan = true;
+        args.provider.provider = "mock".to_string();
+        args.provider.model = Some("mock-prefix-target".to_string());
+        let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
+        let (settings, application) =
+            orchestration::resolve_settings_and_plan(&args, &effective_provider)
+                .expect("real EPUB preflight should succeed");
+        assert!(application.is_some());
+        settings
+    };
+
+    let cjk = planned_settings(translation_fixture_path(false));
+    let latin = planned_settings(translation_fixture_path(true));
+
+    assert!(cjk.batch.target_tokens < latin.batch.target_tokens);
+    assert!(cjk.batch.max_items < latin.batch.max_items);
+}
+
+#[tokio::test]
+async fn applied_plan_decisions_and_reasons_are_persisted_in_run_snapshot() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = temp.path().join("input.epub");
+    let output = temp.path().join("output.epub");
+    let store_path = temp.path().join("jobs.sqlite");
+    build_translation_fixture(&input);
+
+    let mut args = translate_args_with_preset(None);
+    args.input = input.clone();
+    args.out = Some(output.clone());
+    args.plan = true;
+    args.provider.provider = "mock".to_string();
+    args.provider.model = Some("mock-prefix-target".to_string());
+    let effective_provider = apply_provider_preset(&args.provider, args.provider_preset);
+    let (settings, application) =
+        orchestration::resolve_settings_and_plan(&args, &effective_provider)
+            .expect("planned settings should resolve");
+    let config = TranslationConfig {
+        source_language: args.language.source.clone(),
+        target_language: args.language.target.clone(),
+        provider: "mock".to_string(),
+        model: Some("mock-prefix-target".to_string()),
+        concurrency: settings.scheduler.concurrency,
+        max_attempts: settings.scheduler.max_attempts,
+        output,
+    };
+    let progress = Arc::new(RecordingProgressSink::default());
+    orchestration::run_mock_translation_with_store(
+        &input,
+        &config,
+        &effective_provider,
+        &args,
+        &settings,
+        application,
+        &tokio_util::sync::CancellationToken::new(),
+        progress.clone(),
+        Some(JobStore::open(&store_path).unwrap()),
+    )
+    .await
+    .expect("mock translation should finish");
+
+    let job_id = progress
+        .events
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|event| match event {
+            bookforge_core::ProgressEvent::JobCreated { job_id, .. } => Some(job_id.clone()),
+            _ => None,
+        })
+        .expect("job creation should be reported");
+    let snapshot = JobStore::open(&store_path)
+        .unwrap()
+        .load_job_config_snapshot(&job_id)
+        .unwrap()
+        .expect("run snapshot should exist");
+    let applied = snapshot
+        .finalize
+        .applied_plan
+        .expect("run snapshot should record the applied plan");
+
+    assert_eq!(
+        applied.schema_version,
+        crate::commands::plan::PLAN_SCHEMA_VERSION
+    );
+    assert!(!applied.decisions.is_empty());
+    assert!(
+        applied
+            .decisions
+            .iter()
+            .all(|decision| !decision.reason.trim().is_empty())
+    );
 }
 
 #[test]

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -136,6 +136,24 @@ pub struct FallbackRunConfigSnapshot {
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct FinalizeCheckpointSnapshot {
     pub double_check_complete: bool,
+    /// The offline plan applied when this job was created. This stays beside
+    /// the other durable run-evolution metadata so later reconfiguration can
+    /// replace resolved settings without erasing the original rationale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_plan: Option<AppliedPlanSnapshot>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AppliedPlanSnapshot {
+    pub schema_version: u32,
+    pub decisions: Vec<AppliedPlanDecisionSnapshot>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AppliedPlanDecisionSnapshot {
+    pub setting: String,
+    pub value: serde_json::Value,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -124,8 +124,7 @@ estimated default-batch output tail; provider output and thinking controls; and
 the translate flags that follow from those findings. `--source` is recorded for
 the operator but does not affect sizing: script is measured from the EPUB text.
 
-Use `--json` for schema-versioned, stable output suitable for a future
-`translate` consumer:
+Use `--json` for schema-versioned, stable output suitable for tooling:
 
 ```bash
 bookforge plan book.epub --target Italian --provider deepseek --json
@@ -138,6 +137,45 @@ evidence was applied. Concurrency therefore stays at the `v1-fast` default with
 adaptive concurrency enabled until an actual run supplies latency or 429
 evidence. Glossary injection is off by default because its measured A/B found no
 detectable quality effect.
+
+Planning remains opt-in for translation. Add `--plan` to inspect the EPUB
+offline, apply the actionable recommendations, and then start the job:
+
+```bash
+bookforge translate book.epub \
+  --plan \
+  --source Chinese \
+  --target Italian \
+  --provider deepseek
+```
+
+The precedence is direct setting flag, then plan, then the resolved profile,
+target-policy, and provider-preset defaults. For example, an explicit
+`--batch-max-items 64` is never replaced; the plan may still fill an unset
+`--batch-target-tokens`. The current application surface covers batch target
+tokens, batch max items, the optional batch output bound, the provider output
+budget, and supported thinking suppression. Recommendations that merely keep a
+default, such as offline concurrency, are not rewritten.
+
+The EPUB archive is parsed once. Planning inspects that in-memory book and
+constructs the default scheduler segments needed for its size distribution;
+translation then constructs its final segments from the applied settings. Each
+applied setting, typed value, and planner reason is stored in the run snapshot
+under `finalize.applied_plan`. Without `--plan`, no planning inspection runs and
+the existing resolved settings and translation path are unchanged.
+
+`resume` does not accept or rerun the plan. It uses the settings captured when
+the job was created, so a planner rule change after a software update cannot
+silently change only the unfinished part of a book. The current cache namespace
+does not include batch target/items, output budgets, or thinking suppression,
+so those knobs are cache-safe; `reconfigure` may supersede its supported batch
+and scheduler settings for remaining work, and its durable merged settings
+compose with (without erasing) the original plan rationale.
+
+Making planning default-on requires broader evidence: a versioned rule set
+validated across substantially more books, scripts, providers, and models, with
+repeatable gains in blocks recovered, failed requests, or cost per 1,000 source
+characters and no material regression on existing runs.
 
 The coverage report from `inspect` calls out visible text that BookForge would
 not send for translation.

--- a/docs/enabler-design.md
+++ b/docs/enabler-design.md
@@ -5,8 +5,10 @@ book and the provider, chooses settings, watches the run, and adapts when
 something goes wrong.
 
 This document records both the agreed shape and the deliberately narrow first
-slice. `bookforge plan` now implements the read-only planning half; supervision
-and automatic application remain future work.
+slices. `bookforge plan` implements read-only inspection, and `bookforge
+translate --plan` can now apply its actionable recommendations when a job is
+created. Supervision remains future work; plan application is deliberately
+opt-in.
 
 ## What it is, and deliberately is not
 
@@ -124,6 +126,53 @@ it would contradict the command's read-only boundary. Plans say explicitly that
 no prior evidence was consulted. Reuse needs a genuinely read-only store API or
 an explicit state input before it can be added safely.
 
+### Second slice: opt-in application at job creation
+
+`bookforge translate --plan` consumes the same typed `Plan` used by the
+read-only command. The flag fits the existing command surface: it names the
+already-documented operation, remains a simple opt-in, and avoids a second set
+of planner-specific tuning flags.
+
+Precedence is field-specific and unambiguous:
+
+1. direct setting flags (`--batch-max-items`, `--max-output-tokens`, and so on)
+   always win;
+2. actionable plan recommendations fill only fields without a direct flag;
+3. profile, target-style, and provider-preset resolution supplies the baseline.
+
+The current consumer applies batch target tokens, batch max items, an optional
+batch output bound, the provider output budget, and recognized thinking
+suppression. It does not rewrite recommendations whose disposition is merely
+"keep default" or "omit". Every applied value and its original planner reason
+is captured in the run snapshot at `finalize.applied_plan`, including the plan
+schema version.
+
+Planning runs after the EPUB has been parsed but before provider construction
+and the translation's final segmentation. The planner needs the size
+distribution produced by its default scheduler segmentation; it builds that
+inspection from the in-memory `Book`, then the translation builds final
+segments with the applied settings. This repeats a cheap segmentation pass but
+does not parse the EPUB archive twice and does not contort the normal no-plan
+path.
+
+Application is creation-only. `resume` treats the run snapshot as authoritative
+and never reruns rules that may have changed between BookForge revisions. The
+cache namespace hashes segmentation, profile, whether batching is enabled,
+prompt version, and prompt-input fingerprints; it does not hash the applied
+batch target/item bounds, output budgets, or thinking suppression. The current
+plan is therefore cache-namespace-safe, but rerunning it mid-job would still
+make one book use two planner revisions without an operator decision.
+
+`reconfigure` composes on top: its supported cache-safe settings supersede the
+captured baseline for remaining work and are merged durably into the snapshot.
+The initial plan rationale remains present, so a later reader can distinguish
+why the job started with a value from a deliberate runtime change.
+
+The flag should become default-on only after a versioned rule set has been
+validated across substantially more books, scripts, providers, and models, and
+shows repeatable improvement in blocks recovered, failed requests, or cost per
+1,000 source characters without regressions on existing workloads.
+
 ### Supervision, during the run
 
 A failure-signature table, built from signatures already observed:
@@ -179,15 +228,13 @@ architecture should persuade us otherwise.
 
 ## Remaining open questions
 
-- **Should planning become an integrated pre-flight?** The first slice is the
-  separate `bookforge plan` command. An integrated pre-flight may better serve a
-  user who never runs it, but must preserve the same inspectable decisions.
-- **Should a later slice apply recommendations?** The first slice only advises.
-  Applying settings automatically would need to record every decision and its
-  reason in the run snapshot, matching how `reconfigure` already works.
 - **How much does persistence remember?** Per book, per book-and-provider, or a
   global learned profile. Global learning across unrelated books is the kind of
   thing that looks clever and is impossible to debug.
+- **When has opt-in earned default-on?** The minimum evidence is broader,
+  versioned validation across scripts/providers/models with completion and cost
+  gains and no material regressions; three books and one-day-old rules are not
+  enough.
 
 ## Not in scope
 


### PR DESCRIPTION
`bookforge plan` printed good recommendations and **nothing consumed them**. A half-built feature is worse than an unbuilt one — the settings that matter still required a user to read advice and retype flags they'd never have guessed.

The stakes are measured: on 《矛盾论》 with default batching, `deepseek-v4-flash` recovered **61 of 211 blocks**, silently losing 71% of the book. With the settings the planner derives, it recovers all 211.

Verified end to end on the Chinese book through the real code path: batch target **768**, max items **3**, 15/15 segments, zero failures.

## Three properties, each tested

**Explicit flags win.** Precedence is explicit setting flags → plan recommendations → profile/preset defaults. Only settings the plan genuinely changed are attributed to it.

**Every applied decision is recorded with its reason**, at `finalize.applied_plan` in the run snapshot with a schema version:

```json
{ "setting": "batch_max_items", "value": 3,
  "reason": "A guarded 8192-token response fits 3 p90 items at about 501 output
             tokens each. This derives the item bound from the tail instead of
             copying the 800-token/4-item experiment." }
```

That's the difference between a planner and a black box, and this project has repeatedly needed to answer "why is it that?" months later.

**Opt-in.** Without `--plan`, no preflight runs and settings/snapshot serialization are byte-identical to before. The rules are days old and validated on three books — that doesn't earn default-on. What *would* is now written into `enabler-design.md`.

## Two questions answered by reading the code, not assuming

**Resume.** Planning is creation-only. A resumed job uses the settings captured in its snapshot and never re-runs newer planner rules, so batching can't shift between revisions of the same job.

**Cache.** The namespace excludes batch target/items, output budgets, and thinking suppression — so plan decisions do **not** invalidate cached translations. This was the risk worth checking before building: if planning had shifted the namespace, every cached translation across the 30 real jobs would have been thrown away. `reconfigure` can still supersede its cache-safe settings while preserving the original plan rationale.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **951 passed / 0 failed / 3 ignored** (was 947). No provider called — the mock covers the real path, including that a CJK source receives stricter settings than a Latin one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)