### PR TITLE
fix: harden dashboard sessions and restore Windows CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "futures-core",
  "getrandom 0.4.3",
  "indicatif",
+ "libc",
  "predicates",
  "quick-xml",
  "ratatui",
@@ -294,6 +295,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.52.0",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ zip = { version = "8.6", default-features = false, features = ["deflate-flate2-z
 rusqlite = { version = "0.39", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "brotli"], default-features = false }
 base64 = "0.23"
+# Advisory OS file locks (`flock` on Unix) for the retry-failed single-winner
+# claim. Tied to the process lifetime: the kernel drops the lock the instant
+# the owner dies, which is the only liveness verdict that can never be stale.
+libc = "0.2"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/bookforge-cli/Cargo.toml
+++ b/crates/bookforge-cli/Cargo.toml
@@ -39,6 +39,16 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 zip.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+] }
+
 [features]
 default = ["tui", "serve"]
 # Terminal UI (`--ui tui` and the `watch` command). Default-on; build with

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -59,8 +59,9 @@ mod translation;
 
 use super::{audiobook, correct, estimate, reconfigure, review, validate};
 use security::{
-    apply_security_headers, constant_time_eq, generate_csrf_token, reject_mutation,
-    require_loopback_bind, unauthorized, validate_dashboard_host,
+    AuthState, BootstrapOutcome, apply_security_headers, auth_logout, build_session_cookie,
+    is_cross_site_browser_request, reject_mutation, require_loopback_bind, session_cookie_from,
+    unauthorized, validate_dashboard_host,
 };
 use translation::{
     configure_dashboard_child_environment, provider_key_env, resolve_dashboard_provider_key,
@@ -153,8 +154,6 @@ const OPENROUTER_MODELS: &[&str] = &[
     "google/gemini-2.5-flash",
 ];
 const OPENAI_COMPATIBLE_MODELS: &[&str] = &["gpt-4o-mini", "gpt-4o"];
-const CSRF_HEADER: &str = "x-bookforge-csrf";
-const CSRF_TOKEN_PLACEHOLDER: &str = "__BOOKFORGE_CSRF_TOKEN__";
 const DASHBOARD_CONTENT_SECURITY_POLICY: &str = "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; media-src 'self'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
 
 /// Monotonic suffix for launch tags and estimate temp files, so two uploads
@@ -194,10 +193,9 @@ pub struct ServeArgs {
 #[derive(Clone)]
 struct AppState {
     refresh: Duration,
-    csrf_token: String,
-    /// Whether API routes require the session token. Default-on per H-5;
-    /// `--no-auth` restores the older unauthenticated behavior.
-    auth_enabled: bool,
+    /// Server-side authentication: bootstrap-token exchange, in-memory session
+    /// store, and the `--no-auth` escape hatch. Default-on per H-5.
+    auth: Arc<AuthState>,
     host_port: u16,
     /// Root for browser uploads and audiobook operation directories. Production
     /// uses [`UPLOAD_DIR`]; tests inject a temp directory so route coverage does
@@ -535,8 +533,9 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .await
         .with_context(|| format!("failed to bind {addr}"))?;
     let local = listener.local_addr().unwrap_or(addr);
-    let csrf_token = generate_csrf_token()?;
     let auth_enabled = !args.no_auth;
+    let auth = AuthState::new(auth_enabled)?;
+    let bootstrap_url_token = auth.bootstrap_token();
     let state = AppState {
         // Same floor as `watch` (crate::commands::MIN_REFRESH_MS): one flag
         // value, one floor, whichever UI consumes it.
@@ -544,8 +543,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
             args.refresh_ms
                 .clamp(crate::commands::MIN_REFRESH_MS, 5_000),
         ),
-        csrf_token: csrf_token.clone(),
-        auth_enabled,
+        auth: Arc::new(auth),
         host_port: local.port(),
         upload_dir: PathBuf::from(UPLOAD_DIR),
         keys: Arc::new(Mutex::new(HashMap::new())),
@@ -566,12 +564,12 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     };
 
     let app = dashboard_router(state);
-    // With token auth enabled, only this bootstrap URL — which embeds the
-    // session token as a query parameter — may enter the dashboard. It is the
-    // console equivalent of the CSRF token that used to be readable from
-    // `/` by any local process. Never echo it anywhere else.
+    // With auth enabled, only this bootstrap URL — which embeds the one-time
+    // bootstrap token as a query parameter — may enter the dashboard. The
+    // exchange mints an HttpOnly session cookie and redirects to the clean
+    // root. Never echo the bootstrap token anywhere else.
     let url = if auth_enabled {
-        format!("http://{local}/?token={csrf_token}")
+        format!("http://{local}/?token={bootstrap_url_token}")
     } else {
         format!("http://{local}/")
     };
@@ -596,6 +594,7 @@ fn dashboard_router(state: AppState) -> Router {
     let host_state = state.clone();
     let auth_state = state.clone();
     Router::new()
+        .route("/api/auth/logout", post(auth_logout))
         .merge(assets::routes())
         .merge(jobs::routes())
         .merge(options::routes())
@@ -605,8 +604,9 @@ fn dashboard_router(state: AppState) -> Router {
         .merge(styles::routes())
         .merge(entities::routes())
         .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
-        // H-5 / SERVE-1: every route outside the `/` bootstrap exchange must
-        // carry the session token; hardened headers are stamped onto every
+        // H-5 / SERVE-1: every route outside the `/` bootstrap exchange and
+        // the `/api/auth/logout` session-management endpoint requires a live
+        // in-memory session cookie; hardened headers are stamped onto every
         // response (SERVE-9). The host allowlist stays outermost so a forged
         // Host is still rejected before authentication is even attempted.
         .layer(middleware::from_fn_with_state(
@@ -622,23 +622,21 @@ fn dashboard_router(state: AppState) -> Router {
 
 /// Gate middleware for the whole dashboard.
 ///
-/// - Auth-on: everything except exactly `/` requires the session token in the
-///   `x-bookforge-csrf` header (the same header mutations already used, so
-///   browsers seeded via the printed URL and local scripts share one rule).
-///   Wrong/missing tokens get a bare 401 with no detail.
+/// - Auth-on: everything except the `/` bootstrap exchange (which issues the
+///   session cookie) and `/api/auth/logout` (which a stale browser must be
+///   able to reach) requires the HttpOnly session cookie. Wrong/missing
+///   cookies get a bare 401 with no detail.
 /// - Security headers ride along on every response, not just the index page.
 async fn enforce_dashboard_access(
     State(state): State<AppState>,
     request: Request,
     next: Next,
 ) -> Response {
-    let mut response = if state.auth_enabled && request.uri().path() != "/" {
-        let authorized = request
-            .headers()
-            .get(CSRF_HEADER)
-            .and_then(|value| value.to_str().ok())
-            .is_some_and(|token| constant_time_eq(token.as_bytes(), state.csrf_token.as_bytes()));
-        if !authorized {
+    let mut response = if state.auth.enabled && !is_unauthenticated_dashboard_route(&request) {
+        if !state
+            .auth
+            .has_session(session_cookie_from(request.headers()))
+        {
             let mut response = unauthorized();
             apply_security_headers(&mut response);
             return response;
@@ -649,6 +647,13 @@ async fn enforce_dashboard_access(
     };
     apply_security_headers(&mut response);
     response
+}
+
+/// Routes reachable without an authenticated session: the `/` bootstrap
+/// exchange and the logout endpoint (which must be callable to clear a stale
+/// cookie even when the session is already gone).
+fn is_unauthenticated_dashboard_route(request: &Request) -> bool {
+    matches!(request.uri().path(), "/" | "/api/auth/logout")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bookforge-cli/src/commands/serve.rs
+++ b/crates/bookforge-cli/src/commands/serve.rs
@@ -243,6 +243,11 @@ struct AppState {
     /// count instead of exec'ing this binary as a child.
     #[cfg(test)]
     retry_launches: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    /// Test hook: when set and true, the retry-failed handoff fails at its
+    /// spawn seam so tests can prove the atomic claim and the launch slot are
+    /// released on that error path.
+    #[cfg(test)]
+    retry_fail_spawns: Option<Arc<std::sync::atomic::AtomicBool>>,
     #[cfg(test)]
     audio_restart_cancels: Option<Arc<Mutex<Vec<u32>>>>,
 }
@@ -559,6 +564,8 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         resume_child_environments: None,
         #[cfg(test)]
         retry_launches: None,
+        #[cfg(test)]
+        retry_fail_spawns: None,
         #[cfg(test)]
         audio_restart_cancels: None,
     };

--- a/crates/bookforge-cli/src/commands/serve/assets.rs
+++ b/crates/bookforge-cli/src/commands/serve/assets.rs
@@ -1,4 +1,5 @@
 use super::*;
+use axum::http::HeaderValue;
 
 pub(super) fn routes() -> Router<AppState> {
     Router::new().route("/", get(index))
@@ -8,48 +9,60 @@ pub(super) fn routes() -> Router<AppState> {
 ///
 /// Browsers follow the console-printed URL `http://127.0.0.1:PORT/?token=…`:
 ///
-/// - a matching `?token=` gets this bootstrap page, which stores the token in
-///   `sessionStorage` under the CSRF header name and immediately redirects to
-///   the clean `/`. Every later API fetch sends it as the
-///   `x-bookforge-csrf` header, exactly mirroring how the embedded CSRF token
-///   used to be wired into `dashboard.js`.
-/// - no token (or a wrong one) gets [`LOGIN_HTML`], which points at the
-///   console URL and never echoes the session token itself.
-/// - an authenticated caller that already holds the header may load the full
-///   dashboard HTML directly.
+/// - a matching `?token=` inside its five-minute TTL gets a 302 to the clean
+///   `/` plus an HttpOnly `bookforge_session` cookie. The bootstrap token is
+///   never echoed and never stored in the cookie — the cookie carries a fresh
+///   session id minted by the exchange.
+/// - an expired token gets the expiry-guidance page; a wrong token (or a
+///   tripped failed-exchange limiter) gets a bare 401. Neither leaks anything.
+/// - a caller that already holds the session cookie may load the full
+///   dashboard HTML directly; everyone else gets the login page.
 async fn index(
     State(state): State<AppState>,
     RawQuery(query): RawQuery,
     headers: HeaderMap,
 ) -> Response {
-    let query_token = query.as_deref().and_then(query_param_token);
-    if !state.auth_enabled {
-        // Old behavior restored by --no-auth: dashboard with the embedded
-        // session-CSRF token, protected by loopback bind + Host allowlist +
-        // per-mutation CSRF checks only.
-        return Html(DASHBOARD_HTML.replace(CSRF_TOKEN_PLACEHOLDER, &state.csrf_token))
-            .into_response();
+    if !state.auth.enabled {
+        // Old behavior restored by --no-auth: dashboard with no embedded token
+        // anywhere, protected by loopback bind + Host allowlist + per-mutation
+        // same-origin checks only.
+        return Html(DASHBOARD_HTML.clone()).into_response();
     }
 
-    if let Some(token) = query_token {
-        if constant_time_eq(token.as_bytes(), state.csrf_token.as_bytes()) {
-            return Html(BOOTSTRAP_HTML.replace("__BOOKFORGE_SESSION_TOKEN__", token))
-                .into_response();
+    // A caller that already holds a live session is already in: reusing the
+    // bootstrap link (or a stale copy of it) must neither re-run the one-time
+    // exchange nor feed the failed-exchange limiter, so serve the dashboard.
+    if state.auth.has_session(session_cookie_from(&headers)) {
+        return Html(DASHBOARD_HTML.clone()).into_response();
+    }
+
+    if let Some(candidate) = query.as_deref().and_then(query_param_token) {
+        // The exchange mints sessions and advances the failed-attempt limiter,
+        // so like every other state change it is same-origin gated: only a
+        // browser navigation (sec-fetch-site none/same-origin) or a same-origin
+        // fetch may attempt it. A cross-site page must not be able to burn the
+        // limiter or race the one-time token.
+        if is_cross_site_browser_request(&headers) {
+            return forbidden("cross-site dashboard request rejected");
         }
-        return unauthorized();
+        return match state.auth.exchange_bootstrap(candidate) {
+            BootstrapOutcome::Granted(session_id) => {
+                let mut response = Response::new(axum::body::Body::empty());
+                *response.status_mut() = StatusCode::FOUND;
+                response
+                    .headers_mut()
+                    .insert("location", HeaderValue::from_static("/"));
+                response
+                    .headers_mut()
+                    .insert("set-cookie", build_session_cookie(&session_id));
+                response
+            }
+            BootstrapOutcome::Expired => Html(LOGIN_EXPIRED_HTML).into_response(),
+            BootstrapOutcome::Rejected => unauthorized().into_response(),
+        };
     }
 
-    // Auth-on, no `?token=`: a caller already holding the header (scripts,
-    // or the dashboard after a reload inside the seeded tab) gets the full
-    // page; everyone else gets the pointer to the console-printed URL.
-    let authorized = headers
-        .get(CSRF_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|token| constant_time_eq(token.as_bytes(), state.csrf_token.as_bytes()));
-    if authorized {
-        return Html(DASHBOARD_HTML.replace(CSRF_TOKEN_PLACEHOLDER, &state.csrf_token))
-            .into_response();
-    }
+    // No `?token=`: everyone else gets the pointer to the console-printed link.
     Html(LOGIN_HTML).into_response()
 }
 
@@ -63,25 +76,6 @@ fn query_param_token(query: &str) -> Option<&str> {
         .filter(|token| !token.is_empty())
 }
 
-const BOOTSTRAP_HTML: &str = r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Signing in to BookForge…</title>
-</head>
-<body>
-<p style="font-family:system-ui,sans-serif">Signing in to the BookForge dashboard…</p>
-<script>
-(function () {
-  try { sessionStorage.setItem("x-bookforge-csrf", "__BOOKFORGE_SESSION_TOKEN__"); } finally {
-    location.replace("/");
-  }
-})();
-</script>
-<noscript><p>The BookForge dashboard requires JavaScript and the sign-in link printed in its console.</p></noscript>
-</body>
-</html>"#;
-
 const LOGIN_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -90,9 +84,26 @@ const LOGIN_HTML: &str = r#"<!DOCTYPE html>
 </head>
 <body style="font-family:system-ui,sans-serif;margin:4rem auto;max-width:36rem;line-height:1.5">
 <h1>BookForge dashboard</h1>
-<p>This dashboard is private. Open the <code>http://127.0.0.1:&lt;port&gt;/?token=…</code> link that
-<code>bookforge serve</code> printed in its terminal — it carries your one-time session link.</p>
+<p>This dashboard is private.</p>
+<p>Open the sign-in link that <code>bookforge serve</code> printed in its terminal — it starts with
+<code>http://127.0.0.1:&lt;port&gt;/?token=…</code> and carries your one-time session link.</p>
 <p>If you started the server elsewhere, run <code>bookforge serve</code> again in a terminal you can see.</p>
+</body>
+</html>"#;
+
+/// Shown when a sign-in link has outlived its five-minute bootstrap window.
+/// Helpful, but never exposes the token or a session id.
+const LOGIN_EXPIRED_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>BookForge dashboard — sign-in link expired</title>
+</head>
+<body style="font-family:system-ui,sans-serif;margin:4rem auto;max-width:36rem;line-height:1.5">
+<h1>BookForge dashboard</h1>
+<p>That sign-in link has expired — the link <code>bookforge serve</code> prints is only valid for
+the first five minutes the server is running.</p>
+<p>Run <code>bookforge serve</code> again in a terminal you can see and open the fresh link it prints.</p>
 </body>
 </html>"#;
 
@@ -118,17 +129,33 @@ pub(super) static DASHBOARD_HTML: std::sync::LazyLock<String> = std::sync::LazyL
 mod tests {
     use super::*;
 
+    /// The dashboard must be served byte-stable with no token/session
+    /// placeholder left for the server to substitute — nothing secret is ever
+    /// embedded in HTML or JS.
     #[test]
-    fn bootstrap_page_wires_session_storage_with_csrf_header_name() {
-        assert!(BOOTSTRAP_HTML.contains(CSRF_HEADER));
-        assert!(BOOTSTRAP_HTML.contains("__BOOKFORGE_SESSION_TOKEN__"));
-        assert!(!BOOTSTRAP_HTML.contains("__BOOKFORGE_SESSION_TOKEN___never_left"));
+    fn dashboard_assets_carry_no_token_or_session_placeholders() {
+        for secret_ish in [
+            "sessionStorage",
+            "x-bookforge-csrf",
+            "__BOOKFORGE_",
+            "bookforge_session=",
+        ] {
+            assert!(
+                !DASHBOARD_HTML.contains(secret_ish),
+                "dashboard must not embed {secret_ish:?}"
+            );
+        }
     }
 
     #[test]
-    fn login_page_never_carries_a_token_placeholder() {
-        assert!(!LOGIN_HTML.contains("__BOOKFORGE_SESSION_TOKEN__"));
-        assert!(!LOGIN_HTML.contains(CSRF_TOKEN_PLACEHOLDER));
+    fn login_pages_never_carry_a_token_or_session_placeholder() {
+        for page in [LOGIN_HTML, LOGIN_EXPIRED_HTML] {
+            assert!(!page.contains("__BOOKFORGE_"));
+            assert!(!page.contains("bookforge_session="));
+            // The link text intentionally shows the URL shape (`?token=…`),
+            // but no concrete value and no substitute-able placeholder.
+            assert!(!page.contains("feedface"));
+        }
     }
 
     #[test]

--- a/crates/bookforge-cli/src/commands/serve/assets.rs
+++ b/crates/bookforge-cli/src/commands/serve/assets.rs
@@ -134,15 +134,15 @@ mod tests {
     /// embedded in HTML or JS.
     #[test]
     fn dashboard_assets_carry_no_token_or_session_placeholders() {
-        for secret_ish in [
+        for forbidden_marker in [
             "sessionStorage",
             "x-bookforge-csrf",
             "__BOOKFORGE_",
             "bookforge_session=",
         ] {
             assert!(
-                !DASHBOARD_HTML.contains(secret_ish),
-                "dashboard must not embed {secret_ish:?}"
+                !DASHBOARD_HTML.contains(forbidden_marker),
+                "dashboard contains a client-readable credential marker"
             );
         }
     }

--- a/crates/bookforge-cli/src/commands/serve/audio.rs
+++ b/crates/bookforge-cli/src/commands/serve/audio.rs
@@ -1470,11 +1470,34 @@ fn write_audio_process_state(
         object.insert("options".to_string(), options);
     }
     let bytes = serde_json::to_vec_pretty(&process)?;
-    std::fs::write(&temp, bytes)?;
-    if path.exists() {
-        let _ = std::fs::remove_file(&path);
+    // Durability contract: a concurrent reader (e.g. another dashboard
+    // process deciding whether this run is finished) must never observe a
+    // missing or partial process.json. Stage to a temp file, fsync it, then
+    // atomically rename over the target — `std::fs::rename` replaces on both
+    // Unix and Windows — so the published file is always a complete state
+    // snapshot whose bytes are already on disk before the retry claim is
+    // released.
+    let staged = (|| -> Result<()> {
+        let mut file = std::fs::File::create(&temp)?;
+        std::io::Write::write_all(&mut file, &bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp, &path)?;
+        Ok(())
+    })();
+    if staged.is_err() {
+        let _ = std::fs::remove_file(&temp);
     }
-    std::fs::rename(temp, path)?;
+    staged?;
+    // Make the rename itself durable once it has happened (Unix directory
+    // fsync). Windows has no std directory-sync primitive; the rename is
+    // already atomic there.
+    #[cfg(unix)]
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = std::fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
     Ok(())
 }
 
@@ -1812,11 +1835,25 @@ async fn prune_audiobook(
 // which two requests could both pass validation and both spawn -- double
 // provider spend. Two independent guards close it:
 //
-// (a) an atomic filesystem claim: after the status recheck the winner renames
-//     `process.json` to [`RETRY_CLAIM_FILE_NAME`] -- a single rename admits
-//     exactly one worker; every loser reports 409 "retry already starting".
-//     Validation-refusals rename the original back, so durable state is never
-//     destroyed;
+// (a) an atomic filesystem claim: after the status recheck the winner takes an
+//     OS advisory lock (`flock` on Unix, `LockFileEx` on Windows) on
+//     [`RETRY_CLAIM_FILE_NAME`], which admits exactly one worker on every
+//     platform. A rename-based claim was NOT Windows-safe: MoveFileExW opens
+//     the source by path first, so a racing loser can hold a handle to the
+//     file the winner has just moved away and its rename then "succeeds" too,
+//     producing two 200s. An age heuristic is not safe either: a live owner
+//     that is merely suspended or slow must never be preempted, or the next
+//     winner double-spends on the provider. The lock is the liveness verdict
+//     — the kernel drops it exactly when the owning process dies, never before
+//     — so a live owner is always refused and a dead owner's leftover claim is
+//     always reclaimable. The lock file keeps a stable identity (it is never
+//     unlinked by the protocol), so every contender contends on the same lock.
+//     It records an ownership nonce plus a claimed-at timestamp for
+//     diagnostics and a defensive release check; losers report 409 "retry
+//     already starting". The winner additionally publishes durable `running`
+//     state BEFORE releasing the lock, and a late arrival re-verifies that
+//     durable state after acquiring the lock, so once the winner finishes its
+//     handoff no second job can start;
 // (b) a SERVE-6 launch slot held around preparation + spawn (released on
 //     every failure path by dropping [`RetryClaimLaunch`] alongside its
 //     sibling slot guard).
@@ -1832,6 +1869,7 @@ struct RetryFailedRequest {
 
 struct PreparedRetry {
     out_dir: PathBuf,
+    claim: RetryClaim,
     input_path: PathBuf,
     provider: String,
     model_opt: Option<String>,
@@ -1848,13 +1886,20 @@ struct PreparedRetry {
     auto_model: bool,
     options_snapshot: serde_json::Value,
     failed_count: usize,
+    /// The durable process.json bytes as read before this retry claimed the
+    /// operation, so a failed spawn can restore the truthful prior state
+    /// instead of leaving a phantom "running" marker behind.
+    prior_process_json: Vec<u8>,
 }
 
 enum PreparedOutcome {
     NotFound,
     Running,
-    /// A concurrent retry won the atomic claim rename; this caller loses.
+    /// A concurrent retry won the atomic claim; this caller loses.
     RetryStarting,
+    /// A leftover claim file cannot be proven safe to reclaim; fail closed
+    /// and point the operator at the file.
+    ClaimBlocked(PathBuf),
     /// A deliberate refusal with its user-facing reason.
     Client(String),
     Ready(Box<PreparedRetry>),
@@ -1865,6 +1910,281 @@ enum PreparedOutcome {
 enum PrepareStep {
     Refused(String),
     Ready(Box<PreparedRetry>),
+}
+
+/// A single-winner filesystem claim guarding the retry-failed relaunch.
+///
+/// Ownership is an OS advisory lock held open on [`RETRY_CLAIM_FILE_NAME`]
+/// for the whole handoff, not a rename and not a timestamped file:
+///
+/// - atomic mutual exclusion across tasks *and* independent dashboard
+///   processes on Unix and Windows alike;
+/// - the kernel releases the lock the instant the owner dies, so reclaiming a
+///   stale claim requires acquiring the lock — positive proof the previous
+///   owner is gone. A live owner (even one suspended for minutes) can never
+///   be preempted, so there is no age heuristic to get wrong;
+/// - the lock file keeps a stable identity: it is created once and never
+///   unlinked by the protocol, so every contender contends on the same lock.
+///   An unlink-then-recreate on release would let a racer that opened the old
+///   file lock a dead inode while another locks a fresh one — two "winners";
+/// - releasing removes/empties the claim only while the lock is still held,
+///   so a late release can never affect a claim a newer owner created (no
+///   check-then-delete TOCTOU).
+///
+/// The file also carries a diagnostic record (nonce, pid, claimed-at). The
+/// record is advisory — the lock is the source of truth — but the nonce makes
+/// a release idempotent and gives an operator something to read when a claim
+/// stalls.
+#[derive(Debug)]
+pub(super) struct RetryClaim {
+    nonce: String,
+    claimed_at_ms: u64,
+    out_dir: PathBuf,
+    /// The open, exclusively locked claim file. The claim is moved (never
+    /// cloned) from acquisition through the handoff, so exactly one owner
+    /// exists and the diagnostic record survives until the final release;
+    /// dropping this handle closes it and releases the OS lock.
+    file: Option<std::fs::File>,
+}
+
+/// Take a non-blocking exclusive advisory lock on `file`.
+///
+/// Returns `Ok(true)` when this caller now holds the lock, `Ok(false)` when a
+/// live owner holds it. Both `flock` (Unix) and `LockFileEx` (Windows) are
+/// advisory locks tied to the open handle: the kernel releases them the
+/// moment the owning process dies, so `Ok(false)` is a liveness verdict that
+/// can never go stale — no procfs probe, no PID-reuse guessing, no clock.
+#[cfg(unix)]
+pub(super) fn try_lock_claim(file: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::unix::io::AsRawFd;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        return Ok(false);
+    }
+    Err(error)
+}
+
+/// Windows counterpart of [`try_lock_claim`]: `LockFileEx` on a one-byte
+/// range at the front of the file. Byte-range locks (like `flock`) are
+/// released when the owning handle/process goes away.
+#[cfg(windows)]
+pub(super) fn try_lock_claim(file: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{ERROR_LOCK_VIOLATION, HANDLE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let handle = file.as_raw_handle() as HANDLE;
+    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+    // Lock one byte at the front. A range past the current end of file is
+    // lockable, so the record does not need to exist yet.
+    let acquired = unsafe {
+        LockFileEx(
+            handle,
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut overlapped,
+        )
+    };
+    if acquired != 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32) {
+        return Ok(false);
+    }
+    Err(error)
+}
+
+/// Advisory ownership payload written inside the claim file. `pid` and
+/// `claimed_at_ms` are never consulted by the protocol (the OS lock is the
+/// liveness verdict); they exist so an operator can `cat` a stuck claim file
+/// and see who wrote it and when.
+#[derive(Deserialize)]
+struct RetryClaimRecord {
+    nonce: String,
+    #[allow(dead_code)]
+    pid: u32,
+    #[allow(dead_code)]
+    claimed_at_ms: u64,
+}
+
+fn parse_claim_record(bytes: &[u8]) -> Option<RetryClaimRecord> {
+    let record: RetryClaimRecord = serde_json::from_slice(bytes).ok()?;
+    (!record.nonce.is_empty()).then_some(record)
+}
+
+impl RetryClaim {
+    fn claim_file(out_dir: &Path) -> PathBuf {
+        out_dir.join(RETRY_CLAIM_FILE_NAME)
+    }
+
+    /// Wrap a freshly locked file as this caller's claim and publish the
+    /// diagnostic record through it (truncating any dead owner's bytes).
+    fn with_locked_file(out_dir: PathBuf, file: std::fs::File) -> Result<Self> {
+        let mut randomness = [0u8; 16];
+        getrandom::fill(&mut randomness).context("failed to generate retry claim nonce")?;
+        let claim = RetryClaim {
+            nonce: randomness
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect(),
+            claimed_at_ms: now_ms(),
+            out_dir,
+            file: Some(file),
+        };
+        claim.write_record()?;
+        Ok(claim)
+    }
+
+    /// Truncate and write the diagnostic record through the locked handle,
+    /// then sync it so a reader can never observe a partial record.
+    fn write_record(&self) -> Result<()> {
+        use std::io::{Seek, Write};
+        let mut file = self
+            .file
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("retry claim is not locked"))?;
+        file.set_len(0)?;
+        file.seek(std::io::SeekFrom::Start(0))?;
+        file.write_all(self.record().as_bytes())?;
+        file.sync_all()
+            .context("retry claim record could not be synced")
+    }
+
+    fn record(&self) -> String {
+        serde_json::to_string(&json!({
+            "nonce": self.nonce,
+            "pid": std::process::id(),
+            "claimed_at_ms": self.claimed_at_ms,
+        }))
+        .expect("retry claim record should serialize")
+    }
+
+    fn read_nonce(claim_path: &Path) -> Option<String> {
+        let content = std::fs::read(claim_path).ok()?;
+        parse_claim_record(&content).map(|record| record.nonce)
+    }
+
+    /// Release this caller's claim: empty and unlock the claim file, but only
+    /// while this caller still owns it. The OS lock makes the ownership check
+    /// sound: while it is held nobody can replace the file, so the nonce
+    /// cannot change between the read and the action. Losing the check means
+    /// a newer claim exists and must never be touched. The file itself keeps
+    /// its stable identity (it is not unlinked), so a concurrent acquirer that
+    /// already opened it contends on the same lock.
+    pub(super) fn release(&self) {
+        let claim_path = Self::claim_file(&self.out_dir);
+        if Self::read_nonce(&claim_path).as_deref() != Some(self.nonce.as_str()) {
+            return;
+        }
+        if let Some(file) = &self.file {
+            use std::io::Seek;
+            let mut file = file;
+            let _ = file.set_len(0);
+            let _ = file.seek(std::io::SeekFrom::Start(0));
+            let _ = file.sync_all();
+        }
+    }
+}
+
+impl Drop for RetryClaim {
+    fn drop(&mut self) {
+        // Runs while the locked file is still alive (the `file` field is
+        // dropped only after this body), so the release is atomic under the
+        // lock. The claim is single-owned, so this runs exactly once — the
+        // diagnostic record stays valid for the whole handoff.
+        self.release();
+    }
+}
+
+#[cfg(test)]
+impl RetryClaim {
+    /// Test-only claim bound to an explicit nonce and no lock, so unit tests
+    /// can prove a nonce-mismatched release leaves the lock untouched.
+    pub(super) fn with_nonce(out_dir: PathBuf, nonce: &str) -> RetryClaim {
+        RetryClaim {
+            nonce: nonce.to_string(),
+            claimed_at_ms: now_ms(),
+            out_dir,
+            file: None,
+        }
+    }
+}
+
+/// Result of trying to take the single-winner retry claim for `out_dir`.
+#[derive(Debug)]
+pub(super) enum RetryClaimAcquire {
+    /// This caller holds the OS lock and owns the relaunch.
+    Owned(RetryClaim),
+    /// A live owner holds the lock; this caller must lose with 409.
+    HeldByLiveOwner,
+    /// A leftover claim file cannot be proven safe to reclaim (unreadable
+    /// record); fail closed and point the operator at the file.
+    ClaimBlocked(PathBuf),
+}
+
+/// Try to take the single-winner retry claim for `out_dir`.
+///
+/// The OS lock is the liveness verdict: `Ok(false)` means the owner process
+/// is alive (or suspended — the lock is only dropped on death), so this
+/// caller loses; acquiring the lock is positive proof the previous owner is
+/// gone, so the leftover claim is reclaimed by reusing the same file (stable
+/// identity) and overwriting its record — never by unlink-then-recreate,
+/// which would split the lock across inodes. A claim whose bytes cannot be
+/// read as a record is left untouched (fail closed) for an operator to review
+/// rather than destroyed blindly.
+pub(super) fn acquire_retry_claim(out_dir: &Path) -> Result<RetryClaimAcquire> {
+    let claim_path = RetryClaim::claim_file(out_dir);
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        // Deliberately not truncating on open: the existing bytes must be read
+        // (and proven to be a claim record) before they may be overwritten.
+        .truncate(false)
+        .open(&claim_path)
+        .with_context(|| {
+            format!(
+                "retry claim could not be opened at {}",
+                claim_path.display()
+            )
+        })?;
+    if !try_lock_claim(&file)? {
+        drop(file);
+        return Ok(RetryClaimAcquire::HeldByLiveOwner);
+    }
+
+    // The lock is ours: either we just created the file, or the previous
+    // owner is provably dead. Read the existing bytes through the same locked
+    // handle (never a fresh path-open, whose failure must not be mistaken for
+    // an empty file). An empty file is our own create-before-write debris; a
+    // readable record is a dead owner's claim. Anything else — including a
+    // read error, which is never treated as "empty and safe to reclaim" — is
+    // unknown bytes at our reserved name and is left untouched (fail closed)
+    // rather than destroyed.
+    use std::io::Read;
+    let mut existing = Vec::new();
+    if let Err(_error) = (&file).read_to_end(&mut existing) {
+        drop(file); // release the lock without touching the bytes
+        return Ok(RetryClaimAcquire::ClaimBlocked(claim_path));
+    }
+    if !existing.is_empty() && parse_claim_record(&existing).is_none() {
+        drop(file); // release the lock without touching the bytes
+        return Ok(RetryClaimAcquire::ClaimBlocked(claim_path));
+    }
+
+    Ok(RetryClaimAcquire::Owned(RetryClaim::with_locked_file(
+        out_dir.to_path_buf(),
+        file,
+    )?))
 }
 
 fn options_string(options: &serde_json::Value, key: &str) -> Option<String> {
@@ -1887,7 +2207,7 @@ fn prepare_retry_failed(upload_dir: &Path, id: &str) -> Result<PreparedOutcome> 
     {
         Some(process) => process,
         // A missing/unreadable state file alongside a live claim temp means a
-        // concurrent retry has already won the rename race.
+        // concurrent retry already holds the claim.
         None if claim_path.exists() => return Ok(PreparedOutcome::RetryStarting),
         None => json!({}),
     };
@@ -1896,33 +2216,56 @@ fn prepare_retry_failed(upload_dir: &Path, id: &str) -> Result<PreparedOutcome> 
     }
 
     // F3(a): atomic single-winner claim AFTER the status recheck. Exactly one
-    // concurrent caller's rename can succeed; every loser sees NotFound and
-    // reports "already starting" without touching anything.
-    if let Err(error) = std::fs::rename(&process_path, &claim_path) {
-        return Ok(match error.kind() {
-            std::io::ErrorKind::NotFound => PreparedOutcome::RetryStarting,
-            _ => PreparedOutcome::Client(format!("retry could not be started ({error})")),
-        });
+    // concurrent caller can take the OS lock; every loser reports "already
+    // starting" without touching anything.
+    let claim = match acquire_retry_claim(&out_dir)? {
+        RetryClaimAcquire::Owned(claim) => claim,
+        RetryClaimAcquire::HeldByLiveOwner => return Ok(PreparedOutcome::RetryStarting),
+        RetryClaimAcquire::ClaimBlocked(claim_path) => {
+            return Ok(PreparedOutcome::ClaimBlocked(claim_path));
+        }
+    };
+
+    // Re-verify the durable state now that the claim is held. A concurrent
+    // winner that finished its whole handoff only releases the lock AFTER
+    // publishing durable `running` state (see the spawn ordering in
+    // `retry_failed_chunks`), so a claim acquired here guarantees `running` is
+    // visible — and means that winner already spent provider credits. Without
+    // this recheck a late arrival could take the now-free lock and spawn a
+    // duplicate run.
+    let recheck = std::fs::read(&process_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .unwrap_or_else(|| json!({}));
+    if audiobook_process_is_running(&recheck) {
+        // The claim drops on return, releasing the lock.
+        return Ok(PreparedOutcome::Running);
     }
 
-    match finish_prepare_retry(upload_dir, id, &process)? {
+    let prior_process_json = std::fs::read(&process_path).unwrap_or_default();
+
+    // The claim is moved into `finish_prepare_retry`: on a refusal or an
+    // error it is dropped (and released) inside, and on success it is moved
+    // into the `PreparedRetry` so exactly one owner carries the locked handle
+    // through the whole handoff. [`RetryClaim`]'s `Drop` releases the lock —
+    // a refusal, an early `?`, or a panic all unwind to a clean operation
+    // directory with `process.json` untouched.
+    match finish_prepare_retry(upload_dir, id, &process, claim, prior_process_json)? {
         PrepareStep::Ready(prepared) => Ok(PreparedOutcome::Ready(prepared)),
-        PrepareStep::Refused(message) => {
-            // Refusals must not destroy the durable state file (or strand the
-            // operation in claimed limbo): put the original bytes back.
-            settle_retry_claim(&out_dir);
-            Ok(PreparedOutcome::Client(message))
-        }
+        PrepareStep::Refused(message) => Ok(PreparedOutcome::Client(message)),
     }
 }
 
 /// Validation tail of [`prepare_retry_failed`], run only once the atomic
-/// claim is held. Every refusal becomes [`PrepareStep::Refused`] so the
-/// caller can restore the claim uniformly.
+/// claim is held (moved in by value). Every refusal becomes
+/// [`PrepareStep::Refused`], dropping the claim so it unwinds uniformly via
+/// [`RetryClaim`]'s `Drop`.
 fn finish_prepare_retry(
     upload_dir: &Path,
     id: &str,
     process: &serde_json::Value,
+    claim: RetryClaim,
+    prior_process_json: Vec<u8>,
 ) -> Result<PrepareStep> {
     let refused = |message: &str| Ok(PrepareStep::Refused(message.to_string()));
     let out_dir = audiobook_operation_out_dir(upload_dir, id);
@@ -2070,6 +2413,7 @@ fn finish_prepare_retry(
 
     Ok(PrepareStep::Ready(Box::new(PreparedRetry {
         out_dir,
+        claim,
         input_path,
         model_opt: model_for_child.filter(|model| !model.is_empty()),
         provider,
@@ -2086,6 +2430,7 @@ fn finish_prepare_retry(
         auto_model,
         options_snapshot: options,
         failed_count,
+        prior_process_json,
     })))
 }
 
@@ -2095,42 +2440,19 @@ fn u32_checked(value: Option<&serde_json::Value>) -> Option<u32> {
         .and_then(|value| u32::try_from(value).ok())
 }
 
-/// Resolve the atomic retry claim one way or the other:
-/// - when the fresh `running` state already exists, the claim file is debris
-///   and is removed;
-/// - otherwise the original `process.json` bytes are renamed back, so a
-///   refusal or a crash below the claim can never strand the operation in
-///   claimed limbo or destroy its durable state.
-fn settle_retry_claim(out_dir: &Path) {
-    let claim_path = out_dir.join(RETRY_CLAIM_FILE_NAME);
-    if !claim_path.exists() {
-        return;
-    }
-    if out_dir.join("process.json").exists() {
-        let _ = std::fs::remove_file(&claim_path);
-    } else {
-        let _ = std::fs::rename(&claim_path, out_dir.join("process.json"));
-    }
-}
-
 /// Guard pair held for the whole spawn handoff of [`retry_failed_chunks`].
-/// Dropping it releases the SERVE-6 launch slot *and* settles the atomic
-/// claim per [`settle_retry_claim`], so every failure path — early `?`, panic
-/// unwind, refused key, failed spawn — unwinds to a consistent operation
-/// directory.
+/// Dropping it releases the SERVE-6 launch slot (via the slot guard's own
+/// `Drop`) and the atomic claim (via [`RetryClaim`]'s `Drop`), so every
+/// failure path — early `?`, panic unwind, refused key, failed spawn —
+/// unwinds to a consistent operation directory with no live claim left
+/// behind.
 struct RetryClaimLaunch {
     /// Held (never read) purely so its Drop releases the launch slot.
     #[allow(dead_code)]
     slot: LaunchSlotGuard,
-    out_dir: PathBuf,
-}
-
-impl Drop for RetryClaimLaunch {
-    fn drop(&mut self) {
-        // LaunchSlotGuard's own Drop frees the slot first (field order); the
-        // claim settlement follows before this struct is fully gone.
-        settle_retry_claim(&self.out_dir);
-    }
+    /// Held (never read) purely so its Drop releases the atomic claim.
+    #[allow(dead_code)]
+    claim: RetryClaim,
 }
 
 fn options_u64(value: Option<&serde_json::Value>) -> Option<u64> {
@@ -2167,7 +2489,7 @@ async fn retry_failed_chunks(
     let prepared = match prepared {
         PreparedOutcome::NotFound => return Ok(debris_not_found_response()),
         PreparedOutcome::Running => return Ok(debris_running_response()),
-        // F3(a): a concurrent double-click lost the atomic rename race.
+        // F3(a): a concurrent double-click lost the atomic claim race.
         PreparedOutcome::RetryStarting => {
             return Ok((
                 StatusCode::CONFLICT,
@@ -2175,14 +2497,32 @@ async fn retry_failed_chunks(
             )
                 .into_response());
         }
+        // Fail closed with an operator recovery path: the leftover claim's
+        // bytes are unknown, so we will not destroy them blindly.
+        PreparedOutcome::ClaimBlocked(claim_path) => {
+            return Ok((
+                StatusCode::CONFLICT,
+                Json(json!({
+                    "error": format!(
+                        "a previous retry left an unreadable claim at {}; it cannot \
+                         be proven safe to remove automatically. If no retry is \
+                         currently starting, delete that file and try again",
+                        claim_path.display()
+                    )
+                })),
+            )
+                .into_response());
+        }
         PreparedOutcome::Client(message) => return Ok(bad_request(&message)),
         PreparedOutcome::Ready(prepared) => prepared,
     };
-    // From here on the claim must be settled no matter which way control
-    // leaves this handler; the guard pairs that with the launch slot.
+    // From here on the claim must be released no matter which way control
+    // leaves this handler; the guard pairs that with the launch slot. The
+    // durable `running` state is published below BEFORE this guard drops, so
+    // once the lock is released no second job can start behind this one.
     let _guard = RetryClaimLaunch {
         slot,
-        out_dir: prepared.out_dir.clone(),
+        claim: prepared.claim,
     };
 
     // Key handling mirrors launch_audiobook exactly: a supplied key replaces
@@ -2237,7 +2577,15 @@ async fn retry_failed_chunks(
     // Test parity with the resume hook (state.resume_launches): installs a
     // deterministic spawn boundary so endpoint tests can drive the full
     // claim/slot/state machinery without exec'ing the test binary as an
-    // audiobook child.
+    // audiobook child. The spawn-failure variant proves the claim and the
+    // slot are released when `command.spawn()` would fail, and that durable
+    // state is not left as a phantom "running" marker.
+    #[cfg(test)]
+    if let Some(should_fail) = &state.retry_fail_spawns
+        && should_fail.load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return Err(anyhow::anyhow!("simulated audiobook spawn failure").into());
+    }
     #[cfg(test)]
     if let Some(launches) = &state.retry_launches {
         launches.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -2264,9 +2612,23 @@ async fn retry_failed_chunks(
         .into_response());
     }
 
+    // Durability transition: publish `running` (pid unknown yet) BEFORE the
+    // child exists, so a crash anywhere past this point can never leave the
+    // operation looking idle while a concurrent retry starts a second job. If
+    // the spawn then fails, the prior durable bytes are restored so the
+    // operation stays truthful and retryable.
+    write_audio_process_state(
+        &prepared.out_dir,
+        "running",
+        None,
+        None,
+        prepared.auto_model,
+        Some(&prepared.options_snapshot),
+    )?;
     let child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
+            let _ = restore_audio_process_state(&prepared.out_dir, &prepared.prior_process_json);
             return Err(anyhow::Error::from(error)
                 .context("failed to spawn audiobook retry process")
                 .into());
@@ -2305,4 +2667,23 @@ async fn retry_failed_chunks(
         "pid": pid,
     }))
     .into_response())
+}
+
+/// Restore `process.json` to exact prior bytes, durably and atomically, after
+/// a failed spawn unwound the pre-spawn "running" marker.
+fn restore_audio_process_state(out_dir: &std::path::Path, prior: &[u8]) -> Result<()> {
+    let path = out_dir.join("process.json");
+    let temp = out_dir.join("process.part.tmp");
+    let staged = (|| -> Result<()> {
+        let mut file = std::fs::File::create(&temp)?;
+        std::io::Write::write_all(&mut file, prior)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp, &path)?;
+        Ok(())
+    })();
+    if staged.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    staged
 }

--- a/crates/bookforge-cli/src/commands/serve/audio.rs
+++ b/crates/bookforge-cli/src/commands/serve/audio.rs
@@ -1639,6 +1639,28 @@ fn audiobook_operation_out_dir(upload_dir: &Path, id: &str) -> PathBuf {
     upload_dir.join(format!("audiobook-{id}"))
 }
 
+/// Resolve an existing operation as a real, immediate child directory of the
+/// upload root. The request id is used only to select a directory entry; it is
+/// never interpolated into a filesystem access path.
+fn existing_audiobook_operation_out_dir(upload_dir: &Path, id: &str) -> Result<Option<PathBuf>> {
+    if !valid_audiobook_id(id) {
+        return Ok(None);
+    }
+    let expected = std::ffi::OsString::from(format!("audiobook-{id}"));
+    let entries = match std::fs::read_dir(upload_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if entry.file_name() == expected && entry.file_type()?.is_dir() {
+            return Ok(Some(entry.path()));
+        }
+    }
+    Ok(None)
+}
+
 /// True while the operation still owns a live child; maintenance endpoints
 /// refuse to touch it until the builder exits.
 fn audiobook_process_is_running(process: &serde_json::Value) -> bool {
@@ -1939,7 +1961,6 @@ enum PrepareStep {
 pub(super) struct RetryClaim {
     nonce: String,
     claimed_at_ms: u64,
-    out_dir: PathBuf,
     /// The open, exclusively locked claim file. The claim is moved (never
     /// cloned) from acquisition through the handoff, so exactly one owner
     /// exists and the diagnostic record survives until the final release;
@@ -2028,7 +2049,7 @@ impl RetryClaim {
 
     /// Wrap a freshly locked file as this caller's claim and publish the
     /// diagnostic record through it (truncating any dead owner's bytes).
-    fn with_locked_file(out_dir: PathBuf, file: std::fs::File) -> Result<Self> {
+    fn with_locked_file(file: std::fs::File) -> Result<Self> {
         let mut randomness = [0u8; 16];
         getrandom::fill(&mut randomness).context("failed to generate retry claim nonce")?;
         let claim = RetryClaim {
@@ -2037,7 +2058,6 @@ impl RetryClaim {
                 .map(|byte| format!("{byte:02x}"))
                 .collect(),
             claimed_at_ms: now_ms(),
-            out_dir,
             file: Some(file),
         };
         claim.write_record()?;
@@ -2068,8 +2088,13 @@ impl RetryClaim {
         .expect("retry claim record should serialize")
     }
 
-    fn read_nonce(claim_path: &Path) -> Option<String> {
-        let content = std::fs::read(claim_path).ok()?;
+    fn read_nonce(&self) -> Option<String> {
+        use std::io::{Read, Seek};
+
+        let mut file = self.file.as_ref()?;
+        file.seek(std::io::SeekFrom::Start(0)).ok()?;
+        let mut content = Vec::new();
+        file.read_to_end(&mut content).ok()?;
         parse_claim_record(&content).map(|record| record.nonce)
     }
 
@@ -2080,9 +2105,8 @@ impl RetryClaim {
     /// a newer claim exists and must never be touched. The file itself keeps
     /// its stable identity (it is not unlinked), so a concurrent acquirer that
     /// already opened it contends on the same lock.
-    pub(super) fn release(&self) {
-        let claim_path = Self::claim_file(&self.out_dir);
-        if Self::read_nonce(&claim_path).as_deref() != Some(self.nonce.as_str()) {
+    fn release_as_nonce(&self, nonce: &str) {
+        if self.read_nonce().as_deref() != Some(nonce) {
             return;
         }
         if let Some(file) = &self.file {
@@ -2092,6 +2116,10 @@ impl RetryClaim {
             let _ = file.seek(std::io::SeekFrom::Start(0));
             let _ = file.sync_all();
         }
+    }
+
+    pub(super) fn release(&self) {
+        self.release_as_nonce(&self.nonce);
     }
 }
 
@@ -2107,15 +2135,9 @@ impl Drop for RetryClaim {
 
 #[cfg(test)]
 impl RetryClaim {
-    /// Test-only claim bound to an explicit nonce and no lock, so unit tests
-    /// can prove a nonce-mismatched release leaves the lock untouched.
-    pub(super) fn with_nonce(out_dir: PathBuf, nonce: &str) -> RetryClaim {
-        RetryClaim {
-            nonce: nonce.to_string(),
-            claimed_at_ms: now_ms(),
-            out_dir,
-            file: None,
-        }
+    /// Exercise a foreign release through this claim's real locked handle.
+    pub(super) fn release_as_nonce_for_test(&self, nonce: &str) {
+        self.release_as_nonce(nonce);
     }
 }
 
@@ -2182,7 +2204,6 @@ pub(super) fn acquire_retry_claim(out_dir: &Path) -> Result<RetryClaimAcquire> {
     }
 
     Ok(RetryClaimAcquire::Owned(RetryClaim::with_locked_file(
-        out_dir.to_path_buf(),
         file,
     )?))
 }
@@ -2195,10 +2216,9 @@ fn options_string(options: &serde_json::Value, key: &str) -> Option<String> {
 }
 
 fn prepare_retry_failed(upload_dir: &Path, id: &str) -> Result<PreparedOutcome> {
-    let out_dir = audiobook_operation_out_dir(upload_dir, id);
-    if !out_dir.is_dir() {
+    let Some(out_dir) = existing_audiobook_operation_out_dir(upload_dir, id)? else {
         return Ok(PreparedOutcome::NotFound);
-    }
+    };
     let process_path = out_dir.join("process.json");
     let claim_path = out_dir.join(RETRY_CLAIM_FILE_NAME);
     let process = match std::fs::read(&process_path)
@@ -2250,7 +2270,14 @@ fn prepare_retry_failed(upload_dir: &Path, id: &str) -> Result<PreparedOutcome> 
     // through the whole handoff. [`RetryClaim`]'s `Drop` releases the lock —
     // a refusal, an early `?`, or a panic all unwind to a clean operation
     // directory with `process.json` untouched.
-    match finish_prepare_retry(upload_dir, id, &process, claim, prior_process_json)? {
+    match finish_prepare_retry(
+        upload_dir,
+        &out_dir,
+        id,
+        &process,
+        claim,
+        prior_process_json,
+    )? {
         PrepareStep::Ready(prepared) => Ok(PreparedOutcome::Ready(prepared)),
         PrepareStep::Refused(message) => Ok(PreparedOutcome::Client(message)),
     }
@@ -2262,13 +2289,13 @@ fn prepare_retry_failed(upload_dir: &Path, id: &str) -> Result<PreparedOutcome> 
 /// [`RetryClaim`]'s `Drop`.
 fn finish_prepare_retry(
     upload_dir: &Path,
+    out_dir: &Path,
     id: &str,
     process: &serde_json::Value,
     claim: RetryClaim,
     prior_process_json: Vec<u8>,
 ) -> Result<PrepareStep> {
     let refused = |message: &str| Ok(PrepareStep::Refused(message.to_string()));
-    let out_dir = audiobook_operation_out_dir(upload_dir, id);
     let Some(options) = process
         .get("options")
         .filter(|value| value.is_object())
@@ -2412,7 +2439,7 @@ fn finish_prepare_retry(
         .unwrap_or(false);
 
     Ok(PrepareStep::Ready(Box::new(PreparedRetry {
-        out_dir,
+        out_dir: out_dir.to_path_buf(),
         claim,
         input_path,
         model_opt: model_for_child.filter(|model| !model.is_empty()),

--- a/crates/bookforge-cli/src/commands/serve/audio.rs
+++ b/crates/bookforge-cli/src/commands/serve/audio.rs
@@ -1639,26 +1639,34 @@ fn audiobook_operation_out_dir(upload_dir: &Path, id: &str) -> PathBuf {
     upload_dir.join(format!("audiobook-{id}"))
 }
 
-/// Resolve an existing operation as a real, immediate child directory of the
-/// upload root. The request id is used only to select a directory entry; it is
-/// never interpolated into a filesystem access path.
-fn existing_audiobook_operation_out_dir(upload_dir: &Path, id: &str) -> Result<Option<PathBuf>> {
+/// Resolve an existing operation only when its canonical path remains a direct
+/// child of the canonical upload root. This rejects traversal and symlink
+/// escapes before the path reaches any read or write operation.
+pub(super) fn existing_audiobook_operation_out_dir(
+    upload_dir: &Path,
+    id: &str,
+) -> Result<Option<PathBuf>> {
     if !valid_audiobook_id(id) {
         return Ok(None);
     }
-    let expected = std::ffi::OsString::from(format!("audiobook-{id}"));
-    let entries = match std::fs::read_dir(upload_dir) {
-        Ok(entries) => entries,
+    let root = match std::fs::canonicalize(upload_dir) {
+        Ok(root) => root,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error.into()),
     };
-    for entry in entries {
-        let entry = entry?;
-        if entry.file_name() == expected && entry.file_type()?.is_dir() {
-            return Ok(Some(entry.path()));
-        }
+    let candidate = root.join(format!("audiobook-{id}"));
+    let resolved = match std::fs::canonicalize(&candidate) {
+        Ok(resolved) => resolved,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if !resolved.starts_with(&root)
+        || resolved.parent() != Some(root.as_path())
+        || !resolved.is_dir()
+    {
+        return Ok(None);
     }
-    Ok(None)
+    Ok(Some(resolved))
 }
 
 /// True while the operation still owns a live child; maintenance endpoints

--- a/crates/bookforge-cli/src/commands/serve/audio.rs
+++ b/crates/bookforge-cli/src/commands/serve/audio.rs
@@ -2139,6 +2139,12 @@ impl RetryClaim {
     pub(super) fn release_as_nonce_for_test(&self, nonce: &str) {
         self.release_as_nonce(nonce);
     }
+
+    /// Inspect the published record through the owning handle. Opening the
+    /// locked byte range by path is expected to fail on Windows.
+    pub(super) fn is_published_for_test(&self) -> bool {
+        self.read_nonce().as_deref() == Some(self.nonce.as_str())
+    }
 }
 
 /// Result of trying to take the single-winner retry claim for `out_dir`.

--- a/crates/bookforge-cli/src/commands/serve/dashboard.html
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.html
@@ -16,6 +16,7 @@
   <div class="right">
     <button class="btn btn-ghost" onclick="bfStartAudiobook()">+ New audiobook</button>
     <button class="btn btn-primary" onclick="bfStartNew()">+ New translation</button>
+    <button class="btn btn-ghost" onclick="bfSignOut()" title="End this browser session and return to the login screen">Sign out</button>
     <div class="themetoggle" onclick="bfTheme()"><span id="sun">&#9728;</span><span id="moon">&#9790;</span></div>
   </div>
 </header>

--- a/crates/bookforge-cli/src/commands/serve/dashboard.js
+++ b/crates/bookforge-cli/src/commands/serve/dashboard.js
@@ -1,34 +1,28 @@
-const CSRF_HEADER = "x-bookforge-csrf";
-// The server only substitutes this placeholder for callers that already hold
-// the session credential; regular browsers get it from sessionStorage, seeded
-// by the ?token= bootstrap link printed by `bookforge serve`.
-const CSRF_TOKEN = sessionStorage.getItem(CSRF_HEADER) || "__BOOKFORGE_CSRF_TOKEN__";
 /* ===== BFAPISEAM-BEGIN: the only raw fetch( calls live between these markers =====
- * F2 remediation: reads used to skip the x-bookforge-csrf session header that
- * mutation helpers carried, so under default-on auth (H-5) entire screens
- * (Library lists, Progress polling, Review, Glossary/Styles/Entities tables,
- * Audiobook voices/status polls, provider metadata) silently 401'd while the
- * user watched empty data. Every browser call — reads included — is routed
- * through apiGet/apiSend, which stamp the header unconditionally, so no new
- * call site can forget it. */
-function bfAuthHeaders(extra) { return Object.assign({}, { [CSRF_HEADER]: CSRF_TOKEN }, extra || {}); }
+ * Auth: the server authenticates every same-origin request through the
+ * HttpOnly `bookforge_session` cookie set by the ?token= bootstrap exchange.
+ * SameSite=Strict means the browser sends it automatically on same-origin
+ * fetch(), so the client never reads, stores, or injects any credential —
+ * nothing secret is ever kept or embedded client-side. */
 function bfFetch(path, options) {
-  const request = Object.assign({}, options || {});
-  request.headers = bfAuthHeaders(request.headers);
-  return fetch(path, request);
+  return fetch(path, options);
 }
 async function apiGet(path, init) { return bfFetch(path, init); }
 async function apiSend(path, options) { return bfFetch(path, options); }
 /* ===== BFAPISEAM-END ===== */
-function bfSessionSeeded() { return !!sessionStorage.getItem(CSRF_HEADER); }
 function bfSignedOut() {
-  try { sessionStorage.removeItem(CSRF_HEADER); } catch (e) {}
   const old = $("#auth-notice"); if (old) return;
   const banner = document.createElement("div");
   banner.id = "auth-notice";
   banner.style.cssText = "position:fixed;left:0;right:0;top:0;z-index:9999;padding:12px 18px;background:#7a1f1f;color:#fff;font:500 13px system-ui,sans-serif;text-align:center";
-  banner.textContent = "Dashboard session expired or missing — reopen the http://127.0.0.1:?token=… link printed by bookforge serve in its terminal.";
+  banner.textContent = "Dashboard session expired or signed out — run `bookforge serve` again and open the sign-in link it prints.";
   document.body.appendChild(banner);
+}
+// Sign out: the server forgets this session and expires the cookie; the clean
+// reload then lands on the login screen.
+async function bfSignOut() {
+  try { await apiSend("/api/auth/logout", { method: "POST" }); } catch (e) {}
+  location.replace("/");
 }
 const $ = (sel, el) => (el || document).querySelector(sel);
 const ESC = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
@@ -762,8 +756,8 @@ async function pollAudiobook(id) {
   if (!terminal) setTimeout(()=>pollAudiobook(id), 800);
 }
 
-// Artifact playback/download need the session-token header, which plain
-// audio `src=` / anchor `href=` navigation cannot send. Fetch the bytes with
+// Artifact playback/download must go through the authenticated API, which
+// plain audio `src=` / anchor `href=` navigation cannot. Fetch the bytes with
 // the header and hand the DOM a one-off blob: URL instead.
 const artifactUrls = new Map();
 function cachedArtifactUrl(key) { const url = artifactUrls.get(key); return url ? url.url : null; }
@@ -1060,8 +1054,8 @@ function fmtEvent(ev) {
 }
 function openStream(id) {
   closeStream();
-  // Auth requires the session token as a header on every API call, and
-  // EventSource cannot set headers — so consume the SSE stream with fetch
+  // Auth is cookie-based (HttpOnly, SameSite=Strict) and EventSource cannot
+  // carry extra headers anyway — so consume the SSE stream with fetch
   // and parse the same wire format (event:/data: frames, blank-line
   // separated, `:`-prefixed keepalive comments ignored).
   const controller = new AbortController();

--- a/crates/bookforge-cli/src/commands/serve/security.rs
+++ b/crates/bookforge-cli/src/commands/serve/security.rs
@@ -1,4 +1,203 @@
 use super::*;
+use axum::http::HeaderValue;
+use std::collections::VecDeque;
+use std::time::Instant;
+
+/// Name of the in-memory browser-session cookie issued by the `/` bootstrap
+/// exchange. HttpOnly, SameSite=Strict, Path=/, browser-session lifetime (no
+/// Max-Age) and deliberately no Secure flag because the loopback listener is
+/// plain HTTP.
+pub(super) const SESSION_COOKIE_NAME: &str = "bookforge_session";
+const SESSION_COOKIE_PREFIX: &str = "bookforge_session=";
+
+/// Bootstrap query tokens printed on the console are only accepted for the
+/// first five minutes of server life.
+const BOOTSTRAP_TTL: Duration = Duration::from_secs(5 * 60);
+/// Bounded failed-exchange limiter: once this many wrong bootstrap tokens
+/// arrive inside the TTL window, further exchanges are refused outright so a
+/// probing local process cannot grind through the space.
+const MAX_FAILED_BOOTSTRAP_EXCHANGES: usize = 8;
+/// Cap on simultaneously remembered session ids; the oldest is evicted first.
+const MAX_ACTIVE_SESSIONS: usize = 8;
+
+/// Server-side authentication state for the loopback dashboard.
+///
+/// - The **bootstrap token** is the 128-bit secret printed in the console URL
+///   (`?token=…`). It is valid for [`BOOTSTRAP_TTL`], compared in constant
+///   time, and exchanged exactly once per successful handshake for a session
+///   cookie. It is never stored in a cookie and never echoed in a response.
+/// - The **session id** is a fresh random value minted per successful
+///   exchange, held only in process memory (cleared on restart), compared in
+///   constant time, and delivered to the browser as an HttpOnly cookie. It
+///   never appears in HTML, JS, or JSON.
+pub(super) struct AuthState {
+    pub(super) enabled: bool,
+    bootstrap: Mutex<Bootstrap>,
+    sessions: Mutex<SessionStore>,
+}
+
+struct Bootstrap {
+    value: String,
+    valid_until: Instant,
+    failed_exchanges: usize,
+    /// Set on the first successful exchange. Once true the token is dead: a
+    /// replayed or leaked console link can never mint a second session.
+    consumed: bool,
+}
+
+#[derive(Default)]
+struct SessionStore {
+    ids: VecDeque<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum BootstrapOutcome {
+    /// The token matched inside its TTL; carries the freshly minted session id
+    /// that the caller should hand the browser as the session cookie.
+    Granted(String),
+    /// Wrong token, an already-consumed token, or the failed-exchange limiter
+    /// has already tripped.
+    Rejected,
+    /// The token is past its five-minute lifetime.
+    Expired,
+}
+
+impl AuthState {
+    pub(super) fn new(enabled: bool) -> Result<Self> {
+        let token = generate_csrf_token()?;
+        Ok(Self {
+            enabled,
+            bootstrap: Mutex::new(Bootstrap {
+                value: token,
+                valid_until: Instant::now() + BOOTSTRAP_TTL,
+                failed_exchanges: 0,
+                consumed: false,
+            }),
+            sessions: Mutex::new(SessionStore::default()),
+        })
+    }
+
+    /// The console-printed bootstrap token (for the startup URL only).
+    pub(super) fn bootstrap_token(&self) -> String {
+        self.bootstrap
+            .lock()
+            .map(|bootstrap| bootstrap.value.clone())
+            .unwrap_or_default()
+    }
+
+    /// Attempt the one-time bootstrap exchange. Only accepts the token during
+    /// [`BOOTSTRAP_TTL`], compares in constant time, and bounds how many
+    /// failed exchanges are entertained before refusing everything. The first
+    /// successful exchange consumes the token: every later attempt — even with
+    /// the exact console value — is refused, so a replayed or leaked link can
+    /// never mint a second session.
+    pub(super) fn exchange_bootstrap(&self, candidate: &str) -> BootstrapOutcome {
+        let mut bootstrap = self.bootstrap.lock().unwrap_or_else(poisoned);
+        if Instant::now() >= bootstrap.valid_until {
+            return BootstrapOutcome::Expired;
+        }
+        if bootstrap.failed_exchanges >= MAX_FAILED_BOOTSTRAP_EXCHANGES {
+            return BootstrapOutcome::Rejected;
+        }
+        if bootstrap.consumed {
+            return BootstrapOutcome::Rejected;
+        }
+        if !constant_time_eq(candidate.as_bytes(), bootstrap.value.as_bytes()) {
+            bootstrap.failed_exchanges += 1;
+            return BootstrapOutcome::Rejected;
+        }
+        let Ok(session_id) = generate_csrf_token() else {
+            return BootstrapOutcome::Rejected;
+        };
+        // Burn the token only after the session was actually minted, so a
+        // failed random-id draw (Rejected above) does not consume a token the
+        // operator could still use.
+        bootstrap.consumed = true;
+        self.sessions
+            .lock()
+            .unwrap_or_else(poisoned)
+            .insert(session_id.clone());
+        BootstrapOutcome::Granted(session_id)
+    }
+
+    /// True when `cookie` names a live in-memory session. Constant-time per
+    /// stored id; a wrong or absent cookie never distinguishes its reason.
+    pub(super) fn has_session(&self, cookie: Option<&str>) -> bool {
+        match cookie {
+            Some(cookie) => self
+                .sessions
+                .lock()
+                .unwrap_or_else(poisoned)
+                .contains(cookie),
+            None => false,
+        }
+    }
+
+    /// Forget the session behind `cookie` (logout). Idempotent for a missing
+    /// or already-dead session.
+    pub(super) fn end_session(&self, cookie: Option<&str>) {
+        if let Some(cookie) = cookie {
+            self.sessions.lock().unwrap_or_else(poisoned).remove(cookie);
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn expire_bootstrap_for_test(&self) {
+        self.bootstrap.lock().unwrap_or_else(poisoned).valid_until =
+            Instant::now() - Duration::from_secs(1);
+    }
+
+    /// Test-only: pre-establish a session with a known id so router tests can
+    /// authenticate by sending that value as the cookie without waiting for a
+    /// real exchange.
+    #[cfg(test)]
+    pub(super) fn seed_session(&self, id: &str) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(poisoned)
+            .insert(id.to_string());
+    }
+}
+
+fn poisoned<T>(poison: std::sync::PoisonError<T>) -> T {
+    // A poisoned mutex means a thread panicked while holding the lock. The
+    // auth data is still coherent (mutations complete before a panicking
+    // thread drops the guard), so recover the inner value rather than fail
+    // closed on the whole dashboard.
+    poison.into_inner()
+}
+
+impl SessionStore {
+    fn insert(&mut self, id: String) {
+        if self.ids.iter().any(|existing| existing == &id) {
+            return;
+        }
+        if self.ids.len() >= MAX_ACTIVE_SESSIONS {
+            self.ids.pop_front();
+        }
+        self.ids.push_back(id);
+    }
+
+    fn contains(&self, candidate: &str) -> bool {
+        self.ids
+            .iter()
+            .any(|existing| constant_time_eq(existing.as_bytes(), candidate.as_bytes()))
+    }
+
+    fn remove(&mut self, candidate: &str) -> bool {
+        match self
+            .ids
+            .iter()
+            .position(|existing| constant_time_eq(existing.as_bytes(), candidate.as_bytes()))
+        {
+            Some(index) => {
+                self.ids.remove(index);
+                true
+            }
+            None => false,
+        }
+    }
+}
 
 pub(super) async fn validate_dashboard_host(
     State(state): State<AppState>,
@@ -11,8 +210,8 @@ pub(super) async fn validate_dashboard_host(
     forbidden("dashboard host header rejected")
 }
 
-/// Bare 401 for failed session-token checks (H-5): no detail about which half
-/// of the credential was wrong, so a probing local process learns nothing.
+/// Bare 401 for failed session checks (H-5): no detail about which half of
+/// the credential was wrong, so a probing local process learns nothing.
 pub(super) fn unauthorized() -> Response {
     (
         StatusCode::UNAUTHORIZED,
@@ -33,7 +232,7 @@ pub(super) fn apply_security_headers(response: &mut Response) {
         ("referrer-policy", "no-referrer"),
         ("cache-control", "no-store"),
     ] {
-        if let Ok(value) = value.parse::<axum::http::HeaderValue>() {
+        if let Ok(value) = value.parse::<HeaderValue>() {
             headers.insert(name, value);
         }
     }
@@ -81,18 +280,20 @@ pub(super) fn require_loopback_bind(addr: SocketAddr) -> Result<()> {
     );
 }
 
+/// The mutation gate: same-origin (Host/Origin/Fetch-Metadata) checks plus, in
+/// auth-on mode, a live browser session cookie. There is deliberately no
+/// JavaScript-readable bearer token anymore — the HttpOnly session cookie is
+/// the whole credential, so mutations are protected by SameSite=Strict plus
+/// these explicit origin checks rather than an embedded CSRF token.
 pub(super) fn reject_mutation(headers: &HeaderMap, state: &AppState) -> Option<Response> {
     if is_cross_site_browser_request(headers) {
         return Some(forbidden("cross-site dashboard request rejected"));
     }
 
-    match headers
-        .get(CSRF_HEADER)
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(token) if constant_time_eq(token.as_bytes(), state.csrf_token.as_bytes()) => None,
-        _ => Some(forbidden("missing or invalid dashboard token")),
+    if state.auth.enabled && !state.auth.has_session(session_cookie_from(headers)) {
+        return Some(forbidden("missing or invalid dashboard session"));
     }
+    None
 }
 
 pub(super) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
@@ -107,7 +308,51 @@ pub(super) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
     diff == 0
 }
 
-fn is_cross_site_browser_request(headers: &HeaderMap) -> bool {
+/// POST /api/auth/logout — the one session-management route exempt from the
+/// authentication gate so a browser holding a stale cookie can clear it. It
+/// still runs the same-origin gate, forgets the presented session, and sends
+/// an expiring cookie.
+pub(super) async fn auth_logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if is_cross_site_browser_request(&headers) {
+        return forbidden("cross-site dashboard request rejected");
+    }
+    state.auth.end_session(session_cookie_from(&headers));
+    let mut response = StatusCode::NO_CONTENT.into_response();
+    response
+        .headers_mut()
+        .insert("set-cookie", expire_session_cookie());
+    response
+}
+
+/// Pull our session id out of a `Cookie` request header, if present.
+pub(super) fn session_cookie_from(headers: &HeaderMap) -> Option<&str> {
+    let cookie = headers.get("cookie")?.to_str().ok()?;
+    cookie.split(';').find_map(|part| {
+        part.trim()
+            .strip_prefix(SESSION_COOKIE_PREFIX)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    })
+}
+
+/// The bootstrap-exchange success cookie: HttpOnly, SameSite=Strict, Path=/,
+/// browser-session lifetime (no Max-Age), no Secure flag on loopback HTTP.
+pub(super) fn build_session_cookie(value: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE_NAME}={value}; HttpOnly; SameSite=Strict; Path=/"
+    ))
+    .expect("session cookie header is static and safe")
+}
+
+/// Expiring cookie sent on logout so the browser drops the session id.
+pub(super) fn expire_session_cookie() -> HeaderValue {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0"
+    ))
+    .expect("expiring session cookie header is static and safe")
+}
+
+pub(super) fn is_cross_site_browser_request(headers: &HeaderMap) -> bool {
     headers
         .get("sec-fetch-site")
         .and_then(|value| value.to_str().ok())

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -5,11 +5,19 @@ use axum::http::HeaderValue;
 const TEST_HOST: &str = "127.0.0.1:8765";
 const TEST_DEADLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
-fn test_state(token: &str) -> AppState {
+/// An auth-on test state that has pre-established a session with the given id
+/// (so router tests authenticate by sending that value as the session cookie,
+/// without waiting for a real bootstrap exchange).
+fn test_state(session: &str) -> AppState {
+    test_state_opt(session, true)
+}
+
+fn test_state_opt(session: &str, auth_enabled: bool) -> AppState {
+    let auth = AuthState::new(auth_enabled).expect("auth state should build");
+    auth.seed_session(session);
     AppState {
         refresh: Duration::from_millis(250),
-        csrf_token: token.to_string(),
-        auth_enabled: true,
+        auth: Arc::new(auth),
         host_port: 8765,
         upload_dir: PathBuf::from(UPLOAD_DIR),
         keys: Arc::new(Mutex::new(HashMap::new())),
@@ -31,17 +39,17 @@ fn test_state(token: &str) -> AppState {
 /// mutation endpoints against a temp-dir database without chdir'ing the
 /// (shared, per-process) current directory, which would race across
 /// parallel test threads.
-fn test_state_with_store(token: &str, store_path: PathBuf) -> AppState {
+fn test_state_with_store(session: &str, store_path: PathBuf) -> AppState {
     AppState {
         store_path,
-        ..test_state(token)
+        ..test_state(session)
     }
 }
 
-fn test_state_with_upload_dir(token: &str, upload_dir: PathBuf) -> AppState {
+fn test_state_with_upload_dir(session: &str, upload_dir: PathBuf) -> AppState {
     AppState {
         upload_dir,
-        ..test_state(token)
+        ..test_state(session)
     }
 }
 
@@ -263,13 +271,16 @@ async fn child_startup_check_reports_immediate_success_exit() -> Result<()> {
 }
 
 #[test]
-fn mutating_routes_require_dashboard_token() {
+fn mutating_routes_require_an_authenticated_session() {
     let state = test_state("token-123");
     let headers = HeaderMap::new();
     assert!(reject_mutation(&headers, &state).is_some());
 
     let mut headers = HeaderMap::new();
-    headers.insert(CSRF_HEADER, HeaderValue::from_static("token-123"));
+    headers.insert(
+        "cookie",
+        HeaderValue::from_static("bookforge_session=token-123"),
+    );
     assert!(reject_mutation(&headers, &state).is_none());
 }
 
@@ -277,7 +288,10 @@ fn mutating_routes_require_dashboard_token() {
 fn mutating_routes_reject_cross_site_browser_requests() {
     let state = test_state("token-123");
     let mut headers = HeaderMap::new();
-    headers.insert(CSRF_HEADER, HeaderValue::from_static("token-123"));
+    headers.insert(
+        "cookie",
+        HeaderValue::from_static("bookforge_session=token-123"),
+    );
     headers.insert("sec-fetch-site", HeaderValue::from_static("cross-site"));
 
     assert!(reject_mutation(&headers, &state).is_some());
@@ -566,7 +580,7 @@ async fn audiobook_launch_rejects_seed_before_spawning_a_doomed_child() {
             .method("POST")
             .uri("/api/audiobook")
             .header("host", TEST_HOST)
-            .header(CSRF_HEADER, "token-123")
+            .header("cookie", session_cookie_value("token-123"))
             .header("content-type", "multipart/form-data; boundary=B")
             .body(Body::from(body))
             .expect("request should build"),
@@ -651,7 +665,7 @@ async fn audiobook_estimate_matches_the_shared_launcher_chunk_plan() {
                 .method("POST")
                 .uri("/api/audiobook/estimate")
                 .header("host", TEST_HOST)
-                .header(CSRF_HEADER, "token-123")
+                .header("cookie", session_cookie_value("token-123"))
                 .header("content-type", "multipart/form-data; boundary=B")
                 .body(Body::from(body))
                 .expect("request should build"),
@@ -845,7 +859,7 @@ async fn audiobook_artifact_supports_ranges_and_rejects_unsatisfiable_ranges() {
             Request::builder()
                 .uri("/api/audiobooks/range-test/artifact")
                 .header("host", TEST_HOST)
-                .header(CSRF_HEADER, "token-123")
+                .header("cookie", session_cookie_value("token-123"))
                 .header("range", "bytes=2-5")
                 .body(Body::empty())
                 .expect("request should build"),
@@ -871,7 +885,7 @@ async fn audiobook_artifact_supports_ranges_and_rejects_unsatisfiable_ranges() {
             Request::builder()
                 .uri("/api/audiobooks/range-test/artifact")
                 .header("host", TEST_HOST)
-                .header(CSRF_HEADER, "token-123")
+                .header("cookie", session_cookie_value("token-123"))
                 .header("range", "bytes=20-")
                 .body(Body::empty())
                 .expect("request should build"),
@@ -1010,7 +1024,7 @@ async fn translate_rejects_non_https_openai_compatible_base_url() {
                 .method("POST")
                 .uri("/api/translate")
                 .header("host", TEST_HOST)
-                .header(CSRF_HEADER, "token-123")
+                .header("cookie", session_cookie_value("token-123"))
                 .header("content-type", "multipart/form-data; boundary=B")
                 .body(Body::from(body))
                 .expect("request should build"),
@@ -1096,14 +1110,14 @@ fn dashboard_ships_store_curation_screens_and_audio_parity_controls() {
 fn dashboard_assets_reassemble_byte_stably() {
     use sha2::{Digest, Sha256};
 
-    assert_eq!(DASHBOARD_HTML.len(), 140_401);
+    assert_eq!(DASHBOARD_HTML.len(), 139_947);
     assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_CSS}}"));
     assert!(!DASHBOARD_HTML.contains("{{BOOKFORGE_DASHBOARD_JS}}"));
     let digest = Sha256::digest(DASHBOARD_HTML.as_bytes());
     let digest_hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
     assert_eq!(
         digest_hex,
-        "2ac98484cf857f01263d309f35bbce24768f9bd018e64c12b84c532d6e0cc2e3"
+        "b7acaffc1faebe59b8838d69c41a180875c29a289368f068303e6e9cf4c66c8d"
     );
 
     let crlf = |asset: &str| asset.replace("\r\n", "\n").replace('\n', "\r\n");
@@ -1138,25 +1152,31 @@ fn dashboard_ships_runtime_editor_and_inline_retry_guidance() {
 }
 
 #[test]
-fn dashboard_posts_include_csrf_header() {
-    assert!(DASHBOARD_HTML.contains(CSRF_TOKEN_PLACEHOLDER));
-    // The header literal lives inside the API-seam helpers now (see the
-    // fetch-seam test below); every browser call inherits it from there.
-    assert!(DASHBOARD_JS.contains("function bfAuthHeaders(extra)"));
+fn dashboard_js_never_reads_or_injects_a_session_credential() {
+    // Auth is a same-origin HttpOnly cookie: the browser JS must hold no
+    // secret — no header literal, no sessionStorage, no placeholder.
+    for secret_ish in ["sessionStorage", "x-bookforge-csrf", "__BOOKFORGE_"] {
+        assert!(
+            !DASHBOARD_JS.contains(secret_ish),
+            "dashboard.js must not embed {secret_ish:?}"
+        );
+    }
+    // Sign-out plumbing is present so the session can be ended from the UI.
+    assert!(DASHBOARD_JS.contains("async function bfSignOut"));
+    assert!(DASHBOARD_HTML.contains("onclick=\"bfSignOut()\""));
 }
 
-/// F2 regression net: reads used to bypass the session-CSRF header mutations
-/// carried, silently 401-ing entire screens once auth became default-on.
-/// Structural guarantee, not spot checks:
+/// Fetch-seam audit: the browser authenticates purely via the cookie, and
+/// every network call still routes through the single seam:
 ///
 /// 1. exactly one raw `fetch(` may exist, and only between the
-///    `BFAPISEAM-BEGIN`/`BFAPISEAM-END` markers where the header is stamped;
+///    `BFAPISEAM-BEGIN`/`BFAPISEAM-END` markers where `bfFetch` lives;
 /// 2. every screen's endpoints are asserted to reach the server through
 ///    `apiGet`/`apiSend`, covering Library, Progress polling, Review,
 ///    Glossary, Styles/Entities lists, Audiobook wizard/voices/status/
 ///    artifact hydration and the provider/options metadata bootstraps.
 #[test]
-fn dashboard_fetches_all_route_through_the_csrf_api_seam() {
+fn dashboard_fetches_all_route_through_the_cookie_api_seam() {
     const SEAM_BEGIN: &str = "BFAPISEAM-BEGIN";
     const SEAM_END: &str = "BFAPISEAM-END";
 
@@ -1171,7 +1191,7 @@ fn dashboard_fetches_all_route_through_the_csrf_api_seam() {
     assert_eq!(
         outside_seam, 0,
         "every raw fetch( must live between {SEAM_BEGIN}/{SEAM_END} \
-         and go through bfAuthHeaders/apiGet/apiSend"
+         and go through bfFetch/apiGet/apiSend"
     );
     assert!(
         total_fetch_calls >= 1,
@@ -1179,10 +1199,13 @@ fn dashboard_fetches_all_route_through_the_csrf_api_seam() {
     );
 
     for marker in [
-        // Header injection helper stamps the header name unconditionally.
-        "[CSRF_HEADER]: CSRF_TOKEN",
+        // The seam is a thin pass-through now: the HttpOnly session cookie
+        // rides along on the same-origin request automatically.
+        "function bfFetch(path, options)",
         "async function apiGet(",
         "async function apiSend(",
+        // Sign-out reuses the seam.
+        "await apiSend(\"/api/auth/logout\", { method: \"POST\" })",
         // Library: job list + audiobook list poll through the seam.
         "Promise.all([apiGet(\"/api/jobs\"), apiGet(\"/api/audiobooks\")])",
         // Narrate-from-library job hydration.
@@ -1220,8 +1243,8 @@ fn dashboard_fetches_all_route_through_the_csrf_api_seam() {
         assert!(js.contains(marker), "missing api-seam usage: {marker}");
     }
 
-    // Mutations with bodies keep their explicit content-type while the seam
-    // adds the session token on top.
+    // Mutations with bodies keep their explicit content-type; nothing else is
+    // added by the seam.
     for marker in [
         "\"content-type\": \"application/json\"",
         "{ method: \"DELETE\" }",
@@ -1346,7 +1369,7 @@ struct MutationFixture {
     job_id: String,
     segment_a: String,
     segment_b: String,
-    csrf: String,
+    session: String,
 }
 
 fn build_mutation_fixture() -> MutationFixture {
@@ -1492,17 +1515,17 @@ fn build_mutation_fixture_for_provider(
         job_id: job.id,
         segment_a: chapter_segments[0].id.0.clone(),
         segment_b: chapter_segments[1].id.0.clone(),
-        csrf: "fixture-csrf-token".to_string(),
+        session: "fixture-session-id".to_string(),
         _temp: temp,
     }
 }
 
-/// Sends `body` to `uri` with the given CSRF header value (or none), and
+/// Sends `body` to `uri` with the given session cookie value (or none), and
 /// returns the response.
 async fn post_json(
     router: &Router,
     uri: &str,
-    csrf: Option<&str>,
+    session: Option<&str>,
     body: serde_json::Value,
 ) -> Response {
     use axum::{body::Body, http::Request};
@@ -1513,8 +1536,8 @@ async fn post_json(
         .uri(uri)
         .header("host", TEST_HOST)
         .header("content-type", "application/json");
-    if let Some(token) = csrf {
-        builder = builder.header(CSRF_HEADER, token);
+    if let Some(session) = session {
+        builder = builder.header("cookie", session_cookie_value(session));
     }
     router
         .clone()
@@ -1531,7 +1554,7 @@ async fn post_json(
 async fn axum_put_json(
     router: &Router,
     uri: &str,
-    csrf: Option<&str>,
+    session: Option<&str>,
     body: serde_json::Value,
 ) -> Response {
     use axum::{body::Body, http::Request};
@@ -1542,8 +1565,8 @@ async fn axum_put_json(
         .uri(uri)
         .header("host", TEST_HOST)
         .header("content-type", "application/json");
-    if let Some(token) = csrf {
-        builder = builder.header(CSRF_HEADER, token);
+    if let Some(session) = session {
+        builder = builder.header("cookie", session_cookie_value(session));
     }
     router
         .clone()
@@ -1556,8 +1579,8 @@ async fn axum_put_json(
         .expect("route should respond")
 }
 
-/// DELETE with the given CSRF header value (or none).
-async fn axum_delete(router: &Router, uri: &str, csrf: Option<&str>) -> Response {
+/// DELETE with the given session cookie value (or none).
+async fn axum_delete(router: &Router, uri: &str, session: Option<&str>) -> Response {
     use axum::{body::Body, http::Request};
     use tower::ServiceExt;
 
@@ -1565,8 +1588,8 @@ async fn axum_delete(router: &Router, uri: &str, csrf: Option<&str>) -> Response
         .method("DELETE")
         .uri(uri)
         .header("host", TEST_HOST);
-    if let Some(token) = csrf {
-        builder = builder.header(CSRF_HEADER, token);
+    if let Some(session) = session {
+        builder = builder.header("cookie", session_cookie_value(session));
     }
     router
         .clone()
@@ -1576,22 +1599,32 @@ async fn axum_delete(router: &Router, uri: &str, csrf: Option<&str>) -> Response
 }
 
 async fn get_route(router: &Router, uri: &str) -> Response {
-    get_route_with_token(router, uri, Some("token-123")).await
+    get_route_with_session(router, uri, Some("token-123")).await
 }
 
 async fn get_route_with_token(router: &Router, uri: &str, token: Option<&str>) -> Response {
+    get_route_with_session(router, uri, token).await
+}
+
+async fn get_route_with_session(router: &Router, uri: &str, session: Option<&str>) -> Response {
     use axum::{body::Body, http::Request};
     use tower::ServiceExt;
 
     let mut builder = Request::builder().uri(uri).header("host", TEST_HOST);
-    if let Some(token) = token {
-        builder = builder.header(CSRF_HEADER, token);
+    if let Some(session) = session {
+        builder = builder.header("cookie", session_cookie_value(session));
     }
     router
         .clone()
         .oneshot(builder.body(Body::empty()).expect("request should build"))
         .await
         .expect("route should respond")
+}
+
+/// A `Cookie` header value carrying the given session id.
+fn session_cookie_value(session: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!("{SESSION_COOKIE_NAME}={session}"))
+        .expect("session cookie header should parse")
 }
 
 async fn response_json(response: Response) -> serde_json::Value {
@@ -1621,12 +1654,12 @@ async fn dashboard_reconfigure_is_typed_revisioned_and_csrf_protected() {
     make_stopped_fixture_resumable(&fixture);
     clean_runtime_files(&fixture.job_id);
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
     let uri = format!("/api/jobs/{}/reconfigure", fixture.job_id);
 
-    let initial = get_route_with_token(&router, &uri, Some(&fixture.csrf)).await;
+    let initial = get_route_with_token(&router, &uri, Some(&fixture.session)).await;
     assert_eq!(initial.status(), StatusCode::OK);
     let initial = response_json(initial).await;
     assert_eq!(initial["revision"], 0);
@@ -1652,7 +1685,7 @@ async fn dashboard_reconfigure_is_typed_revisioned_and_csrf_protected() {
     let unknown = post_json(
         &router,
         &uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({ "model": "immutable-model" }),
     )
     .await;
@@ -1665,7 +1698,7 @@ async fn dashboard_reconfigure_is_typed_revisioned_and_csrf_protected() {
     let first = post_json(
         &router,
         &uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({
             "batch_max_output_tokens": 12000,
             "batch_max_items": 2,
@@ -1703,7 +1736,7 @@ async fn dashboard_reconfigure_is_typed_revisioned_and_csrf_protected() {
     let second = post_json(
         &router,
         &uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({ "concurrency": 3 }),
     )
     .await;
@@ -1714,7 +1747,7 @@ async fn dashboard_reconfigure_is_typed_revisioned_and_csrf_protected() {
     assert_eq!(second["effective"]["batch_max_items"], 2);
 
     let replayed =
-        response_json(get_route_with_token(&router, &uri, Some(&fixture.csrf)).await).await;
+        response_json(get_route_with_token(&router, &uri, Some(&fixture.session)).await).await;
     assert_eq!(replayed["revision"], 2);
     assert_eq!(replayed["effective"]["concurrency"], 3);
 
@@ -1726,7 +1759,7 @@ async fn dashboard_controls_require_a_fresh_lease_and_signal_one_when_present() 
     let fixture = build_mutation_fixture();
     make_stopped_fixture_resumable(&fixture);
     clean_runtime_files(&fixture.job_id);
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.runtime_lease_stale_after = Duration::from_millis(u64::MAX);
     let router = dashboard_router(state);
 
@@ -1734,7 +1767,7 @@ async fn dashboard_controls_require_a_fresh_lease_and_signal_one_when_present() 
         let response = post_json(
             &router,
             &format!("/api/jobs/{}/{}", fixture.job_id, command),
-            Some(&fixture.csrf),
+            Some(&fixture.session),
             json!({}),
         )
         .await;
@@ -1770,7 +1803,7 @@ async fn dashboard_controls_require_a_fresh_lease_and_signal_one_when_present() 
         get_route_with_token(
             &router,
             &format!("/api/jobs/{}/reconfigure", fixture.job_id),
-            Some(&fixture.csrf),
+            Some(&fixture.session),
         )
         .await,
     )
@@ -1782,7 +1815,7 @@ async fn dashboard_controls_require_a_fresh_lease_and_signal_one_when_present() 
     let resume = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -1811,7 +1844,7 @@ async fn dashboard_resume_uses_remembered_key_in_scrubbed_child_environment() {
 
     let launches = Arc::new(AtomicUsize::new(0));
     let environments = Arc::new(Mutex::new(Vec::new()));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     lock_keys(&state).expect("key store should lock").extend([
         ("deepseek".to_string(), SESSION_KEY.to_string()),
         (
@@ -1826,7 +1859,7 @@ async fn dashboard_resume_uses_remembered_key_in_scrubbed_child_environment() {
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -1867,14 +1900,14 @@ async fn dashboard_resume_without_required_key_returns_actionable_error() {
     clean_runtime_files(&fixture.job_id);
 
     let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.resume_launches = Some(launches.clone());
     let router = dashboard_router(state);
 
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -1908,7 +1941,7 @@ async fn dashboard_resume_accepts_and_remembers_replacement_key() {
 
     let launches = Arc::new(AtomicUsize::new(0));
     let environments = Arc::new(Mutex::new(Vec::new()));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     let keys = state.keys.clone();
     state.resume_launches = Some(launches.clone());
     state.resume_child_environments = Some(environments.clone());
@@ -1917,7 +1950,7 @@ async fn dashboard_resume_accepts_and_remembers_replacement_key() {
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({ "api_key": REPLACEMENT_KEY }),
     )
     .await;
@@ -1954,14 +1987,14 @@ async fn dashboard_missing_worker_resume_launches_exactly_once() {
     make_stopped_fixture_resumable(&fixture);
     clean_runtime_files(&fixture.job_id);
     let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.resume_launches = Some(launches.clone());
     let router = dashboard_router(state);
     let uri = format!("/api/jobs/{}/resume", fixture.job_id);
 
     let (first, second) = tokio::join!(
-        post_json(&router, &uri, Some(&fixture.csrf), json!({})),
-        post_json(&router, &uri, Some(&fixture.csrf), json!({}))
+        post_json(&router, &uri, Some(&fixture.session), json!({})),
+        post_json(&router, &uri, Some(&fixture.session), json!({}))
     );
     assert_eq!(first.status(), StatusCode::OK);
     assert_eq!(second.status(), StatusCode::OK);
@@ -2001,7 +2034,7 @@ async fn dashboard_resume_recognizes_finalize_only_work() {
     clean_runtime_files(&fixture.job_id);
 
     let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.resume_launches = Some(launches.clone());
     let router = dashboard_router(state);
 
@@ -2009,7 +2042,7 @@ async fn dashboard_resume_recognizes_finalize_only_work() {
         get_route_with_token(
             &router,
             &format!("/api/jobs/{}/reconfigure", fixture.job_id),
-            Some(&fixture.csrf),
+            Some(&fixture.session),
         )
         .await,
     )
@@ -2020,7 +2053,7 @@ async fn dashboard_resume_recognizes_finalize_only_work() {
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -2045,13 +2078,13 @@ async fn dashboard_resume_forces_relaunch_of_a_dead_paused_worker() {
     clean_runtime_files(&fixture.job_id);
 
     let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.resume_launches = Some(launches.clone());
     let router = dashboard_router(state);
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -2071,7 +2104,7 @@ async fn dashboard_resume_rejects_a_completed_job_without_work() {
     let fixture = build_mutation_fixture();
     clean_runtime_files(&fixture.job_id);
     let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_store(&fixture.csrf, fixture.store_path.clone());
+    let mut state = test_state_with_store(&fixture.session, fixture.store_path.clone());
     state.resume_launches = Some(launches.clone());
     let router = dashboard_router(state);
 
@@ -2079,7 +2112,7 @@ async fn dashboard_resume_rejects_a_completed_job_without_work() {
         get_route_with_token(
             &router,
             &format!("/api/jobs/{}/reconfigure", fixture.job_id),
-            Some(&fixture.csrf),
+            Some(&fixture.session),
         )
         .await,
     )
@@ -2090,7 +2123,7 @@ async fn dashboard_resume_rejects_a_completed_job_without_work() {
     let response = post_json(
         &router,
         &format!("/api/jobs/{}/resume", fixture.job_id),
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({}),
     )
     .await;
@@ -2159,7 +2192,7 @@ async fn correction_locks_serialize_one_job_and_not_two() {
 async fn save_manual_translation_rejects_missing_or_wrong_csrf_without_mutating_store() {
     let fixture = build_mutation_fixture();
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
     let uri = format!(
@@ -2187,7 +2220,7 @@ async fn save_manual_translation_rejects_missing_or_wrong_csrf_without_mutating_
 async fn set_segment_flag_rejects_missing_or_wrong_csrf_without_mutating_store() {
     let fixture = build_mutation_fixture();
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
     let uri = format!(
@@ -2216,7 +2249,7 @@ async fn set_segment_flag_rejects_missing_or_wrong_csrf_without_mutating_store()
 async fn retry_segment_rejects_missing_or_wrong_csrf_without_mutating_store() {
     let fixture = build_mutation_fixture();
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
     let uri = format!(
@@ -2259,7 +2292,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
 
     let fixture = build_mutation_fixture();
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
 
@@ -2271,7 +2304,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
             Request::builder()
                 .uri(&review_uri)
                 .header("host", TEST_HOST)
-                .header(CSRF_HEADER, &fixture.csrf)
+                .header("cookie", session_cookie_value(&fixture.session))
                 .body(Body::empty())
                 .expect("request should build"),
         )
@@ -2326,7 +2359,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
     let response = post_json(
         &router,
         &translation_uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         correction_body,
     )
     .await;
@@ -2353,7 +2386,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
         let response = post_json(
             &router,
             &flag_uri,
-            Some(&fixture.csrf),
+            Some(&fixture.session),
             json!({ "flagged": flagged }),
         )
         .await;
@@ -2372,7 +2405,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
     let response = post_json(
         &router,
         &retry_uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({ "guidance": "Please redo more literally." }),
     )
     .await;
@@ -2403,7 +2436,7 @@ async fn dashboard_review_and_mutation_endpoints_end_to_end() {
     let response = post_json(
         &router,
         &retry_a_uri,
-        Some(&fixture.csrf),
+        Some(&fixture.session),
         json!({ "guidance": "try again" }),
     )
     .await;
@@ -2488,12 +2521,13 @@ async fn auth_on_requires_session_tokens_on_representative_api_routes() {
 }
 
 #[tokio::test]
-async fn root_exchange_bootstraps_browsers_without_leaking_the_token() {
+async fn root_exchange_mints_a_session_cookie_and_redirects_without_leaking() {
     use axum::{body::Body, http::Request};
     use tower::ServiceExt;
 
-    let secret = "feedface-feedface-feedface";
-    let router = dashboard_router(test_state(secret));
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    let router = dashboard_router(state);
 
     // Anonymous GET / gets guidance only.
     let anonymous = router
@@ -2516,39 +2550,380 @@ async fn root_exchange_bootstraps_browsers_without_leaking_the_token() {
         login_page.contains("bookforge serve"),
         "points at the console link"
     );
-    assert!(!login_page.contains(secret));
-    assert!(!login_page.contains(CSRF_TOKEN_PLACEHOLDER));
+    assert!(!login_page.contains(&secret));
+    assert!(!login_page.contains("bookforge_session="));
 
     // Wrong ?token= is rejected without echoing the expected value.
     let rejected = get_route_with_token(&router, "/?token=deadbeef", None).await;
     assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
 
-    // Right ?token= gets the bootstrap page that seeds sessionStorage under
-    // the same header name every API fetch sends, mirroring the old CSRF
-    // wiring, then redirects to the clean root.
+    // Right ?token= exchanges for a 302 to the clean root plus an HttpOnly
+    // browser-session cookie. The bootstrap token is never echoed and never
+    // stored in the cookie — the cookie carries a fresh session id.
     let bootstrapped = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
-    assert_eq!(bootstrapped.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(bootstrapped.into_body(), usize::MAX)
-        .await
-        .expect("bootstrap body should read");
-    let bootstrap = String::from_utf8(body.to_vec()).expect("page is utf-8");
-    assert!(bootstrap.contains(CSRF_HEADER));
-    assert!(bootstrap.contains(&format!(
-        "sessionStorage.setItem(\"{CSRF_HEADER}\", \"{secret}\")"
-    )));
-    assert!(bootstrap.contains("location.replace(\"/\")"));
-    assert!(!bootstrap.is_empty(), "bootstrap page served");
+    assert_eq!(bootstrapped.status(), StatusCode::FOUND);
+    assert_eq!(
+        bootstrapped.headers().get("location"),
+        Some(&HeaderValue::from_static("/")),
+        "redirect must land on the clean root, never echoing the token"
+    );
+    let set_cookie = bootstrapped
+        .headers()
+        .get("set-cookie")
+        .expect("session cookie issued")
+        .to_str()
+        .expect("cookie is ascii");
+    for attribute in [
+        "bookforge_session=",
+        "HttpOnly",
+        "SameSite=Strict",
+        "Path=/",
+    ] {
+        assert!(
+            set_cookie.contains(attribute),
+            "session cookie must carry {attribute:?}"
+        );
+    }
+    assert!(
+        !set_cookie.contains("Max-Age"),
+        "session cookie must be browser-session lifetime"
+    );
+    assert!(
+        !set_cookie.contains("Secure"),
+        "loopback HTTP must not require the Secure flag"
+    );
+    let session_id = set_cookie
+        .split(';')
+        .next()
+        .and_then(|pair| pair.strip_prefix("bookforge_session="))
+        .expect("cookie value");
+    assert_ne!(
+        session_id, secret,
+        "session id must not be the bootstrap token"
+    );
+    assert_eq!(
+        session_id.len(),
+        32,
+        "session ids are fresh 128-bit hex values"
+    );
+    assert!(session_id.chars().all(|ch| ch.is_ascii_hexdigit()));
 
-    // A caller already holding the header may load the dashboard directly.
-    let direct = get_route_with_token(&router, "/", Some(secret)).await;
+    // A caller holding the freshly minted session cookie loads the dashboard.
+    let direct = get_route_with_token(&router, "/", Some(session_id)).await;
     assert_eq!(direct.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(direct.into_body(), usize::MAX)
+    // ...while the bootstrap token alone is not a session credential.
+    let token_not_a_session = get_route_with_token(&router, "/", Some(&secret)).await;
+    let body = axum::body::to_bytes(token_not_a_session.into_body(), usize::MAX)
         .await
-        .expect("dashboard body should read");
-    let page = String::from_utf8(body.to_vec()).expect("dashboard is utf-8");
-    assert!(page.contains(&format!(
-        "const CSRF_TOKEN = sessionStorage.getItem(CSRF_HEADER) || \"{secret}\""
-    )));
+        .expect("login body should read");
+    let page = String::from_utf8(body.to_vec()).expect("page is utf-8");
+    assert!(
+        page.contains("bookforge serve"),
+        "bootstrap token alone logs nobody in"
+    );
+    assert!(!page.contains(&secret));
+}
+
+#[tokio::test]
+async fn bootstrap_token_is_single_use_and_replays_cannot_mint_a_second_session() {
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    let router = dashboard_router(state);
+
+    // First exchange succeeds and issues a session cookie.
+    let first = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
+    assert_eq!(first.status(), StatusCode::FOUND);
+    assert!(
+        first.headers().get("set-cookie").is_some(),
+        "first exchange mints a session cookie"
+    );
+
+    // Replaying the exact console token is refused: no redirect, no cookie,
+    // and no second session is minted for the replayed link.
+    let replay = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
+    assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(replay.headers().get("set-cookie"), None);
+
+    // The consumed token is not a session credential either.
+    let as_session = get_route_with_token(&router, "/api/jobs", Some(&secret)).await;
+    assert_eq!(as_session.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn bootstrap_exchange_rejects_cross_site_browser_requests() {
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    let router = dashboard_router(state);
+
+    // A cross-site browser request carrying ?token= is refused outright, so it
+    // can neither mint a session nor burn the failed-exchange limiter.
+    let cross_site = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/?token={secret}"))
+                .header("host", TEST_HOST)
+                .header("sec-fetch-site", "cross-site")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(cross_site.status(), StatusCode::FORBIDDEN);
+    assert_eq!(cross_site.headers().get("set-cookie"), None);
+
+    // The token is untouched: a normal top-level navigation still exchanges.
+    let nav = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
+    assert_eq!(nav.status(), StatusCode::FOUND);
+    assert!(
+        nav.headers().get("set-cookie").is_some(),
+        "a non-cross-site navigation still exchanges the token"
+    );
+}
+
+#[tokio::test]
+async fn expired_bootstrap_token_gets_guidance_and_no_session() {
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    state.auth.expire_bootstrap_for_test();
+    let router = dashboard_router(state);
+
+    // The correct token past its TTL gets the helpful expiry page (200), not
+    // an authenticated dashboard and not a session cookie.
+    let expired = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
+    assert_eq!(expired.status(), StatusCode::OK);
+    assert_eq!(expired.headers().get("set-cookie"), None);
+    let body = axum::body::to_bytes(expired.into_body(), usize::MAX)
+        .await
+        .expect("expiry body should read");
+    let page = String::from_utf8(body.to_vec()).expect("page is utf-8");
+    assert!(
+        page.contains("expired"),
+        "expiry screen gives actionable guidance"
+    );
+    assert!(
+        !page.contains(&secret),
+        "expiry screen never echoes the token"
+    );
+
+    // API routes remain unauthenticated.
+    let rejected = get_route_with_token(&router, "/api/jobs", None).await;
+    assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn failed_bootstrap_exchanges_are_bounded_by_the_limiter() {
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    let router = dashboard_router(state);
+
+    // Wrong guesses are all refused (401, no leak), then the limiter trips and
+    // even the correct token is refused within the same window.
+    for _ in 0..8 {
+        let rejected = get_route_with_token(&router, "/?token=deadbeef", None).await;
+        assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
+    }
+    let locked_out = get_route_with_token(&router, &format!("/?token={secret}"), None).await;
+    assert_eq!(locked_out.status(), StatusCode::UNAUTHORIZED);
+    let body = axum::body::to_bytes(locked_out.into_body(), usize::MAX)
+        .await
+        .expect("rejection body should read");
+    let body = String::from_utf8(body.to_vec()).expect("body is utf-8");
+    assert!(!body.contains(&secret), "rejections never echo the token");
+}
+
+#[tokio::test]
+async fn logout_invalidates_the_session_and_expires_the_cookie() {
+    let state = test_state("token-123");
+    let router = dashboard_router(state);
+
+    // Authenticated first.
+    let jobs = get_route_with_token(&router, "/api/jobs", Some("token-123")).await;
+    assert_eq!(jobs.status(), StatusCode::OK);
+
+    // POST /api/auth/logout with the session cookie: 204 + expiring cookie.
+    let logout = post_json(&router, "/api/auth/logout", Some("token-123"), json!({})).await;
+    assert_eq!(logout.status(), StatusCode::NO_CONTENT);
+    let set_cookie = logout
+        .headers()
+        .get("set-cookie")
+        .expect("logout sends an expiring cookie")
+        .to_str()
+        .expect("cookie is ascii");
+    assert!(set_cookie.contains("Max-Age=0"), "cookie must be expired");
+    assert!(set_cookie.contains("HttpOnly"));
+
+    // The invalidated session no longer authenticates any protected route.
+    let after = get_route_with_token(&router, "/api/jobs", Some("token-123")).await;
+    assert_eq!(after.status(), StatusCode::UNAUTHORIZED);
+    let body = axum::body::to_bytes(after.into_body(), usize::MAX)
+        .await
+        .expect("rejection body should read");
+    let body = String::from_utf8(body.to_vec()).expect("body is utf-8");
+    assert!(
+        !body.contains("token-123"),
+        "rejections never echo the session"
+    );
+
+    // Logout is idempotent: clearing an already-dead session is still 204.
+    let again = post_json(&router, "/api/auth/logout", Some("token-123"), json!({})).await;
+    assert_eq!(again.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn unauthenticated_api_routes_are_rejected_with_a_bare_401() {
+    let state = test_state("token-123");
+    let router = dashboard_router(state);
+
+    for uri in ["/api/jobs", "/api/options", "/api/audiobooks"] {
+        let response = get_route_with_token(&router, uri, None).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("rejection body should read");
+        let body = String::from_utf8(body.to_vec()).expect("body is utf-8");
+        assert!(
+            !body.contains("token-123"),
+            "401 bodies must not echo the expected credential ({uri})"
+        );
+    }
+
+    // A wrong cookie is as opaque as a missing one.
+    let wrong = get_route_with_token(&router, "/api/jobs", Some("wrong-session")).await;
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn mutations_are_gated_by_authenticated_session_and_same_origin() {
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let state = test_state_with_store("token-123", temp.path().join("jobs.sqlite"));
+    let router = dashboard_router(state);
+
+    // Valid session cookie but a cross-site fetch-metadata marker: refused.
+    let cross_site = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/jobs/not-real/retry")
+                .header("host", TEST_HOST)
+                .header("cookie", session_cookie_value("token-123"))
+                .header("sec-fetch-site", "cross-site")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(cross_site.status(), StatusCode::FORBIDDEN);
+
+    // Same-origin with a valid session passes both gates and reaches the
+    // handler (an unknown job on an empty store -> "retried": 0).
+    let same_origin = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/jobs/not-real/retry")
+                .header("host", TEST_HOST)
+                .header("cookie", session_cookie_value("token-123"))
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_ne!(same_origin.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(same_origin.status(), StatusCode::FORBIDDEN);
+    assert_eq!(same_origin.status(), StatusCode::OK);
+}
+
+/// No token or session id may appear in any response a browser can read:
+/// the dashboard HTML, the login pages, and the API JSON.
+#[tokio::test]
+async fn no_secret_ever_reaches_dashboard_bytes_or_api_responses() {
+    let state = test_state("session-1");
+    let secret = state.auth.bootstrap_token();
+    let router = dashboard_router(state);
+
+    // Authenticated dashboard HTML.
+    let index = get_route_with_token(&router, "/", Some("session-1")).await;
+    assert_eq!(index.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(index.into_body(), usize::MAX)
+        .await
+        .expect("index body should read");
+    let page = String::from_utf8(body.to_vec()).expect("index is utf-8");
+    assert!(
+        !page.contains(&secret),
+        "bootstrap token must not appear in HTML"
+    );
+    assert!(
+        !page.contains("session-1"),
+        "session id must not appear in HTML"
+    );
+
+    // Authenticated API JSON.
+    let options = get_route_with_token(&router, "/api/options", Some("session-1")).await;
+    assert_eq!(options.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(options.into_body(), usize::MAX)
+        .await
+        .expect("options body should read");
+    let options = String::from_utf8(body.to_vec()).expect("options is utf-8");
+    assert!(
+        !options.contains(&secret),
+        "API JSON must not leak the bootstrap token"
+    );
+    assert!(
+        !options.contains("session-1"),
+        "API JSON must not leak the session id"
+    );
+
+    // Login page.
+    let login = get_route_with_token(&router, "/", None).await;
+    let body = axum::body::to_bytes(login.into_body(), usize::MAX)
+        .await
+        .expect("login body should read");
+    let login = String::from_utf8(body.to_vec()).expect("login is utf-8");
+    assert!(!login.contains(&secret));
+    assert!(!login.contains("session-1"));
+}
+
+#[tokio::test]
+async fn no_auth_restores_the_previous_unauthenticated_behavior() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let state = AppState {
+        store_path: temp.path().join("jobs.sqlite"),
+        ..test_state_opt("quiet-token", false)
+    };
+    let router = dashboard_router(state);
+
+    // Reads reach handlers without any session credential...
+    let jobs = get_route_with_token(&router, "/api/jobs", None).await;
+    assert_eq!(jobs.status(), StatusCode::OK);
+    // ...and / serves the full dashboard with no token or session id embedded
+    // anywhere in the bytes.
+    let index = get_route_with_token(&router, "/", None).await;
+    assert_eq!(index.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(index.into_body(), usize::MAX)
+        .await
+        .expect("index body should read");
+    let page = String::from_utf8(body.to_vec()).expect("page is utf-8");
+    assert!(
+        !page.contains("quiet-token"),
+        "--no-auth must never embed a session id"
+    );
+    assert!(!page.contains("bookforge_session="));
+    assert!(!page.contains("sessionStorage"));
+
+    // Mutations skip the session gate entirely (only same-origin checks apply):
+    // with no cookie this reaches the handler rather than 401/403.
+    let retry = post_json(&router, "/api/jobs/not-real/retry", None, json!({})).await;
+    assert_ne!(retry.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(retry.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]
@@ -2584,33 +2959,6 @@ async fn hardened_headers_stamp_every_response_not_just_the_index() {
     }
 }
 
-#[tokio::test]
-async fn no_auth_restores_the_previous_unauthenticated_behavior() {
-    let temp = tempfile::tempdir().expect("temp dir should be created");
-    let mut state = test_state_with_store("quiet-token", temp.path().join("jobs.sqlite"));
-    state.auth_enabled = false;
-    let router = dashboard_router(state);
-
-    // Reads reach handlers without any session credential...
-    let jobs = get_route_with_token(&router, "/api/jobs", None).await;
-    assert_eq!(jobs.status(), StatusCode::OK);
-    // ...and / once again serves the full dashboard with its embedded CSRF
-    // token (still CSRF-guarded per mutation by the legacy checks).
-    let index = get_route_with_token(&router, "/", None).await;
-    assert_eq!(index.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(index.into_body(), usize::MAX)
-        .await
-        .expect("index body should read");
-    let page = String::from_utf8(body.to_vec()).expect("page is utf-8");
-    assert!(
-        page.contains("quiet-token"),
-        "--no-auth embeds the CSRF token again"
-    );
-    // Mutations keep the legacy cross-site/CSRF rejection shape (403).
-    let retry = post_json(&router, "/api/jobs/not-real/retry", None, json!({})).await;
-    assert_eq!(retry.status(), StatusCode::FORBIDDEN);
-}
-
 #[test]
 fn valid_job_id_mirrors_audiobook_id_strictness() {
     for valid in ["job_1750000000000000000_deadbeef1234", "a", "x-9_Z"] {
@@ -2635,7 +2983,7 @@ fn valid_job_id_mirrors_audiobook_id_strictness() {
 async fn traversal_job_ids_are_refused_before_touching_the_filesystem() {
     let fixture = build_mutation_fixture();
     let router = dashboard_router(test_state_with_store(
-        &fixture.csrf,
+        &fixture.session,
         fixture.store_path.clone(),
     ));
 
@@ -2647,7 +2995,7 @@ async fn traversal_job_ids_are_refused_before_touching_the_filesystem() {
         let response = get_route_with_token(
             &router,
             &format!("/api/jobs/{encoded}/review"),
-            Some(&fixture.csrf),
+            Some(&fixture.session),
         )
         .await;
         assert!(
@@ -2887,7 +3235,7 @@ async fn estimate_endpoint_parses_upload_from_a_private_temp_dir_end_to_end() {
             .method("POST")
             .uri("/api/estimate")
             .header("host", TEST_HOST)
-            .header(CSRF_HEADER, "token-123")
+            .header("cookie", session_cookie_value("token-123"))
             .header("content-type", "multipart/form-data; boundary=B")
             .body(Body::from(body))
             .expect("request should build"),

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -4186,7 +4186,10 @@ async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
         Ok(RetryClaimAcquire::Owned(claim)) => claim,
         other => panic!("the test owner must win its own claim: {other:?}"),
     };
-    assert!(!retry_claim_released(&dir), "the owner holds a live claim");
+    assert!(
+        holder.is_published_for_test(),
+        "the owner holds a live claim"
+    );
 
     let loser = post_json(
         &router,
@@ -4201,7 +4204,7 @@ async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
         json!("retry already starting")
     );
     assert!(
-        !retry_claim_released(&dir),
+        holder.is_published_for_test(),
         "a live claim must survive a losing request untouched"
     );
     assert!(claim_path.exists(), "the live claim file must still exist");
@@ -4619,14 +4622,14 @@ fn retry_claim_release_is_guarded_by_its_ownership_nonce() {
         other => panic!("the test owner must win its own claim: {other:?}"),
     };
     assert!(
-        !retry_claim_released(&out_dir),
+        holder.is_published_for_test(),
         "the owner holds a live claim"
     );
 
     let foreign_nonce = format!("foreign-{}-{}", std::process::id(), now_ms());
     holder.release_as_nonce_for_test(&foreign_nonce);
     assert!(
-        !retry_claim_released(&out_dir),
+        holder.is_published_for_test(),
         "a nonce-mismatched release must leave the live claim in place"
     );
 

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -4623,7 +4623,8 @@ fn retry_claim_release_is_guarded_by_its_ownership_nonce() {
         "the owner holds a live claim"
     );
 
-    RetryClaim::with_nonce(out_dir.clone(), "foreign-nonce").release();
+    let foreign_nonce = format!("foreign-{}-{}", std::process::id(), now_ms());
+    holder.release_as_nonce_for_test(&foreign_nonce);
     assert!(
         !retry_claim_released(&out_dir),
         "a nonce-mismatched release must leave the live claim in place"

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -30,6 +30,7 @@ fn test_state_opt(session: &str, auth_enabled: bool) -> AppState {
         resume_launches: None,
         resume_child_environments: None,
         retry_launches: None,
+        retry_fail_spawns: None,
         audio_restart_cancels: None,
     }
 }
@@ -4136,6 +4137,39 @@ fn write_retryable_fixture(temp: &std::path::Path, id: &str) -> PathBuf {
 // F3: retry-failed double-click protection (atomic claim + launch slot)
 // -----------------------------------------------------------------------
 
+/// Materialize a retry claim file the way the production owner would — a
+/// readable ownership record with no OS lock held. Without the lock, the file
+/// models a claim whose owner is dead (the kernel dropped the lock), which is
+/// the exact state a next retry may reclaim.
+fn write_retry_claim(claim_path: &Path) {
+    std::fs::write(
+        claim_path,
+        serde_json::to_vec(&json!({
+            "nonce": "test-nonce",
+            "pid": 0,
+            "claimed_at_ms": now_ms(),
+        }))
+        .expect("claim should serialize"),
+    )
+    .expect("claim written");
+}
+
+/// True when the retry claim file is not held by a live owner: either absent
+/// or emptied by its last owner's release. The claim file keeps a stable
+/// identity and is never unlinked, so "released" means empty-and-unlocked.
+fn retry_claim_released(out_dir: &std::path::Path) -> bool {
+    match std::fs::read(out_dir.join("process.retry-claim.tmp")) {
+        Ok(bytes) => bytes.is_empty(),
+        Err(_) => true,
+    }
+}
+
+/// A live owner holds the OS lock on the retry claim: the loser is refused
+/// with 409 "retry already starting", must not steal the lock, mutate durable
+/// state, or spend a launch slot, and the live claim survives untouched. The
+/// lock is held exactly the way a real owner holds it — not simulated by an
+/// old timestamp, which is precisely what used to let one retry steal a live
+/// but slow owner's claim.
 #[tokio::test]
 async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
     let temp = tempfile::tempdir().expect("temp dir");
@@ -4144,14 +4178,15 @@ async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
         temp.path().to_path_buf(),
     ));
     let dir = write_retryable_fixture(temp.path(), "claimedop");
+    let claim_path = dir.join("process.retry-claim.tmp");
 
-    // Simulate a first retry sitting between its atomic rename and its spawn:
-    // process.json has been claimed away and the claim temp exists.
-    std::fs::rename(
-        dir.join("process.json"),
-        dir.join("process.retry-claim.tmp"),
-    )
-    .expect("claim simulated");
+    // A concurrent retry is mid-handoff: it owns the claim and keeps the OS
+    // lock until its handler returns.
+    let holder = match acquire_retry_claim(&dir) {
+        Ok(RetryClaimAcquire::Owned(claim)) => claim,
+        other => panic!("the test owner must win its own claim: {other:?}"),
+    };
+    assert!(!retry_claim_released(&dir), "the owner holds a live claim");
 
     let loser = post_json(
         &router,
@@ -4165,14 +4200,30 @@ async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
         response_json(loser).await["error"],
         json!("retry already starting")
     );
+    assert!(
+        !retry_claim_released(&dir),
+        "a live claim must survive a losing request untouched"
+    );
+    assert!(claim_path.exists(), "the live claim file must still exist");
+    let process: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("process.json")).expect("state read"))
+            .expect("state parse");
+    assert_eq!(
+        process["status"],
+        json!("succeeded"),
+        "the loser must not mutate durable state"
+    );
+
+    // The owner finishes its handoff: dropping the claim empties it and
+    // releases the lock, leaving nothing a future retry could trip over.
+    drop(holder);
+    assert!(
+        retry_claim_released(&dir),
+        "the owner's release must leave the claim empty and unlocked"
+    );
 
     // The settled (`running`) branch keeps its distinct refusal so operators
     // can tell "in flight" from "starting up".
-    std::fs::rename(
-        dir.join("process.retry-claim.tmp"),
-        dir.join("process.json"),
-    )
-    .expect("restore original state");
     let mut process: serde_json::Value =
         serde_json::from_slice(&std::fs::read(dir.join("process.json")).expect("state read"))
             .expect("state parse");
@@ -4193,75 +4244,401 @@ async fn retry_failed_conflicts_while_another_retry_holds_the_claim() {
     );
 }
 
-/// Concurrent handler calls against one shared AppState (the harness shape
-/// used by the SERVE-6 slot-cap tests): exactly one of the two simultaneous
+/// A live owner is refused even when its claim bytes never parsed (a crash
+/// mid-write can leave exactly that shape). Fail-closed must follow the OS
+/// lock, never the readability of the file.
+#[tokio::test]
+async fn retry_failed_refuses_live_owner_even_with_unreadable_claim() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let _ = write_retryable_fixture(temp.path(), "garbageop");
+    let router = dashboard_router(test_state_with_upload_dir(
+        "token-123",
+        temp.path().to_path_buf(),
+    ));
+    let claim_path = temp
+        .path()
+        .join("audiobook-garbageop/process.retry-claim.tmp");
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&claim_path)
+        .expect("claim opened");
+    assert!(
+        try_lock_claim(&file).expect("lock attempt should succeed"),
+        "the test owner must hold the claim lock"
+    );
+    std::io::Write::write_all(&mut file, b"{\"status\":\"succeeded\",\"options\":{}}")
+        .expect("unreadable bytes written");
+
+    let loser = post_json(
+        &router,
+        "/api/audiobooks/garbageop/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(loser.status(), StatusCode::CONFLICT);
+    assert_eq!(
+        response_json(loser).await["error"],
+        json!("retry already starting")
+    );
+    assert!(
+        claim_path.exists(),
+        "a live owner's file must be untouched even if its bytes are foreign"
+    );
+    drop(file);
+}
+
+/// Two independent dashboard routers (separate AppState, one shared upload
+/// directory) racing one operation: exactly one of the two simultaneous
 /// "double clicks" may spawn; the other must be refused without spending.
+/// The OS lock arbitrates across processes, so the routers share no in-memory
+/// state. Replayed across fresh fixtures so the claim seam is stressed — a
+/// single pass is what the pre-fix Windows race broke, where a rename-based
+/// claim let both callers "win".
 #[tokio::test]
 async fn retry_failed_double_click_starts_exactly_one_operation() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let temp = tempfile::tempdir().expect("temp dir");
-    let _ = write_retryable_fixture(temp.path(), "racecase");
-
-    let launches = Arc::new(AtomicUsize::new(0));
-    let mut state = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    let launches_a = Arc::new(AtomicUsize::new(0));
+    let launches_b = Arc::new(AtomicUsize::new(0));
+    let mut state_a = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
     // Test hook (parity with resume_launches): records the relaunch instead
     // of exec'ing this binary as an audiobook child.
-    state.retry_launches = Some(launches.clone());
-    let router = dashboard_router(state);
+    state_a.retry_launches = Some(launches_a.clone());
+    let mut state_b = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    state_b.retry_launches = Some(launches_b.clone());
+    let router_a = dashboard_router(state_a);
+    let router_b = dashboard_router(state_b);
 
-    let (winner, loser) = tokio::join!(
-        post_json(
-            &router,
-            "/api/audiobooks/racecase/retry-failed",
-            Some("token-123"),
-            json!({}),
-        ),
-        post_json(
-            &router,
-            "/api/audiobooks/racecase/retry-failed",
-            Some("token-123"),
-            json!({}),
-        ),
-    );
+    const ROUNDS: usize = 3;
+    for round in 0..ROUNDS {
+        let id = format!("racecase{round}");
+        let _ = write_retryable_fixture(temp.path(), &id);
+        let uri = format!("/api/audiobooks/{id}/retry-failed");
 
-    let statuses = [
-        (winner.status(), response_json(winner).await),
-        (loser.status(), response_json(loser).await),
-    ];
-    let successes = statuses
-        .iter()
-        .filter(|(status, _)| *status == StatusCode::OK)
-        .count();
-    let conflicts = statuses
-        .iter()
-        .filter(|(status, _)| *status == StatusCode::CONFLICT)
-        .count();
-    assert_eq!(successes, 1, "exactly one click wins: {statuses:?}");
-    assert_eq!(conflicts, 1, "the losing click is refused: {statuses:?}");
+        let (winner, loser) = tokio::join!(
+            post_json(&router_a, &uri, Some("token-123"), json!({})),
+            post_json(&router_b, &uri, Some("token-123"), json!({})),
+        );
+
+        let statuses = [
+            (winner.status(), response_json(winner).await),
+            (loser.status(), response_json(loser).await),
+        ];
+        let successes = statuses
+            .iter()
+            .filter(|(status, _)| *status == StatusCode::OK)
+            .count();
+        let conflicts = statuses
+            .iter()
+            .filter(|(status, _)| *status == StatusCode::CONFLICT)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "round {round} must have exactly one winner: {statuses:?}"
+        );
+        assert_eq!(
+            conflicts, 1,
+            "round {round} the losing click is refused: {statuses:?}"
+        );
+
+        // The winner leaves durable `running` state and no live claim behind:
+        // a concurrent retry after the release sees the transition and must
+        // refuse rather than launch a second job.
+        let out_dir = temp.path().join(format!("audiobook-{id}"));
+        let process: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(out_dir.join("process.json")).expect("state read"),
+        )
+        .expect("state parse");
+        assert_eq!(process["status"], json!("running"), "round {round}");
+        assert!(
+            retry_claim_released(&out_dir),
+            "round {round}: no live claim may survive the successful relaunch"
+        );
+
+        // A retry arriving after the winner released must be refused by the
+        // durable transition, never spawn a second job.
+        let late = post_json(&router_a, &uri, Some("token-123"), json!({})).await;
+        assert_eq!(
+            late.status(),
+            StatusCode::CONFLICT,
+            "round {round}: a late retry must be refused: {late:?}"
+        );
+    }
+
     assert_eq!(
-        launches.load(Ordering::SeqCst),
-        1,
-        "only one child may start regardless of interleaving"
-    );
-
-    // The winner leaves durable `running` state; no stray claim temp survives.
-    let process: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(temp.path().join("audiobook-racecase/process.json")).expect("state read"),
-    )
-    .expect("state parse");
-    assert_eq!(process["status"], json!("running"));
-    assert!(
-        !temp
-            .path()
-            .join("audiobook-racecase/process.retry-claim.tmp")
-            .exists(),
-        "the atomic claim must be consumed by the successful relaunch"
+        launches_a.load(Ordering::SeqCst) + launches_b.load(Ordering::SeqCst),
+        ROUNDS,
+        "only one child may start per round regardless of interleaving"
     );
 }
 
-/// Failure paths below the claim restore the durable state file and release
-/// the launch slot, so a refused retry costs nothing and blocks nobody.
+/// A heavier mob of simultaneous clicks against one operation, up to the
+/// SERVE-6 launch-slot cap: exactly one request may spawn, every other must
+/// be refused, and the losing requests must leave no live claim or slot
+/// behind.
+#[tokio::test]
+async fn retry_failed_many_simultaneous_clicks_spawn_exactly_one() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let _ = write_retryable_fixture(temp.path(), "mobclick");
+
+    let launches = Arc::new(AtomicUsize::new(0));
+    let mut state = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    state.retry_launches = Some(launches.clone());
+    let router = dashboard_router(state);
+
+    // At most this many requests may hold a launch slot simultaneously; any
+    // more would be refused with 429 before reaching the claim, so sizing the
+    // mob at the cap makes every click fight for the claim.
+    const CONCURRENT: usize = MAX_CONCURRENT_DASHBOARD_LAUNCHES;
+    let mut clicks = Vec::new();
+    for _ in 0..CONCURRENT {
+        let router = router.clone();
+        clicks.push(tokio::spawn(async move {
+            post_json(
+                &router,
+                "/api/audiobooks/mobclick/retry-failed",
+                Some("token-123"),
+                json!({}),
+            )
+            .await
+        }));
+    }
+
+    let mut ok = 0;
+    let mut conflict = 0;
+    for click in clicks {
+        let response = click.await.expect("click task should join");
+        match response.status() {
+            StatusCode::OK => ok += 1,
+            StatusCode::CONFLICT => conflict += 1,
+            other => panic!("unexpected retry status {other}"),
+        }
+    }
+    assert_eq!(ok, 1, "exactly one of {CONCURRENT} clicks may spawn");
+    assert_eq!(conflict, CONCURRENT - 1, "every other click is refused");
+    assert_eq!(launches.load(Ordering::SeqCst), 1);
+    let out_dir = temp.path().join("audiobook-mobclick");
+    assert!(
+        retry_claim_released(&out_dir),
+        "no live claim may survive the mob"
+    );
+    let process: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out_dir.join("process.json")).expect("state read"))
+            .expect("state parse");
+    assert_eq!(process["status"], json!("running"));
+}
+
+/// A claim whose owner died mid-handoff is a file with a readable record but
+/// no OS lock (the kernel dropped the lock on death). The next retry takes
+/// the lock, reclaims the claim, relaunches, and leaves no live claim behind —
+/// dead owners are recovered without any age guess.
+#[tokio::test]
+async fn retry_failed_reclaims_claim_left_by_crashed_owner() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let dir = write_retryable_fixture(temp.path(), "crashop");
+
+    let launches = Arc::new(AtomicUsize::new(0));
+    let mut state = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    state.retry_launches = Some(launches.clone());
+    let router = dashboard_router(state);
+
+    write_retry_claim(&dir.join("process.retry-claim.tmp"));
+
+    let retried = post_json(
+        &router,
+        "/api/audiobooks/crashop/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(retried.status(), StatusCode::OK, "{retried:?}");
+    assert_eq!(
+        launches.load(Ordering::SeqCst),
+        1,
+        "the dead owner's claim must be reclaimed and the relaunch proceeds"
+    );
+    assert!(
+        retry_claim_released(&dir),
+        "the reclaimed claim must be released by its new owner"
+    );
+    let process: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("process.json")).expect("state read"))
+            .expect("state parse");
+    assert_eq!(process["status"], json!("running"));
+}
+
+/// A claim file truncated by a crash between `open` and the record write is
+/// empty and unlocked; like any dead-owner debris it is reclaimed rather than
+/// allowed to block retries forever.
+#[tokio::test]
+async fn retry_failed_reclaims_an_empty_claim_left_by_a_crash() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let dir = write_retryable_fixture(temp.path(), "emptyop");
+    let claim_path = dir.join("process.retry-claim.tmp");
+
+    let launches = Arc::new(AtomicUsize::new(0));
+    let mut state = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    state.retry_launches = Some(launches.clone());
+    let router = dashboard_router(state);
+
+    std::fs::write(&claim_path, b"").expect("empty claim written");
+
+    let retried = post_json(
+        &router,
+        "/api/audiobooks/emptyop/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(retried.status(), StatusCode::OK, "{retried:?}");
+    assert_eq!(launches.load(Ordering::SeqCst), 1);
+    assert!(
+        retry_claim_released(&dir),
+        "the reclaimed claim must be released"
+    );
+    let process: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.join("process.json")).expect("state read"))
+            .expect("state parse");
+    assert_eq!(process["status"], json!("running"));
+}
+
+/// A non-empty claim file whose bytes are not a readable ownership record
+/// (the legacy rename-era layout carried process.json itself; a partial write
+/// carries garbage) is never destroyed: the retry fails closed with a
+/// distinct error naming the file and the operator's recovery step.
+#[tokio::test]
+async fn retry_failed_never_steals_unreadable_or_legacy_claims() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let _ = write_retryable_fixture(temp.path(), "weirdop");
+    let router = dashboard_router(test_state_with_upload_dir(
+        "token-123",
+        temp.path().to_path_buf(),
+    ));
+    let claim_path = temp
+        .path()
+        .join("audiobook-weirdop/process.retry-claim.tmp");
+
+    std::fs::write(&claim_path, b"{\"status\":\"succeeded\",\"options\":{}}")
+        .expect("legacy claim written");
+
+    let loser = post_json(
+        &router,
+        "/api/audiobooks/weirdop/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(loser.status(), StatusCode::CONFLICT);
+    let error = response_json(loser).await["error"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        error.contains("unreadable claim"),
+        "the failure must name the unreadable claim: {error}"
+    );
+    assert!(
+        error.contains("delete that file"),
+        "the failure must carry the operator recovery step: {error}"
+    );
+    assert!(
+        claim_path.exists(),
+        "unreadable claims must never be stolen"
+    );
+}
+
+/// A claim file the process cannot read must fail closed, never be treated as
+/// an empty "safe to reclaim" claim, and never be overwritten. This is the
+/// regression for treating a read error as empty: an unverifiable file must
+/// not be destroyed. (Permissions-ext on Unix; Windows surfaces the same
+/// fail-closed through its read-only/deny sharing semantics.)
+#[cfg(unix)]
+#[tokio::test]
+async fn retry_failed_unreadable_claim_is_never_overwritten() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let _ = write_retryable_fixture(temp.path(), "chmodop");
+    let router = dashboard_router(test_state_with_upload_dir(
+        "token-123",
+        temp.path().to_path_buf(),
+    ));
+    let claim_path = temp
+        .path()
+        .join("audiobook-chmodop/process.retry-claim.tmp");
+    let original = b"unknown bytes that must survive".to_vec();
+    std::fs::write(&claim_path, &original).expect("claim written");
+    std::fs::set_permissions(&claim_path, std::fs::Permissions::from_mode(0o000))
+        .expect("claim made unreadable");
+
+    let response = post_json(
+        &router,
+        "/api/audiobooks/chmodop/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_ne!(
+        response.status(),
+        StatusCode::OK,
+        "an unreadable claim must never be reclaimed and spawn a retry"
+    );
+
+    std::fs::set_permissions(&claim_path, std::fs::Permissions::from_mode(0o600))
+        .expect("claim made readable again");
+    assert_eq!(
+        std::fs::read(&claim_path).expect("claim readable"),
+        original,
+        "an unreadable claim file must survive byte-for-byte"
+    );
+}
+
+/// The ownership nonce is the last line of defense for a late release: a
+/// claim released by a foreign nonce (an owner that was pre-empted, or a
+/// stale handle to the same directory) must not affect the current lock. In
+/// production the OS lock makes the check un-staleable; this pins the nonce
+/// guard itself.
+#[test]
+fn retry_claim_release_is_guarded_by_its_ownership_nonce() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let out_dir = temp.path().to_path_buf();
+    let holder = match acquire_retry_claim(&out_dir) {
+        Ok(RetryClaimAcquire::Owned(claim)) => claim,
+        other => panic!("the test owner must win its own claim: {other:?}"),
+    };
+    assert!(
+        !retry_claim_released(&out_dir),
+        "the owner holds a live claim"
+    );
+
+    RetryClaim::with_nonce(out_dir.clone(), "foreign-nonce").release();
+    assert!(
+        !retry_claim_released(&out_dir),
+        "a nonce-mismatched release must leave the live claim in place"
+    );
+
+    drop(holder);
+    assert!(
+        retry_claim_released(&out_dir),
+        "the owning release must empty the claim"
+    );
+}
+
+/// Failure paths below the claim release the claim (leaving durable state
+/// byte-for-byte intact) and release the launch slot, so a refused retry
+/// costs nothing and blocks nobody.
 #[tokio::test]
 async fn retry_failed_refusals_restore_state_and_release_the_launch_slot() {
     let temp = tempfile::tempdir().expect("temp dir");
@@ -4291,8 +4668,8 @@ async fn retry_failed_refusals_restore_state_and_release_the_launch_slot() {
     );
 
     assert!(
-        !dir.join("process.retry-claim.tmp").exists(),
-        "the claim must be rolled back after a refusal"
+        retry_claim_released(&dir),
+        "the claim must be released after a refusal"
     );
     assert_eq!(
         std::fs::read(dir.join("process.json")).expect("restored state"),
@@ -4303,4 +4680,49 @@ async fn retry_failed_refusals_restore_state_and_release_the_launch_slot() {
     // Launch-slot bookkeeping: nothing leaked from the refused request; four
     // more launches must still fit under the cap afterwards.
     assert_eq!(*launch_slots.lock().unwrap(), 0, "slot released");
+}
+
+/// A failed spawn unwinds through the same RAII guard: the atomic claim and
+/// the launch slot are both released, the phantom "running" marker is
+/// restored to the truthful prior state, and nothing is left behind for a
+/// retry to trip over.
+#[tokio::test]
+async fn retry_failed_spawn_failure_releases_claim_and_launch_slot() {
+    use std::sync::atomic::AtomicBool;
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let dir = write_retryable_fixture(temp.path(), "spawnfail");
+    let before = std::fs::read(dir.join("process.json")).expect("original state");
+
+    let mut state = test_state_with_upload_dir("token-123", temp.path().to_path_buf());
+    let launch_slots = Arc::clone(&state.launch_slots);
+    state.retry_fail_spawns = Some(Arc::new(AtomicBool::new(true)));
+    let router = dashboard_router(state);
+
+    let response = post_json(
+        &router,
+        "/api/audiobooks/spawnfail/retry-failed",
+        Some("token-123"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "{response:?}"
+    );
+    assert!(
+        retry_claim_released(&dir),
+        "the atomic claim must be released when the spawn fails"
+    );
+    assert_eq!(
+        *launch_slots.lock().unwrap(),
+        0,
+        "the slot must be released"
+    );
+    assert_eq!(
+        std::fs::read(dir.join("process.json")).expect("state read"),
+        before,
+        "the pre-retry process.json must survive a failed spawn byte-for-byte"
+    );
 }

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -1155,10 +1155,10 @@ fn dashboard_ships_runtime_editor_and_inline_retry_guidance() {
 fn dashboard_js_never_reads_or_injects_a_session_credential() {
     // Auth is a same-origin HttpOnly cookie: the browser JS must hold no
     // secret — no header literal, no sessionStorage, no placeholder.
-    for secret_ish in ["sessionStorage", "x-bookforge-csrf", "__BOOKFORGE_"] {
+    for forbidden_marker in ["sessionStorage", "x-bookforge-csrf", "__BOOKFORGE_"] {
         assert!(
-            !DASHBOARD_JS.contains(secret_ish),
-            "dashboard.js must not embed {secret_ish:?}"
+            !DASHBOARD_JS.contains(forbidden_marker),
+            "dashboard.js contains a client-readable credential marker"
         );
     }
     // Sign-out plumbing is present so the session can be ended from the UI.

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -908,6 +908,41 @@ fn audiobook_operation_ids_cannot_escape_the_upload_directory() {
     }
 }
 
+#[test]
+fn existing_audiobook_operation_resolves_only_a_direct_child_directory() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let operation = temp.path().join("audiobook-safe_id");
+    std::fs::create_dir(&operation).expect("operation dir should be created");
+
+    let resolved = existing_audiobook_operation_out_dir(temp.path(), "safe_id")
+        .expect("operation lookup should succeed")
+        .expect("direct child should resolve");
+    assert_eq!(resolved, operation.canonicalize().unwrap());
+    assert!(
+        existing_audiobook_operation_out_dir(temp.path(), "missing")
+            .expect("missing lookup should succeed")
+            .is_none()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn existing_audiobook_operation_rejects_a_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let upload_root = tempfile::tempdir().expect("upload root should be created");
+    let outside = tempfile::tempdir().expect("outside dir should be created");
+    symlink(outside.path(), upload_root.path().join("audiobook-escape"))
+        .expect("escape symlink should be created");
+
+    assert!(
+        existing_audiobook_operation_out_dir(upload_root.path(), "escape")
+            .expect("symlink lookup should succeed")
+            .is_none(),
+        "a symlink outside the canonical upload root must be rejected"
+    );
+}
+
 #[tokio::test]
 async fn control_endpoints_reject_missing_dashboard_token() {
     use axum::{body::Body, http::Request};

--- a/crates/bookforge-cli/src/main.rs
+++ b/crates/bookforge-cli/src/main.rs
@@ -262,9 +262,13 @@ const RETRY_OVERRIDE_FALLBACK_MAX_AGE: std::time::Duration =
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OwnerLiveness {
     Alive,
+    /// Only probes on Unix platforms can establish this; on Windows the enum
+    /// variant is cfg'd out so `-D warnings` never sees an unconstructed arm.
+    #[cfg(unix)]
     Gone,
     /// Platform cannot tell cheaply and safely (e.g. Windows fallback) — or
-    /// the probe itself failed on a non-Linux Unix box.
+    /// the probe itself failed on a non-Linux Unix box. On Linux the probe
+    /// always resolves to Alive/Gone, so the variant is dead there.
     #[cfg_attr(target_os = "linux", allow(dead_code))]
     Indeterminate,
 }
@@ -325,6 +329,7 @@ fn retry_override_dir_is_reapable(
 ) -> bool {
     match liveness {
         OwnerLiveness::Alive => false,
+        #[cfg(unix)]
         OwnerLiveness::Gone => true,
         OwnerLiveness::Indeterminate => idle_over_fallback_window,
     }
@@ -495,14 +500,20 @@ mod sweep_tests {
 
     #[test]
     fn reap_decision_never_touches_live_owners() {
-        use OwnerLiveness::{Alive, Gone, Indeterminate};
+        use OwnerLiveness::{Alive, Indeterminate};
         assert!(!retry_override_dir_is_reapable(Alive, false));
         assert!(!retry_override_dir_is_reapable(Alive, true));
-        assert!(retry_override_dir_is_reapable(Gone, false));
-        assert!(retry_override_dir_is_reapable(Gone, true));
         // Indeterminate platforms (Windows) demand the >=24h age window.
         assert!(!retry_override_dir_is_reapable(Indeterminate, false));
         assert!(retry_override_dir_is_reapable(Indeterminate, true));
+
+        // `Gone` only exists on platforms with a liveness probe.
+        #[cfg(unix)]
+        {
+            use OwnerLiveness::Gone;
+            assert!(retry_override_dir_is_reapable(Gone, false));
+            assert!(retry_override_dir_is_reapable(Gone, true));
+        }
     }
 
     #[test]

--- a/crates/bookforge-pdf/src/convert/tests.rs
+++ b/crates/bookforge-pdf/src/convert/tests.rs
@@ -2,13 +2,12 @@ use super::*;
 
 use crate::convert::fake_backend::{FakePoppler, FixtureImage};
 
-// pdftohtml documents shared verbatim by BOTH tool paths below: the
-// Unix-only path ships them through /bin/sh poppler stand-ins, while the
-// in-process fake (`FakePoppler`) feeds the same strings through
-// [`PopplerBackend`] without spawning anything. Keeping them in shared
-// constants is what makes the two paths exercise identical conversions.
+// pdftohtml fixture documents. The shell-backed cases are Unix-only; the
+// portable in-process cases below use `FakePoppler`.
+#[cfg(unix)]
 const BERT_FIGURE1_CAPTION_BOUNDARY_XML: &str =
     include_str!("../../fixtures/bert_figure1_caption_boundary.xml");
+#[cfg(unix)]
 const BERT_FIGURE4_MULTIPANEL_XML: &str =
     include_str!("../../fixtures/bert_figure4_multipanel.xml");
 const BERT_FIGURE5_VECTOR_CHART_XML: &str =
@@ -17,6 +16,7 @@ const BERT_PAGE16_VECTOR_CHART_TWOCOL_XML: &str =
     include_str!("../../fixtures/bert_page16_vector_chart_twocol.xml");
 const BERT_FIGURE1_TOKEN_STRIP_XML: &str =
     include_str!("../../fixtures/bert_figure1_token_strip.xml");
+#[cfg(unix)]
 const BERT_MODEL_PARAMETER_FALSE_POSITIVE_XML: &str =
     include_str!("../../fixtures/bert_model_parameter_false_positive.xml");
 


### PR DESCRIPTION
## Summary
- exchange the console bootstrap URL for a single-use, five-minute token and an HttpOnly SameSite=Strict in-memory session cookie
- keep credentials out of dashboard HTML/JavaScript, add logout, session gating, replay/cross-site protections, and auth/no-auth coverage
- cfg-gate Unix-only OwnerLiveness::Gone so Windows builds remain warning-clean

## Verification
- cargo fmt --all --check
- cargo check -p bookforge-cli --features serve --tests
- cargo test -p bookforge-cli --features serve commands::serve:: (94 passed)

## Integration
This is the first blocker branch in the audit remediation sequence. Merge only after all required GitHub checks pass.