### PR TITLE
Let convert split PDFs into chapters on a heading prefix

### DIFF
--- a/crates/bookforge-cli/src/commands/convert.rs
+++ b/crates/bookforge-cli/src/commands/convert.rs
@@ -28,6 +28,11 @@ pub struct ConvertArgs {
     #[arg(long)]
     pub title: Option<String>,
 
+    /// Start chapters at text blocks beginning with this case-insensitive
+    /// literal prefix after whitespace normalization. Omit for one chapter.
+    #[arg(long)]
+    pub chapter_prefix: Option<String>,
+
     /// Low-confidence page handling: preserve as page image or keep best-effort text.
     #[arg(long, value_enum, default_value_t = LowConfidenceArg::Linearize)]
     pub low_confidence: LowConfidenceArg,
@@ -149,6 +154,7 @@ pub async fn run(args: ConvertArgs) -> Result<()> {
         low_confidence: args.low_confidence.into(),
         language: args.language.clone(),
         title: args.title.clone().unwrap_or_default(),
+        chapter_prefix: args.chapter_prefix.clone(),
     };
 
     let mut ocr_config = args.ocr_endpoint.as_ref().map(|endpoint| {
@@ -207,6 +213,18 @@ pub async fn run(args: ConvertArgs) -> Result<()> {
 
     println!("Input: {}", input.display());
     println!("Output: {}", outcome.output.display());
+    if args.chapter_prefix.is_some() {
+        println!("Chapters: {}", outcome.chapters);
+        println!(
+            "Blocks per chapter: {}",
+            outcome
+                .blocks_per_chapter
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     if let Some((endpoint, model, dialect)) = ocr_summary {
         println!("OCR: {endpoint} ({model}, {dialect})");
     }

--- a/crates/bookforge-pdf/src/convert.rs
+++ b/crates/bookforge-pdf/src/convert.rs
@@ -12,7 +12,10 @@ use bookforge_core::math::{is_inline_math_operator, is_strong_inline_math_operat
 
 use crate::{
     Result,
-    epub::write_epub,
+    epub::{
+        ChapterSplitOutcome, MAX_CHAPTER_MATCHES, MIN_TEXT_BLOCKS_PER_MATCH,
+        write_epub_with_chapter_prefix,
+    },
     model::{
         ColumnMode, DocBlock, Fragment, ImageAsset, ImageRegion, LowConfidenceMode, Page, Span,
         normalize_text_key, spans_text,
@@ -56,6 +59,9 @@ pub struct ConvertOptions {
     pub language: String,
     /// dc:title; defaults to the input file stem when empty.
     pub title: String,
+    /// Case-insensitive literal prefix that starts a new EPUB chapter after
+    /// whitespace normalization. `None` preserves the legacy single chapter.
+    pub chapter_prefix: Option<String>,
 }
 
 impl Default for ConvertOptions {
@@ -65,6 +71,7 @@ impl Default for ConvertOptions {
             low_confidence: LowConfidenceMode::Linearize,
             language: "en".to_string(),
             title: String::new(),
+            chapter_prefix: None,
         }
     }
 }
@@ -72,6 +79,8 @@ impl Default for ConvertOptions {
 pub struct ConvertOutcome {
     pub output: PathBuf,
     pub report: ConversionReport,
+    pub chapters: usize,
+    pub blocks_per_chapter: Vec<usize>,
 }
 
 pub fn convert_pdf(
@@ -194,7 +203,26 @@ fn convert_pdf_with_tools(
     } else {
         options.title.clone()
     };
-    write_epub(&output_blocks, &title, &options.language, output)?;
+    let chapter_outcome = write_epub_with_chapter_prefix(
+        &output_blocks,
+        &title,
+        &options.language,
+        output,
+        options.chapter_prefix.as_deref(),
+    )?;
+    let blocks_per_chapter = match chapter_outcome {
+        ChapterSplitOutcome::SingleChapter => vec![output_blocks.len()],
+        ChapterSplitOutcome::Split { blocks_per_chapter } => blocks_per_chapter,
+        ChapterSplitOutcome::Guarded {
+            matches,
+            text_blocks,
+        } => {
+            layout_warnings.push(format!(
+                "chapter prefix matched {matches} of {text_blocks} text blocks; kept the legacy single chapter because the split guard allows at most {MAX_CHAPTER_MATCHES} matches and requires at least {MIN_TEXT_BLOCKS_PER_MATCH} text blocks per match"
+            ));
+            vec![output_blocks.len()]
+        }
+    };
 
     let report = ConversionReport::build(
         &input.to_string_lossy(),
@@ -216,6 +244,8 @@ fn convert_pdf_with_tools(
     Ok(ConvertOutcome {
         output: output.to_path_buf(),
         report,
+        chapters: blocks_per_chapter.len(),
+        blocks_per_chapter,
     })
 }
 

--- a/crates/bookforge-pdf/src/epub.rs
+++ b/crates/bookforge-pdf/src/epub.rs
@@ -18,6 +18,16 @@ const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
   </rootfiles>
 </container>"#;
 
+pub(crate) const MAX_CHAPTER_MATCHES: usize = 256;
+pub(crate) const MIN_TEXT_BLOCKS_PER_MATCH: usize = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChapterSplitOutcome {
+    SingleChapter,
+    Split { blocks_per_chapter: Vec<usize> },
+    Guarded { matches: usize, text_blocks: usize },
+}
+
 pub fn write_epub(blocks: &[DocBlock], title: &str, language: &str, output: &Path) -> Result<()> {
     let file = File::create(output)?;
     let mut zip = ZipWriter::new(file);
@@ -34,6 +44,118 @@ pub fn write_epub(blocks: &[DocBlock], title: &str, language: &str, output: &Pat
     zip.write_all(chapter_xhtml(blocks, title).as_bytes())?;
     zip.start_file("nav.xhtml", deflated)?;
     zip.write_all(nav_xhtml(title).as_bytes())?;
+    for asset in figure_assets(blocks) {
+        zip.start_file(asset.href.as_str(), deflated)?;
+        zip.write_all(&asset.bytes)?;
+    }
+    zip.finish()?;
+    Ok(())
+}
+
+pub(crate) fn write_epub_with_chapter_prefix(
+    blocks: &[DocBlock],
+    title: &str,
+    language: &str,
+    output: &Path,
+    chapter_prefix: Option<&str>,
+) -> Result<ChapterSplitOutcome> {
+    let Some(chapter_prefix) = chapter_prefix else {
+        write_epub(blocks, title, language, output)?;
+        return Ok(ChapterSplitOutcome::SingleChapter);
+    };
+    let normalized_prefix = normalize_visible_text(chapter_prefix).to_lowercase();
+    let text_blocks = blocks
+        .iter()
+        .filter(|block| !normalize_visible_text(&block.text()).is_empty())
+        .count();
+    let matches = blocks
+        .iter()
+        .enumerate()
+        .filter_map(|(index, block)| {
+            let text = normalize_visible_text(&block.text());
+            (!text.is_empty() && text.to_lowercase().starts_with(&normalized_prefix))
+                .then_some(index)
+        })
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        write_epub(blocks, title, language, output)?;
+        return Ok(ChapterSplitOutcome::SingleChapter);
+    }
+    if matches.len() > MAX_CHAPTER_MATCHES
+        || matches.len().saturating_mul(MIN_TEXT_BLOCKS_PER_MATCH) > text_blocks
+    {
+        write_epub(blocks, title, language, output)?;
+        return Ok(ChapterSplitOutcome::Guarded {
+            matches: matches.len(),
+            text_blocks,
+        });
+    }
+
+    let has_front_matter = matches[0] != 0;
+    let mut starts = Vec::with_capacity(matches.len() + 1);
+    if has_front_matter {
+        starts.push(0);
+    }
+    starts.extend(matches.iter().copied());
+    if starts.len() < 2 {
+        write_epub(blocks, title, language, output)?;
+        return Ok(ChapterSplitOutcome::SingleChapter);
+    }
+
+    let chapters = starts
+        .iter()
+        .enumerate()
+        .map(|(index, start)| {
+            let end = starts.get(index + 1).copied().unwrap_or(blocks.len());
+            let chapter_title = if index == 0 && has_front_matter {
+                title.to_string()
+            } else {
+                normalize_visible_text(&blocks[*start].text())
+            };
+            EpubChapter {
+                blocks: &blocks[*start..end],
+                title: chapter_title,
+            }
+        })
+        .collect::<Vec<_>>();
+    let blocks_per_chapter = chapters
+        .iter()
+        .map(|chapter| chapter.blocks.len())
+        .collect();
+    write_multi_chapter_epub(blocks, &chapters, title, language, output)?;
+    Ok(ChapterSplitOutcome::Split { blocks_per_chapter })
+}
+
+struct EpubChapter<'a> {
+    blocks: &'a [DocBlock],
+    title: String,
+}
+
+fn write_multi_chapter_epub(
+    blocks: &[DocBlock],
+    chapters: &[EpubChapter<'_>],
+    title: &str,
+    language: &str,
+    output: &Path,
+) -> Result<()> {
+    let file = File::create(output)?;
+    let mut zip = ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored)?;
+    zip.write_all(b"application/epub+zip")?;
+    zip.start_file("META-INF/container.xml", deflated)?;
+    zip.write_all(CONTAINER_XML.as_bytes())?;
+    zip.start_file("content.opf", deflated)?;
+    zip.write_all(multi_chapter_opf(title, language, chapters, figure_assets(blocks)).as_bytes())?;
+    for (index, chapter) in chapters.iter().enumerate() {
+        zip.start_file(chapter_href(index), deflated)?;
+        zip.write_all(chapter_xhtml(chapter.blocks, &chapter.title).as_bytes())?;
+    }
+    zip.start_file("nav.xhtml", deflated)?;
+    zip.write_all(multi_chapter_nav_xhtml(chapters).as_bytes())?;
     for asset in figure_assets(blocks) {
         zip.start_file(asset.href.as_str(), deflated)?;
         zip.write_all(&asset.bytes)?;
@@ -84,6 +206,69 @@ fn opf(title: &str, language: &str, assets: Vec<&ImageAsset>) -> String {
     )
 }
 
+fn multi_chapter_opf(
+    title: &str,
+    language: &str,
+    chapters: &[EpubChapter<'_>],
+    assets: Vec<&ImageAsset>,
+) -> String {
+    let chapter_items = chapters
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            format!(
+                r#"    <item id="{}" href="{}" media-type="application/xhtml+xml"/>"#,
+                chapter_id(index),
+                chapter_href(index)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let spine_items = chapters
+        .iter()
+        .enumerate()
+        .map(|(index, _)| format!(r#"    <itemref idref="{}"/>"#, chapter_id(index)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let asset_items = assets
+        .iter()
+        .map(|asset| {
+            format!(
+                r#"    <item id="{}" href="{}" media-type="{}"/>"#,
+                escape_attr(&asset.id),
+                escape_attr(&asset.href),
+                escape_attr(&asset.media_type)
+            )
+        })
+        .collect::<Vec<_>>();
+    let asset_items = if asset_items.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", asset_items.join("\n"))
+    };
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">bookforge-pdf-conversion</dc:identifier>
+    <dc:title>{}</dc:title>
+    <dc:language>{}</dc:language>
+    <meta property="dcterms:modified">1970-01-01T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+{chapter_items}
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+{asset_items}  </manifest>
+  <spine>
+{spine_items}
+  </spine>
+</package>"#,
+        escape_text(title),
+        escape_text(language)
+    )
+}
+
 fn nav_xhtml(title: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -98,6 +283,45 @@ fn nav_xhtml(title: &str) -> String {
 </html>"#,
         escape_text(title)
     )
+}
+
+fn multi_chapter_nav_xhtml(chapters: &[EpubChapter<'_>]) -> String {
+    let entries = chapters
+        .iter()
+        .enumerate()
+        .map(|(index, chapter)| {
+            format!(
+                r#"<li><a href="{}">{}</a></li>"#,
+                chapter_href(index),
+                escape_text(&chapter.title)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head><title>Contents</title></head>
+<body>
+<nav epub:type="toc" id="toc">
+<h1>Contents</h1>
+<ol>{entries}</ol>
+</nav>
+</body>
+</html>"#
+    )
+}
+
+fn chapter_id(index: usize) -> String {
+    format!("chapter-{:04}", index + 1)
+}
+
+fn chapter_href(index: usize) -> String {
+    format!("chapter-{:04}.xhtml", index + 1)
+}
+
+fn normalize_visible_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn chapter_xhtml(blocks: &[DocBlock], title: &str) -> String {
@@ -206,6 +430,23 @@ mod tests {
         }
     }
 
+    fn paragraph(text: &str) -> DocBlock {
+        DocBlock::Paragraph {
+            spans: vec![span(text)],
+        }
+    }
+
+    fn zip_entry(path: &Path, name: &str) -> String {
+        let mut archive = ZipArchive::new(File::open(path).expect("epub opens")).expect("zip");
+        let mut value = String::new();
+        archive
+            .by_name(name)
+            .unwrap_or_else(|_| panic!("{name} exists"))
+            .read_to_string(&mut value)
+            .unwrap_or_else(|_| panic!("{name} reads"));
+        value
+    }
+
     #[test]
     fn produced_epub_is_readable_by_the_bookforge_reader() {
         let dir = tempfile::tempdir().expect("temp dir");
@@ -257,5 +498,135 @@ mod tests {
             .expect("nav reads");
         assert!(nav.contains("epub:type=\"toc\""));
         assert!(nav.contains("<a href=\"content.xhtml\">Paper Title</a>"));
+    }
+
+    #[test]
+    fn absent_chapter_prefix_is_byte_identical_to_the_legacy_writer() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let legacy = dir.path().join("legacy.epub");
+        let optional = dir.path().join("optional.epub");
+        let blocks = vec![
+            paragraph("Preface"),
+            paragraph("Chapter 1"),
+            paragraph("Body"),
+        ];
+
+        write_epub(&blocks, "Book", "en", &legacy).expect("legacy EPUB writes");
+        let outcome = write_epub_with_chapter_prefix(&blocks, "Book", "en", &optional, None)
+            .expect("optional EPUB writes");
+
+        assert_eq!(outcome, ChapterSplitOutcome::SingleChapter);
+        assert_eq!(
+            std::fs::read(legacy).expect("legacy EPUB reads"),
+            std::fs::read(optional).expect("optional EPUB reads")
+        );
+    }
+
+    #[test]
+    fn chapter_prefix_splits_expected_boundaries_and_retains_front_matter() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("split.epub");
+        let blocks = vec![
+            DocBlock::Heading {
+                level: 1,
+                spans: vec![span("Book Title")],
+            },
+            paragraph("Prefatory matter"),
+            paragraph("  Chapter   1: Origins  "),
+            paragraph("First chapter body"),
+            DocBlock::Heading {
+                level: 2,
+                spans: vec![span("CHAPTER 2: Consequences")],
+            },
+            paragraph("Second chapter body"),
+            paragraph("Second chapter conclusion"),
+        ];
+
+        let outcome =
+            write_epub_with_chapter_prefix(&blocks, "Book Title", "en", &path, Some("chapter "))
+                .expect("split EPUB writes");
+
+        assert_eq!(
+            outcome,
+            ChapterSplitOutcome::Split {
+                blocks_per_chapter: vec![2, 2, 3]
+            }
+        );
+        let book = bookforge_epub::read_epub(&path).expect("split EPUB reads");
+        assert_eq!(book.spine.len(), 3);
+        assert_eq!(
+            book.sections
+                .iter()
+                .filter(|section| section.href.starts_with("chapter-"))
+                .count(),
+            3
+        );
+        assert_eq!(
+            bookforge_epub::text_coverage(&path).unwrap().percent(),
+            100.0
+        );
+
+        let front_matter = zip_entry(&path, "chapter-0001.xhtml");
+        assert!(front_matter.contains("Prefatory matter"));
+        assert!(!front_matter.contains("Chapter   1"));
+        let first_chapter = zip_entry(&path, "chapter-0002.xhtml");
+        assert!(first_chapter.contains("Chapter   1: Origins"));
+        assert!(first_chapter.contains("First chapter body"));
+        let nav = zip_entry(&path, "nav.xhtml");
+        assert!(nav.contains("chapter-0001.xhtml\">Book Title</a>"));
+        assert!(nav.contains("chapter-0002.xhtml\">Chapter 1: Origins</a>"));
+        assert!(nav.contains("chapter-0003.xhtml\">CHAPTER 2: Consequences</a>"));
+    }
+
+    #[test]
+    fn chapter_prefix_matching_nothing_uses_the_legacy_epub() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let legacy = dir.path().join("legacy.epub");
+        let unmatched = dir.path().join("unmatched.epub");
+        let blocks = vec![
+            paragraph("Preface"),
+            paragraph("Section One"),
+            paragraph("Body"),
+        ];
+
+        write_epub(&blocks, "Book", "en", &legacy).expect("legacy EPUB writes");
+        let outcome =
+            write_epub_with_chapter_prefix(&blocks, "Book", "en", &unmatched, Some("Chapter "))
+                .expect("unmatched EPUB writes");
+
+        assert_eq!(outcome, ChapterSplitOutcome::SingleChapter);
+        assert_eq!(
+            std::fs::read(legacy).expect("legacy EPUB reads"),
+            std::fs::read(unmatched).expect("unmatched EPUB reads")
+        );
+    }
+
+    #[test]
+    fn overmatching_chapter_prefix_is_guarded_by_the_legacy_epub() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let legacy = dir.path().join("legacy.epub");
+        let guarded = dir.path().join("guarded.epub");
+        let blocks = vec![
+            paragraph("One"),
+            paragraph("Two"),
+            paragraph("Three"),
+            paragraph("Four"),
+        ];
+
+        write_epub(&blocks, "Book", "en", &legacy).expect("legacy EPUB writes");
+        let outcome = write_epub_with_chapter_prefix(&blocks, "Book", "en", &guarded, Some(""))
+            .expect("guarded EPUB writes");
+
+        assert_eq!(
+            outcome,
+            ChapterSplitOutcome::Guarded {
+                matches: 4,
+                text_blocks: 4
+            }
+        );
+        assert_eq!(
+            std::fs::read(legacy).expect("legacy EPUB reads"),
+            std::fs::read(guarded).expect("guarded EPUB reads")
+        );
     }
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -379,6 +379,35 @@ Review the conversion report before translating. It records text coverage,
 layout decisions, preserved media, and low-confidence pages. See
 [EPUB_PIPELINE.md](EPUB_PIPELINE.md) for pipeline details.
 
+PDF conversion keeps the historical single-spine-section output unless an
+explicit chapter prefix is supplied:
+
+```bash
+bookforge convert book.pdf --out book.epub --chapter-prefix "CHAPTER "
+```
+
+`--chapter-prefix <TEXT>` starts a new EPUB chapter before each reconstructed
+text-bearing block whose whitespace-normalized visible text begins with the
+literal prefix, compared case-insensitively. It checks complete block text, not
+raw Poppler lines or a fixed character window, so a chapter label reconstructed
+as a paragraph can still form a boundary. Content before the first match is
+retained as its own front-matter chapter. No matches preserve the legacy
+single-chapter EPUB byte for byte.
+
+To prevent a broad prefix from producing thousands of tiny spine items, the
+split falls back to the legacy single chapter when it finds more than 256
+matches or fewer than two text blocks per match on average. The conversion
+report records a warning when that guard fires.
+
+A literal prefix cannot express headings that vary in their leading text, which
+is a real limit for some languages: Chinese chapter labels such as 第一章 and
+第二章 share only 第, and 第 alone also begins ordinary words, so it over-matches
+into the guard rather than splitting usefully. A regular-expression form would
+cover those cases, but `regex` is currently a dev-dependency only, so making it
+a runtime dependency would add roughly a megabyte to the shipped single binary.
+The prefix is the cheap form that covers Latin-script books; the trade is
+recorded here so it can be revisited deliberately.
+
 `reflow` is an explicit preprocessing command for broken paragraph flow; normal
 EPUB reading does not silently rewrite the source.
 

--- a/docs/EPUB_PIPELINE.md
+++ b/docs/EPUB_PIPELINE.md
@@ -13,6 +13,27 @@ The EPUB pipeline parses package metadata, preserves resources, translates XML t
 
 The reader suppresses `script`, `style`, `svg`, and `math`. It preserves package resources, stylesheets, images, fonts, and non-translated XML entries. Named and numeric entities are decoded for segmentation, while path accounting ignores entity events so reader and writer stay aligned.
 
+## PDF-derived chapter boundaries
+
+`bookforge convert` normally preserves its historical synthetic EPUB shape: one
+`content.xhtml` spine item containing every reconstructed PDF block. The opt-in
+`--chapter-prefix <TEXT>` surface instead creates one spine item per detected
+chapter boundary. Matching is case-insensitive against the literal prefix of a
+block's complete whitespace-normalized visible text. It is not limited to
+blocks classified as headings because noisy PDF extraction can reconstruct a
+visually obvious chapter label as a paragraph.
+
+Blocks before the first match become a front-matter spine item, so title pages,
+introductions, and prefaces are not dropped. A prefix matching nothing uses the
+legacy single-chapter writer. A prefix matching more than 256 text blocks, or
+matching so densely that there are fewer than two text blocks per match on
+average, also falls back to that writer and adds a conversion warning.
+
+The resulting structural sections are scheduler boundaries: segments never
+cross from one spine section into another. This removes single-chapter
+structure as a confound when evaluating PDF-derived books, but does not by
+itself establish or claim an improvement in translation quality.
+
 ## Inline Structure
 
 Inline formatting, links, anchors, and empty inline elements are represented as marker tokens inside a block's prose. New extraction emits short per-block markers such as `<m1>...</m1>` and `<r1/>`. The marker parser also accepts the older verbose marker forms so stored jobs and tests can read legacy text.


### PR DESCRIPTION
`bookforge-pdf` wrote one `content.xhtml` holding every reconstructed block, so a converted PDF became a single-chapter EPUB regardless of length. Segments never cross a spine section, so a one-section book gives the scheduler nothing to work with.

## The flag

```bash
bookforge convert book.pdf --out book.epub --chapter-prefix "CHAPTER "
```

A new chapter starts at each text-bearing block whose whitespace-normalized visible text begins with the prefix, compared case-insensitively.

It matches **complete block text rather than detected headings** — on the verification PDF, poppler classified every chapter label as a paragraph, so restricting to headings would have found nothing.

- Blocks before the first match become a front-matter chapter; title pages and prefaces are not dropped.
- A prefix matching nothing falls through to the legacy writer.
- So does one matching >256 blocks, or matching so densely there are fewer than two text blocks per match — thousands of one-block chapters are their own pathology. The conversion report carries a warning when the guard fires.
- Without the flag, output is byte-identical to today (pinned by a test; separate real conversions matched on every archive member's payload hash and compressed size).

## Literal prefix rather than regex — and the reason isn't free expressiveness

`regex` is currently a **dev-dependency only**, so a pattern form would add roughly a megabyte to the shipped single binary.

That cost buys a real gap: Chinese chapter labels such as 第一章 and 第二章 share only 第, which also begins ordinary words, so a prefix over-matches into the guard rather than splitting. **Latin-script books are covered; Chinese ones are not.** The trade is written into `CLI_REFERENCE.md` rather than left implicit, so it can be revisited deliberately.

## The segment-size argument that motivated this doesn't survive measurement

Verified against a generated 122-page, 12-chapter book (368 blocks):

| Metric | Before | With `--chapter-prefix "CHAPTER "` |
|---|---:|---:|
| Spine sections | 1 | 13 |
| Scheduler segments | 33 | 39 |
| Mean tokens | 1062 | 904 |
| p90 / max tokens | 1136 / 1140 | 1154 / 1160 |
| Segments <600 tokens | 2 | 14 |

**The tail barely moved.** Segmentation already caps at `max_segment_tokens`, so single-chapter structure does *not* produce oversized segments the way the backlog note claimed — that premise was wrong.

What this actually buys is real chapter structure and a shorter mean. It removes single-chapter shape as a confound in the Lenin volumes' quality scores. It does **not** fix that gap, and nothing here should be read as claiming it does.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **951 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)