### PR TITLE
fix(translation): harden cache identity and attempt state

### DIFF
--- a/crates/bookforge-cli/src/checkpoint.rs
+++ b/crates/bookforge-cli/src/checkpoint.rs
@@ -261,19 +261,22 @@ fn apply(store: &JobStore, cmd: CheckpointCommand) -> Result<()> {
                 &translation.segment_id.0,
                 translation.error.as_deref().unwrap_or("translation failed"),
             )?;
-            if store.segment_records(&job_id).is_ok_and(|records| {
-                records.iter().any(|record| {
-                    record.id == translation.segment_id.0 && record.status == "failed"
-                })
-            }) {
-                persist_checkpoint_findings(
-                    store,
-                    &job_id,
-                    &translation.segment_id.0,
-                    &translation.findings,
-                    translation.error.as_deref(),
-                );
-            }
+            // NO ledger row is derived here: a checkpoint failure is a
+            // synthetic segment-state outcome, not a provider wire attempt.
+            // Batch/retry aggregation also makes the checkpoint's token and
+            // provenance semantics false (a failed batch item carries no
+            // honest per-attempt tokens). The append-only ledger is written
+            // only by the attempt-recording lane that instruments real
+            // provider calls (see `JobStore::record_translation_attempt`);
+            // until that lane exists the ledger stays empty rather than
+            // fabricate rows.
+            persist_checkpoint_findings(
+                store,
+                &job_id,
+                &translation.segment_id.0,
+                &translation.findings,
+                translation.error.as_deref(),
+            );
         }
         _ => {}
     }
@@ -910,6 +913,103 @@ mod tests {
             model: "mock-model".to_string(),
             prompt_version: "v1".to_string(),
         }
+    }
+
+    #[test]
+    fn checkpoints_never_fabricate_provider_wire_attempt_rows() {
+        let db_path = temp_path("no_synthetic_attempts.sqlite");
+        let input_path = temp_path("no_synthetic_input.epub");
+        fs::write(&input_path, b"epub bytes").expect("input fixture writable");
+
+        let store = JobStore::open(&db_path).expect("store open for setup");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("no_synthetic_output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-model",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("job created");
+        store
+            .insert_segments(
+                &job.id,
+                &[
+                    test_segment("seg_ok", 0),
+                    test_segment("seg_review", 1),
+                    test_segment("seg_failed", 2),
+                ],
+                "v1",
+                "mock",
+                "mock-model",
+                "test_ns",
+            )
+            .expect("segments inserted");
+
+        apply(
+            &store,
+            CheckpointCommand::SaveTranslation {
+                job_id: job.id.clone(),
+                translation: Box::new(test_translation("seg_ok", 0, SegmentStatus::Succeeded)),
+                provider: "mock".to_string(),
+                model: "mock-model".to_string(),
+                prompt_version: "v1".to_string(),
+            },
+        )
+        .expect("succeeded checkpoint applies");
+        let mut review = test_translation("seg_review", 1, SegmentStatus::NeedsReview);
+        review.error = Some(needs_review_error_text());
+        apply(
+            &store,
+            CheckpointCommand::SaveTranslation {
+                job_id: job.id.clone(),
+                translation: Box::new(review),
+                provider: "mock".to_string(),
+                model: "mock-model".to_string(),
+                prompt_version: "v1".to_string(),
+            },
+        )
+        .expect("needs_review checkpoint applies");
+        apply(
+            &store,
+            CheckpointCommand::SaveTranslation {
+                job_id: job.id.clone(),
+                translation: Box::new(test_translation("seg_failed", 2, SegmentStatus::Failed)),
+                provider: "mock".to_string(),
+                model: "mock-model".to_string(),
+                prompt_version: "v1".to_string(),
+            },
+        )
+        .expect("failed checkpoint applies");
+
+        // Checkpoints record segment STATE; none of them are provider wire
+        // attempts, so the append-only ledger must stay empty here. Real wire
+        // attempts are recorded explicitly by the attempt-recording lane.
+        let attempts = store
+            .translation_attempts(&job.id, None, None)
+            .expect("attempts should load");
+        assert!(
+            attempts.is_empty(),
+            "success/needs-review/failure checkpoints must not fabricate wire-attempt rows"
+        );
+
+        // Segment state is still persisted honestly for later aggregation.
+        let summary = store
+            .summary(&job.id)
+            .expect("summary query")
+            .expect("job exists");
+        assert_eq!(summary.total_segments, 3);
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.needs_review, 1);
+        assert_eq!(summary.failed, 1);
+
+        let _ = fs::remove_file(db_path);
+        let _ = fs::remove_file(input_path);
     }
 
     #[test]

--- a/crates/bookforge-cli/src/commands/resume.rs
+++ b/crates/bookforge-cli/src/commands/resume.rs
@@ -596,6 +596,7 @@ async fn run_inner(
         .cloned()
         .collect::<Vec<_>>();
     let cached_translations = apply_cached_translations(
+        &segments,
         &cacheable_pending_segments,
         CacheContext {
             store,
@@ -1062,9 +1063,11 @@ fn snapshot_context_run_config(snapshot: &RunConfigSnapshot) -> ContextRunConfig
         window: snapshot.context_window,
         budget_tokens: snapshot.context_budget_tokens,
         scope: snapshot.context_scope,
-        // Strictness is a scheduling choice, not part of the cached
-        // translation contract, so it is not persisted in the snapshot.
-        // Resumed jobs use the best-effort default.
+        // Strictness is a scheduling choice for the resumed run's own
+        // translation pass, so it is not rehydrated from the snapshot here.
+        // The persisted CachePolicySnapshot (jobs.cache_policy_json) carries
+        // the original strict-context choice and feeds the cache identity
+        // used by lookups on resume.
         strict: false,
     }
 }

--- a/crates/bookforge-cli/src/commands/translate/cache.rs
+++ b/crates/bookforge-cli/src/commands/translate/cache.rs
@@ -15,11 +15,34 @@ pub struct CacheContext<'a> {
     pub cache_namespace: &'a str,
 }
 
+/// Apply cross-job cache hits to the eligible `segments`.
+///
+/// `all_segments` is the FULL ordered segment set of the current run: the
+/// expected cache identity is computed over it because per-segment glossary
+/// selection depends on the ordered neighborhood/window, and a sparse subset
+/// (e.g. the pending candidates passed on resume) would select different terms
+/// than the original run and compute different fingerprints. `segments` is the
+/// subset the lookup is restricted to (pending, cacheable candidates).
 pub fn apply_cached_translations(
+    all_segments: &[Segment],
     segments: &[Segment],
     cache: CacheContext<'_>,
 ) -> Result<Vec<SegmentTranslation>> {
     let mut cached = Vec::new();
+
+    // The expected structured cache identity fingerprint is computed from the
+    // job's persisted run snapshot + cache policy over the FULL ordered
+    // segment set (never discovered from a prior segment row) and passed
+    // straight into the lookup for the eligible candidates only.
+    let expected_fingerprints = cache.store.expected_cache_fingerprints(
+        cache.job_id,
+        all_segments,
+        segments,
+        cache.provider,
+        cache.model,
+        cache.prompt_version,
+        cache.cache_namespace,
+    )?;
 
     let request = bookforge_store::CacheLookupRequest {
         prompt_version: cache.prompt_version,
@@ -28,6 +51,7 @@ pub fn apply_cached_translations(
         source_lang: cache.source_lang,
         target_lang: cache.target_lang,
         cache_namespace: cache.cache_namespace,
+        expected_fingerprints: &expected_fingerprints,
     };
 
     let hits = cache

--- a/crates/bookforge-cli/src/commands/translate/orchestration.rs
+++ b/crates/bookforge-cli/src/commands/translate/orchestration.rs
@@ -528,6 +528,7 @@ where
     };
     let mut translations = apply_cached_translations(
         &segments,
+        &segments,
         CacheContext {
             store: &store,
             job_id: &job.id,

--- a/crates/bookforge-cli/src/commands/translate/snapshot.rs
+++ b/crates/bookforge-cli/src/commands/translate/snapshot.rs
@@ -6,7 +6,8 @@ use std::{
 
 use bookforge_core::{
     FallbackRunConfigSnapshot, FinalizeCheckpointSnapshot, GlossaryTerm, ResolvedRunSettings,
-    ResolvedRunSettingsSnapshot, RunConfigSnapshot, run_snapshot::AppliedPlanSnapshot,
+    ResolvedRunSettingsSnapshot, RunConfigSnapshot,
+    run_snapshot::{AppliedPlanSnapshot, CachePolicySnapshot},
 };
 use bookforge_store::{JobRecord, JobStore};
 use sha2::{Digest, Sha256};
@@ -14,6 +15,7 @@ use sha2::{Digest, Sha256};
 use crate::{ProviderArgs as CliProviderArgs, report::report_paths};
 
 use super::args::TranslateArgs;
+use super::context_run_config_from_args;
 
 pub(crate) fn default_event_path(job_id: &str) -> PathBuf {
     PathBuf::from(".bookforge/runs")
@@ -97,6 +99,16 @@ pub(crate) fn persist_snapshot(
         settings: ResolvedRunSettingsSnapshot::from_settings(settings),
     };
     store.update_job_config_snapshot(&job.id, &snapshot)?;
+    // Persist the durable cache-policy record (strict-context choice) BEFORE
+    // segments are stamped, so the structured cache identity written at
+    // insert time and recomputed at lookup time both carry the exact policy
+    // the CLI resolved from `--context-strict`.
+    store.update_job_cache_policy(
+        &job.id,
+        &CachePolicySnapshot {
+            strict_context: Some(context_run_config_from_args(cli_args).strict),
+        },
+    )?;
     store.update_job_event_path(&job.id, &events_path)?;
     Ok(snapshot)
 }

--- a/crates/bookforge-core/src/run_snapshot.rs
+++ b/crates/bookforge-core/src/run_snapshot.rs
@@ -6,7 +6,27 @@ use crate::{
     SegmentationConfig, TranslationProfile,
     config::ContextScope,
     glossary::{GlossaryFormat, GlossaryTerm},
+    segment::{CacheIdentity, Segment},
 };
+
+/// The actual per-segment prompt ingredients that shape the rendered request.
+///
+/// The cache identity hashes these strings (not just the configuration that
+/// produced them): two runs whose config fingerprints agree but whose rendered
+/// content differs — different neighbor text, a different per-segment glossary
+/// selection, an edited style/entity block — must never reuse a cache row.
+/// [`RunConfigSnapshot::cache_identity`] combines them with the segment's own
+/// neighbor context and the provider/runtime settings into one fingerprint.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CachePromptInputs {
+    /// Canonical rendering of the actual per-segment glossary terms selected
+    /// for this segment (ordered, budget-bounded; empty when no glossary).
+    pub glossary_rendered: String,
+    /// The actual rendered style-guide block substituted into the prompt.
+    pub style_rendered: String,
+    /// The actual rendered entity-agreement block substituted into the prompt.
+    pub entities_rendered: String,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct RunConfigSnapshot {
@@ -108,6 +128,106 @@ fn default_glossary_format() -> GlossaryFormat {
 
 fn default_bilingual_separator() -> String {
     " / ".to_string()
+}
+
+/// Durable cache-policy fields that are not part of [`RunConfigSnapshot`]'s
+/// historical surface and therefore live in their own persisted record
+/// (`jobs.cache_policy_json`). Old jobs that never recorded a policy read
+/// back the conservative default, which prevents their cache entries from
+/// being reused by runs that state an explicit policy.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct CachePolicySnapshot {
+    /// The strict-context completion fence (`ContextRunConfig::strict`).
+    /// `None` means the run never recorded its choice — hashed distinctly
+    /// from both explicit values so legacy cache rows can never be reused by
+    /// a run that pins strictness (and vice versa).
+    #[serde(default)]
+    pub strict_context: Option<bool>,
+}
+
+impl CachePolicySnapshot {
+    /// Conservative fallback for rows that predate the policy record: no
+    /// explicit strictness. Fingerprints built with this value are
+    /// incompatible with any run that states `Some(true)` or `Some(false)`.
+    pub fn conservative() -> Self {
+        Self {
+            strict_context: None,
+        }
+    }
+}
+
+impl RunConfigSnapshot {
+    /// Build the structured [`CacheIdentity`] for one segment from this
+    /// snapshot's full output-affecting settings plus the ACTUAL rendered
+    /// prompt ingredients (`request.prompt_inputs`) and the segment's own
+    /// neighbor context. `request.strict_context` comes from the separately
+    /// persisted [`CachePolicySnapshot`]; pass `None` when the job never
+    /// recorded a policy (conservative).
+    pub fn cache_identity(&self, request: CacheIdentityRequest<'_>) -> CacheIdentity {
+        let CacheIdentityRequest {
+            segment,
+            provider,
+            model,
+            prompt_version,
+            cache_namespace,
+            strict_context,
+            prompt_inputs,
+        } = request;
+        CacheIdentity {
+            schema_version: crate::segment::CACHE_IDENTITY_SCHEMA_VERSION,
+            source_hash: segment.checksum.clone(),
+            provider: provider.to_string(),
+            model: model.to_string(),
+            source_lang: self.source_language.clone(),
+            target_lang: self.target_language.clone(),
+            prompt_version: prompt_version.to_string(),
+            cache_namespace: cache_namespace.to_string(),
+            prompt_extra: self.prompt_extra.clone(),
+            max_segment_tokens: self.settings.segmentation.max_segment_tokens,
+            context_tokens: self.settings.segmentation.context_tokens,
+            context_window: self.context_window,
+            context_budget_tokens: self.context_budget_tokens,
+            context_scope: self.context_scope,
+            strict_context,
+            profile: self.profile,
+            batch_enabled: self.settings.batch.enabled,
+            batch_target_tokens: self.settings.batch.target_tokens,
+            batch_max_items: self.settings.batch.max_items,
+            batch_adaptive_sizing: self.settings.batch.adaptive_sizing,
+            batch_split_on_json_failure: self.settings.batch.split_on_json_failure,
+            batch_repair_invalid_items: self.settings.batch.repair_invalid_items,
+            compact_prompts: self.settings.compact_prompts,
+            glossary_fingerprint: self.glossary_fingerprint.clone(),
+            style_fingerprint: self.style_fingerprint.clone(),
+            entities_fingerprint: self.entities_fingerprint.clone(),
+            context_before: segment.context.before.clone().unwrap_or_default(),
+            context_after: segment.context.after.clone().unwrap_or_default(),
+            glossary_rendered: prompt_inputs.glossary_rendered.clone(),
+            style_rendered: prompt_inputs.style_rendered.clone(),
+            entities_rendered: prompt_inputs.entities_rendered.clone(),
+            bilingual_mode: self.bilingual_mode,
+            bilingual_separator: self.bilingual_separator.clone(),
+            bilingual_style: self.bilingual_style,
+            thinking_disabled: self.settings.provider.thinking_disabled,
+            max_output_tokens: self.settings.provider.max_output_tokens,
+            batch_max_output_tokens: self.settings.provider.batch_max_output_tokens,
+            json_mode: self.settings.provider.json_mode,
+        }
+    }
+}
+
+/// Inputs for [`RunConfigSnapshot::cache_identity`]: the request-visible
+/// fields plus the actual rendered prompt ingredients. Bundling them keeps the
+/// identity construction signature stable as more request fields are added.
+#[derive(Debug, Clone, Copy)]
+pub struct CacheIdentityRequest<'a> {
+    pub segment: &'a Segment,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub prompt_version: &'a str,
+    pub cache_namespace: &'a str,
+    pub strict_context: Option<bool>,
+    pub prompt_inputs: &'a CachePromptInputs,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -329,5 +449,277 @@ impl ResolvedRunSettingsSnapshot {
                 correction_rounds: self.double_check.correction_rounds,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_policy_conservative_is_unknown_strictness() {
+        assert_eq!(CachePolicySnapshot::conservative().strict_context, None);
+        let serialized =
+            serde_json::to_string(&CachePolicySnapshot::conservative()).expect("policy serializes");
+        let round_trip: CachePolicySnapshot =
+            serde_json::from_str(&serialized).expect("policy deserializes");
+        assert_eq!(round_trip, CachePolicySnapshot::conservative());
+    }
+
+    #[test]
+    fn cache_policy_missing_field_deserializes_to_conservative_default() {
+        let empty = CachePolicySnapshot::conservative();
+        let from_partial: CachePolicySnapshot = serde_json::from_str("{}").expect("empty policy");
+        assert_eq!(from_partial, empty);
+        assert_eq!(from_partial.strict_context, None);
+    }
+
+    #[test]
+    fn cache_identity_carries_snapshot_settings_and_strict_context() {
+        let mut snapshot = RunConfigSnapshot {
+            input_path: PathBuf::from("input.epub"),
+            input_snapshot_path: None,
+            input_sha256: None,
+            output_path: PathBuf::from("output.epub"),
+            events_path: None,
+            report_json_path: None,
+            report_markdown_path: None,
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            creator: None,
+            provider: "openrouter".to_string(),
+            model: "google/gemini-2.5-flash".to_string(),
+            base_url: None,
+            api_key_env: None,
+            profile: TranslationProfile::Balanced,
+            provider_preset: None,
+            prompt_version: "batch_v3".to_string(),
+            cache_namespace: "legacy_namespace".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: "glossary:a".to_string(),
+            glossary_terms: Vec::new(),
+            context_window: 4,
+            context_budget_tokens: 400,
+            context_scope: ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
+            bilingual_mode: BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: BilingualStyle::Minimal,
+            bilingual_css: None,
+            fallback: None,
+            finalize: FinalizeCheckpointSnapshot::default(),
+            qa_mode: "off".to_string(),
+            validate_output: false,
+            settings: ResolvedRunSettingsSnapshot {
+                profile: TranslationProfile::Balanced,
+                segmentation: SegmentationConfigSnapshot {
+                    max_segment_tokens: 2_500,
+                    context_tokens: 80,
+                },
+                batch: BatchConfigSnapshot {
+                    enabled: true,
+                    target_tokens: 8_000,
+                    max_items: 64,
+                    adaptive_sizing: false,
+                    split_on_json_failure: true,
+                    repair_invalid_items: true,
+                },
+                scheduler: SchedulerConfigSnapshot {
+                    concurrency: 16,
+                    max_attempts: 2,
+                },
+                provider: ProviderRuntimeConfigSnapshot {
+                    timeout_seconds: 120,
+                    provider_max_attempts: 2,
+                    validation_max_attempts: 1,
+                    retry_after_policy: RetryAfterPolicy::JitteredExponential,
+                    max_backoff_seconds: 30,
+                    thinking_disabled: false,
+                    model_context_tokens: None,
+                    max_output_tokens: None,
+                    batch_max_output_tokens: None,
+                    json_mode: JsonMode::Auto,
+                    max_idle_per_host: 32,
+                },
+                compact_prompts: true,
+                retry_failed_only: true,
+                adaptive_concurrency: true,
+                qa: QaRunConfigSnapshot {
+                    concurrency: 8,
+                    batch_target_tokens: 8_000,
+                    model: None,
+                    provider: None,
+                    base_url: None,
+                    api_key_env: None,
+                },
+                double_check: DoubleCheckConfigSnapshot {
+                    mode: crate::DoubleCheckMode::Off,
+                    model: None,
+                    provider: None,
+                    base_url: None,
+                    api_key_env: None,
+                    concurrency: 4,
+                    batch_target_tokens: 8_000,
+                    auto_correct: false,
+                    correction_rounds: 1,
+                },
+            },
+        };
+        snapshot.settings.segmentation.max_segment_tokens = 2_500;
+
+        let segment = crate::segment::Segment {
+            id: crate::segment::SegmentId("seg_a".to_string()),
+            section_id: crate::ir::SectionId("sec_0".to_string()),
+            ordinal: 0,
+            block_ids: Vec::new(),
+            source: crate::segment::SegmentSource {
+                text: "source".to_string(),
+                blocks: Vec::new(),
+                token_estimate: 2,
+            },
+            context: crate::segment::SegmentContext::default(),
+            metadata: crate::segment::SegmentMetadata::default(),
+            constraints: crate::segment::SegmentConstraints::default(),
+            checksum: "checksum_a".to_string(),
+        };
+
+        let default_inputs = CachePromptInputs::default();
+        let request = |strict_context| CacheIdentityRequest {
+            segment: &segment,
+            provider: "openrouter",
+            model: "google/gemini-2.5-flash",
+            prompt_version: "batch_v3",
+            cache_namespace: "legacy_namespace",
+            strict_context,
+            prompt_inputs: &default_inputs,
+        };
+
+        let loose = snapshot.cache_identity(request(Some(false)));
+        let strict = snapshot.cache_identity(request(Some(true)));
+        let unknown = snapshot.cache_identity(request(None));
+
+        assert_ne!(loose.fingerprint(), strict.fingerprint());
+        assert_ne!(unknown.fingerprint(), loose.fingerprint());
+        assert_ne!(unknown.fingerprint(), strict.fingerprint());
+        assert_eq!(snapshot.settings.segmentation.max_segment_tokens, 2_500);
+        assert_eq!(
+            snapshot.cache_identity(request(Some(false))),
+            loose,
+            "identity construction is deterministic"
+        );
+    }
+
+    #[test]
+    fn cache_identity_hashes_actual_rendered_prompt_inputs() {
+        let snapshot = RunConfigSnapshot {
+            input_path: PathBuf::from("input.epub"),
+            input_snapshot_path: None,
+            input_sha256: None,
+            output_path: PathBuf::from("output.epub"),
+            events_path: None,
+            report_json_path: None,
+            report_markdown_path: None,
+            source_language: Some("English".to_string()),
+            target_language: "Italian".to_string(),
+            creator: None,
+            provider: "openrouter".to_string(),
+            model: "google/gemini-2.5-flash".to_string(),
+            base_url: None,
+            api_key_env: None,
+            profile: TranslationProfile::Balanced,
+            provider_preset: None,
+            prompt_version: "batch_v3".to_string(),
+            cache_namespace: "legacy_namespace".to_string(),
+            book_id: None,
+            series_id: None,
+            glossary_budget_tokens: 800,
+            glossary_format: GlossaryFormat::Json,
+            prompt_extra: None,
+            glossary_fingerprint: "same_config_fp".to_string(),
+            glossary_terms: Vec::new(),
+            context_window: 4,
+            context_budget_tokens: 400,
+            context_scope: ContextScope::Chapter,
+            style_fingerprint: String::new(),
+            style_rendered_block: String::new(),
+            entities_fingerprint: String::new(),
+            entities_rendered_block: String::new(),
+            bilingual_mode: BilingualMode::Replace,
+            bilingual_separator: " / ".to_string(),
+            bilingual_style: BilingualStyle::Minimal,
+            bilingual_css: None,
+            fallback: None,
+            finalize: FinalizeCheckpointSnapshot::default(),
+            qa_mode: "off".to_string(),
+            validate_output: false,
+            settings: snapshot_fixture_settings(),
+        };
+
+        let segment = crate::segment::Segment {
+            id: crate::segment::SegmentId("seg_a".to_string()),
+            section_id: crate::ir::SectionId("sec_0".to_string()),
+            ordinal: 0,
+            block_ids: Vec::new(),
+            source: crate::segment::SegmentSource {
+                text: "identical text".to_string(),
+                blocks: Vec::new(),
+                token_estimate: 2,
+            },
+            context: crate::segment::SegmentContext {
+                before: Some("before A".to_string()),
+                after: Some("after A".to_string()),
+            },
+            metadata: crate::segment::SegmentMetadata::default(),
+            constraints: crate::segment::SegmentConstraints::default(),
+            checksum: "checksum_identical".to_string(),
+        };
+        let mut segment_b = segment.clone();
+        segment_b.context.before = Some("before B".to_string());
+        segment_b.context.after = Some("after B".to_string());
+
+        let inputs_a = CachePromptInputs {
+            glossary_rendered: "[{\"source\":\"hello\",\"target\":\"ciao\"}]".to_string(),
+            style_rendered: "Style block A".to_string(),
+            entities_rendered: "Entity block A".to_string(),
+        };
+        let inputs_b = CachePromptInputs {
+            glossary_rendered: "[{\"source\":\"world\",\"target\":\"mondo\"}]".to_string(),
+            style_rendered: "Style block B".to_string(),
+            entities_rendered: "Entity block B".to_string(),
+        };
+
+        let identity = |segment: &crate::segment::Segment, inputs: &CachePromptInputs| {
+            snapshot.cache_identity(CacheIdentityRequest {
+                segment,
+                provider: "openrouter",
+                model: "google/gemini-2.5-flash",
+                prompt_version: "batch_v3",
+                cache_namespace: "legacy_namespace",
+                strict_context: Some(false),
+                prompt_inputs: inputs,
+            })
+        };
+
+        let a = identity(&segment, &inputs_a);
+        let b = identity(&segment_b, &inputs_b);
+        assert_eq!(a.source_hash, b.source_hash);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+
+        // Identical config fingerprint but different actual rendered blocks
+        // must still differ (same snapshot, different prompt inputs).
+        let rendered_difference = identity(&segment, &inputs_b);
+        assert_ne!(a.fingerprint(), rendered_difference.fingerprint());
+    }
+
+    fn snapshot_fixture_settings() -> ResolvedRunSettingsSnapshot {
+        let settings = crate::TranslationProfile::Balanced.resolve();
+        ResolvedRunSettingsSnapshot::from_settings(&settings)
     }
 }

--- a/crates/bookforge-core/src/segment.rs
+++ b/crates/bookforge-core/src/segment.rs
@@ -3,7 +3,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     BookforgeError, Result,
-    config::SegmentationConfig,
+    config::{BilingualMode, BilingualStyle, ContextScope, JsonMode, SegmentationConfig},
     ir::{Block, BlockId, BlockKind, Book, ProtectedSpan, Section, SectionId},
 };
 
@@ -13,7 +13,27 @@ use crate::{
 /// script weights (`crate::token_estimate`). Segment groupings and
 /// persisted block token estimates differ on mixed- and CJK-heavy
 /// books, so cached rows from the old estimator are ineligible.
+///
+/// This legacy namespace is deliberately frozen at v3 for compatibility
+/// with the CLI's resume path (which compares a recomputed namespace
+/// against the persisted snapshot). The single structured cache identity
+/// used by `bookforge_store` is [`CacheIdentity`] and its own
+/// `CACHE_IDENTITY_SCHEMA_VERSION`; the two are unrelated.
 pub const CACHE_KEY_SCHEMA_VERSION: u32 = 3;
+
+/// Version of the structured cache identity serialization
+/// ([`CacheIdentity::fingerprint`]). Bump once whenever any field or its
+/// meaning changes incompatibly — every stored fingerprint changes and
+/// previously cached rows (which carry an older fingerprint) can no longer
+/// match, so ambiguous old entries are excluded forever without a data
+/// migration.
+///
+/// v2: the identity now hashes the ACTUAL rendered prompt ingredients — the
+/// ordered neighbor/context strings around each segment and the actual
+/// rendered glossary/style/entity blocks — not just the configuration that
+/// produced them. Two identical source texts in different contexts, or with
+/// different per-segment glossary selections, can never reuse a cache row.
+pub const CACHE_IDENTITY_SCHEMA_VERSION: u32 = 2;
 /// Bumped when Segment / SegmentBlock layout changes incompatibly.
 pub const SEGMENT_SCHEMA_VERSION: u32 = 1;
 /// Stable label for the canonical unit checkpointed, retried, resumed, and
@@ -144,6 +164,360 @@ fn compute_cache_namespace_inner(
         hex.push_str(&format!("{byte:02x}"));
     }
     hex
+}
+
+/// The single structured cache identity for a translation checkpoint.
+///
+/// Unlike the legacy [`compute_cache_namespace`] string (a flat bundle of a
+/// handful of segmentation knobs), this struct captures *every* output-
+/// affecting input — schema version, source identity, the effective
+/// provider/model that actually produced the output, source/target language,
+/// prompt template version and extra text, segmentation and context
+/// window/budget/scope, the strict-context completion fence, batch shape,
+/// compact-prompt mode, the style/glossary/entity fingerprints, bilingual
+/// rendering, and the provider runtime settings that shape the request.
+///
+/// [`CacheIdentity::fingerprint`] serializes the fields deterministically
+/// (fixed field order with domain-separated names, so no two distinct
+/// inputs can collide) and is what `bookforge_store` persists per segment as
+/// `segments.cache_fingerprint` and matches on during cache lookup. Rows
+/// stamped before this identity existed carry an empty fingerprint and are
+/// permanently ineligible for reuse.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CacheIdentity {
+    /// [`CACHE_IDENTITY_SCHEMA_VERSION`] at the time the identity was
+    /// serialized. A bump invalidates every stored fingerprint.
+    pub schema_version: u32,
+    /// Source content identity (`Segment::checksum`).
+    pub source_hash: String,
+    /// Effective provider that produced the output (not necessarily the
+    /// primary run config — fallback outputs keep their real provenance).
+    pub provider: String,
+    /// Effective model that produced the output.
+    pub model: String,
+    pub source_lang: Option<String>,
+    pub target_lang: String,
+    /// Prompt template/schema version tag (`PromptVersion::as_str`).
+    pub prompt_version: String,
+    /// The legacy namespace bundle (segmentation/batch/profile/prompt
+    /// version/fingerprints). Kept as a member so rows stamped before the
+    /// structured identity still agree with their namespace-based lookup.
+    pub cache_namespace: String,
+    pub prompt_extra: Option<String>,
+    pub max_segment_tokens: usize,
+    pub context_tokens: usize,
+    pub context_window: usize,
+    pub context_budget_tokens: usize,
+    pub context_scope: ContextScope,
+    /// `Some(true)`/`Some(false)` when the run recorded its strict-context
+    /// choice; `None` for legacy runs that never persisted it. `None` hashes
+    /// to its own domain value so it can never match an explicit choice.
+    pub strict_context: Option<bool>,
+    pub profile: crate::config::TranslationProfile,
+    pub batch_enabled: bool,
+    pub batch_target_tokens: usize,
+    pub batch_max_items: usize,
+    pub batch_adaptive_sizing: bool,
+    pub batch_split_on_json_failure: bool,
+    pub batch_repair_invalid_items: bool,
+    pub compact_prompts: bool,
+    pub glossary_fingerprint: String,
+    pub style_fingerprint: String,
+    pub entities_fingerprint: String,
+    /// Actual ordered neighbor content rendered immediately BEFORE this
+    /// segment in the prompt (`Segment::context.before`, raw). Empty when the
+    /// run has no context. Different neighbors at the same source text must
+    /// never reuse a cache row, so this is hashed into the identity.
+    pub context_before: String,
+    /// Actual ordered neighbor content rendered immediately AFTER this
+    /// segment in the prompt (`Segment::context.after`, raw).
+    pub context_after: String,
+    /// Canonical rendering of the actual per-segment glossary terms selected
+    /// for this segment (ordered, budget-bounded). Empty when the run has no
+    /// glossary. Two segments that select different terms are different
+    /// prompts even if the config-level glossary fingerprint is identical.
+    pub glossary_rendered: String,
+    /// The actual rendered style-guide block substituted into the prompt
+    /// (not just its config fingerprint).
+    pub style_rendered: String,
+    /// The actual rendered entity-agreement block substituted into the
+    /// prompt (not just its config fingerprint).
+    pub entities_rendered: String,
+    pub bilingual_mode: BilingualMode,
+    pub bilingual_separator: String,
+    pub bilingual_style: BilingualStyle,
+    pub thinking_disabled: bool,
+    pub max_output_tokens: Option<u32>,
+    pub batch_max_output_tokens: Option<u32>,
+    pub json_mode: JsonMode,
+}
+
+/// Request inputs for [`CacheIdentity::minimal`]: the request-visible fields
+/// (source identity, effective provider/model, languages, prompt tag, legacy
+/// namespace). Every snapshot-only setting falls back to a constant
+/// conservative default inside the identity.
+#[derive(Debug, Clone, Copy)]
+pub struct MinimalCacheIdentity<'a> {
+    pub segment: &'a Segment,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub source_lang: Option<&'a str>,
+    pub target_lang: &'a str,
+    pub prompt_version: &'a str,
+    pub cache_namespace: &'a str,
+}
+
+impl CacheIdentity {
+    /// Minimal identity for runs that have no persisted configuration
+    /// snapshot (legacy databases and fixtures). The request-visible fields
+    /// are real; every snapshot-only setting falls back to a constant
+    /// conservative default, so identities never diverge for the same
+    /// request inputs and always diverge when the request inputs differ.
+    pub fn minimal(args: MinimalCacheIdentity<'_>) -> Self {
+        Self {
+            schema_version: CACHE_IDENTITY_SCHEMA_VERSION,
+            source_hash: args.segment.checksum.clone(),
+            provider: args.provider.to_string(),
+            model: args.model.to_string(),
+            source_lang: args.source_lang.map(str::to_string),
+            target_lang: args.target_lang.to_string(),
+            prompt_version: args.prompt_version.to_string(),
+            cache_namespace: args.cache_namespace.to_string(),
+            prompt_extra: None,
+            max_segment_tokens: 0,
+            context_tokens: 0,
+            context_window: 0,
+            context_budget_tokens: 0,
+            context_scope: ContextScope::Chapter,
+            strict_context: None,
+            profile: crate::config::TranslationProfile::Balanced,
+            batch_enabled: false,
+            batch_target_tokens: 0,
+            batch_max_items: 0,
+            batch_adaptive_sizing: false,
+            batch_split_on_json_failure: false,
+            batch_repair_invalid_items: false,
+            compact_prompts: false,
+            glossary_fingerprint: String::new(),
+            style_fingerprint: String::new(),
+            entities_fingerprint: String::new(),
+            context_before: args.segment.context.before.clone().unwrap_or_default(),
+            context_after: args.segment.context.after.clone().unwrap_or_default(),
+            glossary_rendered: String::new(),
+            style_rendered: String::new(),
+            entities_rendered: String::new(),
+            bilingual_mode: BilingualMode::Replace,
+            bilingual_separator: String::new(),
+            bilingual_style: BilingualStyle::Minimal,
+            thinking_disabled: false,
+            max_output_tokens: None,
+            batch_max_output_tokens: None,
+            json_mode: JsonMode::Auto,
+        }
+    }
+
+    /// Deterministic, domain-separated serialization of every identity
+    /// field. Field names act as domain separators (a value cannot alias
+    /// another field's name), and the schema version is hashed first so a
+    /// bump changes every fingerprint.
+    pub fn fingerprint(&self) -> String {
+        let mut hasher = Sha256::new();
+        feed(
+            &mut hasher,
+            "schema_version",
+            &self.schema_version.to_le_bytes(),
+        );
+        feed(&mut hasher, "source_hash", self.source_hash.as_bytes());
+        feed(&mut hasher, "provider", self.provider.as_bytes());
+        feed(&mut hasher, "model", self.model.as_bytes());
+        feed(
+            &mut hasher,
+            "source_lang",
+            self.source_lang.as_deref().unwrap_or("").as_bytes(),
+        );
+        feed(&mut hasher, "target_lang", self.target_lang.as_bytes());
+        feed(
+            &mut hasher,
+            "prompt_version",
+            self.prompt_version.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "cache_namespace",
+            self.cache_namespace.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "prompt_extra",
+            self.prompt_extra.as_deref().unwrap_or("").as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "max_segment_tokens",
+            &(self.max_segment_tokens as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "context_tokens",
+            &(self.context_tokens as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "context_window",
+            &(self.context_window as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "context_budget_tokens",
+            &(self.context_budget_tokens as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "context_scope",
+            self.context_scope.as_str().as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "strict_context",
+            match self.strict_context {
+                Some(true) => b"strict".as_slice(),
+                Some(false) => b"loose".as_slice(),
+                None => b"unknown".as_slice(),
+            },
+        );
+        feed(
+            &mut hasher,
+            "profile",
+            self.profile.namespace_str().as_bytes(),
+        );
+        feed(&mut hasher, "batch_enabled", &[self.batch_enabled as u8]);
+        feed(
+            &mut hasher,
+            "batch_target_tokens",
+            &(self.batch_target_tokens as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "batch_max_items",
+            &(self.batch_max_items as u64).to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "batch_adaptive_sizing",
+            &[self.batch_adaptive_sizing as u8],
+        );
+        feed(
+            &mut hasher,
+            "batch_split_on_json_failure",
+            &[self.batch_split_on_json_failure as u8],
+        );
+        feed(
+            &mut hasher,
+            "batch_repair_invalid_items",
+            &[self.batch_repair_invalid_items as u8],
+        );
+        feed(
+            &mut hasher,
+            "compact_prompts",
+            &[self.compact_prompts as u8],
+        );
+        feed(
+            &mut hasher,
+            "glossary_fingerprint",
+            self.glossary_fingerprint.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "style_fingerprint",
+            self.style_fingerprint.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "entities_fingerprint",
+            self.entities_fingerprint.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "context_before",
+            self.context_before.as_bytes(),
+        );
+        feed(&mut hasher, "context_after", self.context_after.as_bytes());
+        feed(
+            &mut hasher,
+            "glossary_rendered",
+            self.glossary_rendered.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "style_rendered",
+            self.style_rendered.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "entities_rendered",
+            self.entities_rendered.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "bilingual_mode",
+            self.bilingual_mode.as_str().as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "bilingual_separator",
+            self.bilingual_separator.as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "bilingual_style",
+            self.bilingual_style.as_str().as_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "thinking_disabled",
+            &[self.thinking_disabled as u8],
+        );
+        feed(
+            &mut hasher,
+            "max_output_tokens",
+            &self.max_output_tokens.unwrap_or_default().to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "batch_max_output_tokens",
+            &self
+                .batch_max_output_tokens
+                .unwrap_or_default()
+                .to_le_bytes(),
+        );
+        feed(
+            &mut hasher,
+            "json_mode",
+            match self.json_mode {
+                JsonMode::Auto => b"auto".as_slice(),
+                JsonMode::ResponseFormat => b"response_format".as_slice(),
+                JsonMode::PromptOnly => b"prompt_only".as_slice(),
+            },
+        );
+        let digest = hasher.finalize();
+        let mut hex = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            use std::fmt::Write as _;
+            write!(&mut hex, "{byte:02x}").expect("writing to string should not fail");
+        }
+        hex
+    }
+}
+
+/// Feed one domain-separated field into the identity hasher. `0xff` opens a
+/// field boundary (never appears in ASCII field names), the name ends at a
+/// `0x00` terminator, and the raw value follows — so a value cannot be
+/// confused with a later name.
+fn feed(hasher: &mut Sha256, name: &str, value: &[u8]) {
+    hasher.update([0xff]);
+    hasher.update(name.as_bytes());
+    hasher.update([0x00]);
+    hasher.update(value);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -805,6 +1179,276 @@ mod tests {
         let as_entities =
             compute_cache_namespace(1200, 160, "Balanced", false, "v1", "glossary:a", "", "ab");
         assert_ne!(as_style, as_entities);
+    }
+
+    fn identity_fixture() -> CacheIdentity {
+        CacheIdentity::minimal(MinimalCacheIdentity {
+            segment: &test_segment(),
+            provider: "openrouter",
+            model: "google/gemini-2.5-flash",
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            prompt_version: "batch_v3",
+            cache_namespace: "namespace_a",
+        })
+    }
+
+    fn test_segment() -> Segment {
+        Segment {
+            id: SegmentId("seg_identity".to_string()),
+            section_id: SectionId("sec_000000".to_string()),
+            ordinal: 0,
+            block_ids: Vec::new(),
+            source: SegmentSource {
+                text: "Source".to_string(),
+                blocks: Vec::new(),
+                token_estimate: 2,
+            },
+            context: SegmentContext::default(),
+            metadata: SegmentMetadata::default(),
+            constraints: SegmentConstraints::default(),
+            checksum: "checksum_identity".to_string(),
+        }
+    }
+
+    #[test]
+    fn cache_identity_is_deterministic() {
+        assert_eq!(
+            identity_fixture().fingerprint(),
+            identity_fixture().fingerprint()
+        );
+    }
+
+    #[test]
+    fn cache_identity_is_sensitive_to_every_field() {
+        let baseline = identity_fixture();
+        let baseline_fp = baseline.fingerprint();
+        let mut altered = Vec::new();
+
+        let mut tweak = identity_fixture();
+        tweak.schema_version += 1;
+        altered.push(("schema_version", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.source_hash = "other_hash".to_string();
+        altered.push(("source_hash", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.provider = "deepseek".to_string();
+        altered.push(("provider", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.model = "deepseek-v4-flash".to_string();
+        altered.push(("model", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.source_lang = Some("French".to_string());
+        altered.push(("source_lang", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.target_lang = "French".to_string();
+        altered.push(("target_lang", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.prompt_version = "v2".to_string();
+        altered.push(("prompt_version", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.cache_namespace = "namespace_b".to_string();
+        altered.push(("cache_namespace", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.prompt_extra = Some("be brief".to_string());
+        altered.push(("prompt_extra", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.max_segment_tokens = 2_500;
+        altered.push(("max_segment_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_tokens = 80;
+        altered.push(("context_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_window = 4;
+        altered.push(("context_window", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_budget_tokens = 400;
+        altered.push(("context_budget_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_scope = crate::config::ContextScope::Book;
+        altered.push(("context_scope", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.strict_context = Some(false);
+        altered.push(("strict_context_loose", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.strict_context = Some(true);
+        altered.push(("strict_context_strict", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.profile = crate::config::TranslationProfile::Safe;
+        altered.push(("profile", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_enabled = true;
+        altered.push(("batch_enabled", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_target_tokens = 16_000;
+        altered.push(("batch_target_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_max_items = 64;
+        altered.push(("batch_max_items", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_adaptive_sizing = true;
+        altered.push(("batch_adaptive_sizing", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_split_on_json_failure = true;
+        altered.push(("batch_split_on_json_failure", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_repair_invalid_items = true;
+        altered.push(("batch_repair_invalid_items", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.compact_prompts = true;
+        altered.push(("compact_prompts", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.glossary_fingerprint = "glossary:a".to_string();
+        altered.push(("glossary_fingerprint", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.style_fingerprint = "style:a".to_string();
+        altered.push(("style_fingerprint", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.entities_fingerprint = "entities:a".to_string();
+        altered.push(("entities_fingerprint", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_before = "Neighbor before".to_string();
+        altered.push(("context_before", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.context_after = "Neighbor after".to_string();
+        altered.push(("context_after", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.glossary_rendered = "glossary:a".to_string();
+        altered.push(("glossary_rendered", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.style_rendered = "style block".to_string();
+        altered.push(("style_rendered", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.entities_rendered = "entity block".to_string();
+        altered.push(("entities_rendered", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.bilingual_mode = crate::config::BilingualMode::AppendText;
+        altered.push(("bilingual_mode", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.bilingual_separator = "\n\n".to_string();
+        altered.push(("bilingual_separator", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.bilingual_style = crate::config::BilingualStyle::Prominent;
+        altered.push(("bilingual_style", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.thinking_disabled = true;
+        altered.push(("thinking_disabled", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.max_output_tokens = Some(2048);
+        altered.push(("max_output_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.batch_max_output_tokens = Some(8192);
+        altered.push(("batch_max_output_tokens", tweak));
+
+        let mut tweak = identity_fixture();
+        tweak.json_mode = crate::config::JsonMode::ResponseFormat;
+        altered.push(("json_mode", tweak));
+
+        let mut failures = Vec::new();
+        for (name, identity) in altered {
+            if identity.fingerprint() == baseline_fp {
+                failures.push(name);
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "cache identity must be sensitive to every field; insensitive: {failures:?}"
+        );
+    }
+
+    #[test]
+    fn cache_identity_distinguishes_unknown_strict_context() {
+        // A legacy run (None) must never match an explicit strict or loose
+        // choice, and the two explicit choices must differ from each other.
+        let unknown = identity_fixture().fingerprint();
+        let mut loose = identity_fixture();
+        loose.strict_context = Some(false);
+        let mut strict = identity_fixture();
+        strict.strict_context = Some(true);
+        assert_ne!(unknown, loose.fingerprint());
+        assert_ne!(unknown, strict.fingerprint());
+        assert_ne!(loose.fingerprint(), strict.fingerprint());
+    }
+
+    #[test]
+    fn cache_identity_fingerprint_bumps_with_schema_version() {
+        let baseline = identity_fixture().fingerprint();
+        let mut bumped = identity_fixture();
+        bumped.schema_version += 1;
+        assert_ne!(baseline, bumped.fingerprint());
+    }
+
+    #[test]
+    fn cache_identity_distinguishes_same_source_in_different_contexts() {
+        // The same source text at a different position (different ordered
+        // neighbor/context content) must never collide: identical checksum,
+        // different fingerprint.
+        let mut seg_a = test_segment();
+        seg_a.source.text = "identical text".to_string();
+        seg_a.checksum = stable_hash(&seg_a.source.text);
+        seg_a.context.before = Some("before A".to_string());
+        seg_a.context.after = Some("after A".to_string());
+        let mut seg_b = seg_a.clone();
+        seg_b.context.before = Some("before B".to_string());
+        seg_b.context.after = Some("after B".to_string());
+
+        let identity = |segment: &Segment| {
+            CacheIdentity::minimal(MinimalCacheIdentity {
+                segment,
+                provider: "openrouter",
+                model: "google/gemini-2.5-flash",
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                prompt_version: "batch_v3",
+                cache_namespace: "namespace_a",
+            })
+        };
+
+        let a = identity(&seg_a);
+        let b = identity(&seg_b);
+        assert_eq!(a.source_hash, b.source_hash, "source text is identical");
+        assert_ne!(
+            a.fingerprint(),
+            b.fingerprint(),
+            "different neighbor content must not share a cache identity"
+        );
     }
 
     fn book_with_two_sections() -> Book {

--- a/crates/bookforge-store/migrations/0012_v3_0_translation_attempts_cache_identity.sql
+++ b/crates/bookforge-store/migrations/0012_v3_0_translation_attempts_cache_identity.sql
@@ -1,0 +1,69 @@
+-- v3.0 (translation-state audit): structured cache identity + append-only
+-- translation provenance ledger.
+--
+-- This file documents the schema delta; it is NOT executed at runtime
+-- (schema.rs builds the schema procedurally — see STORE-5). Migration 12 in
+-- schema.rs applies the equivalent change, gated behind a `migration_applied`
+-- check so reopened stores never take a write lock just to re-record it.
+--
+-- `segments.cache_fingerprint` persists the single structured cache identity
+-- (bookforge_core::segment::CacheIdentity, versioned by
+-- CACHE_IDENTITY_SCHEMA_VERSION) that captures every output-affecting input —
+-- source hash, effective provider/model, languages, prompt template version
+-- and extras, segmentation, context window/budget/scope, the strict-context
+-- completion fence, batch shape, compact-prompt mode, style/glossary/entity
+-- fingerprints, bilingual rendering, and provider runtime request shaping.
+-- Legacy rows carry the empty string and are permanently ineligible for cache
+-- reuse, so ambiguous old entries can never match a new lookup.
+--
+-- `jobs.cache_policy_json` persists the durable cache-policy record
+-- (CachePolicySnapshot) that is not part of the historical RunConfigSnapshot
+-- surface — currently the strict-context choice. Absent (NULL) reads back the
+-- conservative default (unknown strictness), which is hashed distinctly from
+-- either explicit value so legacy jobs can never reuse incompatible cache.
+--
+-- `translation_attempts` is the append-only attempt ledger: one row per
+-- provider/QA attempt (phase, attempt ordinal, effective provider/model,
+-- outcome, tokens, cost), written transactionally with the final translation
+-- state. Rows are inserted once and never updated (a BEFORE UPDATE trigger
+-- rejects in-place edits); deletion is reserved for job retention/prune.
+-- The composite foreign key pins each attempt to the segment row that owns
+-- it, and the unique (job, segment, attempt_ordinal) constraint makes the
+-- ordinal sequence immutable and monotonic. Aggregates prefer the ledger over
+-- the legacy segments token columns while still reading legacy rows for jobs
+-- that predate the ledger.
+ALTER TABLE segments ADD COLUMN cache_fingerprint TEXT NOT NULL DEFAULT '';
+ALTER TABLE jobs ADD COLUMN cache_policy_json TEXT;
+
+CREATE TABLE IF NOT EXISTS translation_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  job_id TEXT NOT NULL,
+  segment_id TEXT NOT NULL,
+  batch_id TEXT,
+  phase TEXT NOT NULL CHECK(phase IN
+    ('primary', 'fallback', 'repair', 'qa', 'double_check')),
+  attempt_ordinal INTEGER NOT NULL,
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK(outcome IN
+    ('success', 'failure', 'partial', 'skipped')),
+  error TEXT,
+  input_tokens INTEGER,
+  input_cached_tokens INTEGER,
+  output_tokens INTEGER,
+  cost_estimate REAL,
+  created_at TEXT NOT NULL,
+  UNIQUE(job_id, segment_id, attempt_ordinal),
+  FOREIGN KEY(job_id, segment_id) REFERENCES segments(job_id, id)
+);
+
+CREATE TRIGGER IF NOT EXISTS translation_attempts_immutable_update
+BEFORE UPDATE ON translation_attempts
+BEGIN
+  SELECT RAISE(ABORT, 'translation_attempts is append-only');
+END;
+
+CREATE INDEX IF NOT EXISTS idx_translation_attempts_segment
+  ON translation_attempts(job_id, segment_id);
+CREATE INDEX IF NOT EXISTS idx_translation_attempts_job
+  ON translation_attempts(job_id);

--- a/crates/bookforge-store/src/db.rs
+++ b/crates/bookforge-store/src/db.rs
@@ -11,10 +11,13 @@ use std::{
 use bookforge_core::{
     Result as CoreResult,
     entity::EntityGender,
-    glossary::{GlossaryCategory, GlossaryScopeKind, GlossaryStatus, GlossaryTerm},
+    glossary::{
+        GlossaryCategory, GlossaryPromptTerm, GlossaryScopeKind, GlossaryStatus, GlossaryTerm,
+        select_glossary_for_segments,
+    },
     ir::BlockId,
-    run_snapshot::RunConfigSnapshot,
-    segment::{BlockTranslation, Segment},
+    run_snapshot::{CachePolicySnapshot, CachePromptInputs, RunConfigSnapshot},
+    segment::{BlockTranslation, CacheIdentity, MinimalCacheIdentity, Segment},
 };
 use rusqlite::{Connection, OptionalExtension, params, types::Type};
 use sha2::{Digest, Sha256};
@@ -35,7 +38,7 @@ mod migrations_docs;
 
 // Internal cross-module helpers shared by the transactional checkpoint paths.
 use findings::{NewQaFindingRow, insert_qa_finding_row};
-use jobs::touch_job_unless_status_on;
+use jobs::{job_exists_on, touch_job_unless_status_on};
 use translations::{
     clear_segment_findings_on, record_segment_engine_findings_on, record_segment_findings_on,
 };
@@ -288,6 +291,140 @@ pub struct CacheLookupRequest<'a> {
     pub source_lang: Option<&'a str>,
     pub target_lang: &'a str,
     pub cache_namespace: &'a str,
+    /// Caller-computed expected structured cache identity fingerprints keyed
+    /// by CURRENT segment id (see
+    /// [`JobStore::expected_cache_fingerprints`]). Keying by segment id — not
+    /// by source checksum — makes the per-current-segment contract
+    /// unambiguous: duplicate source text at different positions/context
+    /// resolves to different expected fingerprints and can never collide.
+    /// Lookups match candidates on these directly and never discover an
+    /// expected fingerprint by searching prior segment rows.
+    pub expected_fingerprints: &'a HashMap<String, String>,
+}
+
+/// Pipeline phase of a translation attempt, persisted in the append-only
+/// `translation_attempts` ledger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranslationAttemptPhase {
+    Primary,
+    Fallback,
+    Repair,
+    Qa,
+    DoubleCheck,
+}
+
+impl TranslationAttemptPhase {
+    pub fn as_db_text(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Fallback => "fallback",
+            Self::Repair => "repair",
+            Self::Qa => "qa",
+            Self::DoubleCheck => "double_check",
+        }
+    }
+
+    pub fn from_db_text(text: &str) -> Option<Self> {
+        match text {
+            "primary" => Some(Self::Primary),
+            "fallback" => Some(Self::Fallback),
+            "repair" => Some(Self::Repair),
+            "qa" => Some(Self::Qa),
+            "double_check" => Some(Self::DoubleCheck),
+            _ => None,
+        }
+    }
+}
+
+/// Outcome of a translation attempt. `Skipped` covers cache hits: the segment
+/// was fulfilled without a fresh provider call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranslationAttemptOutcome {
+    Success,
+    Failure,
+    Partial,
+    Skipped,
+}
+
+impl TranslationAttemptOutcome {
+    pub fn as_db_text(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+            Self::Partial => "partial",
+            Self::Skipped => "skipped",
+        }
+    }
+
+    pub fn from_db_text(text: &str) -> Option<Self> {
+        match text {
+            "success" => Some(Self::Success),
+            "failure" => Some(Self::Failure),
+            "partial" => Some(Self::Partial),
+            "skipped" => Some(Self::Skipped),
+            _ => None,
+        }
+    }
+}
+
+/// Append-only attempt record request. `batch_id` ties the attempt to a batch
+/// when it was produced by one; `cost_estimate` is an optional dollar cost.
+/// `attempt_ordinal` is assigned monotonically by the store (one past the
+/// current per-(job, segment) count); `phase` is inferred from the provider/
+/// model against the job's primary configuration when `None`.
+#[derive(Debug, Clone, Copy)]
+pub struct RecordTranslationAttempt<'a> {
+    pub job_id: &'a str,
+    pub segment_id: &'a str,
+    pub batch_id: Option<&'a str>,
+    pub phase: Option<TranslationAttemptPhase>,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub outcome: TranslationAttemptOutcome,
+    pub error: Option<&'a str>,
+    pub input_tokens: Option<u64>,
+    pub input_cached_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost_estimate: Option<f64>,
+}
+
+/// One persisted `translation_attempts` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TranslationAttemptRecord {
+    pub id: i64,
+    pub job_id: String,
+    pub segment_id: String,
+    pub batch_id: Option<String>,
+    pub phase: String,
+    pub attempt_ordinal: usize,
+    pub provider: String,
+    pub model: String,
+    pub outcome: String,
+    pub error: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub input_cached_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost_estimate: Option<f64>,
+    pub created_at: String,
+}
+
+/// Aggregated token/cost totals for one job, derived from the append-only
+/// ledger. [`Self::has_ledger`] reports whether the job has any attempt rows
+/// at all; job-level summaries mix the ledger with legacy per-segment token
+/// columns so jobs that straddle the ledger boundary aggregate accurately.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TranslationAttemptSummary {
+    pub attempts: usize,
+    pub input_tokens: u64,
+    pub input_cached_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_estimate: f64,
+}
+
+impl TranslationAttemptSummary {
+    pub fn has_ledger(&self) -> bool {
+        self.attempts > 0
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/bookforge-store/src/db/jobs.rs
+++ b/crates/bookforge-store/src/db/jobs.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+/// Whether a `jobs` row exists. Mutation APIs use this to surface
+/// [`StoreError::NotFound`] instead of silently succeeding on a missing job.
+pub(super) fn job_exists_on(conn: &Connection, job_id: &str) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM jobs WHERE id = ?1)",
+        params![job_id],
+        |row| row.get::<_, bool>(0),
+    )?)
+}
+
 impl JobStore {
     pub fn create_job(&self, request: CreateJob<'_>) -> Result<JobRecord> {
         let input_hash = file_hash(request.input)?;
@@ -120,6 +130,45 @@ impl JobStore {
             ],
         )?;
         Ok(())
+    }
+
+    /// Persist the durable cache policy (strict-context and future
+    /// cache-affecting settings that are not part of the historical
+    /// [`RunConfigSnapshot`] surface). Jobs that never record a policy read
+    /// back the conservative default, which can never reuse cache written by
+    /// a run that states an explicit policy.
+    pub fn update_job_cache_policy(
+        &self,
+        job_id: &str,
+        policy: &CachePolicySnapshot,
+    ) -> Result<()> {
+        let json = serde_json::to_string(policy)
+            .map_err(|error| StoreError::Serialization(error.to_string()))?;
+        let conn = self.conn.borrow();
+        let updated = conn.execute(
+            "UPDATE jobs
+             SET cache_policy_json = ?1, updated_at = ?2
+             WHERE id = ?3",
+            params![json, timestamp_string(), job_id],
+        )?;
+        if updated == 0 {
+            return Err(StoreError::NotFound(format!(
+                "job '{job_id}' was not found"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Load the persisted cache policy, defaulting to the conservative
+    /// unknown-strictness policy for jobs that never recorded one.
+    pub fn load_job_cache_policy(&self, job_id: &str) -> Result<CachePolicySnapshot> {
+        let conn = self.conn.borrow();
+        if !job_exists_on(&conn, job_id)? {
+            return Err(StoreError::NotFound(format!(
+                "job '{job_id}' was not found"
+            )));
+        }
+        super::translations::load_cache_policy_on(&conn, job_id)
     }
 
     pub fn load_job_config_snapshot(&self, job_id: &str) -> Result<Option<RunConfigSnapshot>> {
@@ -403,20 +452,40 @@ impl JobStore {
         let Some(job) = self.get_job(job_id)? else {
             return Ok(None);
         };
-        let conn = self.conn.borrow();
+        // Aggregation is per-segment, mixing the append-only attempt ledger
+        // with legacy token columns (STORE-A): a segment that has any ledger
+        // row is aggregated from the ledger (its authoritative attempt record);
+        // a segment with NO ledger rows — a pre-ledger completion, a cache hit,
+        // or a state-only record — keeps its legacy token columns. Summing
+        // both for the same segment would double count; dropping the legacy
+        // columns for ledger-less segments would undercount.
+        let ledger = self.translation_attempt_summary(job_id)?;
         let mut summary = JobSummary {
             id: job.id,
             status: job.status,
             ..JobSummary::default()
         };
+        summary.input_tokens = ledger.input_tokens;
+        summary.input_cached_tokens = ledger.input_cached_tokens;
+        summary.output_tokens = ledger.output_tokens;
 
+        let conn = self.conn.borrow();
         let mut stmt = conn.prepare(
             "SELECT status,
                     COUNT(*),
-                    COALESCE(SUM(COALESCE(tokens_input, input_tokens)), 0),
-                    COALESCE(SUM(tokens_input_cached), 0),
-                    COALESCE(SUM(COALESCE(tokens_output, output_tokens)), 0)
-             FROM segments WHERE job_id = ?1 GROUP BY status",
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN COALESCE(s.tokens_input, s.input_tokens) ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN s.tokens_input_cached ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN COALESCE(s.tokens_output, s.output_tokens) ELSE 0 END), 0)
+             FROM segments s WHERE s.job_id = ?1 GROUP BY status",
         )?;
         let rows = stmt.query_map(params![job_id], |row| {
             Ok((
@@ -485,15 +554,29 @@ impl JobStore {
             .query_map([], Self::job_record_from_row)?
             .collect::<rusqlite::Result<Vec<JobRecord>>>()?;
 
-        // One pass over the segments table, aggregated per (job, status).
+        // One pass over the segments table, aggregated per (job, status). The
+        // token columns only count for segments with NO ledger rows: a segment
+        // covered by the append-only ledger aggregates from the ledger (its
+        // authoritative attempt record), while a segment without ledger rows
+        // (pre-ledger completion, cache hit) keeps its legacy columns. This
+        // keeps mixed legacy/new jobs accurate without double counting.
         let mut aggregates: HashMap<String, JobSummary> = HashMap::new();
         let mut seg_stmt = conn.prepare(
             "SELECT job_id, status,
                     COUNT(*),
-                    COALESCE(SUM(COALESCE(tokens_input, input_tokens)), 0),
-                    COALESCE(SUM(tokens_input_cached), 0),
-                    COALESCE(SUM(COALESCE(tokens_output, output_tokens)), 0)
-             FROM segments GROUP BY job_id, status",
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN COALESCE(s.tokens_input, s.input_tokens) ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN s.tokens_input_cached ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM translation_attempts a
+                        WHERE a.job_id = s.job_id AND a.segment_id = s.id
+                    ) THEN COALESCE(s.tokens_output, s.output_tokens) ELSE 0 END), 0)
+             FROM segments s GROUP BY job_id, status",
         )?;
         let seg_rows = seg_stmt.query_map([], |row| {
             Ok((
@@ -534,6 +617,36 @@ impl JobStore {
         for row in retried_rows {
             let (job_id, retried) = row?;
             aggregates.entry(job_id).or_default().retried = retried as usize;
+        }
+
+        // Append the attempt ledger for jobs that have one, ADDING it to the
+        // legacy-column contribution above (which already excluded segments
+        // covered by the ledger), so mixed legacy/new jobs stay accurate.
+        let mut ledger_stmt = conn.prepare(
+            "SELECT job_id,
+                    COUNT(*),
+                    COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(input_cached_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0)
+             FROM translation_attempts GROUP BY job_id",
+        )?;
+        let ledger_rows = ledger_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        })?;
+        for row in ledger_rows {
+            let (job_id, attempts, input_tokens, input_cached_tokens, output_tokens) = row?;
+            if attempts > 0 {
+                let summary = aggregates.entry(job_id).or_default();
+                summary.input_tokens += input_tokens as u64;
+                summary.input_cached_tokens += input_cached_tokens as u64;
+                summary.output_tokens += output_tokens as u64;
+            }
         }
 
         Ok(jobs

--- a/crates/bookforge-store/src/db/migrations_docs.rs
+++ b/crates/bookforge-store/src/db/migrations_docs.rs
@@ -77,6 +77,11 @@ const MIGRATION_DOCS: &[(i64, &str, &str)] = &[
         "v3_0_qa_finding_block_attribution",
         include_str!("../../migrations/0011_v3_0_qa_finding_block_attribution.sql"),
     ),
+    (
+        12,
+        "v3_0_translation_attempts_cache_identity",
+        include_str!("../../migrations/0012_v3_0_translation_attempts_cache_identity.sql"),
+    ),
 ];
 
 /// Historical applied-name → canonical-doc-name mapping for versions whose
@@ -85,7 +90,7 @@ const MIGRATION_DOCS: &[(i64, &str, &str)] = &[
 /// canonical naming starts with this mapping instead.
 const LEGACY_ALIASES: &[(i64, &str)] = &[(3, "v1_1_segment_flags")];
 
-/// Canonical applied ledger expected after a fresh open through migration 11.
+/// Canonical applied ledger expected after a fresh open through migration 12.
 const APPLIED_LEDGER: &[(&str, i64, &str)] = &[
     ("file", 1, "initial"),
     ("file", 2, "v1_0_1_input_snapshot"),
@@ -98,6 +103,7 @@ const APPLIED_LEDGER: &[(&str, i64, &str)] = &[
     ("file", 8, "v2_7_qa_findings"),
     ("file", 9, "v2_7_1_global_scope_unique_indexes"),
     ("file", 11, "v3_0_qa_finding_block_attribution"),
+    ("file", 12, "v3_0_translation_attempts_cache_identity"),
 ];
 
 #[derive(Default)]
@@ -406,7 +412,7 @@ fn applied_ledger_names_match_doc_files_under_recorded_aliases() {
         }
     }
 
-    // Versions 1..=11 are all accounted for; 10 is gated cleanup whose
+    // Versions 1..=12 are all accounted for; 10 is gated cleanup whose
     // presence depends on conforming data (asserted in the hardening tests).
     // Version 10 is gated cleanup: recorded whenever data conforms (fresh
     // stores and repaired legacy ones), legitimately absent otherwise.

--- a/crates/bookforge-store/src/db/prune.rs
+++ b/crates/bookforge-store/src/db/prune.rs
@@ -35,6 +35,7 @@ pub struct PruneJobDeletion {
     pub translation_blocks: usize,
     pub qa_findings: usize,
     pub segment_flags: usize,
+    pub translation_attempts: usize,
     /// Artifact files successfully unlinked: events log, JSON report,
     /// markdown report.
     pub artifacts_removed: Vec<PathBuf>,
@@ -50,6 +51,7 @@ impl PruneJobDeletion {
             + self.translation_blocks
             + self.qa_findings
             + self.segment_flags
+            + self.translation_attempts
     }
 }
 
@@ -228,6 +230,7 @@ impl JobStore {
             translation_blocks: count("translation_blocks")?,
             qa_findings: count("qa_findings")?,
             segment_flags: count("segment_flags")?,
+            translation_attempts: count("translation_attempts")?,
             artifacts_removed: Vec::new(),
             artifacts_missing: 0,
         })
@@ -254,8 +257,10 @@ impl JobStore {
     /// returns `None` without deleting anything.
     fn prune_job_now(&self, job_id: &str) -> Result<Option<PruneJobDeletion>> {
         // Child-before-parent inside one IMMEDIATE transaction; only plain FKs
-        // point at segments/translations/blocks/findings, so explicit deletes
-        // keep this correct even where ON DELETE CASCADE is absent.
+        // point at segments/translations/blocks/findings/attempts, so explicit
+        // deletes keep this correct even where ON DELETE CASCADE is absent.
+        // The append-only attempt ledger references segments, so it must go
+        // before both segments and jobs.
         let mut conn = self.conn.borrow_mut();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         if job_status_is_running(&tx, job_id)? {
@@ -265,6 +270,7 @@ impl JobStore {
         let qa_findings = delete_job_rows(&tx, "qa_findings", job_id)?;
         let translation_blocks = delete_job_rows(&tx, "translation_blocks", job_id)?;
         let translations = delete_job_rows(&tx, "translations", job_id)?;
+        let translation_attempts = delete_job_rows(&tx, "translation_attempts", job_id)?;
         let segments = delete_job_rows(&tx, "segments", job_id)?;
         let segment_flags = delete_job_rows(&tx, "segment_flags", job_id)?;
         // Read referenced artifacts while the job row still exists.
@@ -297,6 +303,7 @@ impl JobStore {
             translation_blocks,
             qa_findings,
             segment_flags,
+            translation_attempts,
             artifacts_removed: removed_files,
             artifacts_missing: missing,
         }))

--- a/crates/bookforge-store/src/db/schema.rs
+++ b/crates/bookforge-store/src/db/schema.rs
@@ -211,6 +211,42 @@ impl JobStore {
               FOREIGN KEY(job_id) REFERENCES jobs(id) ON DELETE CASCADE
             );
 
+            -- Append-only translation provenance ledger (migration 12). Rows
+            -- are inserted once per attempt and never updated or deleted, so
+            -- earlier attempts are preserved verbatim and cost/usage can be
+            -- aggregated per job/segment/phase. Referential integrity is
+            -- pinned to the segment row that owns each attempt (composite
+            -- FK); the unique (job, segment, attempt_ordinal) makes the
+            -- ordinal sequence immutable and monotonic; triggers forbid
+            -- in-place edits (deletion is reserved for job retention/prune).
+            CREATE TABLE IF NOT EXISTS translation_attempts (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              job_id TEXT NOT NULL,
+              segment_id TEXT NOT NULL,
+              batch_id TEXT,
+              phase TEXT NOT NULL CHECK(phase IN
+                ('primary', 'fallback', 'repair', 'qa', 'double_check')),
+              attempt_ordinal INTEGER NOT NULL,
+              provider TEXT NOT NULL,
+              model TEXT NOT NULL,
+              outcome TEXT NOT NULL CHECK(outcome IN
+                ('success', 'failure', 'partial', 'skipped')),
+              error TEXT,
+              input_tokens INTEGER,
+              input_cached_tokens INTEGER,
+              output_tokens INTEGER,
+              cost_estimate REAL,
+              created_at TEXT NOT NULL,
+              UNIQUE(job_id, segment_id, attempt_ordinal),
+              FOREIGN KEY(job_id, segment_id) REFERENCES segments(job_id, id)
+            );
+
+            CREATE TRIGGER IF NOT EXISTS translation_attempts_immutable_update
+            BEFORE UPDATE ON translation_attempts
+            BEGIN
+              SELECT RAISE(ABORT, 'translation_attempts is append-only');
+            END;
+
             CREATE TABLE IF NOT EXISTS glossary_terms (
               id INTEGER PRIMARY KEY,
               scope_kind TEXT NOT NULL CHECK(scope_kind IN ('global', 'series', 'book')),
@@ -276,10 +312,20 @@ impl JobStore {
         ensure_column(&conn, "jobs", "report_markdown_path", "TEXT")?;
         ensure_column(&conn, "jobs", "book_id", "TEXT")?;
         ensure_column(&conn, "jobs", "series_id", "TEXT")?;
+        // Serialized CachePolicySnapshot (strict-context and future
+        // cache-affecting policies). NULL/absent means the job never recorded
+        // a policy: reads fall back to CachePolicySnapshot::conservative().
+        ensure_column(&conn, "jobs", "cache_policy_json", "TEXT")?;
         ensure_column(
             &conn,
             "segments",
             "cache_namespace",
+            "TEXT NOT NULL DEFAULT ''",
+        )?;
+        ensure_column(
+            &conn,
+            "segments",
+            "cache_fingerprint",
             "TEXT NOT NULL DEFAULT ''",
         )?;
         ensure_column(&conn, "segments", "tokens_input", "INTEGER")?;
@@ -326,6 +372,10 @@ impl JobStore {
              ON qa_findings(job_id, kind);
              CREATE INDEX IF NOT EXISTS idx_qa_findings_segment
              ON qa_findings(job_id, segment_id);
+             CREATE INDEX IF NOT EXISTS idx_translation_attempts_segment
+             ON translation_attempts(job_id, segment_id);
+             CREATE INDEX IF NOT EXISTS idx_translation_attempts_job
+             ON translation_attempts(job_id);
              CREATE INDEX IF NOT EXISTS idx_jobs_created_at
              ON jobs(created_at);",
         )?;
@@ -373,6 +423,14 @@ impl JobStore {
         if !migration_applied(&conn, 11)? {
             ensure_column(&conn, "qa_findings", "block_id", "TEXT")?;
             record_migration(&conn, 11, "v3_0_qa_finding_block_attribution")?;
+        }
+
+        // Version 12 (translation-state audit) introduces the append-only
+        // translation provenance ledger plus the structured cache identity
+        // column. The DDL above is idempotent, but recording the migration
+        // is gated so reopened stores never take a write lock to re-record it.
+        if !migration_applied(&conn, 12)? {
+            record_migration(&conn, 12, "v3_0_translation_attempts_cache_identity")?;
         }
 
         Ok(())
@@ -638,6 +696,7 @@ const JOB_COLUMNS_ALL: &[&str] = &[
     "series_id",
     "created_at",
     "updated_at",
+    "cache_policy_json",
 ];
 
 const SEGMENT_COLUMNS_ALL: &[&str] = &[
@@ -661,6 +720,7 @@ const SEGMENT_COLUMNS_ALL: &[&str] = &[
     "error",
     "translated_hash",
     "cache_namespace",
+    "cache_fingerprint",
 ];
 
 fn job_status_column_definition() -> String {
@@ -707,6 +767,7 @@ fn harden_status_tables_with_check_constraints(conn: &mut Connection) -> Result<
           report_markdown_path TEXT,
           book_id TEXT,
           series_id TEXT,
+          cache_policy_json TEXT,
           created_at TEXT NOT NULL,
           updated_at TEXT NOT NULL
         );"
@@ -733,6 +794,7 @@ fn harden_status_tables_with_check_constraints(conn: &mut Connection) -> Result<
           error TEXT,
           translated_hash TEXT,
           cache_namespace TEXT NOT NULL DEFAULT '',
+          cache_fingerprint TEXT NOT NULL DEFAULT '',
           PRIMARY KEY (job_id, id),
           FOREIGN KEY(job_id) REFERENCES jobs(id)
         );"

--- a/crates/bookforge-store/src/db/tests.rs
+++ b/crates/bookforge-store/src/db/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use bookforge_core::{
     finding::EngineFinding,
     ir::{BlockId, SectionId},
+    run_snapshot::CachePolicySnapshot,
     segment::{
         Segment, SegmentBlock, SegmentConstraints, SegmentContext, SegmentId, SegmentMetadata,
         SegmentSource, SegmentTextRun,
@@ -202,6 +203,55 @@ fn temp_path(name: &str) -> PathBuf {
         unix_timestamp_nanos(),
         COUNTER.fetch_add(1, Ordering::Relaxed)
     ))
+}
+
+/// Compute the caller-computed expected fingerprints for the given segments,
+/// mirroring how the CLI wires cache lookups. Keyed by the current segment id
+/// so duplicate source text in different contexts stays unambiguous. The
+/// identity is derived over the SAME slice passed here (the full ordered set
+/// and the eligible candidates coincide in these fixtures).
+fn expected_fingerprints_for(
+    store: &JobStore,
+    job_id: &str,
+    segments: &[Segment],
+    provider: &str,
+    model: &str,
+    prompt_version: &str,
+    cache_namespace: &str,
+) -> HashMap<String, String> {
+    store
+        .expected_cache_fingerprints(
+            job_id,
+            segments,
+            segments,
+            provider,
+            model,
+            prompt_version,
+            cache_namespace,
+        )
+        .expect("expected fingerprints should compute")
+}
+
+/// Build a [`CacheLookupRequest`] carrying the caller-computed expected
+/// fingerprints map (which must outlive the returned request).
+fn cache_lookup_request<'a>(
+    prompt_version: &'a str,
+    provider: &'a str,
+    model: &'a str,
+    source_lang: Option<&'a str>,
+    target_lang: &'a str,
+    cache_namespace: &'a str,
+    expected_fingerprints: &'a HashMap<String, String>,
+) -> CacheLookupRequest<'a> {
+    CacheLookupRequest {
+        prompt_version,
+        provider,
+        model,
+        source_lang,
+        target_lang,
+        cache_namespace,
+        expected_fingerprints,
+    }
 }
 
 #[test]
@@ -942,12 +992,23 @@ fn cached_translation_requires_matching_cache_namespace() {
     let hit = store
         .find_cached_translation(
             &seg,
-            "v1",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "ns_one",
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_one",
+                &expected_fingerprints_for(
+                    &store,
+                    &_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "ns_one",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(hit.is_some(), "matching namespace should hit");
@@ -955,12 +1016,23 @@ fn cached_translation_requires_matching_cache_namespace() {
     let miss = store
         .find_cached_translation(
             &seg,
-            "v1",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "ns_two",
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_two",
+                &expected_fingerprints_for(
+                    &store,
+                    &_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "ns_two",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(miss.is_none(), "different namespace must not hit");
@@ -1033,12 +1105,23 @@ fn cached_translation_rejects_mismatched_prompt_version() {
     let hit_v2 = store
         .find_cached_translation(
             &seg,
-            "v2",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "ns_bump",
+            cache_lookup_request(
+                "v2",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_bump",
+                &expected_fingerprints_for(
+                    &store,
+                    &job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v2",
+                    "ns_bump",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(
@@ -1049,12 +1132,23 @@ fn cached_translation_rejects_mismatched_prompt_version() {
     let miss_v3 = store
         .find_cached_translation(
             &seg,
-            "v3",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "ns_bump",
+            cache_lookup_request(
+                "v3",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_bump",
+                &expected_fingerprints_for(
+                    &store,
+                    &job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v3",
+                    "ns_bump",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(
@@ -1062,28 +1156,54 @@ fn cached_translation_rejects_mismatched_prompt_version() {
         "row stored under v2 must not be served back for a v3 (retry_guidance) query"
     );
 
-    let batch_request_v3 = CacheLookupRequest {
-        prompt_version: "v3",
-        provider: "mock",
-        model: "mock-prefix",
-        source_lang: Some("English"),
-        target_lang: "Italian",
-        cache_namespace: "ns_bump",
-    };
     let batch_miss = store
-        .find_cached_translations_batch(std::slice::from_ref(&seg), batch_request_v3)
+        .find_cached_translations_batch(
+            std::slice::from_ref(&seg),
+            cache_lookup_request(
+                "v3",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_bump",
+                &expected_fingerprints_for(
+                    &store,
+                    &job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v3",
+                    "ns_bump",
+                ),
+            ),
+        )
         .expect("batch query ok");
     assert!(
         batch_miss.is_empty(),
         "batch lookup must not return v2-era rows for a v3 query"
     );
 
-    let batch_request_v2 = CacheLookupRequest {
-        prompt_version: "v2",
-        ..batch_request_v3
-    };
     let batch_hit = store
-        .find_cached_translations_batch(std::slice::from_ref(&seg), batch_request_v2)
+        .find_cached_translations_batch(
+            std::slice::from_ref(&seg),
+            cache_lookup_request(
+                "v2",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_bump",
+                &expected_fingerprints_for(
+                    &store,
+                    &job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v2",
+                    "ns_bump",
+                ),
+            ),
+        )
         .expect("batch query ok");
     assert!(
         batch_hit.contains_key(&seg.id.0),
@@ -1106,12 +1226,23 @@ fn cached_translation_rejects_mismatched_block_ids() {
     let miss = store
         .find_cached_translation(
             &seg,
-            "v1",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "ns_x",
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "ns_x",
+                &expected_fingerprints_for(
+                    &store,
+                    &_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "ns_x",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(
@@ -1214,28 +1345,50 @@ fn cached_translation_prefers_repaired_succeeded_rows_over_cached_clones() {
         })
         .expect("repaired translation should save");
 
-    let request = CacheLookupRequest {
-        prompt_version: "v1",
-        provider: "mock",
-        model: "mock-prefix",
-        source_lang: Some("English"),
-        target_lang: "Italian",
-        cache_namespace: "cache_ns",
-    };
     let single_hit = store
         .find_cached_translation(
             &seg,
-            request.prompt_version,
-            request.provider,
-            request.model,
-            request.source_lang,
-            request.target_lang,
-            request.cache_namespace,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "cache_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &repaired_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "cache_ns",
+                ),
+            ),
         )
         .expect("single lookup should succeed")
         .expect("single lookup should hit");
     let batch_hit = store
-        .find_cached_translations_batch(std::slice::from_ref(&seg), request)
+        .find_cached_translations_batch(
+            std::slice::from_ref(&seg),
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "cache_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &repaired_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "cache_ns",
+                ),
+            ),
+        )
         .expect("batch lookup should succeed")
         .remove(&seg.id.0)
         .expect("batch lookup should hit");
@@ -1259,12 +1412,23 @@ fn old_empty_cache_namespace_rows_do_not_match_new_runs() {
     let miss = store
         .find_cached_translation(
             &seg,
-            "v1",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "real_ns",
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "real_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "real_ns",
+                ),
+            ),
         )
         .expect("query ok");
     assert!(
@@ -1949,12 +2113,23 @@ fn manual_correction_is_auditable_frozen_and_not_cacheable() {
     let cached = store
         .find_cached_translation(
             &segment,
-            "v1",
-            "mock",
-            "mock-prefix",
-            Some("English"),
-            "Italian",
-            "manual_ns",
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "manual_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &job.id,
+                    std::slice::from_ref(&segment),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "manual_ns",
+                ),
+            ),
         )
         .expect("cache lookup should succeed");
     assert!(cached.is_none(), "manual corrections must remain job-local");
@@ -4671,4 +4846,1726 @@ fn migration_eleven_adds_block_id_once_and_reopen_takes_no_write_transaction() {
     }
 
     let _ = fs::remove_file(db_path);
+}
+
+/// A snapshot whose settings fully match the CLI's `mock`/`mock-prefix` test
+/// jobs, so structured cache identities built from it are stable across tests.
+fn snapshot_fixture() -> RunConfigSnapshot {
+    let settings = bookforge_core::TranslationProfile::Balanced.resolve();
+    RunConfigSnapshot {
+        input_path: PathBuf::from("input.epub"),
+        input_snapshot_path: None,
+        input_sha256: Some("abc123".to_string()),
+        output_path: PathBuf::from("output.epub"),
+        events_path: None,
+        report_json_path: None,
+        report_markdown_path: None,
+        source_language: Some("English".to_string()),
+        target_language: "Italian".to_string(),
+        creator: None,
+        provider: "mock".to_string(),
+        model: "mock-prefix".to_string(),
+        base_url: None,
+        api_key_env: None,
+        profile: settings.profile,
+        provider_preset: None,
+        prompt_version: "v1".to_string(),
+        cache_namespace: "identity_ns".to_string(),
+        book_id: None,
+        series_id: None,
+        glossary_budget_tokens: 800,
+        glossary_format: bookforge_core::GlossaryFormat::Json,
+        prompt_extra: None,
+        glossary_fingerprint: String::new(),
+        glossary_terms: Vec::new(),
+        context_window: 4,
+        context_budget_tokens: 400,
+        context_scope: bookforge_core::config::ContextScope::Chapter,
+        style_fingerprint: String::new(),
+        style_rendered_block: String::new(),
+        entities_fingerprint: String::new(),
+        entities_rendered_block: String::new(),
+        bilingual_mode: bookforge_core::BilingualMode::Replace,
+        bilingual_separator: " / ".to_string(),
+        bilingual_style: bookforge_core::BilingualStyle::Minimal,
+        bilingual_css: None,
+        fallback: None,
+        finalize: bookforge_core::run_snapshot::FinalizeCheckpointSnapshot::default(),
+        qa_mode: "off".to_string(),
+        validate_output: false,
+        settings: bookforge_core::ResolvedRunSettingsSnapshot::from_settings(&settings),
+    }
+}
+
+/// Create a job with a persisted run snapshot + cache policy, stamp one
+/// segment, and return both. `provider`/`model` must be `"mock"`/`"mock-prefix"`
+/// (the CLI primary for fixtures) unless a fallback provenance test overrides
+/// them via `save_translation`.
+fn seed_job_with_policy(
+    store: &JobStore,
+    cache_namespace: &str,
+    strict: bool,
+) -> (JobRecord, Segment) {
+    let input_path = temp_path("policy-input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("policy-output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut snapshot = snapshot_fixture();
+    snapshot.cache_namespace = cache_namespace.to_string();
+    store
+        .update_job_config_snapshot(&job.id, &snapshot)
+        .expect("snapshot should persist");
+    store
+        .update_job_cache_policy(
+            &job.id,
+            &CachePolicySnapshot {
+                strict_context: Some(strict),
+            },
+        )
+        .expect("policy should persist");
+
+    let mut seg = segment("seg_identity", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            cache_namespace,
+        )
+        .expect("segments should insert");
+    let _ = fs::remove_file(input_path);
+    (job, seg)
+}
+
+fn save_segment_translation(
+    store: &JobStore,
+    job_id: &str,
+    segment_id: &str,
+    provider: &str,
+    model: &str,
+    translated_text: &str,
+    prompt_version: &str,
+) {
+    store
+        .save_translation(SaveTranslation {
+            job_id,
+            segment_id,
+            translated_text,
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: translated_text.to_string(),
+            }],
+            provider,
+            model,
+            prompt_version,
+            input_tokens: Some(11),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(7),
+            tokens_estimated: false,
+        })
+        .expect("translation should save");
+}
+
+#[test]
+fn cache_lookup_isolates_strict_context_across_jobs() {
+    let db_path = temp_path("cache_strict.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    let (strict_job, seg) = seed_job_with_policy(&store, "strict_ns", true);
+    save_segment_translation(
+        &store,
+        &strict_job.id,
+        "seg_identity",
+        "mock",
+        "mock-prefix",
+        "Strict output",
+        "v1",
+    );
+
+    let (loose_job, _) = seed_job_with_policy(&store, "strict_ns", false);
+
+    // The loose job's expected identity is computed from ITS persisted policy
+    // (strict=false), so the strict-stamped cross-job row must never be
+    // reused — strict true vs false must differ.
+    let miss = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "strict_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &loose_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "strict_ns",
+                ),
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        miss.is_none(),
+        "strict and loose contexts must not share cache"
+    );
+
+    // And the strict job's own row IS visible to a strict lookup.
+    let hit = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "strict_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &strict_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "strict_ns",
+                ),
+            ),
+        )
+        .expect("query ok")
+        .expect("strict lookup should hit its own row");
+    assert_eq!(hit.translated_text, "Strict output");
+
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
+fn cache_lookup_never_serves_fallback_provenance_as_primary() {
+    let db_path = temp_path("cache_fallback.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    // Two jobs with identical primary config stamp the same fingerprint; the
+    // second's output was produced by a fallback provider/model.
+    let (primary_job, _) = seed_job_with_policy(&store, "fallback_ns", false);
+    save_segment_translation(
+        &store,
+        &primary_job.id,
+        "seg_identity",
+        "mock",
+        "mock-prefix",
+        "Primary output",
+        "v1",
+    );
+    let (fallback_job, seg) = seed_job_with_policy(&store, "fallback_ns", false);
+    save_segment_translation(
+        &store,
+        &fallback_job.id,
+        "seg_identity",
+        "deepseek",
+        "deepseek-v4-flash",
+        "Fallback output",
+        "v1",
+    );
+
+    // A fresh lookup context (no own translation) requesting the primary
+    // provider must only see the primary-produced row: the fallback row's
+    // real provenance (t.provider/t.model) excludes it.
+    let (lookup_job, _) = seed_job_with_policy(&store, "fallback_ns", false);
+    let hit = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "fallback_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "fallback_ns",
+                ),
+            ),
+        )
+        .expect("query ok")
+        .expect("primary lookup should hit the primary-produced row");
+    assert_eq!(hit.translated_text, "Primary output");
+
+    // Requesting the fallback provenance never surfaces it either: the
+    // expected identity (computed with the fallback provider/model) does not
+    // match the primary-stamped segment, so the fallback output stays
+    // job-local.
+    let fallback_miss = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "deepseek",
+                "deepseek-v4-flash",
+                Some("English"),
+                "Italian",
+                "fallback_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "deepseek",
+                    "deepseek-v4-flash",
+                    "v1",
+                    "fallback_ns",
+                ),
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        fallback_miss.is_none(),
+        "fallback-produced output must remain job-local"
+    );
+
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
+fn cache_lookup_isolates_different_provider_contexts() {
+    let db_path = temp_path("cache_provider.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    // Job A translates with openrouter/gemini; job B with deepseek — same
+    // source hash and namespace otherwise. Neither may reuse the other.
+    let (job_a, seg_a) = seed_job_with_policy(&store, "prov_ns", false);
+    store
+        .insert_segments(
+            &job_a.id,
+            std::slice::from_ref(&seg_a),
+            "v1",
+            "openrouter",
+            "google/gemini-2.5-flash",
+            "prov_ns",
+        )
+        .expect("job A segment should insert");
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job_a.id,
+            segment_id: "seg_identity",
+            translated_text: "gemini output",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "gemini output".to_string(),
+            }],
+            provider: "openrouter",
+            model: "google/gemini-2.5-flash",
+            prompt_version: "v1",
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            tokens_estimated: false,
+        })
+        .expect("job A translation should save");
+
+    let (job_b, seg_b) = seed_job_with_policy(&store, "prov_ns", false);
+    store
+        .insert_segments(
+            &job_b.id,
+            std::slice::from_ref(&seg_b),
+            "v1",
+            "deepseek",
+            "deepseek-v4-flash",
+            "prov_ns",
+        )
+        .expect("job B segment should insert");
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job_b.id,
+            segment_id: "seg_identity",
+            translated_text: "deepseek output",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "deepseek output".to_string(),
+            }],
+            provider: "deepseek",
+            model: "deepseek-v4-flash",
+            prompt_version: "v1",
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            tokens_estimated: false,
+        })
+        .expect("job B translation should save");
+
+    let (lookup_job, seg) = seed_job_with_policy(&store, "prov_ns", false);
+    let hit = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "deepseek",
+                "deepseek-v4-flash",
+                Some("English"),
+                "Italian",
+                "prov_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "deepseek",
+                    "deepseek-v4-flash",
+                    "v1",
+                    "prov_ns",
+                ),
+            ),
+        )
+        .expect("query ok")
+        .expect("deepseek lookup should hit job B");
+    assert_eq!(hit.translated_text, "deepseek output");
+
+    // A gemini context reuses the gemini-produced row (same effective
+    // provider/model) and never the deepseek output.
+    let gemini_hit = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "openrouter",
+                "google/gemini-2.5-flash",
+                Some("English"),
+                "Italian",
+                "prov_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "openrouter",
+                    "google/gemini-2.5-flash",
+                    "v1",
+                    "prov_ns",
+                ),
+            ),
+        )
+        .expect("query ok")
+        .expect("gemini context should hit job A");
+    assert_eq!(gemini_hit.translated_text, "gemini output");
+
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
+fn cache_policy_mutation_apis_return_not_found_for_missing_rows() {
+    let db_path = temp_path("missing_rows.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    let policy = CachePolicySnapshot {
+        strict_context: Some(true),
+    };
+    let update_missing_job = store.update_job_cache_policy("job_missing", &policy);
+    assert!(
+        matches!(update_missing_job, Err(StoreError::NotFound(_))),
+        "update_job_cache_policy must reject a missing job"
+    );
+    let load_missing_job = store.load_job_cache_policy("job_missing");
+    assert!(
+        matches!(load_missing_job, Err(StoreError::NotFound(_))),
+        "load_job_cache_policy must reject a missing job"
+    );
+
+    let input_path = temp_path("missing-input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("missing-output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+
+    let insert_into_missing_job = store.insert_segments(
+        "job_missing",
+        &[],
+        "v1",
+        "mock",
+        "mock-prefix",
+        "missing_ns",
+    );
+    assert!(
+        matches!(insert_into_missing_job, Err(StoreError::NotFound(_))),
+        "insert_segments must reject a missing job even with empty segments"
+    );
+
+    let save_missing = store.save_translation(SaveTranslation {
+        job_id: &job.id,
+        segment_id: "seg_missing",
+        translated_text: "x",
+        blocks: &[BlockTranslation {
+            block_id: BlockId("b_000000".to_string()),
+            text: "x".to_string(),
+        }],
+        provider: "mock",
+        model: "mock-prefix",
+        prompt_version: "v1",
+        input_tokens: None,
+        input_cached_tokens: None,
+        output_tokens: None,
+        tokens_estimated: false,
+    });
+    assert!(
+        matches!(save_missing, Err(StoreError::NotFound(_))),
+        "save_translation must reject a missing segment"
+    );
+
+    let record_missing = store.record_translation_attempt(RecordTranslationAttempt {
+        job_id: &job.id,
+        segment_id: "seg_missing",
+        batch_id: None,
+        phase: None,
+        provider: "mock",
+        model: "mock-prefix",
+        outcome: TranslationAttemptOutcome::Failure,
+        error: Some("boom"),
+        input_tokens: None,
+        input_cached_tokens: None,
+        output_tokens: None,
+        cost_estimate: None,
+    });
+    assert!(
+        matches!(record_missing, Err(StoreError::NotFound(_))),
+        "record_translation_attempt must reject a missing segment"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn translation_attempt_ledger_aggregates_tokens_and_costs_monotonically() {
+    let db_path = temp_path("attempt_ledger.sqlite");
+    let input_path = temp_path("ledger-input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("store should open");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("ledger-output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut seg = segment("seg_ledger", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "ledger_ns",
+        )
+        .expect("segments should insert");
+
+    store
+        .record_translation_attempt(RecordTranslationAttempt {
+            job_id: &job.id,
+            segment_id: "seg_ledger",
+            batch_id: None,
+            phase: None,
+            provider: "mock",
+            model: "mock-prefix",
+            outcome: TranslationAttemptOutcome::Failure,
+            error: Some("timeout"),
+            input_tokens: Some(100),
+            input_cached_tokens: Some(5),
+            output_tokens: Some(0),
+            cost_estimate: Some(1.0),
+        })
+        .expect("first attempt should record");
+    store
+        .record_translation_attempt(RecordTranslationAttempt {
+            job_id: &job.id,
+            segment_id: "seg_ledger",
+            batch_id: Some("batch_1"),
+            phase: Some(TranslationAttemptPhase::Repair),
+            provider: "mock",
+            model: "mock-prefix",
+            outcome: TranslationAttemptOutcome::Success,
+            error: None,
+            input_tokens: Some(40),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(60),
+            cost_estimate: Some(0.7),
+        })
+        .expect("second attempt should record");
+
+    let rows = store
+        .translation_attempts(&job.id, None, None)
+        .expect("attempts should load");
+    assert_eq!(rows.len(), 2, "both attempts persist");
+    assert_eq!(rows[0].attempt_ordinal, 1, "ordinals start at one");
+    assert_eq!(rows[1].attempt_ordinal, 2, "ordinals are monotonic");
+    assert_eq!(
+        rows[0].phase, "primary",
+        "phase inferred from provider/model"
+    );
+    assert_eq!(rows[1].phase, "repair", "explicit phase preserved");
+    assert_eq!(
+        rows[1].batch_id.as_deref(),
+        Some("batch_1"),
+        "batch id preserved"
+    );
+
+    let summary = store
+        .translation_attempt_summary(&job.id)
+        .expect("summary should aggregate");
+    assert_eq!(summary.attempts, 2);
+    assert_eq!(summary.input_tokens, 140, "input tokens aggregate");
+    assert_eq!(summary.input_cached_tokens, 5, "cached tokens aggregate");
+    assert_eq!(summary.output_tokens, 60, "output tokens aggregate");
+    assert!(
+        (summary.cost_estimate - 1.7).abs() < f64::EPSILON,
+        "cost aggregates"
+    );
+
+    // The job-level summary prefers the ledger once it has rows.
+    let job_summary = store
+        .summary(&job.id)
+        .expect("job summary should load")
+        .expect("job should exist");
+    assert_eq!(job_summary.input_tokens, 140);
+    assert_eq!(job_summary.output_tokens, 60);
+
+    // The ledger is immutable at the schema level: in-place edits are rejected.
+    let conn = store.conn.borrow();
+    let update_rejected = conn.execute(
+        "UPDATE translation_attempts SET outcome = 'success' WHERE job_id = ?1",
+        params![job.id],
+    );
+    assert!(
+        update_rejected.is_err(),
+        "append-only ledger must reject in-place updates"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn translation_attempt_ledger_rejects_duplicate_ordinals() {
+    let db_path = temp_path("attempt_ordinal.sqlite");
+    let input_path = temp_path("ordinal-input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("store should open");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("ordinal-output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut seg = segment("seg_ordinal", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "ordinal_ns",
+        )
+        .expect("segments should insert");
+
+    let request = RecordTranslationAttempt {
+        job_id: &job.id,
+        segment_id: "seg_ordinal",
+        batch_id: None,
+        phase: None,
+        provider: "mock",
+        model: "mock-prefix",
+        outcome: TranslationAttemptOutcome::Failure,
+        error: Some("boom"),
+        input_tokens: None,
+        input_cached_tokens: None,
+        output_tokens: None,
+        cost_estimate: None,
+    };
+    let _ = store
+        .record_translation_attempt(request)
+        .expect("first attempt");
+
+    // A manual attempt to force a duplicate ordinal violates the unique
+    // (job, segment, attempt_ordinal) constraint even though the store's
+    // own API always assigns the next ordinal.
+    let conn = store.conn.borrow();
+    let duplicate = conn.execute(
+        "INSERT INTO translation_attempts
+         (job_id, segment_id, batch_id, phase, attempt_ordinal, provider, model, outcome, error,
+          input_tokens, input_cached_tokens, output_tokens, cost_estimate, created_at)
+         VALUES (?1, ?2, NULL, 'primary', 1, 'mock', 'mock-prefix', 'failure', NULL,
+                 NULL, NULL, NULL, NULL, ?3)",
+        params![job.id, "seg_ordinal", timestamp_string()],
+    );
+    assert!(
+        duplicate.is_err(),
+        "duplicate attempt ordinals must be rejected"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+/// Create a job with a persisted run snapshot but NO cache policy record, so
+/// lookups compute the conservative unknown-strictness identity.
+fn seed_job_with_snapshot_only(store: &JobStore, cache_namespace: &str) -> (JobRecord, Segment) {
+    let input_path = temp_path("snapshot-only-input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("snapshot-only-output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut snapshot = snapshot_fixture();
+    snapshot.cache_namespace = cache_namespace.to_string();
+    store
+        .update_job_config_snapshot(&job.id, &snapshot)
+        .expect("snapshot should persist");
+    let mut seg = segment("seg_identity", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            cache_namespace,
+        )
+        .expect("segments should insert");
+    let _ = fs::remove_file(input_path);
+    (job, seg)
+}
+
+/// A segment whose source text/checksum is shared across clones while the
+/// ordered neighbor/context content differs — the duplicate-text /
+/// different-context cache-collision scenario.
+fn segment_with_neighbors(
+    id: &str,
+    source_text: &str,
+    before: Option<&str>,
+    after: Option<&str>,
+) -> Segment {
+    let mut seg = segment(id, 0);
+    seg.checksum = "identical_source_checksum".to_string();
+    seg.source.text = source_text.to_string();
+    seg.source.blocks[0].text = source_text.to_string();
+    seg.source.blocks[0].text_runs[0].text = source_text.to_string();
+    seg.context = SegmentContext {
+        before: before.map(str::to_string),
+        after: after.map(str::to_string),
+    };
+    seg
+}
+
+#[test]
+fn duplicate_source_text_in_different_contexts_never_collides() {
+    let db_path = temp_path("cache_dup_ctx.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    let seg_a =
+        segment_with_neighbors("seg_a", "identical text", Some("before A"), Some("after A"));
+    let seg_b =
+        segment_with_neighbors("seg_b", "identical text", Some("before B"), Some("after B"));
+    assert_eq!(
+        seg_a.checksum, seg_b.checksum,
+        "both segments share the identical source checksum"
+    );
+
+    let (job_a, _) = seed_job_with_policy(&store, "dup_ctx_ns", false);
+    store
+        .insert_segments(
+            &job_a.id,
+            std::slice::from_ref(&seg_a),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "dup_ctx_ns",
+        )
+        .expect("job A segment should insert");
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job_a.id,
+            segment_id: "seg_a",
+            translated_text: "A output",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "A output".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            tokens_estimated: false,
+        })
+        .expect("job A translation should save");
+
+    let (job_b, _) = seed_job_with_policy(&store, "dup_ctx_ns", false);
+    store
+        .insert_segments(
+            &job_b.id,
+            std::slice::from_ref(&seg_b),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "dup_ctx_ns",
+        )
+        .expect("job B segment should insert");
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job_b.id,
+            segment_id: "seg_b",
+            translated_text: "B output",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "B output".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            tokens_estimated: false,
+        })
+        .expect("job B translation should save");
+
+    let (lookup_job, _) = seed_job_with_policy(&store, "dup_ctx_ns", false);
+
+    // The expected fingerprint is keyed by the CURRENT segment id; identical
+    // checksums in different contexts resolve to distinct expectations.
+    let expected_b = expected_fingerprints_for(
+        &store,
+        &lookup_job.id,
+        std::slice::from_ref(&seg_b),
+        "mock",
+        "mock-prefix",
+        "v1",
+        "dup_ctx_ns",
+    );
+    let hit_b = store
+        .find_cached_translation(
+            &seg_b,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "dup_ctx_ns",
+                &expected_b,
+            ),
+        )
+        .expect("query ok")
+        .expect("seg_b contract must hit job B");
+    assert_eq!(hit_b.translated_text, "B output", "never job A's row");
+
+    let hit_a = store
+        .find_cached_translation(
+            &seg_a,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "dup_ctx_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg_a),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "dup_ctx_ns",
+                ),
+            ),
+        )
+        .expect("query ok")
+        .expect("seg_a contract must hit job A");
+    assert_eq!(hit_a.translated_text, "A output");
+
+    // The batch path must also keep the two identical-source rows apart.
+    let both = &[seg_a.clone(), seg_b.clone()];
+    let hits = store
+        .find_cached_translations_batch(
+            both,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "dup_ctx_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    both,
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "dup_ctx_ns",
+                ),
+            ),
+        )
+        .expect("batch query ok");
+    assert_eq!(hits["seg_a"].translated_text, "A output");
+    assert_eq!(hits["seg_b"].translated_text, "B output");
+
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
+fn fallback_attempts_carry_effective_provenance_and_phase() {
+    let db_path = temp_path("fallback_provenance.sqlite");
+    let input_path = temp_path("fallback_prov_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("store should open");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("fallback_prov_output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut seg = segment("seg_fb", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "fb_ns",
+        )
+        .expect("segment should insert");
+
+    // The output was produced by the fallback provider/model: the
+    // translations row must preserve that effective provenance.
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job.id,
+            segment_id: "seg_fb",
+            translated_text: "fallback output",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "fallback output".to_string(),
+            }],
+            provider: "deepseek",
+            model: "deepseek-v4-flash",
+            prompt_version: "v1",
+            input_tokens: Some(9),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(6),
+            tokens_estimated: false,
+        })
+        .expect("fallback translation should save");
+
+    // The real wire attempt records the same effective provider/model and the
+    // phase inference labels it a fallback attempt against the job primary.
+    let ordinal = store
+        .record_translation_attempt(RecordTranslationAttempt {
+            job_id: &job.id,
+            segment_id: "seg_fb",
+            batch_id: None,
+            phase: None,
+            provider: "deepseek",
+            model: "deepseek-v4-flash",
+            outcome: TranslationAttemptOutcome::Success,
+            error: None,
+            input_tokens: Some(9),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(6),
+            cost_estimate: Some(0.5),
+        })
+        .expect("attempt should record");
+    assert_eq!(ordinal, 1);
+
+    let attempts = store
+        .translation_attempts(&job.id, Some("seg_fb"), None)
+        .expect("attempts should load");
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].phase, "fallback",
+        "effective provider infers fallback"
+    );
+    assert_eq!(attempts[0].provider, "deepseek");
+    assert_eq!(attempts[0].model, "deepseek-v4-flash");
+    assert_eq!(attempts[0].outcome, "success");
+
+    let stored = store
+        .load_terminal_segment_translations(&job.id)
+        .expect("terminal translations should load");
+    let record = stored
+        .iter()
+        .find(|record| record.segment_id == "seg_fb")
+        .expect("fallback segment translation");
+    assert_eq!(record.provider, "deepseek");
+    assert_eq!(record.model, "deepseek-v4-flash");
+
+    // A primary-context lookup never serves the fallback-produced row.
+    let (lookup_job, _) = seed_job_with_policy(&store, "fb_ns", false);
+    let miss = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "fb_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "fb_ns",
+                ),
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        miss.is_none(),
+        "fallback provenance must never be served to a primary context"
+    );
+
+    // The segment's stamped cache fingerprint was computed with the job's
+    // PRIMARY provider/model at insert time (the fallback was not known yet),
+    // while the output's real provenance is the fallback provider/model. The
+    // write-time identity and a fallback-context expected identity therefore
+    // disagree, so even a fallback-context lookup cannot match this row: the
+    // fallback-produced output stays job-local and is never reused under a
+    // fabricated effective provider/model fingerprint. This is conservative
+    // (a missed cache opportunity, never a wrong reuse).
+    let fallback_miss = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "deepseek",
+                "deepseek-v4-flash",
+                Some("English"),
+                "Italian",
+                "fb_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &lookup_job.id,
+                    std::slice::from_ref(&seg),
+                    "deepseek",
+                    "deepseek-v4-flash",
+                    "v1",
+                    "fb_ns",
+                ),
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        fallback_miss.is_none(),
+        "a fallback-produced row must stay job-local (never served under the effective provider)"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn summary_mixes_ledger_and_legacy_segment_tokens_without_double_counting() {
+    let db_path = temp_path("mixed_ledger.sqlite");
+    let input_path = temp_path("mixed_ledger_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("store should open");
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("mixed_ledger_output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let seg_a = segment("seg_a", 0);
+    let seg_b = segment("seg_b", 1);
+    store
+        .insert_segments(
+            &job.id,
+            &[seg_a.clone(), seg_b.clone()],
+            "v1",
+            "mock",
+            "mock-prefix",
+            "mixed_ns",
+        )
+        .expect("segments should insert");
+
+    // seg_a completes with only legacy token columns (pre-ledger style: no
+    // wire attempt is recorded on the checkpoint path).
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job.id,
+            segment_id: "seg_a",
+            translated_text: "A",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000000".to_string()),
+                text: "A".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(10),
+            input_cached_tokens: Some(1),
+            output_tokens: Some(5),
+            tokens_estimated: false,
+        })
+        .expect("seg_a translation should save");
+
+    // seg_b has BOTH a legacy token record AND a real wire-attempt ledger row
+    // for the same attempt; the summary must use the ledger, not both.
+    store
+        .save_translation(SaveTranslation {
+            job_id: &job.id,
+            segment_id: "seg_b",
+            translated_text: "B",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000001".to_string()),
+                text: "B".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(20),
+            input_cached_tokens: Some(2),
+            output_tokens: Some(7),
+            tokens_estimated: false,
+        })
+        .expect("seg_b translation should save");
+    store
+        .record_translation_attempt(RecordTranslationAttempt {
+            job_id: &job.id,
+            segment_id: "seg_b",
+            batch_id: None,
+            phase: Some(TranslationAttemptPhase::Primary),
+            provider: "mock",
+            model: "mock-prefix",
+            outcome: TranslationAttemptOutcome::Success,
+            error: None,
+            input_tokens: Some(20),
+            input_cached_tokens: Some(2),
+            output_tokens: Some(7),
+            cost_estimate: None,
+        })
+        .expect("seg_b wire attempt should record");
+
+    let summary = store
+        .summary(&job.id)
+        .expect("summary query")
+        .expect("job exists");
+    assert_eq!(
+        summary.input_tokens, 30,
+        "seg_a legacy 10 + seg_b ledger 20 (not 50: seg_b must not double count)"
+    );
+    assert_eq!(summary.input_cached_tokens, 3);
+    assert_eq!(summary.output_tokens, 12);
+
+    let listed = store
+        .list_job_summaries()
+        .expect("list summaries")
+        .into_iter()
+        .find(|(record, _)| record.id == job.id)
+        .expect("job listed");
+    assert_eq!(listed.1.input_tokens, 30);
+    assert_eq!(listed.1.input_cached_tokens, 3);
+    assert_eq!(listed.1.output_tokens, 12);
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn concurrent_attempt_ordinals_are_monotonic_and_unique() {
+    let db_path = temp_path("concurrent_ordinals.sqlite");
+    let input_path = temp_path("concurrent_ord_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+
+    let job_id = {
+        let store = JobStore::open(&db_path).expect("store should open");
+        let job = store
+            .create_job(CreateJob {
+                input: &input_path,
+                output: &temp_path("concurrent_ord_output.epub"),
+                source_lang: Some("English"),
+                target_lang: "Italian",
+                provider: "mock",
+                model: "mock-prefix",
+                base_url: None,
+                api_key_env: None,
+                book_id: None,
+                series_id: None,
+            })
+            .expect("job should be created");
+        let mut seg = segment("seg_conc", 0);
+        seg.block_ids = vec![BlockId("b_000000".to_string())];
+        store
+            .insert_segments(
+                &job.id,
+                std::slice::from_ref(&seg),
+                "v1",
+                "mock",
+                "mock-prefix",
+                "conc_ns",
+            )
+            .expect("segments should insert");
+        job.id
+    };
+
+    // Each thread opens its OWN connection and records a wire attempt for the
+    // same (job, segment). The IMMEDIATE transaction + atomic ordinal
+    // allocation serializes the writers; every attempt must succeed with a
+    // unique monotonic ordinal.
+    const THREADS: usize = 6;
+    let mut ordinals: Vec<i64> = Vec::new();
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let db_path = db_path.clone();
+                let job_id = job_id.clone();
+                scope.spawn(move || {
+                    let store = JobStore::open(&db_path).expect("thread store opens");
+                    store
+                        .record_translation_attempt(RecordTranslationAttempt {
+                            job_id: &job_id,
+                            segment_id: "seg_conc",
+                            batch_id: None,
+                            phase: Some(TranslationAttemptPhase::Primary),
+                            provider: "mock",
+                            model: "mock-prefix",
+                            outcome: TranslationAttemptOutcome::Failure,
+                            error: Some("concurrent"),
+                            input_tokens: Some(1),
+                            input_cached_tokens: Some(0),
+                            output_tokens: Some(0),
+                            cost_estimate: None,
+                        })
+                        .expect("concurrent attempt should record")
+                })
+            })
+            .collect();
+        for handle in handles {
+            ordinals.push(handle.join().expect("thread should not panic"));
+        }
+    });
+
+    ordinals.sort_unstable();
+    let expected: Vec<i64> = (1..=THREADS as i64).collect();
+    assert_eq!(
+        ordinals, expected,
+        "ordinals must be a unique monotonic 1..=N sequence"
+    );
+
+    let store = JobStore::open(&db_path).expect("store reopens");
+    let rows = store
+        .translation_attempts(&job_id, Some("seg_conc"), None)
+        .expect("attempts should load");
+    assert_eq!(rows.len(), THREADS);
+    let mut loaded: Vec<usize> = rows.iter().map(|row| row.attempt_ordinal).collect();
+    loaded.sort_unstable();
+    assert_eq!(
+        loaded,
+        expected
+            .iter()
+            .map(|value| *value as usize)
+            .collect::<Vec<_>>()
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn migration_twelve_upgrades_legacy_schema_and_composite_fk_holds() {
+    let db_path = temp_path("migration12_legacy.sqlite");
+    // Hand-build a pre-v12 database: migrations 1..=7 recorded, the legacy
+    // jobs/segments tables WITHOUT the cache identity columns, and no
+    // translation_attempts table yet.
+    {
+        let conn = Connection::open(&db_path).expect("legacy connection opens");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE _migrations (
+              version INTEGER PRIMARY KEY,
+              name TEXT NOT NULL,
+              applied_at TEXT NOT NULL
+            );
+            INSERT INTO _migrations (version, name, applied_at) VALUES
+              (1, 'initial', '0'),
+              (2, 'v1_0_1_input_snapshot', '0'),
+              (3, 'v1_1_segment_flags', '0'),
+              (4, 'v1_2_glossary_terms', '0'),
+              (5, 'v1_2_1_nullable_glossary_candidate_targets', '0'),
+              (6, 'v1_3_context_styles_entities', '0'),
+              (7, 'v2_4_human_corrections', '0');
+            CREATE TABLE jobs (
+              id TEXT PRIMARY KEY,
+              input_path TEXT NOT NULL DEFAULT '',
+              input_snapshot_path TEXT,
+              input_sha256 TEXT,
+              output_path TEXT NOT NULL DEFAULT '',
+              input_hash TEXT NOT NULL,
+              source_lang TEXT,
+              target_lang TEXT NOT NULL,
+              provider TEXT NOT NULL,
+              model TEXT NOT NULL,
+              base_url TEXT,
+              api_key_env TEXT,
+              status TEXT NOT NULL,
+              config_json TEXT,
+              events_path TEXT,
+              report_json_path TEXT,
+              report_markdown_path TEXT,
+              book_id TEXT,
+              series_id TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            );
+            CREATE TABLE segments (
+              id TEXT NOT NULL,
+              job_id TEXT NOT NULL,
+              section_id TEXT NOT NULL,
+              ordinal INTEGER NOT NULL,
+              source_hash TEXT NOT NULL,
+              prompt_version TEXT NOT NULL,
+              provider TEXT NOT NULL,
+              model TEXT NOT NULL,
+              status TEXT NOT NULL,
+              attempts INTEGER NOT NULL DEFAULT 0,
+              input_tokens INTEGER,
+              output_tokens INTEGER,
+              tokens_input INTEGER,
+              tokens_input_cached INTEGER,
+              tokens_output INTEGER,
+              tokens_estimated INTEGER NOT NULL DEFAULT 0,
+              cost_estimate REAL,
+              error TEXT,
+              translated_hash TEXT,
+              PRIMARY KEY (job_id, id),
+              FOREIGN KEY(job_id) REFERENCES jobs(id)
+            );
+            "#,
+        )
+        .expect("legacy schema should build");
+    }
+
+    let input_path = temp_path("migration12_legacy_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let store = JobStore::open(&db_path).expect("migration should upgrade the legacy database");
+
+    // Migration 12 added the cache identity columns and the ledger table:
+    // they are usable immediately.
+    let job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("migration12_legacy_output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("job should be created");
+    let mut seg = segment("seg_m12", 0);
+    seg.block_ids = vec![BlockId("b_000000".to_string())];
+    store
+        .insert_segments(
+            &job.id,
+            std::slice::from_ref(&seg),
+            "v1",
+            "mock",
+            "mock-prefix",
+            "m12_ns",
+        )
+        .expect("segments should insert");
+    let ordinal = store
+        .record_translation_attempt(RecordTranslationAttempt {
+            job_id: &job.id,
+            segment_id: "seg_m12",
+            batch_id: None,
+            phase: Some(TranslationAttemptPhase::Primary),
+            provider: "mock",
+            model: "mock-prefix",
+            outcome: TranslationAttemptOutcome::Failure,
+            error: None,
+            input_tokens: None,
+            input_cached_tokens: None,
+            output_tokens: None,
+            cost_estimate: None,
+        })
+        .expect("attempt should record");
+    assert_eq!(ordinal, 1);
+
+    // The composite FK pins attempts to the segment row: a raw row for a
+    // missing (job, segment) pair is rejected at the SQL layer.
+    let conn = store.conn.borrow();
+    let fk_error = conn.execute(
+        "INSERT INTO translation_attempts
+         (job_id, segment_id, batch_id, phase, attempt_ordinal, provider, model, outcome, error,
+          input_tokens, input_cached_tokens, output_tokens, cost_estimate, created_at)
+         VALUES ('phantom_job', 'phantom_seg', NULL, 'primary', 1, 'mock', 'mock-prefix', 'failure',
+                 NULL, NULL, NULL, NULL, NULL, ?1)",
+        params![timestamp_string()],
+    );
+    assert!(
+        fk_error.is_err(),
+        "the composite foreign key must reject attempts for a missing segment"
+    );
+    drop(conn);
+
+    // Reopen is clean: data persists and the schema stays intact.
+    drop(store);
+    let store = JobStore::open(&db_path).expect("store reopens cleanly");
+    let attempts = store
+        .translation_attempts(&job.id, None, None)
+        .expect("attempts should load after reopen");
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(attempts[0].attempt_ordinal, 1);
+    let conn = store.conn.borrow();
+    let has_fingerprint = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM pragma_table_info('segments') WHERE name = 'cache_fingerprint')",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .expect("column check");
+    assert!(
+        has_fingerprint,
+        "segments.cache_fingerprint must exist after migration"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
+}
+
+#[test]
+fn unknown_cache_policy_fails_closed_against_explicit_choices() {
+    let db_path = temp_path("cache_unknown_policy.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    let (strict_job, seg) = seed_job_with_policy(&store, "unknown_ns", true);
+    save_segment_translation(
+        &store,
+        &strict_job.id,
+        "seg_identity",
+        "mock",
+        "mock-prefix",
+        "Strict output",
+        "v1",
+    );
+    let (loose_job, _) = seed_job_with_policy(&store, "unknown_ns", false);
+    save_segment_translation(
+        &store,
+        &loose_job.id,
+        "seg_identity",
+        "mock",
+        "mock-prefix",
+        "Loose output",
+        "v1",
+    );
+
+    // A lookup job that NEVER recorded a policy must not reuse either row: the
+    // unknown (conservative) expected fingerprint is hashed distinctly from
+    // both explicit choices, so it fails closed.
+    let (unknown_job, _) = seed_job_with_snapshot_only(&store, "unknown_ns");
+    let miss = store
+        .find_cached_translation(
+            &seg,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "unknown_ns",
+                &expected_fingerprints_for(
+                    &store,
+                    &unknown_job.id,
+                    std::slice::from_ref(&seg),
+                    "mock",
+                    "mock-prefix",
+                    "v1",
+                    "unknown_ns",
+                ),
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        miss.is_none(),
+        "an unknown cache policy must never reuse an explicit strict or loose row"
+    );
+
+    let _ = fs::remove_file(db_path);
+}
+
+#[test]
+fn resume_identity_uses_full_ordered_neighborhood_for_glossary_selection() {
+    let db_path = temp_path("resume_window_glossary.sqlite");
+    let store = JobStore::open(&db_path).expect("store should open");
+
+    // Six segments in ONE section. The glossary term "anchor" appears only in
+    // segment 0; segment 5 picks it up through the recently-active window
+    // (previous 5 segments), so the per-segment selection is order/window
+    // sensitive: computing it over ONLY segment 5 would select nothing.
+    let anchor = bookforge_core::glossary::GlossaryTerm {
+        id: Some(1),
+        scope_kind: bookforge_core::GlossaryScopeKind::Global,
+        scope_id: None,
+        source_text: "anchor".to_string(),
+        target_text: "ancora".to_string(),
+        category: bookforge_core::GlossaryCategory::Other,
+        notes: None,
+        case_sensitive: false,
+        always_active: false,
+        status: bookforge_core::GlossaryStatus::UserSeeded,
+        source_language: "English".to_string(),
+        target_language: "Italian".to_string(),
+        source_count: 1,
+    };
+    let windowed = (0..6)
+        .map(|index| {
+            let mut seg = segment(&format!("seg_w{index}"), index);
+            let text = if index == 0 {
+                "anchor term".to_string()
+            } else {
+                format!("other text {index}")
+            };
+            seg.source.text = text.clone();
+            seg.source.blocks[0].text = text.clone();
+            seg.source.blocks[0].text_runs[0].text = text;
+            seg
+        })
+        .collect::<Vec<_>>();
+    let seg_5 = windowed[5].clone();
+
+    // Original run: snapshot carries the glossary term, all six segments are
+    // inserted together, and the last segment is translated.
+    let input_path = temp_path("resume_window_input.epub");
+    fs::write(&input_path, b"epub bytes").expect("input fixture should be writable");
+    let original = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("resume_window_output.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("original job should be created");
+    let mut snapshot = snapshot_fixture();
+    snapshot.cache_namespace = "window_ns".to_string();
+    snapshot.glossary_terms = vec![anchor];
+    store
+        .update_job_config_snapshot(&original.id, &snapshot)
+        .expect("snapshot should persist");
+    store
+        .insert_segments(
+            &original.id,
+            &windowed,
+            "v1",
+            "mock",
+            "mock-prefix",
+            "window_ns",
+        )
+        .expect("full segment set should insert");
+    store
+        .save_translation(SaveTranslation {
+            job_id: &original.id,
+            segment_id: "seg_w5",
+            translated_text: "translated w5",
+            blocks: &[BlockTranslation {
+                block_id: BlockId("b_000005".to_string()),
+                text: "translated w5".to_string(),
+            }],
+            provider: "mock",
+            model: "mock-prefix",
+            prompt_version: "v1",
+            input_tokens: Some(1),
+            input_cached_tokens: Some(0),
+            output_tokens: Some(1),
+            tokens_estimated: false,
+        })
+        .expect("original translation should save");
+
+    // Resume run: the segment set rebuilds identically, but the lookup is
+    // restricted to the eligible pending candidate (segment 5 alone). The
+    // identity MUST still be computed over the FULL ordered set so the
+    // per-segment glossary selection (and therefore the fingerprint) matches
+    // what the original run stamped.
+    let resume_job = store
+        .create_job(CreateJob {
+            input: &input_path,
+            output: &temp_path("resume_window_output2.epub"),
+            source_lang: Some("English"),
+            target_lang: "Italian",
+            provider: "mock",
+            model: "mock-prefix",
+            base_url: None,
+            api_key_env: None,
+            book_id: None,
+            series_id: None,
+        })
+        .expect("resume job should be created");
+    store
+        .update_job_config_snapshot(&resume_job.id, &snapshot)
+        .expect("resume snapshot should persist");
+
+    let full_set = std::slice::from_ref(&windowed[5]);
+
+    // Correct behavior (full ordered set for identity, candidate restricted):
+    // the resume reuses the original run's segment-5 row.
+    let expected_full = store
+        .expected_cache_fingerprints(
+            &resume_job.id,
+            &windowed,
+            full_set,
+            "mock",
+            "mock-prefix",
+            "v1",
+            "window_ns",
+        )
+        .expect("expected fingerprints should compute");
+    let hit = store
+        .find_cached_translation(
+            &seg_5,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "window_ns",
+                &expected_full,
+            ),
+        )
+        .expect("query ok")
+        .expect("full-set identity must hit the original row");
+    assert_eq!(hit.translated_text, "translated w5");
+
+    // Regression guard: computing the identity over ONLY the pending candidate
+    // (the sparse slice the pre-fix code passed on resume) selects no
+    // recently-active glossary term, so it must NOT match the stamped row.
+    let expected_sparse = store
+        .expected_cache_fingerprints(
+            &resume_job.id,
+            full_set,
+            full_set,
+            "mock",
+            "mock-prefix",
+            "v1",
+            "window_ns",
+        )
+        .expect("sparse expected fingerprints should compute");
+    assert_ne!(
+        expected_sparse["seg_w5"], expected_full["seg_w5"],
+        "sparse-set identity must differ from full-set identity"
+    );
+    let sparse_miss = store
+        .find_cached_translation(
+            &seg_5,
+            cache_lookup_request(
+                "v1",
+                "mock",
+                "mock-prefix",
+                Some("English"),
+                "Italian",
+                "window_ns",
+                &expected_sparse,
+            ),
+        )
+        .expect("query ok");
+    assert!(
+        sparse_miss.is_none(),
+        "a sparse window must never reuse the original prompt's cache row"
+    );
+
+    let _ = fs::remove_file(db_path);
+    let _ = fs::remove_file(input_path);
 }

--- a/crates/bookforge-store/src/db/translations.rs
+++ b/crates/bookforge-store/src/db/translations.rs
@@ -31,24 +31,44 @@ impl JobStore {
     ) -> Result<()> {
         let mut conn = self.conn.borrow_mut();
         let tx = conn.transaction()?;
+        if !job_exists_on(&tx, job_id)? {
+            return Err(StoreError::NotFound(format!(
+                "job '{job_id}' was not found"
+            )));
+        }
+        // The cache identity for every segment is derived once per job from
+        // the persisted run snapshot + cache policy (never from a prior cache
+        // row), so all rows of this run agree on the rendered inputs.
+        let identity_ctx = load_cache_identity_context(&tx, job_id, segments)?;
         let queued_status = SegmentStatus::Queued.as_db_text();
         for segment in segments {
-            // Resume re-runs this against rows that already exist. The
-            // conflict arm refreshes the cache-attribution identity columns
-            // to the current run's config so a resume after a provider/model
-            // change cannot leave stale values that future cache lookups
-            // would misattribute; status/attempts/tokens stay untouched.
+            // Stamp the single structured cache identity for this segment so
+            // cache lookups match on one deterministic fingerprint that
+            // captures every output-affecting input (the actual rendered
+            // context, glossary/style/entity blocks, the persisted run
+            // snapshot, and cache policy). Resume re-runs refresh it to the
+            // current run's config, and conflict-arm refreshes never touch
+            // status/attempts/tokens.
+            let cache_fingerprint = cache_identity_fingerprint_for(
+                &identity_ctx,
+                segment,
+                provider,
+                model,
+                prompt_version,
+                cache_namespace,
+            );
             tx.execute(
                 &format!(
                     "INSERT INTO segments
-                     (id, job_id, section_id, ordinal, source_hash, prompt_version, provider, model, status, attempts, cache_namespace)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, '{queued_status}', 0, ?9)
+                     (id, job_id, section_id, ordinal, source_hash, prompt_version, provider, model, status, attempts, cache_namespace, cache_fingerprint)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, '{queued_status}', 0, ?9, ?10)
                      ON CONFLICT(job_id, id) DO UPDATE SET
                        source_hash = excluded.source_hash,
                        prompt_version = excluded.prompt_version,
                        provider = excluded.provider,
                        model = excluded.model,
-                       cache_namespace = excluded.cache_namespace"
+                       cache_namespace = excluded.cache_namespace,
+                       cache_fingerprint = excluded.cache_fingerprint"
                 ),
                 params![
                     segment.id.0,
@@ -60,6 +80,7 @@ impl JobStore {
                     provider,
                     model,
                     cache_namespace,
+                    cache_fingerprint,
                 ],
             )?;
         }
@@ -90,6 +111,12 @@ impl JobStore {
         let translated_hash = stable_hash(request.translated_text);
         let mut conn = self.conn.borrow_mut();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if !segment_exists_on(&tx, request.job_id, request.segment_id)? {
+            return Err(StoreError::NotFound(format!(
+                "segment '{}' was not found in job '{}'",
+                request.segment_id, request.job_id
+            )));
+        }
         if translation_is_human_corrected_on(&tx, request.job_id, request.segment_id)? {
             return Ok(());
         }
@@ -134,6 +161,11 @@ impl JobStore {
                 request.segment_id,
             ],
         )?;
+        // A fresh model write replaces the output, so any LLM-review findings
+        // about the previous output are stale: drop them here so QA-off
+        // reruns cannot leave old `llm_*` rows attached to re-translated
+        // segments. Deterministic findings are refreshed below.
+        clear_segment_llm_findings_on(&tx, request.job_id, request.segment_id)?;
         // Findings are instrumentation, so a failed findings write must never
         // fail the surrounding translation checkpoint.
         let findings = findings.map(str::trim).filter(|value| !value.is_empty());
@@ -144,6 +176,12 @@ impl JobStore {
             }
             None => clear_segment_findings_on(&tx, request.job_id, request.segment_id),
         };
+        // No ledger row is written here: this checkpoint records segment STATE,
+        // not a provider wire attempt. Real wire attempts are recorded
+        // explicitly by the attempt-recording lane (see
+        // `JobStore::record_translation_attempt`); deriving an attempt from the
+        // checkpoint would fabricate a synthetic wire outcome and double-count
+        // once the provider lane instruments its own requests.
         consume_dashboard_retry_guidance_on(&tx, request.job_id, request.segment_id)?;
         touch_job_unless_status_on(
             &tx,
@@ -164,6 +202,12 @@ impl JobStore {
         let translated_hash = stable_hash(request.preserved_text);
         let mut conn = self.conn.borrow_mut();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if !segment_exists_on(&tx, request.job_id, request.segment_id)? {
+            return Err(StoreError::NotFound(format!(
+                "segment '{}' was not found in job '{}'",
+                request.segment_id, request.job_id
+            )));
+        }
         if translation_is_human_corrected_on(&tx, request.job_id, request.segment_id)? {
             return Ok(());
         }
@@ -209,9 +253,14 @@ impl JobStore {
                 request.segment_id
             ],
         )?;
+        // A preserved/fresh output replaces the segment text; stale LLM QA
+        // rows about the previous output are no longer valid.
+        clear_segment_llm_findings_on(&tx, request.job_id, request.segment_id)?;
         // Findings are instrumentation, so a failed findings write must never
         // fail the surrounding translation checkpoint.
         let _ = record_segment_findings_on(&tx, request.job_id, request.segment_id, request.error);
+        // Like the success path, no ledger row is derived from this
+        // checkpoint: it records segment state, not a provider wire attempt.
         consume_dashboard_retry_guidance_on(&tx, request.job_id, request.segment_id)?;
         touch_job_unless_status_on(
             &tx,
@@ -230,6 +279,12 @@ impl JobStore {
         let translated_hash = stable_hash(request.translated_text);
         let mut conn = self.conn.borrow_mut();
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if !segment_exists_on(&tx, request.job_id, request.segment_id)? {
+            return Err(StoreError::NotFound(format!(
+                "segment '{}' was not found in job '{}'",
+                request.segment_id, request.job_id
+            )));
+        }
         if translation_is_human_corrected_on(&tx, request.job_id, request.segment_id)? {
             return Ok(());
         }
@@ -261,9 +316,14 @@ impl JobStore {
             ),
             params![translated_hash, request.job_id, request.segment_id],
         )?;
+        // The segment output is replaced by the cache-hit value; stale LLM QA
+        // rows about the previous output no longer describe this segment.
+        clear_segment_llm_findings_on(&tx, request.job_id, request.segment_id)?;
         // Findings are instrumentation, so a failed findings write must never
         // fail the surrounding translation checkpoint.
         let _ = clear_segment_findings_on(&tx, request.job_id, request.segment_id);
+        // A cache hit is NOT a provider wire attempt, so no ledger row is
+        // derived here: the ledger counts real wire traffic only.
         consume_dashboard_retry_guidance_on(&tx, request.job_id, request.segment_id)?;
         touch_job_unless_status_on(
             &tx,
@@ -534,30 +594,33 @@ impl JobStore {
             .map_err(StoreError::from)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn find_cached_translation(
         &self,
         segment: &Segment,
-        prompt_version: &str,
-        provider: &str,
-        model: &str,
-        source_lang: Option<&str>,
-        target_lang: &str,
-        cache_namespace: &str,
+        request: CacheLookupRequest<'_>,
     ) -> Result<Option<CachedTranslation>> {
         let conn = self.conn.borrow();
+        // The expected fingerprint is computed by the caller from the current
+        // run's persisted config + cache policy (never discovered from a prior
+        // segment row), keyed by the CURRENT segment id so duplicate source
+        // text in different contexts resolves to distinct expectations.
+        // Absent means the segment is ineligible for reuse.
+        let Some(expected_fingerprint) = request.expected_fingerprints.get(&segment.id.0) else {
+            return Ok(None);
+        };
+
+        // Match cross-job candidates on the single expected identity and the
+        // actual output provenance (t.provider/t.model), so output produced
+        // by a fallback provider/model is never reused as if the primary
+        // produced it.
         let sql = format!(
             "SELECT t.job_id, t.segment_id, t.translated_text
              FROM translations t
              JOIN segments s ON s.job_id = t.job_id AND s.id = t.segment_id
-             JOIN jobs j ON j.id = t.job_id
              WHERE s.source_hash = ?1
-               AND s.prompt_version = ?2
-               AND s.provider = ?3
-               AND s.model = ?4
-               AND ((?5 IS NULL AND j.source_lang IS NULL) OR j.source_lang = ?5)
-               AND j.target_lang = ?6
-               AND s.cache_namespace = ?7
+               AND s.cache_fingerprint = ?2
+               AND t.provider = ?3
+               AND t.model = ?4
                AND s.status IN ({})
                AND t.human_corrected = 0
              ORDER BY CASE s.status WHEN '{}' THEN 0 ELSE 1 END,
@@ -572,12 +635,9 @@ impl JobStore {
                 &sql,
                 params![
                     segment.checksum,
-                    prompt_version,
-                    provider,
-                    model,
-                    source_lang,
-                    target_lang,
-                    cache_namespace,
+                    expected_fingerprint,
+                    request.provider,
+                    request.model,
                 ],
                 |row| {
                     Ok((
@@ -639,55 +699,76 @@ impl JobStore {
             return Ok(results);
         }
 
-        const SQLITE_IN_CHUNK_SIZE: usize = 900;
+        const SQLITE_IN_CHUNK_SIZE: usize = 450;
 
         for chunk in segments.chunks(SQLITE_IN_CHUNK_SIZE) {
-            let hashes: Vec<&str> = chunk.iter().map(|s| s.checksum.as_str()).collect();
-            let placeholders: Vec<String> =
-                (0..hashes.len()).map(|i| format!("?{}", i + 1)).collect();
-            let placeholders_sql = placeholders.join(", ");
+            // Expected fingerprints are caller-computed (from the current
+            // run's persisted config + cache policy), keyed by CURRENT segment
+            // id. Each entry carries the segment's own source hash AND its
+            // expected fingerprint, so two segments that share a checksum but
+            // differ in rendered context resolve to different (hash,
+            // fingerprint) pairs and can never collide. Segments without one
+            // are ineligible for reuse.
+            let pairs: Vec<(&str, &str, &str)> = chunk
+                .iter()
+                .filter_map(|segment| {
+                    request
+                        .expected_fingerprints
+                        .get(&segment.id.0)
+                        .map(|fingerprint| {
+                            (
+                                segment.id.0.as_str(),
+                                segment.checksum.as_str(),
+                                fingerprint.as_str(),
+                            )
+                        })
+                })
+                .collect();
+            if pairs.is_empty() {
+                continue;
+            }
 
+            // One direct lookup: candidates must carry the exact expected
+            // fingerprint for their own source hash AND the actual output
+            // provenance (t.provider/t.model), so a fallback-produced row is
+            // never reused as if the primary produced it. The returned
+            // (source_hash, cache_fingerprint) pair maps each hit back to the
+            // exact requesting segment, keeping duplicate source texts apart.
+            let pair_conditions = (0..pairs.len())
+                .map(|index| {
+                    let hash_slot = index * 2 + 1;
+                    let fingerprint_slot = index * 2 + 2;
+                    format!("(s.source_hash = ?{hash_slot} AND s.cache_fingerprint = ?{fingerprint_slot})")
+                })
+                .collect::<Vec<_>>()
+                .join(" OR ");
             let sql = format!(
-                "SELECT t.job_id, t.segment_id, t.translated_text, s.source_hash
+                "SELECT t.job_id, t.segment_id, t.translated_text, s.source_hash, s.cache_fingerprint
                  FROM translations t
                  JOIN segments s ON s.job_id = t.job_id AND s.id = t.segment_id
-                 JOIN jobs j ON j.id = t.job_id
-                 WHERE s.source_hash IN ({placeholders_sql})
-                   AND s.prompt_version = ?{}
-                   AND s.provider = ?{}
-                   AND s.model = ?{}
-                   AND ((?{} IS NULL AND j.source_lang IS NULL) OR j.source_lang = ?{})
-                   AND j.target_lang = ?{}
-                   AND s.cache_namespace = ?{}
+                 WHERE ({pair_conditions})
+                   AND t.provider = ?{}
+                   AND t.model = ?{}
                    AND s.status IN ({})
                    AND t.human_corrected = 0
                  ORDER BY CASE s.status WHEN '{}' THEN 0 ELSE 1 END,
                           CAST(t.created_at AS INTEGER) DESC,
                           t.rowid DESC",
-                hashes.len() + 1,
-                hashes.len() + 2,
-                hashes.len() + 3,
-                hashes.len() + 4,
-                hashes.len() + 5,
-                hashes.len() + 6,
-                hashes.len() + 7,
+                pairs.len() * 2 + 1,
+                pairs.len() * 2 + 2,
                 SegmentStatus::sql_set(SegmentStatus::resolved()),
                 SegmentStatus::Succeeded.as_db_text()
             );
 
+            let conn = self.conn.borrow();
             let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-            for hash in &hashes {
+            for (_, hash, fingerprint) in &pairs {
                 params.push(Box::new(hash.to_string()));
+                params.push(Box::new(fingerprint.to_string()));
             }
-            params.push(Box::new(request.prompt_version.to_string()));
             params.push(Box::new(request.provider.to_string()));
             params.push(Box::new(request.model.to_string()));
-            params.push(Box::new(request.source_lang.map(|s| s.to_string())));
-            params.push(Box::new(request.source_lang.map(|s| s.to_string())));
-            params.push(Box::new(request.target_lang.to_string()));
-            params.push(Box::new(request.cache_namespace.to_string()));
 
-            let conn = self.conn.borrow();
             let mut stmt = conn.prepare(&sql)?;
             let param_refs: Vec<&dyn rusqlite::types::ToSql> =
                 params.iter().map(|p| p.as_ref()).collect();
@@ -698,65 +779,224 @@ impl JobStore {
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
                     row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
                 ))
             })?;
 
-            let mut hash_to_hit: HashMap<String, (String, String, String)> = HashMap::new();
+            // A hit is only valid for a requesting segment whose (source
+            // hash, expected fingerprint) pair matches exactly — never by
+            // checksum alone.
+            let mut hit_by_key: HashMap<(String, String), (String, String, String)> =
+                HashMap::new();
             for row in rows {
-                let (job_id, segment_id, translated_text, source_hash) = row?;
-                hash_to_hit
-                    .entry(source_hash)
+                let (job_id, segment_id, translated_text, source_hash, cache_fingerprint) = row?;
+                hit_by_key
+                    .entry((source_hash, cache_fingerprint))
                     .or_insert((job_id, segment_id, translated_text));
             }
 
             for segment in chunk {
-                if let Some((job_id, segment_id, translated_text)) =
-                    hash_to_hit.get(&segment.checksum)
-                {
-                    let mut block_stmt = conn.prepare(
-                        "SELECT block_id, translated_text
-                         FROM translation_blocks
-                         WHERE job_id = ?1 AND segment_id = ?2
-                         ORDER BY block_id",
-                    )?;
-                    let block_rows = block_stmt.query_map(params![job_id, segment_id], |row| {
-                        Ok(BlockTranslation {
-                            block_id: BlockId(row.get::<_, String>(0)?),
-                            text: row.get(1)?,
-                        })
-                    })?;
-                    let blocks = block_rows.collect::<std::result::Result<Vec<_>, _>>()?;
+                let Some(fingerprint) = request.expected_fingerprints.get(&segment.id.0) else {
+                    continue;
+                };
+                let Some((job_id, segment_id, translated_text)) =
+                    hit_by_key.get(&(segment.checksum.clone(), fingerprint.clone()))
+                else {
+                    continue;
+                };
+                let mut block_stmt = conn.prepare(
+                    "SELECT block_id, translated_text
+                     FROM translation_blocks
+                     WHERE job_id = ?1 AND segment_id = ?2
+                     ORDER BY block_id",
+                )?;
+                let block_rows = block_stmt.query_map(params![job_id, segment_id], |row| {
+                    Ok(BlockTranslation {
+                        block_id: BlockId(row.get::<_, String>(0)?),
+                        text: row.get(1)?,
+                    })
+                })?;
+                let blocks = block_rows.collect::<std::result::Result<Vec<_>, _>>()?;
 
-                    let mut by_id = blocks
-                        .into_iter()
-                        .map(|block| (block.block_id.0.clone(), block))
-                        .collect::<HashMap<_, _>>();
+                let mut by_id = blocks
+                    .into_iter()
+                    .map(|block| (block.block_id.0.clone(), block))
+                    .collect::<HashMap<_, _>>();
 
-                    let mut ordered = Vec::with_capacity(segment.block_ids.len());
-                    let mut valid = true;
-                    for id in &segment.block_ids {
-                        let Some(block) = by_id.remove(&id.0) else {
-                            valid = false;
-                            break;
-                        };
-                        ordered.push(block);
-                    }
-                    if !valid || !by_id.is_empty() {
-                        continue;
-                    }
-
-                    results.insert(
-                        segment.id.0.clone(),
-                        CachedTranslation {
-                            translated_text: translated_text.clone(),
-                            blocks: ordered,
-                        },
-                    );
+                let mut ordered = Vec::with_capacity(segment.block_ids.len());
+                let mut valid = true;
+                for id in &segment.block_ids {
+                    let Some(block) = by_id.remove(&id.0) else {
+                        valid = false;
+                        break;
+                    };
+                    ordered.push(block);
                 }
+                if !valid || !by_id.is_empty() {
+                    continue;
+                }
+
+                results.insert(
+                    segment.id.0.clone(),
+                    CachedTranslation {
+                        translated_text: translated_text.clone(),
+                        blocks: ordered,
+                    },
+                );
             }
         }
 
         Ok(results)
+    }
+
+    /// Compute the expected structured cache identity fingerprint for the
+    /// eligible candidate segments from the job's persisted run snapshot,
+    /// cache policy, and the ACTUAL rendered prompt ingredients. This is
+    /// computed from the current run's configuration — never read from
+    /// segment rows.
+    ///
+    /// The identity is derived over the FULL ordered segment set
+    /// (`all_segments`), because per-segment glossary selection depends on the
+    /// ordered neighborhood (recently-active window) and the high-frequency
+    /// anchors of the whole book: a resume that passes only a sparse subset of
+    /// pending candidates would otherwise select different terms and compute a
+    /// different identity than the original run stamped. `segments` narrows the
+    /// returned map to the current lookup's eligible candidates, and the
+    /// returned map is keyed by CURRENT segment id (not source checksum), so
+    /// duplicate source text at different positions/context resolves to
+    /// distinct expectations and can never collide.
+    ///
+    /// Jobs that never recorded a snapshot fall back to the request-visible
+    /// minimal identity, mirroring what [`JobStore::insert_segments`] stamps.
+    #[allow(clippy::too_many_arguments)]
+    pub fn expected_cache_fingerprints(
+        &self,
+        job_id: &str,
+        all_segments: &[Segment],
+        segments: &[Segment],
+        provider: &str,
+        model: &str,
+        prompt_version: &str,
+        cache_namespace: &str,
+    ) -> Result<HashMap<String, String>> {
+        let mut fingerprints = HashMap::with_capacity(segments.len());
+        let conn = self.conn.borrow();
+        if segments.is_empty() {
+            return Ok(fingerprints);
+        }
+        let identity_ctx = load_cache_identity_context(&conn, job_id, all_segments)?;
+        for segment in segments {
+            let fingerprint = cache_identity_fingerprint_for(
+                &identity_ctx,
+                segment,
+                provider,
+                model,
+                prompt_version,
+                cache_namespace,
+            );
+            fingerprints.insert(segment.id.0.clone(), fingerprint);
+        }
+        Ok(fingerprints)
+    }
+
+    /// Record one attempt in the append-only `translation_attempts` ledger.
+    /// Rows are never updated or deleted: earlier attempts stay verbatim and
+    /// the ledger is the provenance-of-record for cost/usage aggregation.
+    pub fn record_translation_attempt(&self, request: RecordTranslationAttempt<'_>) -> Result<i64> {
+        let mut conn = self.conn.borrow_mut();
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if !segment_exists_on(&tx, request.job_id, request.segment_id)? {
+            return Err(StoreError::NotFound(format!(
+                "segment '{}' was not found in job '{}'",
+                request.segment_id, request.job_id
+            )));
+        }
+        let now = timestamp_string();
+        let ordinal = append_attempt_on(&tx, request, &now)?;
+        tx.commit()?;
+        Ok(ordinal)
+    }
+
+    /// Read back attempt rows, optionally filtered by segment and/or phase.
+    /// Unknown jobs return an empty vec (matching the other read APIs).
+    pub fn translation_attempts(
+        &self,
+        job_id: &str,
+        segment_id: Option<&str>,
+        phase: Option<TranslationAttemptPhase>,
+    ) -> Result<Vec<TranslationAttemptRecord>> {
+        let conn = self.conn.borrow();
+        let mut sql = String::from(
+            "SELECT id, job_id, segment_id, batch_id, phase, attempt_ordinal,
+                    provider, model, outcome, error,
+                    input_tokens, input_cached_tokens, output_tokens,
+                    cost_estimate, created_at
+             FROM translation_attempts
+             WHERE job_id = ?1",
+        );
+        if segment_id.is_some() {
+            sql.push_str(" AND segment_id = ?2");
+        }
+        // `phase` comes from the fixed enum vocabulary (never user input), so
+        // embedding its literal mirrors the established status.sql_set pattern.
+        if let Some(phase) = phase {
+            sql.push_str(&format!(" AND phase = '{}'", phase.as_db_text()));
+        }
+        sql.push_str(" ORDER BY attempt_ordinal, id");
+        let mut stmt = conn.prepare(&sql)?;
+        // Bind only the parameters the built SQL actually declares: `?2` is
+        // present only when a segment filter was requested.
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(job_id.to_string())];
+        if let Some(segment_id) = segment_id {
+            params.push(Box::new(segment_id.to_string()));
+        }
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|param| param.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), |row| {
+            Ok(TranslationAttemptRecord {
+                id: row.get(0)?,
+                job_id: row.get(1)?,
+                segment_id: row.get(2)?,
+                batch_id: row.get(3)?,
+                phase: row.get(4)?,
+                attempt_ordinal: row.get::<_, i64>(5)? as usize,
+                provider: row.get(6)?,
+                model: row.get(7)?,
+                outcome: row.get(8)?,
+                error: row.get(9)?,
+                input_tokens: row.get::<_, Option<i64>>(10)?.map(|v| v as u64),
+                input_cached_tokens: row.get::<_, Option<i64>>(11)?.map(|v| v as u64),
+                output_tokens: row.get::<_, Option<i64>>(12)?.map(|v| v as u64),
+                cost_estimate: row.get(13)?,
+                created_at: row.get(14)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StoreError::from)
+    }
+
+    /// Aggregate one job's attempts from the append-only ledger.
+    pub fn translation_attempt_summary(&self, job_id: &str) -> Result<TranslationAttemptSummary> {
+        let conn = self.conn.borrow();
+        conn.query_row(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(input_cached_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0),
+                    COALESCE(SUM(cost_estimate), 0)
+             FROM translation_attempts WHERE job_id = ?1",
+            params![job_id],
+            |row| {
+                Ok(TranslationAttemptSummary {
+                    attempts: row.get::<_, i64>(0)? as usize,
+                    input_tokens: row.get::<_, i64>(1)? as u64,
+                    input_cached_tokens: row.get::<_, i64>(2)? as u64,
+                    output_tokens: row.get::<_, i64>(3)? as u64,
+                    cost_estimate: row.get(4)?,
+                })
+            },
+        )
+        .map_err(StoreError::from)
     }
 }
 
@@ -923,4 +1163,255 @@ fn replace_block_translations(
         )?;
     }
     Ok(())
+}
+
+/// Whether a segment row exists for `(job_id, segment_id)`. The model-write
+/// paths use this to surface [`StoreError::NotFound`] instead of silently
+/// succeeding (or tripping a foreign-key violation).
+fn segment_exists_on(conn: &Connection, job_id: &str, segment_id: &str) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM segments WHERE job_id = ?1 AND id = ?2)",
+        params![job_id, segment_id],
+        |row| row.get::<_, bool>(0),
+    )?)
+}
+
+/// Everything the structured cache identity needs that is shared across all
+/// segments of one job: the persisted snapshot (when present), the conservative
+/// cache policy, and the per-segment glossary selection. Computed ONCE per
+/// caller transaction so a book's segments do not re-read the snapshot or
+/// re-run glossary selection per row.
+struct CacheIdentityContext {
+    source_lang: Option<String>,
+    target_lang: String,
+    snapshot: Option<RunConfigSnapshot>,
+    strict_context: Option<bool>,
+    /// Per-segment selected glossary terms (keyed by segment id) when a
+    /// snapshot exists; the selection is the ACTUAL content the prompt renders
+    /// for each segment, so two segments that select different terms can never
+    /// collide even with identical config fingerprints.
+    glossary_entries: Option<HashMap<String, Vec<GlossaryPromptTerm>>>,
+}
+
+/// Load the shared cache-identity inputs for a job's segments from the
+/// persisted `RunConfigSnapshot` + cache policy. The per-segment glossary
+/// selection is computed once over the whole slice because selection depends on
+/// the ordered neighborhood (recently-active window), mirroring exactly what
+/// the CLI renders into each prompt.
+fn load_cache_identity_context(
+    conn: &Connection,
+    job_id: &str,
+    segments: &[Segment],
+) -> Result<CacheIdentityContext> {
+    let (source_lang, target_lang, config_json, policy_json) = conn.query_row(
+        "SELECT source_lang, target_lang, config_json, cache_policy_json FROM jobs WHERE id = ?1",
+        params![job_id],
+        |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        },
+    )?;
+    let Some(config_json) = config_json.filter(|json| !json.trim().is_empty()) else {
+        return Ok(CacheIdentityContext {
+            source_lang,
+            target_lang,
+            snapshot: None,
+            strict_context: None,
+            glossary_entries: None,
+        });
+    };
+    let snapshot = serde_json::from_str::<RunConfigSnapshot>(&config_json)
+        .map_err(|error| StoreError::Serialization(error.to_string()))?;
+    let strict_context = parse_cache_policy_json(policy_json.as_deref())?.strict_context;
+    let glossary_entries = if segments.is_empty() {
+        None
+    } else {
+        let selection = select_glossary_for_segments(
+            segments,
+            &snapshot.glossary_terms,
+            snapshot.glossary_budget_tokens,
+        );
+        Some(selection.entries_by_segment)
+    };
+    Ok(CacheIdentityContext {
+        source_lang,
+        target_lang,
+        snapshot: Some(snapshot),
+        strict_context,
+        glossary_entries,
+    })
+}
+
+/// Compute the single structured cache identity fingerprint for a segment at
+/// write time. Prefers the job's persisted `RunConfigSnapshot` (full
+/// output-affecting settings) combined with the ACTUAL rendered prompt
+/// ingredients — the segment's own neighbor/context content and the real
+/// per-segment glossary selection plus rendered style/entity blocks; falls back
+/// to the request-visible minimal identity when no snapshot exists
+/// (legacy/fixtures). The strict-context choice comes from the job's persisted
+/// [`CachePolicySnapshot`]; absent policy reads the conservative `None`.
+fn cache_identity_fingerprint_for(
+    ctx: &CacheIdentityContext,
+    segment: &Segment,
+    provider: &str,
+    model: &str,
+    prompt_version: &str,
+    cache_namespace: &str,
+) -> String {
+    let Some(snapshot) = &ctx.snapshot else {
+        return CacheIdentity::minimal(MinimalCacheIdentity {
+            segment,
+            provider,
+            model,
+            source_lang: ctx.source_lang.as_deref(),
+            target_lang: &ctx.target_lang,
+            prompt_version,
+            cache_namespace,
+        })
+        .fingerprint();
+    };
+    let glossary_rendered = ctx
+        .glossary_entries
+        .as_ref()
+        .and_then(|entries| entries.get(&segment.id.0))
+        .map(|entries| serde_json::to_string(entries).unwrap_or_default())
+        .unwrap_or_default();
+    let prompt_inputs = CachePromptInputs {
+        glossary_rendered,
+        style_rendered: snapshot.style_rendered_block.clone(),
+        entities_rendered: snapshot.entities_rendered_block.clone(),
+    };
+    snapshot
+        .cache_identity(bookforge_core::run_snapshot::CacheIdentityRequest {
+            segment,
+            provider,
+            model,
+            prompt_version,
+            cache_namespace,
+            strict_context: ctx.strict_context,
+            prompt_inputs: &prompt_inputs,
+        })
+        .fingerprint()
+}
+
+/// Decode a serialized [`CachePolicySnapshot`]. NULL/absent and empty policy
+/// records read back the conservative default (unknown strictness), which is
+/// hashed distinctly from either explicit choice — an unknown cache policy
+/// fails CLOSED and can never reuse (or be reused by) a run that states one.
+/// Malformed JSON is a hard error so a corrupt policy can never silently
+/// degrade to a permissive default.
+fn parse_cache_policy_json(json: Option<&str>) -> Result<CachePolicySnapshot> {
+    let Some(json) = json.filter(|json| !json.trim().is_empty()) else {
+        return Ok(CachePolicySnapshot::conservative());
+    };
+    serde_json::from_str(json).map_err(|error| StoreError::Serialization(error.to_string()))
+}
+
+/// Load the persisted cache policy for a job. Rows that never recorded a
+/// policy (NULL `cache_policy_json`) read back the conservative default
+/// (unknown strictness), which can never match an explicit choice.
+pub(super) fn load_cache_policy_on(conn: &Connection, job_id: &str) -> Result<CachePolicySnapshot> {
+    let json = conn
+        .query_row(
+            "SELECT cache_policy_json FROM jobs WHERE id = ?1",
+            params![job_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    parse_cache_policy_json(json.as_deref())
+}
+
+/// Drop persisted LLM-review findings for one segment. Called on every path
+/// that replaces a segment's output, so QA-off reruns cannot leave stale
+/// `llm_*` rows attached to re-translated (or cache-replaced) segments.
+pub(super) fn clear_segment_llm_findings_on(
+    conn: &Connection,
+    job_id: &str,
+    segment_id: &str,
+) -> Result<()> {
+    conn.execute(
+        "DELETE FROM qa_findings WHERE job_id = ?1 AND segment_id = ?2 AND kind GLOB 'llm_*'",
+        params![job_id, segment_id],
+    )?;
+    Ok(())
+}
+
+/// Phase inference for a ledger row whose phase was not stated explicitly: an
+/// attempt whose provider/model match the job's primary configuration is
+/// `primary`; anything else is a `fallback` attempt. Keeps the effective
+/// fallback provenance accurate in the ledger.
+fn infer_attempt_phase_on(
+    conn: &Connection,
+    job_id: &str,
+    provider: &str,
+    model: &str,
+) -> Result<TranslationAttemptPhase> {
+    let (job_provider, job_model) = conn.query_row(
+        "SELECT provider, model FROM jobs WHERE id = ?1",
+        params![job_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )?;
+    if job_provider == provider && job_model == model {
+        Ok(TranslationAttemptPhase::Primary)
+    } else {
+        Ok(TranslationAttemptPhase::Fallback)
+    }
+}
+
+/// INSERT one append-only `translation_attempts` row inside the caller's
+/// transaction. `attempt_ordinal` is computed atomically by the INSERT itself
+/// (one past the current maximum for the (job, segment) pair), so the
+/// allocation is safe even inside a DEFERRED transaction: SQLite serializes the
+/// statement under the write lock, and two concurrent writers can never derive
+/// the same ordinal. Earlier attempts are never overwritten; the unique
+/// `(job_id, segment_id, attempt_ordinal)` constraint makes the sequence
+/// immutable and monotonic. When `request.phase` is `None` it is inferred from
+/// the effective provider/model against the job's primary configuration.
+fn append_attempt_on(
+    conn: &Connection,
+    request: RecordTranslationAttempt<'_>,
+    created_at: &str,
+) -> Result<i64> {
+    let phase = match request.phase {
+        Some(phase) => phase,
+        None => infer_attempt_phase_on(conn, request.job_id, request.provider, request.model)?,
+    };
+    conn.execute(
+        "INSERT INTO translation_attempts
+         (job_id, segment_id, batch_id, phase, attempt_ordinal, provider, model, outcome, error,
+          input_tokens, input_cached_tokens, output_tokens, cost_estimate, created_at)
+         VALUES (?1, ?2, ?3, ?4,
+                 (SELECT COALESCE(MAX(attempt_ordinal), 0) + 1
+                  FROM translation_attempts
+                  WHERE job_id = ?1 AND segment_id = ?2),
+                 ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+        params![
+            request.job_id,
+            request.segment_id,
+            request.batch_id,
+            phase.as_db_text(),
+            request.provider,
+            request.model,
+            request.outcome.as_db_text(),
+            request.error,
+            request.input_tokens.map(|value| value as i64),
+            request.input_cached_tokens.map(|value| value as i64),
+            request.output_tokens.map(|value| value as i64),
+            request.cost_estimate,
+            created_at,
+        ],
+    )?;
+    // The ordinal was assigned by the same statement that holds the write
+    // lock; read it back from the row we just inserted.
+    let attempt_ordinal = conn.query_row(
+        "SELECT attempt_ordinal FROM translation_attempts WHERE id = ?1",
+        params![conn.last_insert_rowid()],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(attempt_ordinal)
 }

--- a/crates/bookforge-store/src/lib.rs
+++ b/crates/bookforge-store/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod db;
 
+pub use bookforge_core::run_snapshot::CachePolicySnapshot;
 pub use db::{
     CacheLookupRequest, CachedTranslation, CreateJob, EngineFinding, GlossaryCandidateUpsertResult,
     GlossaryFilter, JobRecord, JobStatus, JobStore, JobSummary, NewEntity, NewGlossaryCandidate,
     NewSegmentFlag, NewStyleSheet, PruneJobDeletion, PruneJobsOptions, PruneJobsReport, QaFinding,
-    QaFindingCount, QaFindingKind, QaFindingSeverity, RetryScope, SaveCachedTranslation,
-    SaveManualCorrection, SaveNeedsReview, SaveTranslation, SegmentRecord, SegmentStatus,
-    StorageDoctor, StoreError, StoredBlockTranslation, StoredEntity, StoredGlossaryCandidate,
-    StoredQaFinding, StoredSegmentTranslation, StoredStyleSheet, aggregate_findings,
-    classify_segment_error, run_doctor,
+    QaFindingCount, QaFindingKind, QaFindingSeverity, RecordTranslationAttempt, RetryScope,
+    SaveCachedTranslation, SaveManualCorrection, SaveNeedsReview, SaveTranslation, SegmentRecord,
+    SegmentStatus, StorageDoctor, StoreError, StoredBlockTranslation, StoredEntity,
+    StoredGlossaryCandidate, StoredQaFinding, StoredSegmentTranslation, StoredStyleSheet,
+    TranslationAttemptOutcome, TranslationAttemptPhase, TranslationAttemptRecord,
+    TranslationAttemptSummary, aggregate_findings, classify_segment_error, run_doctor,
 };


### PR DESCRIPTION
## Summary
- persist a versioned, structured cache identity covering all output-affecting translation inputs
- compute resume cache identity over the full ordered segment neighborhood while restricting hits to eligible candidates
- add migration 12 with conservative legacy behavior and an append-only translation-attempt ledger
- prevent checkpoints from fabricating provider-attempt rows and preserve effective fallback provenance

## Verification
- cargo fmt --all -- --check
- cargo test -p bookforge-core --lib (138 passed)
- cargo test -p bookforge-store --lib (94 passed)
- cargo test -p bookforge-cli (347 + 26 + 1 + 54 + 16 passed)
- cargo test -p bookforge-llm (292 passed)
- cargo clippy -p bookforge-core -p bookforge-store --all-targets -- -D warnings
- cargo build --workspace

CLI clippy reports only the two pre-existing too-many-arguments findings in serve/entities.rs and tui/mod.rs, addressed by the separate cleanup lane.