### PR TITLE
Catch near-copies in unspaced scripts, and unify script detection

### DIFF
--- a/crates/bookforge-cli/src/commands/plan.rs
+++ b/crates/bookforge-cli/src/commands/plan.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use bookforge_core::{
     config::TranslationProfile,
     ir::{Block, BlockKind, Book},
+    script::{ScriptClass, classify, script_counts},
     segment::{build_segments, estimate_tokens},
     style::built_in_sizing_policy_for_target,
 };
@@ -70,24 +71,6 @@ pub struct SourceInspection {
     pub alphabetic_caseless_characters: usize,
     pub sizing_uses_declared_language: bool,
     pub reason: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ScriptClass {
-    Cased,
-    Caseless,
-    Undetermined,
-}
-
-impl ScriptClass {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Cased => "cased",
-            Self::Caseless => "caseless",
-            Self::Undetermined => "undetermined",
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -248,11 +231,7 @@ pub(crate) fn plan_book(
         .join("\n");
     let source_characters = source_text.chars().count();
     let (cased, caseless) = script_counts(&source_text);
-    let detected_script = match cased.cmp(&caseless) {
-        std::cmp::Ordering::Greater => ScriptClass::Cased,
-        std::cmp::Ordering::Less => ScriptClass::Caseless,
-        std::cmp::Ordering::Equal => ScriptClass::Undetermined,
-    };
+    let detected_script = classify((cased, caseless));
 
     let block_tokens = translatable_blocks
         .iter()
@@ -636,18 +615,6 @@ fn block_text(block: &Block) -> String {
         .map(|run| run.text.as_str())
         .collect::<Vec<_>>()
         .join("")
-}
-
-fn script_counts(text: &str) -> (usize, usize) {
-    text.chars()
-        .filter(|ch| ch.is_alphabetic())
-        .fold((0, 0), |(cased, caseless), ch| {
-            if ch.is_lowercase() || ch.is_uppercase() {
-                (cased + 1, caseless)
-            } else {
-                (cased, caseless + 1)
-            }
-        })
 }
 
 fn source_density_guard(source_characters: usize, source_tokens: usize) -> usize {

--- a/crates/bookforge-core/src/glossary.rs
+++ b/crates/bookforge-core/src/glossary.rs
@@ -308,23 +308,18 @@ pub fn extract_glossary_candidates(
 /// occasional Latin word from rerouting a Han, Kana, Hangul, Thai, Arabic,
 /// Hebrew, or Devanagari source.
 fn candidate_extraction_strategy(blocks: &[Block]) -> CandidateExtractionStrategy {
-    let (cased, caseless) = blocks.iter().fold((0usize, 0usize), |counts, block| {
-        block_visible_text(block)
-            .chars()
-            .filter(|ch| ch.is_alphabetic())
-            .fold(counts, |(cased, caseless), ch| {
-                if ch.is_lowercase() || ch.is_uppercase() {
-                    (cased + 1, caseless)
-                } else {
-                    (cased, caseless + 1)
-                }
-            })
+    let counts = blocks.iter().fold((0usize, 0usize), |counts, block| {
+        let (cased, caseless) = crate::script::script_counts(&block_visible_text(block));
+        (counts.0 + cased, counts.1 + caseless)
     });
 
-    if cased > caseless {
-        CandidateExtractionStrategy::Capitalization
-    } else {
-        CandidateExtractionStrategy::Recurrence
+    match crate::script::classify(counts) {
+        crate::script::ScriptClass::Cased => CandidateExtractionStrategy::Capitalization,
+        // Ties and text without alphabetic evidence fall here deliberately;
+        // see the note above on preserving recall.
+        crate::script::ScriptClass::Caseless | crate::script::ScriptClass::Undetermined => {
+            CandidateExtractionStrategy::Recurrence
+        }
     }
 }
 

--- a/crates/bookforge-core/src/lib.rs
+++ b/crates/bookforge-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod math;
 pub mod progress;
 pub mod run_snapshot;
 pub mod scheduler;
+pub mod script;
 pub mod segment;
 pub mod style;
 
@@ -41,6 +42,7 @@ pub use run_snapshot::{
     RunConfigSnapshot,
 };
 pub use scheduler::SchedulerConfig;
+pub use script::{ScriptClass, is_space_delimited, script_class, script_counts};
 pub use style::{
     DoNotFields, RegisterFields, StyleSheet, VoiceFields, merge_style_sheets, render_style_block,
     style_fingerprint,

--- a/crates/bookforge-core/src/script.rs
+++ b/crates/bookforge-core/src/script.rs
@@ -1,0 +1,185 @@
+//! Dominant-script detection, derived from the text rather than from a
+//! declared language.
+//!
+//! Several parts of the pipeline need to know whether prose is written in a
+//! cased script (Latin, Cyrillic, Greek) or a caseless one (Han, Kana, Hangul,
+//! Thai, Arabic, Hebrew, Devanagari), because the two behave differently in
+//! ways that matter: caseless scripts carry far more information per character
+//! and cannot signal a proper noun through capitalization.
+//!
+//! Word spacing is a *separate* axis, and `is_space_delimited` measures it
+//! separately. Arabic and Hebrew are caseless yet space-delimited; Han, Kana
+//! and Hangul are neither. Conflating the two would change behaviour for
+//! Arabic and Hebrew on no evidence, so nothing here infers one from the other.
+//!
+//! Deriving this from the characters, not from `--source`, is deliberate. A
+//! declared language can be wrong, absent, or a label the project has never
+//! enumerated, and the resulting behaviour should still be correct. Counting
+//! the *dominant* kind rather than testing for the presence of any cased
+//! character keeps an occasional Latin word — a name, a citation, a unit — from
+//! rerouting an otherwise caseless book.
+//!
+//! Callers decide what a tie means, because the safe default differs by site:
+//! glossary extraction treats an undetermined script as caseless to preserve
+//! recall, while token estimation treats it as cased so it does not
+//! underestimate. Returning the three-way class rather than a boolean is what
+//! lets each keep the answer it needs.
+
+/// How a body of text scores on the cased/caseless axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScriptClass {
+    /// Predominantly a script that distinguishes upper and lower case.
+    Cased,
+    /// Predominantly a script that does not.
+    Caseless,
+    /// Equal counts, or no alphabetic characters to judge by.
+    Undetermined,
+}
+
+impl ScriptClass {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cased => "cased",
+            Self::Caseless => "caseless",
+            Self::Undetermined => "undetermined",
+        }
+    }
+}
+
+/// Fewer than this many spaces per alphabetic character means the text does not
+/// delimit its words with whitespace. Latin prose sits near 0.18 (roughly one
+/// space every five or six letters) and Arabic and Hebrew are similar; Han,
+/// Kana and Hangul prose sits at or very near zero. The gap between those two
+/// populations is an order of magnitude, so the exact cut is not delicate.
+const UNSPACED_SPACE_RATIO: f64 = 0.02;
+
+/// Whether the text delimits its words with whitespace.
+///
+/// This is measured, not inferred from the script class, because the two do not
+/// coincide: Arabic, Hebrew, Thai and Devanagari are all caseless, but Arabic
+/// and Hebrew are space-delimited while Han, Kana and Hangul are not. Treating
+/// "caseless" as "unspaced" would quietly change behaviour for Arabic and
+/// Hebrew sources on no evidence at all.
+///
+/// It matters because splitting on whitespace — or on runs of alphanumerics,
+/// which for unspaced scripts amounts to splitting on punctuation — returns
+/// whole clauses rather than words, and any threshold expressed in "words" then
+/// means something entirely different.
+pub fn is_space_delimited(text: &str) -> bool {
+    let (alphabetic, spaces) = text
+        .chars()
+        .fold((0usize, 0usize), |(letters, spaces), ch| {
+            if ch.is_alphabetic() {
+                (letters + 1, spaces)
+            } else if ch.is_whitespace() {
+                (letters, spaces + 1)
+            } else {
+                (letters, spaces)
+            }
+        });
+    // No letters means nothing to judge; treat it as ordinary spaced text so
+    // callers keep their existing behaviour on numerals and punctuation.
+    if alphabetic == 0 {
+        return true;
+    }
+    spaces as f64 / alphabetic as f64 >= UNSPACED_SPACE_RATIO
+}
+
+/// Count alphabetic characters by whether their script has case.
+///
+/// Non-alphabetic characters — digits, punctuation, whitespace, symbols — are
+/// ignored, so a table of numbers is `Undetermined` rather than miscounted.
+pub fn script_counts(text: &str) -> (usize, usize) {
+    text.chars()
+        .filter(|ch| ch.is_alphabetic())
+        .fold((0, 0), |(cased, caseless), ch| {
+            if ch.is_lowercase() || ch.is_uppercase() {
+                (cased + 1, caseless)
+            } else {
+                (cased, caseless + 1)
+            }
+        })
+}
+
+/// Classify text by its dominant script.
+pub fn script_class(text: &str) -> ScriptClass {
+    classify(script_counts(text))
+}
+
+/// Classify counts already accumulated elsewhere, for callers that walk a
+/// large structure once rather than materialising its text.
+pub fn classify((cased, caseless): (usize, usize)) -> ScriptClass {
+    match cased.cmp(&caseless) {
+        std::cmp::Ordering::Greater => ScriptClass::Cased,
+        std::cmp::Ordering::Less => ScriptClass::Caseless,
+        std::cmp::Ordering::Equal => ScriptClass::Undetermined,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_by_dominant_script() {
+        assert_eq!(script_class("The quick brown fox"), ScriptClass::Cased);
+        assert_eq!(script_class("Преступление и наказание"), ScriptClass::Cased);
+        assert_eq!(script_class("矛盾的普遍性和特殊性"), ScriptClass::Caseless);
+        assert_eq!(script_class("これは日本語の文です"), ScriptClass::Caseless);
+        assert_eq!(script_class("한국어 문장입니다"), ScriptClass::Caseless);
+    }
+
+    #[test]
+    fn an_occasional_latin_word_does_not_reroute_a_caseless_book() {
+        assert_eq!(
+            script_class("矛盾论的英文标题是 On Contradiction，作者是毛泽东，写于一九三七年。"),
+            ScriptClass::Caseless
+        );
+    }
+
+    #[test]
+    fn text_without_alphabetic_evidence_is_undetermined() {
+        assert_eq!(script_class(""), ScriptClass::Undetermined);
+        assert_eq!(script_class("1234 — !? 56.78"), ScriptClass::Undetermined);
+        // Exactly balanced: two cased letters, two caseless.
+        assert_eq!(script_class("Ab 中国"), ScriptClass::Undetermined);
+    }
+
+    #[test]
+    fn spacing_is_measured_rather_than_inferred_from_case() {
+        assert!(is_space_delimited(
+            "The quick brown fox jumps over the lazy dog"
+        ));
+        assert!(is_space_delimited("Преступление и наказание, роман"));
+        assert!(!is_space_delimited(
+            "矛盾的普遍性和特殊性的关系是矛盾问题的精髓"
+        ));
+        assert!(!is_space_delimited(
+            "これは日本語の文章であり分かち書きをしない"
+        ));
+    }
+
+    #[test]
+    fn caseless_but_spaced_scripts_are_not_treated_as_unspaced() {
+        // The distinction this function exists for: both are caseless, but
+        // only one is written without spaces between words.
+        assert_eq!(
+            script_class("العربية لغة جميلة ومفيدة جدا"),
+            ScriptClass::Caseless
+        );
+        assert!(is_space_delimited("العربية لغة جميلة ومفيدة جدا"));
+
+        assert_eq!(
+            script_class("עברית היא שפה יפה מאוד"),
+            ScriptClass::Caseless
+        );
+        assert!(is_space_delimited("עברית היא שפה יפה מאוד"));
+    }
+
+    #[test]
+    fn text_without_letters_is_treated_as_spaced() {
+        assert!(is_space_delimited(""));
+        assert!(is_space_delimited("1234 5678 90"));
+    }
+}

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -37,25 +37,18 @@ const CASED_SCRIPT_CHAR_UNITS_PER_CHAR: usize = 2;
 /// character per token. Mixed text follows its dominant alphabetic script.
 /// Text without alphabetic evidence keeps the 4.5-character fallback.
 pub fn estimate_tokens(text: &str) -> usize {
-    let mut chars = 0usize;
-    let mut cased = 0usize;
-    let mut caseless = 0usize;
-
-    for ch in text.chars() {
-        chars += 1;
-        if ch.is_alphabetic() {
-            if ch.is_lowercase() || ch.is_uppercase() {
-                cased += 1;
-            } else {
-                caseless += 1;
-            }
-        }
-    }
-
+    let chars = text.chars().count();
     if chars == 0 {
         return 0;
     }
-    if caseless > cased {
+
+    // Only a dominantly caseless text counts one token per character. A tie,
+    // or text with no alphabetic evidence, takes the cased ratio -- which is
+    // the choice this function has always made. Note that a genuinely mixed
+    // book is therefore estimated low, since half of it is being costed at
+    // roughly 4.5 characters per token; no measurement has yet said whether
+    // that matters in practice.
+    if crate::script::script_class(text) == crate::script::ScriptClass::Caseless {
         chars
     } else {
         chars

--- a/crates/bookforge-llm/src/validation.rs
+++ b/crates/bookforge-llm/src/validation.rs
@@ -202,21 +202,65 @@ pub(crate) fn source_copy_validation_error(
         return None;
     }
 
-    let source_words = words(&source_normalized);
-    if source_words.len() < MIN_OVERLAP_WORDS {
+    let (source_units, translation_units, unit) =
+        comparison_units(&source_normalized, &translation_normalized);
+    if source_units.len() < MIN_OVERLAP_WORDS {
         return None;
     }
-    let translation_words = words(&translation_normalized);
-    let overlap = multiset_overlap(&source_words, &translation_words);
-    let ratio = overlap as f64 / source_words.len() as f64;
+    let overlap = multiset_overlap(&source_units, &translation_units);
+    let ratio = overlap as f64 / source_units.len() as f64;
     if overlap >= MIN_OVERLAP_WORDS && ratio >= COPIED_WORD_RATIO {
         return Some(format!(
-            "translation retains {:.0}% of the source-language words",
+            "translation retains {:.0}% of the source-language {unit}",
             ratio * 100.0
         ));
     }
 
     None
+}
+
+/// Choose the unit the near-copy comparison counts in, based on whether the
+/// source delimits its words with whitespace.
+///
+/// `words` splits on runs of alphanumerics, which is only a word count for text
+/// that puts spaces between words. Han, Kana and Hangul characters are
+/// alphanumeric and unspaced, so a whole clause comes back as one "word" and
+/// the `MIN_OVERLAP_WORDS` floor is never cleared: measured across the two
+/// Chinese books in the corpus, only 24% and 67% of substantial paragraphs
+/// reached the overlap test at all, against 83-88% for English and Italian.
+/// The detector was therefore silently switched off for exactly the material
+/// it was most needed on, since a model that echoes an unspaced source stops
+/// being caught by the exact-copy check the moment it alters one token.
+///
+/// For unspaced text the comparison runs on adjacent character pairs instead.
+/// Bigrams are the standard unit for this: they track a near-copy closely, and
+/// a genuine translation into a different script shares essentially none of
+/// them. The test is on spacing rather than on case, because Arabic and Hebrew
+/// are caseless yet space-delimited and should keep counting words.
+fn comparison_units(source: &str, translation: &str) -> (Vec<String>, Vec<String>, &'static str) {
+    if !bookforge_core::script::is_space_delimited(source) {
+        (
+            character_bigrams(source),
+            character_bigrams(translation),
+            "character pairs",
+        )
+    } else {
+        (words(source), words(translation), "words")
+    }
+}
+
+/// Adjacent pairs of the text's alphanumeric characters, in order. Punctuation
+/// and whitespace are dropped first so that a re-punctuated copy still matches.
+fn character_bigrams(text: &str) -> Vec<String> {
+    let characters = text
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<Vec<_>>();
+    characters
+        .windows(2)
+        .map(|pair| pair.iter().collect())
+        .collect()
 }
 
 pub(crate) fn empty_translation_validation_error(
@@ -1163,6 +1207,45 @@ mod tests {
     fn allows_reference_sections() {
         assert!(source_copy_validation_error(SOURCE, SOURCE, Some("Endnotes")).is_none());
         assert!(source_copy_validation_error(SOURCE, SOURCE, Some("Bibliography")).is_none());
+    }
+
+    /// Unspaced prose of a length the detector is meant to cover. `words`
+    /// splits on non-alphanumerics and Han characters are alphanumeric, so
+    /// each of these clauses is one "word" -- far below the word floor the
+    /// English paragraph above clears easily.
+    const CJK_SOURCE: &str = "矛盾的普遍性和特殊性的关系是矛盾问题的精髓，\
+        不懂得它就等于抛弃了辩证法。事物的性质主要地是由取得支配地位的矛盾的主要方面所规定的，\
+        取得支配地位的矛盾的主要方面起了变化，事物的性质也就随着变化。\
+        然而这种情形不是固定的，矛盾的主要和非主要的方面互相转化着，事物的性质也就随着起变化。";
+
+    #[test]
+    fn rejects_nearly_complete_source_copy_in_an_unspaced_script() {
+        // The same defect as `rejects_nearly_complete_source_copy`: a provider
+        // echoed the source back with a token changed rather than translating.
+        let translation = CJK_SOURCE.replace("精髓", "核心");
+        let error = source_copy_validation_error(CJK_SOURCE, &translation, Some("第一章"));
+        assert!(
+            error
+                .as_deref()
+                .is_some_and(|message| message.contains("retains")),
+            "an unspaced near-copy must be caught like a spaced one, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn allows_a_real_translation_of_unspaced_source() {
+        assert!(
+            source_copy_validation_error(
+                CJK_SOURCE,
+                "Il rapporto fra universalità e particolarità della contraddizione è \
+                 l'essenza del problema della contraddizione, e non comprenderlo equivale \
+                 ad abbandonare la dialettica. La natura di una cosa è determinata \
+                 principalmente dall'aspetto principale della contraddizione dominante.",
+                Some("第一章")
+            )
+            .is_none(),
+            "a genuine translation must not be flagged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`source_copy_validation_error` catches a provider that echoes the source back instead of translating. It has two paths: exact equality, and a word-overlap ratio for a near-copy that changed a token or two. The overlap path only runs once the source has 30 "words" — where a word is a run of alphanumerics.

Han, Kana and Hangul characters are alphanumeric and are not separated by spaces, so that split returns whole *clauses*.

## What the corpus says

Share of substantial paragraphs (≥120 chars) that reach the overlap test at all:

| Book | Reaches the test |
|---|---:|
| Italian — *Il Mondo al Contrario* | 88% |
| English — *The Cyberiad* | 83% |
| Russian — *Преступление и наказание* | 74% |
| Chinese — 西游记 | 67% |
| Chinese — 矛盾论 | 24% |
| German — *Also sprach Zarathustra* | 18% |

The detector was largely switched off for the material it was most needed on. A test pins it: the same near-copy caught in English returned `None` in Chinese.

## The fix

For text that doesn't delimit words with whitespace, the comparison counts **adjacent character pairs**. Bigrams track a near-copy closely, and a genuine translation into another script shares almost none of them. The flagged message names the unit so a reader knows which path ran.

**The predicate is spacing, not case, and that distinction is the point.** Arabic and Hebrew are caseless yet space-delimited — routing on caselessness would have changed their behaviour on no evidence. `is_space_delimited` measures spaces-per-letter instead (Latin and Arabic ≈ 0.18, Han ≈ 0, an order of magnitude apart) and is tested on both.

## German at 18% is real, and this does not fix it

Zarathustra's paragraphs are short aphorisms, so they fall under a floor calibrated for long prose. That's a threshold question, and lowering it trades against false positives on short text where function words dominate. It needs a measured false-positive rate, which needs labelled data — so it's reported and left alone rather than tuned by guess.

## Consolidation

Script detection had been written out three times — `segment::estimate_tokens`, `glossary::candidate_extraction_strategy`, `plan.rs` — with **different tie handling in each**. Now one `bookforge_core::script` module returning a three-way class, so each site keeps the tie behaviour it needs and states why: glossary treats a tie as caseless for recall, token estimation as cased.

All three are behaviourally byte-for-byte unchanged. `plan.rs` keeps its serialized `detected_script` field identical via the same serde naming.

Also noted in place but *not* acted on: `estimate_tokens` costs a genuinely mixed book at the cased ratio, which underestimates it. No measurement yet says whether that matters.

## Verification

`fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **967 passed / 0 failed / 3 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)