### PR TITLE
Embed cover art in the m4b, and keep output filenames ASCII

### DIFF
--- a/crates/bookforge-audio/src/stitch.rs
+++ b/crates/bookforge-audio/src/stitch.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::builder::{AudiobookManifest, ChunkRecord};
 use crate::text::ChunkKind;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 pub struct StitchOptions {
@@ -22,6 +23,9 @@ pub struct StitchOptions {
     pub loudnorm: bool,
     pub make_single: bool,
     pub author: Option<String>,
+    /// Optional source-cover image to attach to the M4B. Cover failures are
+    /// non-fatal: assembly is retried without artwork.
+    pub cover_path: Option<PathBuf>,
 }
 
 impl Default for StitchOptions {
@@ -37,6 +41,7 @@ impl Default for StitchOptions {
             loudnorm: false,
             make_single: false,
             author: None,
+            cover_path: None,
         }
     }
 }
@@ -157,7 +162,12 @@ pub fn stitch(manifest: &AudiobookManifest, options: &StitchOptions) -> StitchRe
     } else {
         if options.make_m4b {
             match assemble_m4b(options, &chapters, &report.chapter_files, &gaps) {
-                Ok(path) => report.book_file = Some(path),
+                Ok((path, cover_warning)) => {
+                    report.book_file = Some(path);
+                    if let Some(warning) = cover_warning {
+                        report.warnings.push(warning);
+                    }
+                }
                 Err(error) => report.warnings.push(error),
             }
         }
@@ -281,7 +291,7 @@ fn assemble_m4b(
     chapters: &[(usize, Vec<ChunkRecord>)],
     chapter_files: &[PathBuf],
     gaps: &ConcatGaps,
-) -> std::result::Result<PathBuf, String> {
+) -> std::result::Result<(PathBuf, Option<String>), String> {
     if chapter_files.is_empty() {
         return Err("no chapter files were produced; cannot assemble m4b".into());
     }
@@ -332,9 +342,24 @@ fn assemble_m4b(
             list_name.to_string(),
             "-i".to_string(),
             meta_name.to_string(),
+        ];
+        if let Some(cover_path) = &options.cover_path {
+            args.extend(["-i".to_string(), cover_path.to_string_lossy().into_owned()]);
+        }
+        args.extend([
             "-map_metadata".to_string(),
             "1".to_string(),
-        ];
+            "-map_chapters".to_string(),
+            "1".to_string(),
+        ]);
+        if options.cover_path.is_some() {
+            args.extend([
+                "-map".to_string(),
+                "0:a:0".to_string(),
+                "-map".to_string(),
+                "2:v:0".to_string(),
+            ]);
+        }
         if options.loudnorm {
             args.extend(["-af".to_string(), "loudnorm=I=-18:TP=-2:LRA=11".to_string()]);
         }
@@ -344,6 +369,14 @@ fn assemble_m4b(
             "-b:a".to_string(),
             "128k".to_string(),
         ]);
+        if options.cover_path.is_some() {
+            args.extend([
+                "-c:v".to_string(),
+                "copy".to_string(),
+                "-disposition:v:0".to_string(),
+                "attached_pic".to_string(),
+            ]);
+        }
         append_metadata_args(
             &mut args,
             options.title.as_deref(),
@@ -354,8 +387,21 @@ fn assemble_m4b(
         args.push(file_name_of(&staged));
         let mut command = Command::new("ffmpeg");
         command.current_dir(&options.out_dir).args(&args);
-        run_ffmpeg_transactional(&mut command, &staged, &output_path, "ffmpeg m4b assembly")
-            .map(|()| output_path)
+        match run_ffmpeg_transactional(&mut command, &staged, &output_path, "ffmpeg m4b assembly") {
+            Ok(()) => Ok((output_path, None)),
+            Err(cover_error) if options.cover_path.is_some() => {
+                let mut fallback_options = options.clone();
+                fallback_options.cover_path = None;
+                let (path, _) = assemble_m4b(&fallback_options, chapters, chapter_files, gaps)?;
+                Ok((
+                    path,
+                    Some(format!(
+                        "cover art could not be embedded; produced the m4b without it ({cover_error})"
+                    )),
+                ))
+            }
+            Err(error) => Err(error),
+        }
     })();
     let _ = std::fs::remove_file(options.out_dir.join(list_name));
     let _ = std::fs::remove_file(options.out_dir.join(meta_name));
@@ -772,12 +818,28 @@ pub fn sanitize_filename(title: &str) -> String {
         out = out.replace("--", "-");
     }
     let trimmed = out.trim_matches('-').to_string();
-    let trimmed = if trimmed.is_empty() {
-        "untitled".to_string()
+    let trimmed = if trimmed
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .count()
+        < 3
+    {
+        ascii_fallback_filename(title)
     } else {
         trimmed
     };
     trimmed.chars().take(40).collect::<String>().to_lowercase()
+}
+
+fn ascii_fallback_filename(title: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(title.as_bytes());
+    let mut fallback = String::from("untitled-");
+    for byte in &digest[..4] {
+        fallback.push(char::from(HEX[usize::from(byte >> 4)]));
+        fallback.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    fallback
 }
 
 #[cfg(test)]
@@ -924,8 +986,183 @@ mod tests {
             sanitize_filename("Chapter 1: The Beginning!"),
             "chapter-1-the-beginning"
         );
-        assert_eq!(sanitize_filename("***"), "untitled");
+        assert!(sanitize_filename("***").starts_with("untitled-"));
         assert_eq!(sanitize_filename("  spaced  out  "), "spaced-out");
+    }
+
+    #[test]
+    fn sanitize_filename_is_ascii_nonempty_and_stable_across_scripts() {
+        for title in [
+            "Perché l'Italia",
+            "Преступление и наказание",
+            "Über Größe",
+            "矛盾论",
+        ] {
+            let first = sanitize_filename(title);
+            let second = sanitize_filename(title);
+            assert_eq!(first, second, "{title}");
+            assert!(first.is_ascii(), "{title}: {first}");
+            assert!(!first.is_empty(), "{title}");
+            assert!(
+                first
+                    .chars()
+                    .filter(|ch| ch.is_ascii_alphanumeric())
+                    .count()
+                    >= 3,
+                "{title}: {first}"
+            );
+        }
+    }
+
+    fn completed_manifest() -> AudiobookManifest {
+        AudiobookManifest {
+            schema_version: 3,
+            title: Some("Fixture Book".to_string()),
+            synthesis_id: "mock".to_string(),
+            voice: "voice".to_string(),
+            format: "wav".to_string(),
+            speed: 1.0,
+            max_chars: 2_000,
+            instructions: None,
+            seed: None,
+            language: None,
+            text_normalization: None,
+            gaps: crate::builder::GapSettings::default(),
+            author: Some("Fixture Author".to_string()),
+            chapters: 1,
+            chunks: vec![chunk(0, 1, ChunkKind::Body)],
+            completed_chunks: 1,
+            status: crate::builder::AudiobookStatus::Succeeded,
+            updated_at_ms: 0,
+            error: None,
+        }
+    }
+
+    fn generate_audio_fixture(dir: &Path) {
+        let status = Command::new("ffmpeg")
+            .current_dir(dir)
+            .args([
+                "-y",
+                "-v",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440:duration=0.2",
+                "-c:a",
+                "pcm_s16le",
+                "c0-p1.wav",
+            ])
+            .status()
+            .expect("ffmpeg should launch");
+        assert!(status.success());
+    }
+
+    fn stitch_fixture(dir: &Path, cover_path: Option<PathBuf>) -> StitchReport {
+        stitch(
+            &completed_manifest(),
+            &StitchOptions {
+                out_dir: dir.to_path_buf(),
+                extension: "wav".to_string(),
+                make_m4b: true,
+                title: Some("Fixture Book".to_string()),
+                gap_chapter_ms: 0,
+                gap_title_ms: 0,
+                gap_paragraph_ms: 0,
+                author: Some("Fixture Author".to_string()),
+                cover_path,
+                ..StitchOptions::default()
+            },
+        )
+    }
+
+    fn probe_streams(path: &Path) -> serde_json::Value {
+        let output = Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-show_entries",
+                "stream=index,codec_name,codec_type:stream_disposition=attached_pic",
+                "-of",
+                "json",
+            ])
+            .arg(path)
+            .output()
+            .expect("ffprobe should launch");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).expect("ffprobe should emit JSON")
+    }
+
+    #[test]
+    fn real_m4b_embeds_cover_as_attached_picture() {
+        if !ffmpeg_available() || !ffprobe_available() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        generate_audio_fixture(dir.path());
+        let cover = dir.path().join("cover.png");
+        let status = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-v",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=navy:s=64x64",
+                "-frames:v",
+                "1",
+            ])
+            .arg(&cover)
+            .status()
+            .expect("ffmpeg should generate the cover fixture");
+        assert!(status.success());
+
+        let report = stitch_fixture(dir.path(), Some(cover));
+        assert!(report.warnings.is_empty(), "{:?}", report.warnings);
+        let book = report.book_file.expect("m4b should be produced");
+        let probe = probe_streams(&book);
+        let streams = probe["streams"].as_array().unwrap();
+        assert!(streams.iter().any(|stream| stream["codec_type"] == "audio"));
+        assert!(streams.iter().any(|stream| {
+            stream["codec_type"] == "video" && stream["disposition"]["attached_pic"] == 1
+        }));
+    }
+
+    #[test]
+    fn missing_or_unusable_cover_still_produces_valid_m4b() {
+        if !ffmpeg_available() || !ffprobe_available() {
+            return;
+        }
+        for cover_fixture in [None, Some("missing"), Some("unusable")] {
+            let dir = tempfile::tempdir().unwrap();
+            generate_audio_fixture(dir.path());
+            let cover_path = cover_fixture.map(|fixture| {
+                let path = dir.path().join(format!("{fixture}.image"));
+                if fixture == "unusable" {
+                    std::fs::write(&path, b"this is not an image").unwrap();
+                }
+                path
+            });
+            let expected_warning = cover_path.is_some();
+            let report = stitch_fixture(dir.path(), cover_path);
+            let book = report.book_file.expect("fallback m4b should be produced");
+            let probe = probe_streams(&book);
+            let streams = probe["streams"].as_array().unwrap();
+            assert!(streams.iter().any(|stream| stream["codec_type"] == "audio"));
+            assert!(!streams.iter().any(|stream| stream["codec_type"] == "video"));
+            assert_eq!(
+                report
+                    .warnings
+                    .iter()
+                    .any(|warning| warning.contains("cover art could not be embedded")),
+                expected_warning
+            );
+        }
     }
 
     #[test]

--- a/crates/bookforge-cli/src/commands/audiobook.rs
+++ b/crates/bookforge-cli/src/commands/audiobook.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 #[cfg(feature = "tui")]
 use std::io::IsTerminal;
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1313,6 +1314,19 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
     if human_output {
         println!("Stitching with ffmpeg...");
     }
+    let (cover, cover_warning) = if make_m4b {
+        match extract_epub_cover(book) {
+            Ok(cover) => (cover, None),
+            Err(error) => (
+                None,
+                Some(format!(
+                    "cover art could not be read from the EPUB; produced the m4b without it ({error:#})"
+                )),
+            ),
+        }
+    } else {
+        (None, None)
+    };
     let stitch_options = StitchOptions {
         out_dir: out_dir.to_path_buf(),
         extension: format.extension().to_string(),
@@ -1324,8 +1338,12 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
         loudnorm,
         make_single,
         author: (!book.metadata.creators.is_empty()).then(|| book.metadata.creators.join(", ")),
+        cover_path: cover.as_ref().map(|cover| cover.0.clone()),
     };
-    let result = stitch(&manifest, &stitch_options);
+    let mut result = stitch(&manifest, &stitch_options);
+    if let Some(warning) = cover_warning {
+        result.warnings.push(warning);
+    }
     if human_output {
         for warning in &result.warnings {
             eprintln!("warning: {warning}");
@@ -1341,6 +1359,151 @@ fn stitch_output(request: StitchRequest<'_>) -> Result<bookforge_audio::StitchRe
         println!("Single file: {}", single_file.display());
     }
     Ok(result)
+}
+
+/// Pick the cover information already retained by `bookforge-epub` in the
+/// parsed manifest. EPUB 3's explicit `cover-image` property wins. Older books
+/// often use a cover-like manifest id or image filename; those are the legacy
+/// fallback because the reader IR does not retain OPF meta or guide elements.
+fn cover_image_resource(
+    manifest: &[bookforge_core::ir::Resource],
+) -> Option<&bookforge_core::ir::Resource> {
+    let images = || {
+        manifest
+            .iter()
+            .filter(|resource| resource.media_type.starts_with("image/"))
+    };
+    images()
+        .find(|resource| {
+            resource
+                .properties
+                .iter()
+                .any(|property| property.eq_ignore_ascii_case("cover-image"))
+        })
+        .or_else(|| {
+            images().find(|resource| {
+                matches!(
+                    resource.id.to_ascii_lowercase().as_str(),
+                    "cover" | "cover-image" | "coverimage"
+                )
+            })
+        })
+        .or_else(|| {
+            images().find(|resource| {
+                resource.id.to_ascii_lowercase().contains("cover")
+                    || std::path::Path::new(&resource.href)
+                        .file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .is_some_and(|stem| stem.to_ascii_lowercase().contains("cover"))
+            })
+        })
+}
+
+fn extract_epub_cover(book: &bookforge_core::ir::Book) -> Result<Option<TemporaryCover>> {
+    static SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    const MAX_COVER_BYTES: u64 = 64 * 1024 * 1024;
+
+    let Some(resource) = cover_image_resource(&book.manifest) else {
+        return Ok(None);
+    };
+    let source_path = book
+        .source_path
+        .as_deref()
+        .context("the parsed EPUB has no source path")?;
+    let entry_name = epub_resource_path(&book.id.0, &resource.href)
+        .with_context(|| format!("invalid cover resource path {}", resource.href))?;
+    let source = std::fs::File::open(source_path)
+        .with_context(|| format!("failed to open source EPUB {}", source_path.display()))?;
+    let mut archive = zip::ZipArchive::new(source).context("failed to open source EPUB archive")?;
+    let mut entry = archive
+        .by_name(&entry_name)
+        .with_context(|| format!("cover resource {entry_name} is missing from the EPUB"))?;
+    if entry.size() > MAX_COVER_BYTES {
+        anyhow::bail!(
+            "cover resource {entry_name} is {} bytes (limit: {MAX_COVER_BYTES})",
+            entry.size()
+        );
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(entry.size()).unwrap_or(0));
+    entry
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read cover resource {entry_name}"))?;
+
+    let extension = std::path::Path::new(&entry_name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .filter(|extension| {
+            !extension.is_empty()
+                && extension.len() <= 10
+                && extension.chars().all(|ch| ch.is_ascii_alphanumeric())
+        })
+        .unwrap_or("image");
+    let sequence = SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "bookforge-audio-cover-{}-{}-{sequence}.{extension}",
+        std::process::id(),
+        bookforge_core::now_ms()
+    ));
+    std::fs::write(&path, bytes)
+        .with_context(|| format!("failed to stage cover image {}", path.display()))?;
+    Ok(Some(TemporaryCover(path)))
+}
+
+fn epub_resource_path(package_path: &str, href: &str) -> Option<String> {
+    let href = href.split(['#', '?']).next().unwrap_or(href);
+    let href = percent_decode_epub_path(href)?;
+    let package_dir = package_path.rsplit_once('/').map_or("", |(dir, _)| dir);
+    let joined = if package_dir.is_empty() {
+        href
+    } else {
+        format!("{package_dir}/{href}")
+    };
+    let mut normalized = Vec::new();
+    for part in joined.replace('\\', "/").split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                normalized.pop()?;
+            }
+            _ => normalized.push(part.to_string()),
+        }
+    }
+    (!normalized.is_empty()).then(|| normalized.join("/"))
+}
+
+fn percent_decode_epub_path(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let high = hex_value(*bytes.get(index + 1)?)?;
+            let low = hex_value(*bytes.get(index + 2)?)?;
+            decoded.push((high << 4) | low);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+struct TemporaryCover(PathBuf);
+
+impl Drop for TemporaryCover {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
 }
 
 fn missing_requested_deliverables(
@@ -1441,10 +1604,23 @@ fn validate_audio_base_url(value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AudioProviderKind, BreakTagsArg, missing_requested_deliverables, normalize_language_code,
-        parse_chapter_ranges, resolve_context_chars, resolve_heading_break_tag,
-        resolve_language_code, validate_audio_base_url, write_stitch_warnings_to_process,
+        AudioProviderKind, BreakTagsArg, cover_image_resource, epub_resource_path,
+        missing_requested_deliverables, normalize_language_code, parse_chapter_ranges,
+        resolve_context_chars, resolve_heading_break_tag, resolve_language_code,
+        validate_audio_base_url, write_stitch_warnings_to_process,
     };
+
+    fn image_resource(id: &str, href: &str, properties: &[&str]) -> bookforge_core::ir::Resource {
+        bookforge_core::ir::Resource {
+            id: id.to_string(),
+            href: href.to_string(),
+            media_type: "image/jpeg".to_string(),
+            properties: properties
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect(),
+        }
+    }
 
     #[test]
     fn audio_base_url_allows_https_and_loopback_http_only() {
@@ -1453,6 +1629,46 @@ mod tests {
         assert!(validate_audio_base_url("http://127.0.0.1:8880/v1").is_ok());
         assert!(validate_audio_base_url("http://example.com/v1").is_err());
         assert!(validate_audio_base_url("https://token@example.com/v1").is_err());
+    }
+
+    #[test]
+    fn epub3_cover_property_precedes_legacy_cover_names() {
+        let manifest = vec![
+            image_resource("cover", "Images/legacy.jpg", &[]),
+            image_resource("front", "Images/front.jpg", &["cover-image"]),
+            image_resource("other-cover", "Images/other-cover.jpg", &[]),
+        ];
+        assert_eq!(
+            cover_image_resource(&manifest).map(|resource| resource.id.as_str()),
+            Some("front")
+        );
+    }
+
+    #[test]
+    fn legacy_cover_selection_is_stable_and_does_not_guess_first_image() {
+        let manifest = vec![
+            image_resource("logo", "Images/logo.jpg", &[]),
+            image_resource("front-cover", "Images/art.jpg", &[]),
+            image_resource("cover", "Images/later.jpg", &[]),
+        ];
+        assert_eq!(
+            cover_image_resource(&manifest).map(|resource| resource.id.as_str()),
+            Some("cover")
+        );
+        assert!(cover_image_resource(&[image_resource("logo", "Images/logo.jpg", &[])]).is_none());
+    }
+
+    #[test]
+    fn epub_cover_resource_path_is_decoded_and_normalized() {
+        assert_eq!(
+            epub_resource_path("OPS/package.opf", "Images/Cover%20Art.jpg#front").as_deref(),
+            Some("OPS/Images/Cover Art.jpg")
+        );
+        assert_eq!(
+            epub_resource_path("OPS/package/content.opf", "../Images/cover.jpg").as_deref(),
+            Some("OPS/Images/cover.jpg")
+        );
+        assert!(epub_resource_path("package.opf", "../cover.jpg").is_none());
     }
 
     #[test]

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -624,5 +624,9 @@ bookforge audiobook book.epub --voice alloy --format mp3 --stitch
 ```
 
 See [audiobooks.md](audiobooks.md) for providers, formats, resume hashing,
-pruning, ffmpeg stitching, and M4B assembly.
+pruning, ffmpeg stitching, and M4B assembly. The M4B embeds the EPUB 3
+`cover-image` resource when ffmpeg accepts it, with conservative legacy
+cover-name fallbacks; missing or unusable artwork is non-fatal. Stitched
+chapter names are stable lowercase ASCII slugs, with a deterministic hashed
+fallback when stripping non-ASCII text would leave no useful name.
 

--- a/docs/audiobooks.md
+++ b/docs/audiobooks.md
@@ -40,8 +40,9 @@ local browser dashboard started by `bookforge serve`.
    run finishes the remaining chunks, records every error, and exits as failed.
 7. **Assemble**: only a fully synthesized manifest is assembled. When ffmpeg is
    available, a normal run creates a chaptered `audiobook.m4b` with chapter
-   markers and title/artist metadata (using the EPUB author as the artist). The
-   chunks remain the resumable units on disk.
+   markers, title/artist metadata (using the EPUB author as the artist), and the
+   EPUB cover when one can be identified and embedded. The chunks remain the
+   resumable units on disk.
 
 ## Narration hierarchy and continuity
 
@@ -222,6 +223,16 @@ opts out. `--single` adds one flat `audiobook.<format>`; with MP3 output this is
 the convenient single-file MP3 for players that do not need chapter markers.
 The two book outputs can be requested together.
 
+Cover selection uses the resource manifest already parsed by the EPUB reader.
+An image carrying the EPUB 3 `cover-image` property has first priority. For
+legacy books whose parsed manifest does not retain OPF `meta` or `guide`
+elements, an image with an exact cover-like id (`cover`, `cover-image`, or
+`coverimage`) is next, followed by the first image whose id or filename contains
+`cover`. BookForge does not guess that an unrelated first image is the cover.
+If there is no candidate, the source image is missing, or ffmpeg cannot read or
+mux its format, assembly is retried without artwork and the valid chaptered M4B
+is kept. A rejected candidate produces a warning; no cover is not an error.
+
 `--stitch` and `--m4b` remain available as explicit overrides. Per-chapter
 stitching and ordinary flat-file assembly use stream copy. Raw PCM is rejected
 for stitching because it has no container-level sample metadata; choose WAV
@@ -279,6 +290,15 @@ Superseded chunks stay on disk so prior generations remain auditable. Pass
 space; combine it with `--dry-run` to list them without deleting anything.
 Stitched per-chapter outputs, assembled book files, and `manifest.json` are
 never pruned.
+
+Stitched chapter filenames are ASCII-only, lowercase slugs with repeated
+separators collapsed. Non-ASCII characters are stripped rather than
+transliterated; when that leaves fewer than three ASCII letters or digits,
+BookForge uses `untitled-<hash8>`, derived deterministically from the original
+title. Changing this display slug does not affect resume or pruning because
+those operate on the separate `chapter-NNN-part-NNN-<hash16>.<ext>` chunk names
+recorded in `manifest.json`. A rerun can leave an older stitched chapter beside
+its newly named replacement; cleanup intentionally manages only hashed chunks.
 
 ## Browser dashboard
 


### PR DESCRIPTION
Two backlog items that kept slipping **because they need a real ffmpeg run to verify** rather than a mocked command line. ffmpeg 8.0.1 is now installed, so both are verified against actual output.

## Cover art

The stitched `.m4b` carried no artwork, so most players showed a blank tile.

Covers resolve from the existing `Book.manifest` resources rather than re-parsing the OPF, with precedence: EPUB 3 `properties="cover-image"` → exact legacy image id (`cover`, `cover-image`, `coverimage`) → first image whose id or filename contains `cover`.

**Verified with `ffprobe` on a produced file:**

```json
{ "index": 2, "codec_name": "png", "codec_type": "video",
  "disposition": { "attached_pic": 1 } }
```

alongside the aac audio and chapter data streams.

**Known limit, stated rather than papered over:** the EPUB IR doesn't retain OPF `<meta name="cover">` or guide references, so covers declared only that way can't be resolved. It never guesses that an unrelated first image is the cover.

A missing cover succeeds silently. An unreadable or ffmpeg-incompatible one warns and retries transactionally without artwork — stitching never fails because of a bad image.

## ASCII filenames

Output names derive from book titles, which here routinely means Italian, Russian, German or Chinese. Non-ASCII names aren't indexed by some players and mangle when moved between filesystems.

**Stripping over transliteration**, keeping the existing slug shape and avoiding a new dependency. Titles left with fewer than three ASCII alphanumerics become a deterministic `untitled-<hash8>`.

**That trade-off deserves naming.** A Chinese or Russian title now yields a stable but *meaningless* `untitled-<hash>` rather than a transliterated slug — arguably a downgrade for the non-Latin books we just added support for. Accented Italian and German characters are simply stripped, which reads fine. Transliteration would preserve meaning at the cost of a dependency; worth revisiting if non-Latin-titled books become common.

**Resume, manifests and pruning are unaffected** — they key on `chapter-NNN-part-NNN-<hash16>.<ext>`, not the stitched display slug, and cleanup deliberately excludes stitched outputs. Normal existing slugs are unchanged; only very short or non-ASCII-only chapter names shift, which on a rerun can leave the previous stitched file alongside the new one.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **953 passed / 0 failed / 3 ignored**. Missing- and unusable-cover fallbacks exercised against real ffmpeg 8.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)