### PR TITLE
chore: enforce strict clippy and remove stale surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      # Pre-existing too_many_arguments warnings are tolerated; everything else fails the job.
-      - run: cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings
+      # Treat all clippy warnings as errors.
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Before submitting:
 
 ```bash
 cargo fmt --all --check
-cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test --workspace --locked
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,11 +361,9 @@ version = "3.0.0"
 dependencies = [
  "bookforge-core",
  "rusqlite",
- "serde",
  "serde_json",
  "sha2",
  "thiserror",
- "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ export OPENROUTER_API_KEY=...
 ```bash
 cargo fmt --all --check
 cargo test --workspace
-cargo clippy --all-targets --all-features -- -A clippy::too_many_arguments -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 ```
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for what's expected in issues

--- a/crates/bookforge-cli/src/commands/estimate.rs
+++ b/crates/bookforge-cli/src/commands/estimate.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[derive(Debug, Args)]
 #[command(
-    after_help = "Environment:\n  BOOKFORGE_PRICING_PATH  Override the bundled provider pricing table with a TOML file."
+    after_help = "Environment:\n  BOOKFORGE_PRICING_PATH  Override the bundled provider pricing table with a JSON file."
 )]
 pub struct EstimateArgs {
     pub input: PathBuf,
@@ -36,7 +36,7 @@ pub struct EstimateArgs {
     #[arg(long)]
     pub context_tokens: Option<usize>,
 
-    /// Override the bundled pricing catalog. BOOKFORGE_PRICING_PATH is
+    /// Override the bundled JSON pricing catalog. BOOKFORGE_PRICING_PATH is
     /// used when this flag is omitted.
     #[arg(long)]
     pub pricing: Option<PathBuf>,

--- a/crates/bookforge-cli/src/commands/serve/entities.rs
+++ b/crates/bookforge-cli/src/commands/serve/entities.rs
@@ -132,7 +132,7 @@ fn validated_entity_fields(
     Ok(gender)
 }
 
-fn new_entity<'a>(
+struct NewEntityInput<'a> {
     scope_kind: GlossaryScopeKind,
     scope_id: Option<&'a str>,
     source_name: &'a str,
@@ -142,17 +142,19 @@ fn new_entity<'a>(
     notes: Option<&'a str>,
     source_language: &'a str,
     target_language: &'a str,
-) -> NewEntity<'a> {
+}
+
+fn new_entity(input: NewEntityInput<'_>) -> NewEntity<'_> {
     NewEntity {
-        scope_kind,
-        scope_id,
-        source_name,
-        target_name,
-        gender_target,
-        role,
-        notes,
-        source_language,
-        target_language,
+        scope_kind: input.scope_kind,
+        scope_id: input.scope_id,
+        source_name: input.source_name,
+        target_name: input.target_name,
+        gender_target: input.gender_target,
+        role: input.role,
+        notes: input.notes,
+        source_language: input.source_language,
+        target_language: input.target_language,
     }
 }
 
@@ -238,17 +240,17 @@ async fn add_entity(
     let target_language = req.target_language.trim().to_string();
     let created = tokio::task::spawn_blocking(move || -> Result<i64> {
         let store = JobStore::open(store_path)?;
-        let row = new_entity(
-            requested_scope.0,
-            requested_scope.1.as_deref(),
-            &source_name,
-            &target_name,
-            gender,
-            role.as_deref(),
-            notes.as_deref(),
-            &source_language,
-            &target_language,
-        );
+        let row = new_entity(NewEntityInput {
+            scope_kind: requested_scope.0,
+            scope_id: requested_scope.1.as_deref(),
+            source_name: &source_name,
+            target_name: &target_name,
+            gender_target: gender,
+            role: role.as_deref(),
+            notes: notes.as_deref(),
+            source_language: &source_language,
+            target_language: &target_language,
+        });
         store.upsert_entities(std::slice::from_ref(&row))?;
         Ok(store
             .list_entities(None, None, None, None)?
@@ -351,17 +353,17 @@ async fn update_entity(
     let scope_id = existing.scope_id;
     tokio::task::spawn_blocking(move || -> Result<()> {
         let store = JobStore::open(store_path)?;
-        store.upsert_entities(&[new_entity(
+        store.upsert_entities(&[new_entity(NewEntityInput {
             scope_kind,
-            scope_id.as_deref(),
-            &source_name,
-            &target_name,
-            gender,
-            role.as_deref(),
-            notes.as_deref(),
-            &source_language,
-            &target_language,
-        )])?;
+            scope_id: scope_id.as_deref(),
+            source_name: &source_name,
+            target_name: &target_name,
+            gender_target: gender,
+            role: role.as_deref(),
+            notes: notes.as_deref(),
+            source_language: &source_language,
+            target_language: &target_language,
+        })])?;
         Ok(())
     })
     .await??;

--- a/crates/bookforge-cli/src/exit_code.rs
+++ b/crates/bookforge-cli/src/exit_code.rs
@@ -20,10 +20,6 @@ use std::sync::atomic::{AtomicI32, Ordering};
 
 pub(crate) const SUCCESS: i32 = 0;
 pub(crate) const FAILURE: i32 = 1;
-/// clap already exits with this for parse errors; defined here so the
-/// taxonomy is documented in one place and referenced by tests.
-#[allow(dead_code)]
-pub(crate) const USAGE: i32 = 2;
 /// The run completed but some segments remain failed/needs-review.
 pub(crate) const COMPLETED_WITH_FAILURES: i32 = 3;
 /// Graceful SIGINT/Ctrl+C interruption (128 + SIGINT), matching POSIX shells.
@@ -95,7 +91,6 @@ mod tests {
     fn taxonomy_values_are_the_documented_constants() {
         assert_eq!(SUCCESS, 0);
         assert_eq!(FAILURE, 1);
-        assert_eq!(USAGE, 2);
         assert_eq!(COMPLETED_WITH_FAILURES, 3);
         // POSIX convention: 128 + SIGINT(2).
         assert_eq!(INTERRUPTED, 130);

--- a/crates/bookforge-cli/src/tui/mod.rs
+++ b/crates/bookforge-cli/src/tui/mod.rs
@@ -485,29 +485,32 @@ impl TuiApp {
         terminal.draw(|frame| {
             render_dashboard(
                 frame,
-                &view.state,
-                mode,
-                per_min,
-                eta,
-                ratio,
-                log_scroll,
-                status,
+                DashboardRenderContext {
+                    state: &view.state,
+                    mode,
+                    segments_per_minute: per_min,
+                    eta_secs: eta,
+                    ratio,
+                    scroll: log_scroll,
+                    status,
+                },
             )
         })?;
         Ok(())
     }
 }
 
-fn render_dashboard(
-    frame: &mut Frame,
-    state: &RunState,
+struct DashboardRenderContext<'a> {
+    state: &'a RunState,
     mode: TuiMode,
     segments_per_minute: f64,
     eta_secs: f64,
     ratio: f64,
-    scroll: &mut LogScroll,
-    status: Option<&str>,
-) {
+    scroll: &'a mut LogScroll,
+    status: Option<&'a str>,
+}
+
+fn render_dashboard(frame: &mut Frame, context: DashboardRenderContext<'_>) {
     let chunks = Layout::vertical([
         Constraint::Length(5), // header
         Constraint::Length(3), // progress gauge
@@ -517,12 +520,24 @@ fn render_dashboard(
     ])
     .split(frame.area());
 
-    render_header(frame, chunks[0], state, mode);
+    render_header(frame, chunks[0], context.state, context.mode);
     // Gauge ratio comes from the canonical epoch-aware view (UI-31).
-    render_gauge(frame, chunks[1], state, ratio);
-    render_stats(frame, chunks[2], state, segments_per_minute, eta_secs);
-    render_log(frame, chunks[3], state, scroll);
-    render_footer(frame, chunks[4], state, mode, status);
+    render_gauge(frame, chunks[1], context.state, context.ratio);
+    render_stats(
+        frame,
+        chunks[2],
+        context.state,
+        context.segments_per_minute,
+        context.eta_secs,
+    );
+    render_log(frame, chunks[3], context.state, context.scroll);
+    render_footer(
+        frame,
+        chunks[4],
+        context.state,
+        context.mode,
+        context.status,
+    );
 }
 
 fn render_header(frame: &mut Frame, area: ratatui::layout::Rect, state: &RunState, mode: TuiMode) {
@@ -835,13 +850,15 @@ mod tests {
             .draw(|frame| {
                 render_dashboard(
                     frame,
-                    &state,
-                    TuiMode::Watch,
-                    0.0,
-                    0.0,
-                    0.0,
-                    &mut scroll,
-                    None,
+                    DashboardRenderContext {
+                        state: &state,
+                        mode: TuiMode::Watch,
+                        segments_per_minute: 0.0,
+                        eta_secs: 0.0,
+                        ratio: 0.0,
+                        scroll: &mut scroll,
+                        status: None,
+                    },
                 );
             })
             .unwrap();
@@ -881,13 +898,15 @@ mod tests {
             .draw(|frame| {
                 render_dashboard(
                     frame,
-                    &state,
-                    TuiMode::Attached,
-                    0.0,
-                    0.0,
-                    0.0,
-                    &mut scroll,
-                    None,
+                    DashboardRenderContext {
+                        state: &state,
+                        mode: TuiMode::Attached,
+                        segments_per_minute: 0.0,
+                        eta_secs: 0.0,
+                        ratio: 0.0,
+                        scroll: &mut scroll,
+                        status: None,
+                    },
                 );
             })
             .unwrap();
@@ -923,13 +942,15 @@ mod tests {
             .draw(|frame| {
                 render_dashboard(
                     frame,
-                    &state,
-                    TuiMode::Attached,
-                    0.0,
-                    0.0,
-                    0.0,
-                    &mut scroll,
-                    None,
+                    DashboardRenderContext {
+                        state: &state,
+                        mode: TuiMode::Attached,
+                        segments_per_minute: 0.0,
+                        eta_secs: 0.0,
+                        ratio: 0.0,
+                        scroll: &mut scroll,
+                        status: None,
+                    },
                 );
             })
             .unwrap();
@@ -1011,13 +1032,15 @@ mod tests {
             .draw(|frame| {
                 render_dashboard(
                     frame,
-                    &state,
-                    TuiMode::Watch,
-                    0.0,
-                    0.0,
-                    0.0,
-                    &mut scroll,
-                    None,
+                    DashboardRenderContext {
+                        state: &state,
+                        mode: TuiMode::Watch,
+                        segments_per_minute: 0.0,
+                        eta_secs: 0.0,
+                        ratio: 0.0,
+                        scroll: &mut scroll,
+                        status: None,
+                    },
                 );
             })
             .unwrap();

--- a/crates/bookforge-cli/tests/lifecycle.rs
+++ b/crates/bookforge-cli/tests/lifecycle.rs
@@ -35,6 +35,27 @@ fn fixture_input() -> PathBuf {
     path
 }
 
+fn write_pricing_catalog(path: &Path, input_rate: f64, output_rate: f64) {
+    let catalog = format!(
+        r#"{{
+  "schema_version": 1,
+  "updated_at": "2026-08-31",
+  "providers": {{
+    "test-provider": {{
+      "models": {{
+        "test-model": {{
+          "input_per_million_usd": {input_rate},
+          "output_per_million_usd": {output_rate},
+          "input_cache_per_million_usd": null
+        }}
+      }}
+    }}
+  }}
+}}"#
+    );
+    fs::write(path, catalog).expect("pricing fixture should be writable");
+}
+
 fn build_lifecycle_epub(path: &Path) {
     let file = fs::File::create(path).expect("fixture EPUB should be creatable");
     let mut zip = ZipWriter::new(file);
@@ -197,6 +218,105 @@ fn cli_translate_unsupported_provider_exits_failure() {
     assert!(
         stderr.contains("unsupported translation provider 'not-a-provider'"),
         "stderr should explain unsupported provider, got: {stderr}"
+    );
+}
+
+#[test]
+fn cli_estimate_explicit_pricing_path_wins_over_environment() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let environment_pricing = temp.path().join("environment.json");
+    let explicit_pricing = temp.path().join("explicit.json");
+    write_pricing_catalog(&environment_pricing, 1.0, 1.0);
+    write_pricing_catalog(&explicit_pricing, 2.0, 2.0);
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .env_remove("BOOKFORGE_PRICING_PATH")
+        .env("BOOKFORGE_PRICING_PATH", &environment_pricing)
+        .args([
+            "estimate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "test-provider",
+            "--model",
+            "test-model",
+            "--pricing",
+            explicit_pricing.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains(&format!("Pricing: {}", explicit_pricing.display())),
+        "explicit pricing source should be reported: {stdout}"
+    );
+    assert!(
+        !stdout.contains(&environment_pricing.display().to_string()),
+        "environment pricing must not win over --pricing: {stdout}"
+    );
+}
+
+#[test]
+fn cli_estimate_uses_pricing_environment_when_flag_is_omitted() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let environment_pricing = temp.path().join("environment.json");
+    write_pricing_catalog(&environment_pricing, 3.0, 4.0);
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .env_remove("BOOKFORGE_PRICING_PATH")
+        .env("BOOKFORGE_PRICING_PATH", &environment_pricing)
+        .args([
+            "estimate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "test-provider",
+            "--model",
+            "test-model",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains(&format!("Pricing: {}", environment_pricing.display())),
+        "environment pricing should be reported when --pricing is absent: {stdout}"
+    );
+}
+
+#[test]
+fn cli_estimate_reports_json_error_for_invalid_pricing_override() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let input = fixture_input();
+    let invalid_pricing = temp.path().join("pricing.toml");
+    fs::write(&invalid_pricing, "schema_version = 1\n").expect("invalid fixture should write");
+
+    let assert = bookforge()
+        .current_dir(temp.path())
+        .env_remove("BOOKFORGE_PRICING_PATH")
+        .args([
+            "estimate",
+            input.to_str().unwrap(),
+            "--target",
+            "Italian",
+            "--provider",
+            "test-provider",
+            "--model",
+            "test-model",
+            "--pricing",
+            invalid_pricing.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("parsing pricing JSON"),
+        "invalid pricing should identify JSON, not TOML: {stderr}"
     );
 }
 

--- a/crates/bookforge-llm/src/batch.rs
+++ b/crates/bookforge-llm/src/batch.rs
@@ -224,10 +224,6 @@ pub struct BatchSizer {
 pub struct BatchModeSizing {
     target_tokens: usize,
     max_items: usize,
-    #[allow(dead_code)]
-    initial_target_tokens: usize,
-    #[allow(dead_code)]
-    initial_max_items: usize,
     min_tokens: usize,
     max_tokens: usize,
     min_items: usize,

--- a/crates/bookforge-llm/src/batch/planning.rs
+++ b/crates/bookforge-llm/src/batch/planning.rs
@@ -207,8 +207,6 @@ impl BatchModeSizing {
         let mut state = Self {
             target_tokens: initial_target_tokens,
             max_items: initial_max_items,
-            initial_target_tokens,
-            initial_max_items,
             // Explicit user/runtime limits below the adaptive defaults are
             // still authoritative. They become the floor for this sizing
             // epoch; adaptation may grow from them but must not silently

--- a/crates/bookforge-store/Cargo.toml
+++ b/crates/bookforge-store/Cargo.toml
@@ -10,8 +10,6 @@ rust-version.workspace = true
 [dependencies]
 bookforge-core = { version = "3.0.0", path = "../bookforge-core" }
 rusqlite.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-toml.workspace = true


### PR DESCRIPTION
## Summary
- replace the remaining high-arity serve/TUI call sites with typed input/context structs
- make pricing override help and docs accurately describe JSON and add CLI precedence/error tests
- remove caller-proven dead fields/constants and unused store dependencies
- remove the clippy exception and enforce `-D warnings` in CI and contributor docs

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
