### PR TITLE
fix(security): gate OCR endpoints, reject symlinked audio ops, bound EPUBCheck

### DIFF
--- a/crates/bookforge-cli/src/commands/convert.rs
+++ b/crates/bookforge-cli/src/commands/convert.rs
@@ -180,6 +180,14 @@ pub async fn run(args: ConvertArgs) -> Result<()> {
         config.image_mode = args.ocr_image_mode.as_str().to_string();
         config
     });
+    // Reject remote plain-HTTP OCR endpoints up front: page content and keys
+    // must never traverse an unauthenticated network path. HTTPS and HTTP
+    // loopback remain allowed.
+    if let Some(config) = &ocr_config {
+        config
+            .validate_base_url()
+            .with_context(|| "invalid OCR endpoint")?;
+    }
     if let Some(path) = &args.ocr_logit_processor {
         let processor = tokio::fs::read_to_string(path)
             .await

--- a/crates/bookforge-cli/src/commands/doctor.rs
+++ b/crates/bookforge-cli/src/commands/doctor.rs
@@ -138,6 +138,14 @@ async fn run_ocr_doctor(
     println!("  Base URL: {display_endpoint}");
     println!("  Model: {display_model}");
 
+    // Reject remote plain-HTTP endpoints before any request or key use;
+    // HTTPS and HTTP loopback remain allowed.
+    if let Err(error) = config.validate_base_url() {
+        println!("  Reachable: no");
+        println!("  Error: {}", sanitize_terminal(&error.to_string()));
+        return Ok(false);
+    }
+
     let result = tokio::task::spawn_blocking(move || {
         HttpOcrClient::new(config).and_then(|client| client.health_check())
     })

--- a/crates/bookforge-cli/src/commands/serve/audio.rs
+++ b/crates/bookforge-cli/src/commands/serve/audio.rs
@@ -1789,8 +1789,9 @@ fn truthy_field(fields: &HashMap<String, String>, key: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Resolve an existing operation only when its canonical path remains a direct
-/// child of the canonical upload root. This rejects traversal and symlink
-/// escapes before the path reaches any read or write operation.
+/// child of the canonical upload root. This rejects traversal, symlink
+/// escapes, and any operation directory that is itself a symlink (whatever
+/// its target) before the path reaches any read or write operation.
 pub(super) fn existing_audiobook_operation_out_dir(
     upload_dir: &Path,
     id: &str,
@@ -1804,15 +1805,22 @@ pub(super) fn existing_audiobook_operation_out_dir(
         Err(error) => return Err(error.into()),
     };
     let candidate = root.join(format!("audiobook-{id}"));
+    let metadata = match std::fs::symlink_metadata(&candidate) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    // A symlinked operation directory is refused outright: even a link that
+    // resolves back inside the root aliases one operation under another id.
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(None);
+    }
     let resolved = match std::fs::canonicalize(&candidate) {
         Ok(resolved) => resolved,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error.into()),
     };
-    if !resolved.starts_with(&root)
-        || resolved.parent() != Some(root.as_path())
-        || !resolved.is_dir()
-    {
+    if !resolved.starts_with(&root) || resolved.parent() != Some(root.as_path()) {
         return Ok(None);
     }
     Ok(Some(resolved))

--- a/crates/bookforge-cli/src/commands/serve/tests.rs
+++ b/crates/bookforge-cli/src/commands/serve/tests.rs
@@ -991,6 +991,150 @@ fn existing_audiobook_operation_rejects_a_symlink_escape() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn existing_audiobook_operation_rejects_a_symlink_alias_inside_the_root() {
+    use std::os::unix::fs::symlink;
+
+    let upload_root = tempfile::tempdir().expect("upload root should be created");
+    let real = upload_root.path().join("audiobook-real");
+    std::fs::create_dir(&real).expect("real operation dir should be created");
+    std::fs::write(real.join("process.json"), br#"{"status":"succeeded"}"#)
+        .expect("process record should be written");
+    symlink(&real, upload_root.path().join("audiobook-alias"))
+        .expect("alias symlink should be created");
+
+    assert!(
+        existing_audiobook_operation_out_dir(upload_root.path(), "alias")
+            .expect("symlink lookup should succeed")
+            .is_none(),
+        "a symlinked operation directory must be refused even when it points inside the root"
+    );
+    assert!(
+        existing_audiobook_operation_out_dir(upload_root.path(), "real")
+            .expect("real lookup should succeed")
+            .is_some(),
+        "the real directory must still resolve"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn audiobook_read_routes_refuse_a_symlinked_operation_directory() {
+    use axum::{body::Body, http::Request};
+    use std::os::unix::fs::symlink;
+    use tower::ServiceExt;
+
+    let upload_root = tempfile::tempdir().expect("upload root should be created");
+    let outside = tempfile::tempdir().expect("outside dir should be created");
+    let fake_operation = outside.path().join("operation");
+    std::fs::create_dir(&fake_operation).expect("fake operation dir should be created");
+    std::fs::write(
+        fake_operation.join("process.json"),
+        br#"{"status":"succeeded"}"#,
+    )
+    .expect("process record should be written");
+    std::fs::write(fake_operation.join("audiobook.m4b"), b"audio")
+        .expect("artifact should be written");
+    symlink(
+        &fake_operation,
+        upload_root.path().join("audiobook-symlink"),
+    )
+    .expect("operation symlink should be created");
+
+    let legit = upload_root.path().join("audiobook-legit");
+    std::fs::create_dir(&legit).expect("legit operation dir should be created");
+    std::fs::write(legit.join("process.json"), br#"{"status":"succeeded"}"#)
+        .expect("legit process record should be written");
+    std::fs::write(legit.join("manifest.json"), b"{}").expect("legit manifest should be written");
+
+    let router = dashboard_router(test_state_with_upload_dir(
+        "token-123",
+        upload_root.path().to_path_buf(),
+    ));
+    let cookie = session_cookie_value("token-123");
+
+    let status = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/audiobooks/symlink")
+                .header("host", TEST_HOST)
+                .header("cookie", cookie.clone())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(
+        status.status(),
+        StatusCode::NOT_FOUND,
+        "a symlinked operation must not be readable through the status route"
+    );
+
+    let artifact = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/audiobooks/symlink/artifact")
+                .header("host", TEST_HOST)
+                .header("cookie", cookie.clone())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(
+        artifact.status(),
+        StatusCode::NOT_FOUND,
+        "a symlinked operation must not be readable through the artifact route"
+    );
+
+    let cancel = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/audiobooks/symlink/cancel")
+                .header("host", TEST_HOST)
+                .header("cookie", cookie.clone())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(
+        cancel.status(),
+        StatusCode::CONFLICT,
+        "a symlinked operation must not be cancellable through the cancel route"
+    );
+
+    let list = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/audiobooks")
+                .header("host", TEST_HOST)
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("route should respond");
+    assert_eq!(list.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(list.into_body(), usize::MAX)
+        .await
+        .expect("list body should read");
+    let body = String::from_utf8_lossy(&body);
+    assert!(
+        body.contains("legit"),
+        "read_dir-derived entries must keep listing: {body}"
+    );
+    assert!(
+        !body.contains("symlink"),
+        "a symlinked operation must not be surfaced by the list route: {body}"
+    );
+}
+
 #[tokio::test]
 async fn control_endpoints_reject_missing_dashboard_token() {
     use axum::{body::Body, http::Request};

--- a/crates/bookforge-cli/src/commands/validate.rs
+++ b/crates/bookforge-cli/src/commands/validate.rs
@@ -1,7 +1,10 @@
 use std::{
     env, fs,
+    io::{self, Read},
     path::{Path, PathBuf},
-    process::{Command, Output},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
@@ -14,6 +17,17 @@ use serde_json::Value;
 use super::output;
 
 const VALIDATION_REPORT_SCHEMA_VERSION: u32 = 3;
+
+/// Finite deadlines for EPUBCheck subprocesses. A hung `--version` probe or a
+/// validation run that never exits must never block the CLI forever, and the
+/// child must be killed and reaped on expiry rather than abandoned.
+const EPUBCHECK_VERSION_DEADLINE: Duration = Duration::from_secs(30);
+const EPUBCHECK_VALIDATION_DEADLINE: Duration = Duration::from_secs(600);
+/// Per-stream retained output cap. stdout/stderr are drained concurrently but
+/// only this much of each stream is ever buffered, so a chatty EPUBCheck
+/// cannot grow process memory without bound.
+const EPUBCHECK_STREAM_CAP_BYTES: usize = 128 * 1024;
+const EPUBCHECK_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Debug, Args)]
 #[command(
@@ -278,7 +292,12 @@ enum EpubCheckCommand {
 }
 
 impl EpubCheckCommand {
-    fn output(&self, args: &[&str], input: Option<&Path>) -> std::io::Result<Output> {
+    /// Base process for this invocation: the resolved command line plus a
+    /// scrubbed child environment. Provider/API credentials in the parent
+    /// environment are never inherited by EPUBCheck, Java, or wrapper
+    /// scripts; only the allowlisted variables needed for them to run are
+    /// carried over.
+    fn command(&self) -> Command {
         let mut command = match self {
             EpubCheckCommand::Direct(path) => Command::new(path),
             EpubCheckCommand::JavaJar { java, jar } => {
@@ -292,11 +311,235 @@ impl EpubCheckCommand {
                 command
             }
         };
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+
+            // Run in an isolated process group so a deadline kill can
+            // terminate a wrapper (shell script / cmd) and its descendants
+            // (java) together instead of abandoning a runaway grandchild.
+            let _ = command.process_group(0);
+        }
+        apply_epubcheck_environment_allowlist(&mut command, &mut |name| env::var_os(name));
+        command
+    }
+
+    /// Run `args` (plus `input` when present) under a finite `deadline`:
+    /// stdin is nulled, stdout/stderr are piped and drained concurrently
+    /// with bounded retained memory, and on expiry the process tree is
+    /// killed and reaped (`EpubcheckCapture::timed_out`).
+    fn run(
+        &self,
+        args: &[&str],
+        input: Option<&Path>,
+        deadline: Duration,
+    ) -> io::Result<EpubcheckCapture> {
+        let mut command = self.command();
         command.args(args);
         if let Some(input) = input {
             command.arg(input);
         }
-        command.output()
+        run_epubcheck_bounded(command, deadline, EPUBCHECK_STREAM_CAP_BYTES)
+    }
+}
+
+/// Bounded output of one EPUBCheck subprocess run.
+#[derive(Debug)]
+struct EpubcheckCapture {
+    status: Option<ExitStatus>,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_exceeded: bool,
+    stderr_exceeded: bool,
+    timed_out: bool,
+}
+
+/// Spawn `command`, drain both output streams concurrently while retaining
+/// at most `stream_cap` bytes each, and reap the child when it exits or when
+/// `deadline` expires (killing the process group first). stdin is null so a
+/// tool waiting on a tty fails fast instead of hanging forever.
+fn run_epubcheck_bounded(
+    mut command: Command,
+    deadline: Duration,
+    stream_cap: usize,
+) -> io::Result<EpubcheckCapture> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("EPUBCheck stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("EPUBCheck stderr was not piped"))?;
+    let stdout_reader = match spawn_epubcheck_stream_reader(stdout, stream_cap, "stdout") {
+        Ok(reader) => reader,
+        Err(error) => {
+            terminate_epubcheck_child(&mut child);
+            return Err(error);
+        }
+    };
+    let stderr_reader = match spawn_epubcheck_stream_reader(stderr, stream_cap, "stderr") {
+        Ok(reader) => reader,
+        Err(error) => {
+            terminate_epubcheck_child(&mut child);
+            let _ = stdout_reader.join();
+            return Err(error);
+        }
+    };
+
+    let started = Instant::now();
+    let mut timed_out = false;
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break Some(status);
+        }
+        if started.elapsed() >= deadline {
+            timed_out = true;
+            terminate_epubcheck_child(&mut child);
+            break None;
+        }
+        let delay = deadline
+            .saturating_sub(started.elapsed())
+            .min(EPUBCHECK_POLL_INTERVAL);
+        if delay.is_zero() {
+            timed_out = true;
+            terminate_epubcheck_child(&mut child);
+            break None;
+        }
+        thread::sleep(delay);
+    };
+
+    let stdout = join_epubcheck_stream_reader(stdout_reader)?;
+    let stderr = join_epubcheck_stream_reader(stderr_reader)?;
+    Ok(EpubcheckCapture {
+        status,
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+        stdout_exceeded: stdout.exceeded,
+        stderr_exceeded: stderr.exceeded,
+        timed_out,
+    })
+}
+
+struct EpubcheckStreamCapture {
+    bytes: Vec<u8>,
+    exceeded: bool,
+}
+
+fn spawn_epubcheck_stream_reader<R>(
+    mut reader: R,
+    cap: usize,
+    stream: &'static str,
+) -> io::Result<thread::JoinHandle<io::Result<EpubcheckStreamCapture>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::Builder::new()
+        .name(format!("epubcheck-{stream}-reader"))
+        .spawn(move || {
+            let mut bytes = Vec::with_capacity(cap.min(64 * 1024));
+            let mut exceeded = false;
+            let mut buffer = [0_u8; 16 * 1024];
+            loop {
+                let count = reader.read(&mut buffer)?;
+                if count == 0 {
+                    break;
+                }
+                let retained = count.min(cap.saturating_sub(bytes.len()));
+                bytes.extend_from_slice(&buffer[..retained]);
+                exceeded |= retained < count;
+            }
+            Ok(EpubcheckStreamCapture { bytes, exceeded })
+        })
+}
+
+fn join_epubcheck_stream_reader(
+    reader: thread::JoinHandle<io::Result<EpubcheckStreamCapture>>,
+) -> io::Result<EpubcheckStreamCapture> {
+    reader
+        .join()
+        .map_err(|_| io::Error::other("EPUBCheck output reader thread panicked"))?
+}
+
+/// Kill the child process (group) and reap it. On Unix the child was placed
+/// in its own process group before spawn, so the negative-PID signal covers
+/// wrapper + java descendants; the direct kill + wait is the cross-platform
+/// fallback and reaps the process so no zombie is left behind.
+fn terminate_epubcheck_child(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let pid = child.id();
+        if pid != 0 {
+            let _ = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Minimal cross-platform environment allowlist for EPUBCheck child
+/// processes. Starting from `env_clear` and re-adding only these names means
+/// provider/API credentials and other secrets are never inherited, while Java
+/// (`JAVA_HOME`, temp dirs), wrapper scripts (`PATH`, `HOME`, locale) and
+/// Windows `cmd` (`SYSTEMROOT`/`COMSPEC`) keep working.
+fn apply_epubcheck_environment_allowlist(
+    command: &mut Command,
+    lookup: &mut dyn FnMut(&str) -> Option<std::ffi::OsString>,
+) {
+    command.env_clear();
+    for name in epubcheck_environment_allowlist() {
+        if let Some(value) = lookup(name) {
+            command.env(name, value);
+        }
+    }
+}
+
+fn epubcheck_environment_allowlist() -> &'static [&'static str] {
+    #[cfg(windows)]
+    {
+        &[
+            "PATH",
+            "HOME",
+            "JAVA_HOME",
+            "TMPDIR",
+            "TMP",
+            "TEMP",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "LANGUAGE",
+            "TZ",
+            "SYSTEMROOT",
+            "WINDIR",
+            "COMSPEC",
+            "PATHEXT",
+            "USERPROFILE",
+            "HOMEDRIVE",
+            "HOMEPATH",
+            "NUMBER_OF_PROCESSORS",
+            "PROCESSOR_ARCHITECTURE",
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        &[
+            "PATH",
+            "HOME",
+            "JAVA_HOME",
+            "TMPDIR",
+            "TMP",
+            "TEMP",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "LANGUAGE",
+            "TZ",
+        ]
     }
 }
 
@@ -307,13 +550,14 @@ fn run_epubcheck(input: &Path) -> EpubCheckReport {
     };
 
     let version = command
-        .output(&["--version"], None)
+        .run(&["--version"], None, EPUBCHECK_VERSION_DEADLINE)
         .ok()
-        .and_then(|output| {
+        .filter(|capture| !capture.timed_out)
+        .and_then(|capture| {
             let text = format!(
                 "{}\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&capture.stdout),
+                String::from_utf8_lossy(&capture.stderr)
             );
             parse_version_banner(&text)
         });
@@ -327,14 +571,53 @@ fn run_epubcheck(input: &Path) -> EpubCheckReport {
             .as_nanos()
     ));
     let report_arg = report_path.to_string_lossy().into_owned();
-    let output = match command.output(&["--json", &report_arg], Some(input)) {
-        Ok(output) => output,
+    let capture = match command.run(
+        &["--json", &report_arg],
+        Some(input),
+        EPUBCHECK_VALIDATION_DEADLINE,
+    ) {
+        Ok(capture) => capture,
         Err(error) => {
+            // Spawn failures happen before any child runs; remove the (never
+            // created) temp path anyway so no stale report can survive.
+            let _ = fs::remove_file(&report_path);
             return unavailable_epubcheck(format!("failed to run EPUBCheck: {error}"));
         }
     };
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = String::from_utf8_lossy(&capture.stderr);
+    if capture.stdout_exceeded {
+        tracing::warn!(
+            "EPUBCheck exceeded the {}-byte stdout capture limit; output is truncated",
+            EPUBCHECK_STREAM_CAP_BYTES
+        );
+    }
+    if capture.stderr_exceeded {
+        tracing::warn!(
+            "EPUBCheck exceeded the {}-byte stderr capture limit; diagnostics are truncated",
+            EPUBCHECK_STREAM_CAP_BYTES
+        );
+    }
+    if capture.timed_out {
+        let _ = fs::remove_file(&report_path);
+        return EpubCheckReport {
+            ran: true,
+            version,
+            status: "errors".to_string(),
+            messages: vec![ValidationMessage {
+                severity: "error".to_string(),
+                code: "EPUBCHECK-TIMEOUT".to_string(),
+                location: None,
+                text: format!(
+                    "EPUBCheck did not finish within {} seconds and was terminated. stderr: {}",
+                    EPUBCHECK_VALIDATION_DEADLINE.as_secs(),
+                    stderr.trim()
+                ),
+            }],
+        };
+    }
     let report_json = fs::read_to_string(&report_path);
+    // The report file is private temp state for one validation; remove it as
+    // soon as its bytes are no longer needed, on every path below.
     let _ = fs::remove_file(&report_path);
     let report_json = match report_json {
         Ok(report) => report,
@@ -357,7 +640,8 @@ fn run_epubcheck(input: &Path) -> EpubCheckReport {
     };
     match parse_epubcheck_json(&report_json, version.clone()) {
         Ok(mut report) => {
-            if report.messages.is_empty() && !output.status.success() {
+            if report.messages.is_empty() && !capture.status.is_some_and(|status| status.success())
+            {
                 report.messages.push(ValidationMessage {
                     severity: "error".to_string(),
                     code: "EPUBCHECK-EXIT".to_string(),
@@ -704,6 +988,178 @@ mod tests {
         assert_eq!(
             parse_version_banner("EPUBCheck v5.3.0\nMessages: 0 errors"),
             Some("5.3.0".to_string())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // EPUBCheck subprocess hardening. These tests re-exec the current test
+    // binary as a stand-in "EPUBCheck" so deadline/kill, output-limit and
+    // environment-scrubbing behaviour runs deterministically on any OS
+    // without a real Java/EPUBCheck install (mirroring the tools.rs pattern).
+    // -----------------------------------------------------------------------
+
+    const SLEEPING_EPUBCHECK_STAND_IN: &str =
+        "commands::validate::tests::fake_epubcheck_sleeps_then_marks_completion";
+    const SPAMMING_EPUBCHECK_STAND_IN: &str =
+        "commands::validate::tests::fake_epubcheck_spams_both_streams";
+
+    fn epubcheck_stand_in_command(test_name: &str) -> Command {
+        let executable = std::env::current_exe().expect("current test executable");
+        let mut command = Command::new(executable);
+        command.args(["--ignored", "--exact", test_name, "--nocapture"]);
+        command
+    }
+
+    #[test]
+    #[ignore = "stand-in child invoked by the bounded-capture timeout test"]
+    fn fake_epubcheck_sleeps_then_marks_completion() {
+        // Sleeps well past any deadline the parent test uses, then writes a
+        // marker. If the parent's kill failed, the marker appears and the
+        // parent test fails; if it was killed, the marker never appears.
+        thread::sleep(Duration::from_millis(1_500));
+        fs::write("epubcheck-fake-completed", b"completed").expect("completion marker writes");
+    }
+
+    #[test]
+    #[ignore = "stand-in child invoked by the bounded-capture output-limit test"]
+    fn fake_epubcheck_spams_both_streams() {
+        use std::io::Write as _;
+
+        let bytes = vec![b'x'; 64 * 1024];
+        io::stdout()
+            .write_all(&bytes)
+            .and_then(|()| io::stdout().flush())
+            .expect("stand-in stdout writes");
+        io::stderr()
+            .write_all(&bytes)
+            .and_then(|()| io::stderr().flush())
+            .expect("stand-in stderr writes");
+    }
+
+    #[test]
+    fn timed_out_epubcheck_child_is_killed_and_reaped() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let mut command = epubcheck_stand_in_command(SLEEPING_EPUBCHECK_STAND_IN);
+        command.current_dir(dir.path());
+
+        let started = Instant::now();
+        let capture = run_epubcheck_bounded(command, Duration::from_millis(250), 4096)
+            .expect("stand-in should run and time out");
+        let elapsed = started.elapsed();
+
+        assert!(capture.timed_out, "deadline must be enforced");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "deadline kill must be prompt, took {elapsed:?}"
+        );
+        // Give the stand-in enough time to have written its marker had it
+        // survived: 250 ms deadline vs a 1.5 s sleep.
+        thread::sleep(Duration::from_millis(1_400));
+        assert!(
+            !dir.path().join("epubcheck-fake-completed").exists(),
+            "a timed-out EPUBCheck must be killed and reaped, not left running"
+        );
+    }
+
+    #[test]
+    fn oversized_epubcheck_output_is_retained_within_the_bound() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let mut command = epubcheck_stand_in_command(SPAMMING_EPUBCHECK_STAND_IN);
+        command.current_dir(dir.path());
+
+        let capture = run_epubcheck_bounded(command, Duration::from_secs(30), 4096)
+            .expect("stand-in should exit normally");
+        assert!(!capture.timed_out);
+        assert!(
+            capture.status.is_some_and(|status| status.success()),
+            "a bounded child that exits normally must report success"
+        );
+        assert!(
+            capture.stdout.len() <= 4096,
+            "stdout retention must stay bounded"
+        );
+        assert!(
+            capture.stderr.len() <= 4096,
+            "stderr retention must stay bounded"
+        );
+        assert!(
+            capture.stdout_exceeded,
+            "spammed stdout should trip the limit"
+        );
+        assert!(
+            capture.stderr_exceeded,
+            "spammed stderr should trip the limit"
+        );
+    }
+
+    #[test]
+    fn epubcheck_child_environment_excludes_secrets_but_keeps_allowlist() {
+        // Seed the command with credential-named variables (as an inheriting
+        // spawn would receive them), then apply the scrubbing allowlist: the
+        // secrets must vanish while PATH and the other allowlisted variables
+        // present in the parent environment are copied through.
+        let mut command = Command::new("epubcheck");
+        command.env("OPENAI_API_KEY", "secret-openai");
+        command.env("OCR_API_KEY", "secret-ocr");
+        command.env("ELEVENLABS_API_KEY", "secret-elevenlabs");
+        command.env("BOOKFORGE_EPUBCHECK_TEST_SECRET", "secret-fixture");
+        apply_epubcheck_environment_allowlist(&mut command, &mut |name| env::var_os(name));
+
+        let environment = command.get_envs().collect::<Vec<_>>();
+        for (name, _) in &environment {
+            let name = name.to_string_lossy();
+            assert!(
+                !name.eq_ignore_ascii_case("OPENAI_API_KEY"),
+                "{name} leaked"
+            );
+            assert!(!name.eq_ignore_ascii_case("OCR_API_KEY"), "{name} leaked");
+            assert!(
+                !name.eq_ignore_ascii_case("ELEVENLABS_API_KEY"),
+                "{name} leaked"
+            );
+            assert!(
+                !name.eq_ignore_ascii_case("BOOKFORGE_EPUBCHECK_TEST_SECRET"),
+                "{name} leaked"
+            );
+        }
+
+        let names = environment
+            .iter()
+            .map(|(name, _)| name.to_string_lossy().to_ascii_uppercase())
+            .collect::<Vec<_>>();
+        assert!(
+            !names.iter().any(|name| name == "OPENAI_API_KEY"),
+            "secrets must not be re-added by the allowlist"
+        );
+        assert!(
+            names.iter().any(|name| name == "PATH"),
+            "PATH must survive scrubbing so EPUBCheck/Java/scripts can still run"
+        );
+    }
+
+    #[test]
+    fn bounded_capture_reports_success_for_a_fast_exit() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let mut command = epubcheck_stand_in_command(SPAMMING_EPUBCHECK_STAND_IN);
+        command.current_dir(dir.path());
+
+        let capture = run_epubcheck_bounded(command, Duration::from_secs(30), 1_024 * 1024)
+            .expect("stand-in should exit normally");
+        assert!(!capture.timed_out);
+        assert!(
+            !capture.stdout_exceeded,
+            "a 1 MiB cap must hold 64 KiB of output"
+        );
+        assert!(!capture.stderr_exceeded);
+        assert!(
+            capture.stdout.len() >= 64 * 1024 && capture.stdout.len() <= 1024 * 1024,
+            "full stdout should be retained up to the cap, got {} bytes",
+            capture.stdout.len()
+        );
+        assert!(
+            capture.stderr.len() >= 64 * 1024 && capture.stderr.len() <= 1024 * 1024,
+            "full stderr should be retained up to the cap, got {} bytes",
+            capture.stderr.len()
         );
     }
 }

--- a/crates/bookforge-cli/tests/doctor_ocr.rs
+++ b/crates/bookforge-cli/tests/doctor_ocr.rs
@@ -66,3 +66,16 @@ fn doctor_lists_models_from_loopback_ocr_endpoint() {
         .expect("doctor request captured");
     assert!(request.starts_with("GET /v1/models HTTP/1.1"));
 }
+
+#[test]
+fn doctor_rejects_remote_plain_http_ocr_endpoint_without_connecting() {
+    // Remote plain HTTP must be refused before any connection attempt or key
+    // lookup, so this stays offline-deterministic even if the endpoint were
+    // reachable.
+    bookforge()
+        .args(["doctor", "--ocr-endpoint", "http://example.com/v1"])
+        .assert()
+        .failure()
+        .stdout(contains("Reachable: no"))
+        .stdout(contains("unsafe OCR base URL"));
+}

--- a/crates/bookforge-epub/src/archive_limits.rs
+++ b/crates/bookforge-epub/src/archive_limits.rs
@@ -384,7 +384,10 @@ fn limit_error(message: String) -> BookforgeError {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Write};
+    use std::{
+        io::{Cursor, Write},
+        sync::atomic::{AtomicU64, Ordering},
+    };
 
     use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
 
@@ -466,15 +469,7 @@ mod tests {
                 .map(|(name, size)| (name.as_str(), *size))
                 .collect::<Vec<_>>(),
         );
-        let path = std::env::temp_dir().join(format!(
-            "bookforge-archive-preflight-{}-{}.epub",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-        std::fs::write(&path, bytes).expect("fixture should write");
+        let path = write_temp_archive(&bytes);
         let error = preflight_archive_path(&path).expect_err("entry count must be rejected");
         let _ = std::fs::remove_file(&path);
         assert!(error.to_string().contains("entry count limit exceeded"));
@@ -526,10 +521,14 @@ mod tests {
         assert!(error.to_string().contains("central directory"));
     }
 
+    static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     fn write_temp_archive(bytes: &[u8]) -> std::path::PathBuf {
+        let counter = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
         let path = std::env::temp_dir().join(format!(
-            "bookforge-archive-fixture-{}-{}.epub",
+            "bookforge-archive-fixture-{}-{}-{}.epub",
             std::process::id(),
+            counter,
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("clock")

--- a/crates/bookforge-pdf/src/ocr.rs
+++ b/crates/bookforge-pdf/src/ocr.rs
@@ -59,6 +59,13 @@ impl OcrConfig {
             max_attempts: 3,
         }
     }
+
+    /// Reject a base URL whose transport is unsafe for OCR page data before
+    /// any request is sent or API key is read: only HTTPS, or plain HTTP to a
+    /// loopback host (`localhost`, `127.0.0.1`, `[::1]`), is permitted.
+    pub fn validate_base_url(&self) -> Result<(), OcrError> {
+        validate_ocr_base_url(&self.base_url)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -74,6 +81,9 @@ pub enum OcrError {
 
     #[error("invalid OCR response: {0}")]
     InvalidResponse(String),
+
+    #[error("unsafe OCR base URL: {0}")]
+    UnsafeBaseUrl(String),
 }
 
 pub trait OcrEngine: Send + Sync {
@@ -93,6 +103,10 @@ pub struct HttpOcrClient {
 
 impl HttpOcrClient {
     pub fn new(config: OcrConfig) -> Result<Self, OcrError> {
+        // Transport validation happens before the client is built, so a
+        // remote plain-HTTP endpoint can never reach a request or trigger a
+        // key lookup.
+        config.validate_base_url()?;
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(30))
             .timeout(Duration::from_secs(config.timeout_seconds))
@@ -146,6 +160,34 @@ fn api_key_for_request(config: &OcrConfig) -> Result<Option<String>, OcrError> {
     }
 }
 
+/// Validate that an OCR base URL uses an allowed transport: HTTPS anywhere,
+/// or plain HTTP only to a loopback host. Remote plain HTTP (and any other
+/// scheme) is rejected because page content and credentials would otherwise
+/// traverse an unauthenticated network path.
+pub fn validate_ocr_base_url(base_url: &str) -> Result<(), OcrError> {
+    let url = Url::parse(base_url).map_err(|error| {
+        OcrError::UnsafeBaseUrl(format!("{base_url:?} is not a valid absolute URL: {error}"))
+    })?;
+    let host_loopback = url.host_str().is_some_and(is_loopback_host);
+    let allowed = match url.scheme() {
+        "https" => url.host_str().is_some(),
+        "http" => host_loopback,
+        _ => false,
+    };
+    if allowed {
+        Ok(())
+    } else {
+        Err(OcrError::UnsafeBaseUrl(format!(
+            "{base_url:?} is not allowed: OCR endpoints must use HTTPS, or plain HTTP only to a loopback host (localhost, 127.0.0.1, [::1])"
+        )))
+    }
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
 fn base_url_is_loopback(base_url: &str) -> bool {
     Url::parse(base_url)
         .ok()
@@ -153,12 +195,7 @@ fn base_url_is_loopback(base_url: &str) -> bool {
         // IPv6 hosts serialize with square brackets ("[::1]"); strip them
         // so the documented no-key loopback exemption also applies to
         // bracketed literals.
-        .map(|host| {
-            host.trim_start_matches('[')
-                .trim_end_matches(']')
-                .to_owned()
-        })
-        .is_some_and(|host| matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1"))
+        .is_some_and(|host| is_loopback_host(&host))
 }
 
 fn ocr_request_body(config: &OcrConfig, image_png: &[u8]) -> Value {
@@ -531,6 +568,75 @@ mod tests {
                 .and_then(|url| url.host_str().map(str::to_owned))
                 .is_some_and(|host| host == "[::1]")
         );
+    }
+
+    #[test]
+    fn https_and_http_loopback_ocr_base_urls_are_accepted() {
+        for base_url in [
+            "https://api.example.com/v1",
+            "https://ocr.internal.example/v1/",
+            "https://localhost:8443/v1",
+            "https://127.0.0.1/v1",
+            "https://[::1]/v1",
+            "http://localhost/v1",
+            "http://localhost:11434/v1",
+            "http://127.0.0.1:8080/v1",
+            "http://[::1]:9000/v1",
+        ] {
+            assert!(
+                validate_ocr_base_url(base_url).is_ok(),
+                "expected {base_url:?} to be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn remote_plain_http_ocr_base_urls_are_rejected_before_request_or_key_use() {
+        for base_url in [
+            "http://example.com/v1",
+            "http://api.openai.com/v1",
+            "http://10.0.0.8:8000/v1",
+            "http://192.168.1.10:9000/v1",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[fe80::1]/v1",
+            "ftp://example.com/v1",
+            "file:///etc/passwd",
+            "not a url",
+            "localhost:8000/v1",
+        ] {
+            let error = validate_ocr_base_url(base_url)
+                .expect_err(&format!("expected {base_url:?} to be rejected"));
+            assert!(
+                matches!(error, OcrError::UnsafeBaseUrl(_)),
+                "expected UnsafeBaseUrl for {base_url:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn client_construction_rejects_remote_plain_http_even_without_a_key() {
+        let mut config = OcrConfig::new("http://example.com/v1");
+        config.api_key_env = "BOOKFORGE_OCR_TEST_REMOTE_HTTP_KEY".to_string();
+        // No API key is set (and validation runs before any key lookup), so
+        // refusal must come from the transport gate alone.
+        let error = match HttpOcrClient::new(config) {
+            Ok(_) => panic!("remote http client construction must be refused"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(error, OcrError::UnsafeBaseUrl(_)),
+            "refusal must happen before any key lookup or request: {error}"
+        );
+    }
+
+    #[test]
+    fn client_construction_still_accepts_loopback_http() {
+        let mut config = OcrConfig::new("http://127.0.0.1:1/v1");
+        config.api_key_env = "BOOKFORGE_OCR_TEST_CLIENT_LOOPBACK_KEY".to_string();
+        // No server is listening; the point is only that construction (the
+        // transport gate) succeeds for loopback HTTP and no connection is
+        // attempted during it.
+        assert!(HttpOcrClient::new(config).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject remote plain-HTTP OCR endpoints before request or API key use
- refuse symlinked audiobook operation directories to prevent traversal and alias confusion
- add subprocess deadlines, memory-bounded stream drain, and allowlisted environment for EPUBCheck invocations

## Verification
- cargo fmt --all -- --check
- cargo test -p bookforge-pdf --lib ocr::tests (13 passed)
- cargo test -p bookforge-cli --test doctor_ocr (2 passed)
- cargo test -p bookforge-cli --bin bookforge -- commands::validate::tests (10 passed)
- cargo test -p bookforge-cli --bin bookforge -- audiobook_read_routes_refuse_a_symlinked_operation_directory existing_audiobook_operation_rejects_a_symlink_alias_inside_the_root (2 passed)
- clippy zero warnings